### PR TITLE
feat(bus): warn when a stuck consumer holds the event log open

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -517,6 +517,13 @@ carries the enumerated exception list.
 - Retention trims past the age window but never past an **enabled** consumer's
   cursor. Disabled consumers do not pin the log; they resume at head with a
   logged gap.
+- An enabled consumer that stops consuming therefore grows the log until someone
+  intervenes, so past `bus.DefaultPinAlarmAge` the pin is reported: a warning
+  notification, a `(PINNING …)` tag in `attn bus status`, and a badge on the
+  settings page, all from one predicate in `internal/bus`. Announced once per
+  episode — the cursor moving is what ends one. `ATTN_BUS_PIN_ALARM_AGE` moves
+  the tripwire (0 turns it off), which is also how the condition is demonstrated
+  without waiting an hour.
 - A durable consumer can register and unregister while the daemon runs.
   `Unregister` cancels that consumer alone, waits for its delivery loop to exit,
   and only then deletes the row: deleting first leaves a live loop reading a

--- a/app/src/components/EventBusSettings.test.tsx
+++ b/app/src/components/EventBusSettings.test.tsx
@@ -29,6 +29,8 @@ const consumer = (over: Partial<BusStatus['consumers'][number]> = {}) => ({
   stalled: '',
   oldest_unread_at: '',
   holds_retention_floor: false,
+  pin_alarm: false,
+  pinned_bytes: 0,
   ...over,
 });
 
@@ -44,6 +46,7 @@ const status = (over: Partial<BusStatus> = {}): BusStatus => ({
   recentWindowSeconds: 3600,
   baselineWindowSeconds: 86400,
   surgeRatePerHour: 1000,
+  pinAlarmSeconds: 3600,
   producers: [producer()],
   consumers: [],
   health: [],
@@ -185,6 +188,47 @@ describe('EventBusSettings', () => {
     expect(screen.getByTestId('bus-consumer-pinner')).toHaveTextContent('7d');
     expect(screen.getByTestId('bus-consumer-absent')).toHaveTextContent('Not running');
     expect(screen.getByTestId('bus-consumer-failing')).toHaveTextContent('Stalled');
+  });
+
+  // Holding the floor is the system working; holding it past the tripwire is an
+  // outage. If the page draws the two the same way, opening it after the warning
+  // notification tells the reader nothing they did not already know.
+  it('separates a normal retention floor from one past the tripwire', async () => {
+    renderPane(status({
+      consumers: [
+        consumer({ name: 'ordinary', holds_retention_floor: true, lag: 12 }),
+        consumer({
+          name: 'app:ticketwatch',
+          holds_retention_floor: true,
+          pin_alarm: true,
+          pinned_bytes: 31_000,
+          lag: 41000,
+          oldest_unread_at: '2026-08-03T19:30:00Z',
+        }),
+      ],
+    }));
+    await screen.findByTestId('bus-consumers');
+
+    expect(screen.getByTestId('bus-consumer-ordinary')).toHaveTextContent('Retention floor');
+    expect(screen.getByTestId('bus-consumer-ordinary')).not.toHaveTextContent('Pinning');
+    const alarming = screen.getByTestId('bus-consumer-app:ticketwatch');
+    expect(alarming).toHaveTextContent('Pinning 30.3 KB');
+    expect(alarming).not.toHaveTextContent('Retention floor');
+  });
+
+  // The tripwire is shown so the reader can check the value in force against the
+  // one they set. Rounding 90 seconds to "2m" names a number they cannot set.
+  it('names the tripwire exactly rather than rounding it', async () => {
+    renderPane(status({
+      pinAlarmSeconds: 90,
+      consumers: [
+        consumer({ name: 'app:ticketwatch', holds_retention_floor: true, pin_alarm: true, pinned_bytes: 1024 }),
+      ],
+    }));
+    await screen.findByTestId('bus-consumers');
+
+    const pill = screen.getByTestId('bus-consumer-app:ticketwatch').querySelector('.settings-pill.bad');
+    expect(pill?.getAttribute('title')).toContain('longer than 1m30s');
   });
 
   // `delivering: false` means the snapshot could not know whether a loop is

--- a/app/src/components/EventBusSettings.tsx
+++ b/app/src/components/EventBusSettings.tsx
@@ -52,6 +52,23 @@ const formatSpan = (seconds: number): string => {
   return `${Math.round(seconds)}s`;
 };
 
+/**
+ * Renders a configured limit exactly, where formatSpan renders an observation:
+ * "1h", "1m30s", "45s". A limit rounded to "2m" when it was set to 1m30s names a
+ * number the reader cannot check their own value against. Mirrors limitDuration
+ * in internal/bus.
+ */
+const formatLimit = (seconds: number): string => {
+  if (!Number.isFinite(seconds) || seconds <= 0) return '';
+  const whole = Math.round(seconds);
+  const h = Math.floor(whole / 3600);
+  const m = Math.floor((whole % 3600) / 60);
+  const s = whole % 60;
+  if (h > 0) return s === 0 ? (m === 0 ? `${h}h` : `${h}h${m}m`) : `${h}h${m}m${s}s`;
+  if (m > 0) return s === 0 ? `${m}m` : `${m}m${s}s`;
+  return `${s}s`;
+};
+
 /** Age of an RFC3339 stamp, as a span. Empty for an absent or unparseable one. */
 const formatAge = (iso: string, now: number): string => {
   if (!iso) return '';
@@ -262,9 +279,19 @@ export function EventBusSettings({ getBusStatus, setConsumerEnabled }: EventBusS
               >
                 <span className="bus-name">
                   {c.name}
-                  {c.holds_retention_floor && (
+                  {/* Holding the floor is the system working. Holding it past the
+                      tripwire is the thing to act on, so the two never look alike. */}
+                  {c.holds_retention_floor && !c.pin_alarm && (
                     <span className="settings-pill" title="Retention stops at this consumer's cursor">
                       Retention floor
+                    </span>
+                  )}
+                  {c.pin_alarm && (
+                    <span
+                      className="settings-pill bad"
+                      title={`Nothing below this consumer's cursor can be trimmed, and it has held that for longer than ${formatLimit(status.pinAlarmSeconds)}`}
+                    >
+                      Pinning {formatBytes(c.pinned_bytes)}
                     </span>
                   )}
                   {!c.enabled && <span className="settings-pill warn">Disabled</span>}

--- a/app/src/hooks/daemonBusEvents.ts
+++ b/app/src/hooks/daemonBusEvents.ts
@@ -31,6 +31,8 @@ export interface BusStatus {
   recentWindowSeconds: number;
   baselineWindowSeconds: number;
   surgeRatePerHour: number;
+  /** How long a consumer may pin the retention floor before the pin is reported. */
+  pinAlarmSeconds: number;
   producers: BusProducerStatus[];
   consumers: BusConsumerStatus[];
   health: BusHealthEntry[];
@@ -61,6 +63,7 @@ const toBusStatus = (event: BusDaemonEvent): BusStatus => ({
   recentWindowSeconds: num(event.recent_window_seconds),
   baselineWindowSeconds: num(event.baseline_window_seconds),
   surgeRatePerHour: num(event.surge_rate_per_hour),
+  pinAlarmSeconds: num(event.pin_alarm_seconds),
   producers: list<BusProducerStatus>(event.producers),
   consumers: list<BusConsumerStatus>(event.consumers),
   health: list<BusHealthEntry>(event.health),

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -230,7 +230,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '231';
+export const PROTOCOL_VERSION = '232';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1638,6 +1638,8 @@ export interface BusConsumerStatus {
     live:                  boolean;
     name:                  string;
     oldest_unread_at:      string;
+    pin_alarm:             boolean;
+    pinned_bytes:          number;
     stalled:               string;
     updated_at:            string;
     [property: string]: any;
@@ -1713,6 +1715,7 @@ export interface BusStatusResultMessage {
     health:                  HealthElement[];
     newest_at:               string;
     oldest_at:               string;
+    pin_alarm_seconds:       number;
     producers:               ProducerElement[];
     recent_window_seconds:   number;
     request_id:              string;
@@ -1732,6 +1735,8 @@ export interface ConsumerElement {
     live:                  boolean;
     name:                  string;
     oldest_unread_at:      string;
+    pin_alarm:             boolean;
+    pinned_bytes:          number;
     stalled:               string;
     updated_at:            string;
     [property: string]: any;
@@ -12288,6 +12293,8 @@ const typeMap: any = {
         { json: "live", js: "live", typ: true },
         { json: "name", js: "name", typ: "" },
         { json: "oldest_unread_at", js: "oldest_unread_at", typ: "" },
+        { json: "pin_alarm", js: "pin_alarm", typ: true },
+        { json: "pinned_bytes", js: "pinned_bytes", typ: 0 },
         { json: "stalled", js: "stalled", typ: "" },
         { json: "updated_at", js: "updated_at", typ: "" },
     ], "any"),
@@ -12339,6 +12346,7 @@ const typeMap: any = {
         { json: "health", js: "health", typ: a(r("HealthElement")) },
         { json: "newest_at", js: "newest_at", typ: "" },
         { json: "oldest_at", js: "oldest_at", typ: "" },
+        { json: "pin_alarm_seconds", js: "pin_alarm_seconds", typ: 3.14 },
         { json: "producers", js: "producers", typ: a(r("ProducerElement")) },
         { json: "recent_window_seconds", js: "recent_window_seconds", typ: 3.14 },
         { json: "request_id", js: "request_id", typ: "" },
@@ -12356,6 +12364,8 @@ const typeMap: any = {
         { json: "live", js: "live", typ: true },
         { json: "name", js: "name", typ: "" },
         { json: "oldest_unread_at", js: "oldest_unread_at", typ: "" },
+        { json: "pin_alarm", js: "pin_alarm", typ: true },
+        { json: "pinned_bytes", js: "pinned_bytes", typ: 0 },
         { json: "stalled", js: "stalled", typ: "" },
         { json: "updated_at", js: "updated_at", typ: "" },
     ], "any"),

--- a/changelog.d/bus-pin-alarm.yaml
+++ b/changelog.d/bus-pin-alarm.yaml
@@ -1,0 +1,13 @@
+kind: added
+area: daemon
+change: >
+  attn now tells you when something has stopped reading the event log. A durable
+  consumer that is switched on but not consuming holds the log open — nothing
+  below its position can be trimmed — and until now the only way to notice was to
+  go and look. After an hour of that, you get a warning notification naming the
+  consumer, how much it is holding, how long it has held it, and the command that
+  ends it. `attn bus status` and the event bus settings page mark the same
+  consumer, so the alarm and the page you open to check it always agree. It is
+  said once per outage, not once per check, and nothing is ever dropped or
+  switched off on its behalf — the alarm makes the condition visible and leaves
+  what to do about it to you.

--- a/cmd/attn/bus.go
+++ b/cmd/attn/bus.go
@@ -60,6 +60,16 @@ commands:
         filter, enabled bit, and lag (head - cursor, plus how long its oldest
         unread event has waited); and what is wrong with any of it.
 
+        Whichever enabled consumer sits lowest is tagged "(retention floor)".
+        Once it has held that position past the alarm's tripwire it is tagged
+        "(PINNING <size>)" instead, and the same crossing writes a warning
+        notification — the log is growing for as long as that lasts.
+
+        ATTN_BUS_PIN_ALARM_AGE moves that tripwire (a duration, or 0 to turn it
+        off). The daemon reads it to decide when to warn; this command reads it
+        from its own environment to decide what to tag, so set it for both when
+        you move it, or the table and the notification will disagree.
+
   trim
         run one retention pass now instead of waiting for the daemon's hourly
         tick: drop events past the age window, and reduce the compactable fact
@@ -96,15 +106,18 @@ type busStatusJSON struct {
 	// Delivering is false when the snapshot was read from the database rather
 	// than from the daemon that owns the delivery loops, which is what makes
 	// each consumer's `live` field meaningless.
-	Delivering        bool                `json:"delivering"`
-	RetentionSeconds  float64             `json:"retention_seconds"`
-	SurgeRatePerHour  float64             `json:"surge_rate_per_hour"`
-	SurgeWindowSecs   float64             `json:"surge_window_seconds"`
-	RecentWindowSecs  float64             `json:"recent_window_seconds"`
-	BaselineWindowSec float64             `json:"baseline_window_seconds"`
-	Producers         []busProducerReport `json:"producers"`
-	Consumers         []busConsumerReport `json:"consumers"`
-	Health            []busHealthReport   `json:"health"`
+	Delivering        bool    `json:"delivering"`
+	RetentionSeconds  float64 `json:"retention_seconds"`
+	SurgeRatePerHour  float64 `json:"surge_rate_per_hour"`
+	SurgeWindowSecs   float64 `json:"surge_window_seconds"`
+	RecentWindowSecs  float64 `json:"recent_window_seconds"`
+	BaselineWindowSec float64 `json:"baseline_window_seconds"`
+	// PinAlarmSeconds is the tripwire a retention pin crosses to be reported, so
+	// a script reads the limit beside the value rather than assuming the default.
+	PinAlarmSeconds float64             `json:"pin_alarm_seconds"`
+	Producers       []busProducerReport `json:"producers"`
+	Consumers       []busConsumerReport `json:"consumers"`
+	Health          []busHealthReport   `json:"health"`
 }
 
 type busProducerReport struct {
@@ -134,6 +147,11 @@ type busConsumerReport struct {
 	Stalled             string `json:"stalled,omitempty"`
 	OldestUnreadAt      string `json:"oldest_unread_at,omitempty"`
 	HoldsRetentionFloor bool   `json:"holds_retention_floor"`
+	// PinAlarm says that pin is past the tripwire, and PinnedBytes is what the
+	// backlog weighs — read only for a consumer that is alarming, so a script can
+	// tell "0 bytes held" from "not measured" by the flag beside it.
+	PinAlarm    bool  `json:"pin_alarm"`
+	PinnedBytes int64 `json:"pinned_bytes"`
 }
 
 type busHealthReport struct {
@@ -157,6 +175,7 @@ func busStatusReport(s bus.Status) busStatusJSON {
 		SurgeWindowSecs:   bus.SurgeWindow.Seconds(),
 		RecentWindowSecs:  bus.RecentWindow.Seconds(),
 		BaselineWindowSec: bus.BaselineWindow.Seconds(),
+		PinAlarmSeconds:   s.PinAlarmAge.Seconds(),
 		Producers:         []busProducerReport{},
 		Consumers:         []busConsumerReport{},
 		Health:            []busHealthReport{},
@@ -177,6 +196,8 @@ func busStatusReport(s bus.Status) busStatusJSON {
 			Live: c.Live, Stalled: c.Stalled,
 			OldestUnreadAt:      formatBusTime(c.OldestUnreadAt),
 			HoldsRetentionFloor: c.HoldsRetentionFloor,
+			PinAlarm:            c.PinAlarm,
+			PinnedBytes:         c.PinnedBytes,
 		})
 	}
 	for _, h := range s.Health {
@@ -216,7 +237,15 @@ func runBusStatus(args []string) {
 	// against the same database. This bus registers no consumer and is never
 	// started: it is here to read, so Live and Stalled stay unset and the
 	// snapshot says so (delivering=false).
-	b := bus.New(bus.Options{Store: daemon.NewBusStore(s), Compactable: daemon.CompactableFacts})
+	// The retention-pin tripwire comes from this process's environment for the
+	// same reason it does in the daemon: the two must draw the line in the same
+	// place, or this table calls a consumer fine while a notification calls it
+	// stuck. Anything it has to say goes to stderr, so --json stays machine-clean.
+	b := bus.New(bus.Options{
+		Store:       daemon.NewBusStore(s),
+		Compactable: daemon.CompactableFacts,
+		PinAlarmAge: bus.PinAlarmAgeFromEnv(busStderrLog),
+	})
 	status, err := b.Status()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "bus status: %v\n", err)
@@ -295,7 +324,12 @@ func writeBusStatus(w io.Writer, s bus.Status, now time.Time) {
 		fmt.Fprintln(tw, "CONSUMER\tCURSOR\tLAG\tOLDEST UNREAD\tENABLED\tFILTER")
 		for _, c := range s.Consumers {
 			name := c.Name
-			if c.HoldsRetentionFloor {
+			switch {
+			// Holding the floor is normal; holding it past the tripwire is the
+			// thing to act on, so the two must not read alike in the table.
+			case c.PinAlarm:
+				name += fmt.Sprintf(" (PINNING %s)", humanBytes(c.PinnedBytes))
+			case c.HoldsRetentionFloor:
 				name += " (retention floor)"
 			}
 			unread := "-"
@@ -363,7 +397,7 @@ func runBusTrim(args []string) {
 	b := bus.New(bus.Options{
 		Store:       daemon.NewBusStore(s),
 		Compactable: daemon.CompactableFacts,
-		Log:         func(format string, args ...interface{}) { fmt.Fprintf(os.Stderr, format+"\n", args...) },
+		Log:         busStderrLog,
 	})
 	removed, passErr := b.Trim()
 	after, bytes, err := s.BusLogSize()
@@ -424,6 +458,12 @@ func runBusSetEnabled(args []string, enabled bool) {
 		os.Exit(1)
 	}
 	fmt.Printf("consumer %q %sd\n", name, verb)
+}
+
+// busStderrLog is what the bus says to a person running a bus command: stderr,
+// so it never lands in the middle of --json output someone is parsing.
+func busStderrLog(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
 }
 
 func openBusStore() (*store.Store, func()) {

--- a/cmd/attn/bus_test.go
+++ b/cmd/attn/bus_test.go
@@ -168,3 +168,59 @@ func producerRow(t *testing.T, out, name string) string {
 	t.Fatalf("no table row for %q in:\n%s", name, out)
 	return ""
 }
+
+// Holding the retention floor is normal and holding it past the tripwire is an
+// outage. The table has to read differently for the two, or someone acting on
+// the warning opens the CLI and cannot tell which consumer it meant.
+func TestBusStatusRenderingSeparatesANormalFloorFromAnAlarmingOne(t *testing.T) {
+	s := busStatusFixture()
+	s.PinAlarmAge = time.Hour
+	s.Consumers = []bus.ConsumerStatus{
+		{Name: "ordinary", Cursor: 990, Lag: 10, Enabled: true, HoldsRetentionFloor: true},
+		{
+			Name: "app:ticketwatch", Cursor: 120, Lag: 880, Enabled: true,
+			HoldsRetentionFloor: true, PinAlarm: true, PinnedBytes: 31_000,
+			OldestUnreadAt: busRenderNow.Add(-3 * time.Hour),
+		},
+	}
+
+	out := renderBusStatus(s)
+	if !strings.Contains(out, "ordinary (retention floor)") {
+		t.Errorf("a healthy floor holder lost its tag:\n%s", out)
+	}
+	if !strings.Contains(out, "app:ticketwatch (PINNING 30.3 KB)") {
+		t.Errorf("an alarming pin is not marked, or does not say what it holds:\n%s", out)
+	}
+}
+
+// A script acting on the crossing needs the limit beside the value, and needs to
+// tell "holding nothing" from "not measured" — which is what the flag is for.
+func TestBusStatusJSONCarriesTheTripwireAndWhatIsHeld(t *testing.T) {
+	s := busStatusFixture()
+	s.PinAlarmAge = 90 * time.Minute
+	s.Consumers = []bus.ConsumerStatus{{
+		Name: "app:ticketwatch", Cursor: 120, Lag: 880, Enabled: true,
+		HoldsRetentionFloor: true, PinAlarm: true, PinnedBytes: 31_000,
+	}}
+
+	raw, err := json.Marshal(busStatusReport(s))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got struct {
+		PinAlarmSeconds float64 `json:"pin_alarm_seconds"`
+		Consumers       []struct {
+			PinAlarm    bool  `json:"pin_alarm"`
+			PinnedBytes int64 `json:"pinned_bytes"`
+		} `json:"consumers"`
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.PinAlarmSeconds != 5400 {
+		t.Errorf("pin_alarm_seconds = %v, want the tripwire in effect", got.PinAlarmSeconds)
+	}
+	if len(got.Consumers) != 1 || !got.Consumers[0].PinAlarm || got.Consumers[0].PinnedBytes != 31_000 {
+		t.Errorf("consumer report = %+v", got.Consumers)
+	}
+}

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -305,6 +305,30 @@ failing plugin takes an integration down; a failing app is disabled while
 everything else keeps running. Different trust, different rate of change,
 different blast radius.
 
+## The retention floor, and the pin alarm
+
+The event log is trimmed by age, but never past the lowest cursor any **enabled**
+durable consumer still holds. That position is the **retention floor**, and the
+consumer sitting on it is said to **pin** the log: nothing at or below its cursor
+can be trimmed, because a durable consumer must not lose an unread fact. A
+disabled consumer does not pin — releasing the floor is exactly what `attn bus
+disable` is for.
+
+Holding the floor is ordinary. Every log has a floor holder and it is usually
+just the consumer that read least recently. What is not ordinary is holding it
+without moving: a consumer that is enabled and not consuming grows the log for as
+long as the condition lasts, and nothing ends that on its own.
+
+The **pin alarm** is the tripwire that separates the two. Past it — an hour by
+default, measured against every stall attn resolves by itself — the pin stops
+being the system working and becomes an outage worth a warning notification.
+Three surfaces report the same finding from the same predicate: the notification,
+`attn bus status`, and the event bus settings page. It is announced once per
+episode, and a new episode begins only after the consumer's cursor moves.
+
+The alarm makes the condition visible; it never resolves it. No pinned event is
+ever dropped and no consumer is ever disabled on its behalf.
+
 ## The document store
 
 attn's **document store** is where an app keeps its own data. Three names

--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -87,6 +88,9 @@ type Store interface {
 	Producers(cutoffs []time.Time) ([]ProducerRow, error)
 	// EventTimeAt stamps the first event at or above seq, for age questions.
 	EventTimeAt(seq int64) (time.Time, bool, error)
+	// PendingBytes sums what the log holds above a cursor — the size of one
+	// consumer's backlog, and the cost of the pin it is holding.
+	PendingBytes(above int64) (int64, error)
 }
 
 // Handler receives one event. An error stalls the consumer with backoff and
@@ -104,6 +108,10 @@ type Options struct {
 	PollInterval time.Duration
 	RetryBase    time.Duration
 	RetryCap     time.Duration
+	// PinAlarmAge is how long an enabled consumer may pin the retention floor
+	// before the snapshot reports it; zero falls back to DefaultPinAlarmAge and
+	// a negative value turns the finding off entirely.
+	PinAlarmAge time.Duration
 	// Compactable names fact classes that are pure invalidations, so retention
 	// may keep only the newest per subject (see compact for the cost).
 	Compactable []string
@@ -121,6 +129,7 @@ type Bus struct {
 	pollInterval time.Duration
 	retryBase    time.Duration
 	retryCap     time.Duration
+	pinAlarmAge  time.Duration
 
 	compactable []string
 
@@ -209,9 +218,13 @@ func New(opts Options) *Bus {
 		pollInterval: nonZeroDuration(opts.PollInterval, DefaultPollInterval),
 		retryBase:    nonZeroDuration(opts.RetryBase, DefaultRetryBase),
 		retryCap:     nonZeroDuration(opts.RetryCap, DefaultRetryCap),
-		compactable:  append([]string(nil), opts.Compactable...),
-		ephemeral:    map[int]*ephemeralSub{},
-		retiring:     map[string]struct{}{},
+		// Unlike the other windows, a negative value here is meaningful: it is the
+		// escape hatch that turns the finding off, so it must survive rather than
+		// fall back the way an unset zero does.
+		pinAlarmAge: pinAlarmAgeOrDefault(opts.PinAlarmAge),
+		compactable: append([]string(nil), opts.Compactable...),
+		ephemeral:   map[int]*ephemeralSub{},
+		retiring:    map[string]struct{}{},
 	}
 	if b.now == nil {
 		b.now = time.Now
@@ -1092,6 +1105,53 @@ func backoff(base, ceiling time.Duration, attempt int) time.Duration {
 		return ceiling
 	}
 	return d
+}
+
+// pinAlarmAgeOrDefault keeps a negative age as the off switch, where every other
+// window reads a non-positive value as "unset, use the default".
+func pinAlarmAgeOrDefault(v time.Duration) time.Duration {
+	if v == 0 {
+		return DefaultPinAlarmAge
+	}
+	return v
+}
+
+// PinAlarmAgeEnv overrides the retention-pin tripwire, so the condition can be
+// produced and watched end to end without waiting an hour for it. A duration
+// ("90s", "4m", "2h"); 0 turns the finding off.
+const PinAlarmAgeEnv = "ATTN_BUS_PIN_ALARM_AGE"
+
+// PinAlarmAgeFromEnv resolves the tripwire for one process. It lives here, and
+// not in whichever process happens to want it, because the daemon that raises the
+// alarm and the CLI that reads the same database must draw the line in the same
+// place — a table that says a consumer is fine while a notification says it is not
+// is worse than either surface alone.
+//
+// An unparseable value is refused loudly rather than quietly ignored: a limit
+// nobody can see is worse than no limit.
+func PinAlarmAgeFromEnv(log LogFunc) time.Duration {
+	if log == nil {
+		log = func(string, ...interface{}) {}
+	}
+	raw := strings.TrimSpace(os.Getenv(PinAlarmAgeEnv))
+	if raw == "" {
+		return DefaultPinAlarmAge
+	}
+	age, err := time.ParseDuration(raw)
+	if err != nil {
+		log("bus: %s=%q is not a duration (%v); using the default %s",
+			PinAlarmAgeEnv, raw, err, DefaultPinAlarmAge)
+		return DefaultPinAlarmAge
+	}
+	if age <= 0 {
+		log("bus: %s=%q — the retention-pin alarm is off; a stuck consumer will grow the log unannounced",
+			PinAlarmAgeEnv, raw)
+		// Negative is the off switch inside the bus; zero would read as "unset" and
+		// restore the default.
+		return -1
+	}
+	log("bus: retention-pin alarm set to %s by %s (default %s)", age, PinAlarmAgeEnv, DefaultPinAlarmAge)
+	return age
 }
 
 func nonZeroDuration(v, fallback time.Duration) time.Duration {

--- a/internal/bus/bus_test.go
+++ b/internal/bus/bus_test.go
@@ -271,6 +271,18 @@ func (m *memStore) EventTimeAt(seq int64) (time.Time, bool, error) {
 	return time.Time{}, false, nil
 }
 
+func (m *memStore) PendingBytes(above int64) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var bytes int64
+	for _, e := range m.events {
+		if e.Seq > above {
+			bytes += int64(len(e.Name) + len(e.Subject) + len(e.Payload) + len(e.Source))
+		}
+	}
+	return bytes, nil
+}
+
 // appendOutOfBand puts an event on the log the way a store transaction does:
 // committed, with no fan-out — which is what Announce is for.
 func (m *memStore) appendOutOfBand(name, subject string, now time.Time) int64 {

--- a/internal/bus/pin_test.go
+++ b/internal/bus/pin_test.go
@@ -1,0 +1,324 @@
+package bus
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Retention never trims past an enabled consumer's cursor, so a consumer that
+// stops consuming grows the log for as long as it lasts. These drive the
+// tripwire that turns that from something you have to go and look for into
+// something the system says.
+//
+// The clock is pinned (statusNow), because every claim here is about an age.
+
+// pinStore seeds a log and one consumer whose cursor sits below head, with its
+// oldest unread event `unread` old.
+func pinStore(t *testing.T, name string, enabled bool, unread time.Duration) *memStore {
+	t.Helper()
+	s := newMemStore()
+	// Two events already read, then three the consumer has not reached.
+	for i := 0; i < 2; i++ {
+		if _, err := s.Append(Event{Name: "session.state.changed", Subject: "s1"}, statusNow.Add(-48*time.Hour)); err != nil {
+			t.Fatalf("append read: %v", err)
+		}
+	}
+	for i := 0; i < 3; i++ {
+		if _, err := s.Append(Event{Name: "ticket.updated", Subject: fmt.Sprintf("t%d", i)}, statusNow.Add(-unread)); err != nil {
+			t.Fatalf("append unread: %v", err)
+		}
+	}
+	if err := s.SaveConsumer(Consumer{Name: name, Cursor: 2, Enabled: enabled}, statusNow.Add(-unread)); err != nil {
+		t.Fatalf("save consumer: %v", err)
+	}
+	return s
+}
+
+func pinBus(t *testing.T, s *memStore, age time.Duration) *Bus {
+	t.Helper()
+	return New(Options{Store: s, Now: func() time.Time { return statusNow }, PinAlarmAge: age})
+}
+
+func consumerStatus(t *testing.T, s Status, name string) ConsumerStatus {
+	t.Helper()
+	for _, c := range s.Consumers {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("no consumer %q in status", name)
+	return ConsumerStatus{}
+}
+
+// A consumer a little behind is the system working, and saying so every time is
+// what would make the finding meaningless. Nothing is reported below the line.
+func TestPinUnderTheTripwireIsSilent(t *testing.T) {
+	s := pinStore(t, "notifier", true, 20*time.Minute)
+	b := pinBus(t, s, time.Hour)
+
+	status, err := b.Status()
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	c := consumerStatus(t, status, "notifier")
+	if !c.HoldsRetentionFloor {
+		t.Fatal("the only enabled consumer is the floor; the fixture is wrong")
+	}
+	if c.PinAlarm {
+		t.Errorf("a 20-minute pin alarmed under a 1h tripwire")
+	}
+	if _, ok := findHealth(status, HealthRetentionPinned, "notifier"); ok {
+		t.Errorf("a 20-minute pin produced a health finding")
+	}
+	pins, err := b.PinAlarms()
+	if err != nil {
+		t.Fatalf("pin alarms: %v", err)
+	}
+	if len(pins) != 0 {
+		t.Errorf("PinAlarms reported %+v under the tripwire", pins)
+	}
+}
+
+// Past the line the finding names what is held, how long, and the limit it
+// crossed — everything needed to act on it without reading the code.
+func TestPinPastTheTripwireNamesTheHoldAndTheLimit(t *testing.T) {
+	s := pinStore(t, "notifier", true, 3*time.Hour)
+	b := pinBus(t, s, time.Hour)
+
+	status, err := b.Status()
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	c := consumerStatus(t, status, "notifier")
+	if !c.PinAlarm {
+		t.Fatal("a 3-hour pin did not cross a 1h tripwire")
+	}
+	if c.PinnedBytes <= 0 {
+		t.Errorf("pinned bytes = %d, want the weight of the three unread events", c.PinnedBytes)
+	}
+	h, ok := findHealth(status, HealthRetentionPinned, "notifier")
+	if !ok {
+		t.Fatal("no retention_pinned health entry for an alarming pin")
+	}
+	if h.Level != HealthWarn {
+		t.Errorf("level = %q, want warn", h.Level)
+	}
+	for _, want := range []string{"notifier", "3h", "1h", "3 events", "seq 2"} {
+		if !strings.Contains(h.Message, want) {
+			t.Errorf("message %q is missing %q", h.Message, want)
+		}
+	}
+}
+
+// Both surfaces read one predicate, so the page a user opens to check the alarm
+// cannot disagree with the alarm about who is at fault.
+func TestPinAlarmsMatchesTheSnapshot(t *testing.T) {
+	s := pinStore(t, "app:ticketwatch", true, 6*time.Hour)
+	b := pinBus(t, s, time.Hour)
+
+	status, err := b.Status()
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	pins, err := b.PinAlarms()
+	if err != nil {
+		t.Fatalf("pin alarms: %v", err)
+	}
+	if len(pins) != 1 {
+		t.Fatalf("pins = %+v, want exactly the one the snapshot marked", pins)
+	}
+	c := consumerStatus(t, status, "app:ticketwatch")
+	if pins[0].Consumer != c.Name || pins[0].Cursor != c.Cursor ||
+		pins[0].Events != c.Lag || pins[0].Bytes != c.PinnedBytes {
+		t.Fatalf("pin %+v does not match the snapshot's consumer %+v", pins[0], c)
+	}
+	if pins[0].Threshold != time.Hour {
+		t.Errorf("threshold = %s, want the tripwire it crossed", pins[0].Threshold)
+	}
+	// The finding renders identically wherever it is said.
+	if h, ok := findHealth(status, HealthRetentionPinned, "app:ticketwatch"); !ok || h.Message != PinMessage(pins[0]) {
+		t.Errorf("health message and PinMessage disagree:\n %q\n %q", h.Message, PinMessage(pins[0]))
+	}
+}
+
+// A disabled consumer does not hold retention open — the kill switch is the way
+// out of exactly this condition, so it must not keep reporting it.
+func TestDisabledConsumerNeverAlarms(t *testing.T) {
+	s := pinStore(t, "notifier", false, 30*24*time.Hour)
+	b := pinBus(t, s, time.Hour)
+
+	status, err := b.Status()
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if c := consumerStatus(t, status, "notifier"); c.PinAlarm {
+		t.Error("a disabled consumer alarmed; disabling is the way out, not a way in")
+	}
+	pins, err := b.PinAlarms()
+	if err != nil {
+		t.Fatalf("pin alarms: %v", err)
+	}
+	if len(pins) != 0 {
+		t.Errorf("PinAlarms reported a disabled consumer: %+v", pins)
+	}
+}
+
+// Only the consumer at the floor holds the log. One further along is behind, and
+// that is a different finding — reporting it here would blame the wrong one.
+func TestOnlyTheFloorHolderAlarms(t *testing.T) {
+	s := pinStore(t, "behind", true, 6*time.Hour)
+	if err := s.SaveConsumer(Consumer{Name: "further-behind", Cursor: 0, Enabled: true}, statusNow.Add(-6*time.Hour)); err != nil {
+		t.Fatalf("save second consumer: %v", err)
+	}
+	b := pinBus(t, s, time.Hour)
+
+	pins, err := b.PinAlarms()
+	if err != nil {
+		t.Fatalf("pin alarms: %v", err)
+	}
+	if len(pins) != 1 || pins[0].Consumer != "further-behind" {
+		t.Fatalf("pins = %+v, want only the consumer at the floor", pins)
+	}
+}
+
+// A caught-up consumer is the floor and is holding nothing. Its lag is zero, so
+// there is no oldest unread event and no age to be past.
+func TestCaughtUpConsumerNeverAlarms(t *testing.T) {
+	s := newMemStore()
+	if _, err := s.Append(Event{Name: "ticket.updated", Subject: "t"}, statusNow.Add(-90*24*time.Hour)); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if err := s.SaveConsumer(Consumer{Name: "notifier", Cursor: 1, Enabled: true}, statusNow.Add(-90*24*time.Hour)); err != nil {
+		t.Fatalf("save consumer: %v", err)
+	}
+	b := pinBus(t, s, time.Hour)
+
+	pins, err := b.PinAlarms()
+	if err != nil {
+		t.Fatalf("pin alarms: %v", err)
+	}
+	if len(pins) != 0 {
+		t.Fatalf("a caught-up consumer alarmed: %+v", pins)
+	}
+}
+
+// The escape hatch: a negative age turns the finding off everywhere, so a
+// surface cannot keep marking a consumer the alarm has been told to ignore.
+func TestNegativePinAlarmAgeTurnsTheFindingOff(t *testing.T) {
+	s := pinStore(t, "notifier", true, 30*24*time.Hour)
+	b := pinBus(t, s, -1)
+
+	status, err := b.Status()
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if c := consumerStatus(t, status, "notifier"); c.PinAlarm {
+		t.Error("the snapshot marked a consumer with the alarm turned off")
+	}
+	if _, ok := findHealth(status, HealthRetentionPinned, "notifier"); ok {
+		t.Error("a health finding survived the alarm being turned off")
+	}
+	pins, err := b.PinAlarms()
+	if err != nil {
+		t.Fatalf("pin alarms: %v", err)
+	}
+	if len(pins) != 0 {
+		t.Errorf("PinAlarms reported with the alarm off: %+v", pins)
+	}
+}
+
+// Weighing a backlog is what the alarm's harm number is, so it has to be the
+// backlog and not the log.
+func TestPendingBytesWeighsOnlyTheBacklog(t *testing.T) {
+	s := pinStore(t, "notifier", true, 3*time.Hour)
+	whole, err := s.PendingBytes(0)
+	if err != nil {
+		t.Fatalf("pending bytes: %v", err)
+	}
+	backlog, err := s.PendingBytes(2)
+	if err != nil {
+		t.Fatalf("pending bytes: %v", err)
+	}
+	if backlog <= 0 || backlog >= whole {
+		t.Fatalf("backlog above seq 2 = %d, whole log = %d; want a strict subset", backlog, whole)
+	}
+}
+
+// The tripwire is resolved here, not in whichever process wants it, so the
+// daemon that raises the alarm and the CLI that reads the same database cannot
+// disagree about where the line is. A knob nobody can read back is a limit
+// nobody can see, so every answer it gives is said out loud.
+func TestPinAlarmAgeFromEnv(t *testing.T) {
+	for _, tc := range []struct {
+		raw  string
+		want time.Duration
+		says string
+	}{
+		{raw: "", want: DefaultPinAlarmAge},
+		{raw: "90s", want: 90 * time.Second, says: "retention-pin alarm set to 1m30s"},
+		{raw: "2h", want: 2 * time.Hour, says: "retention-pin alarm set to 2h"},
+		// Off, and negative rather than zero: zero reads as "unset" inside New and
+		// would quietly restore the default the user just turned off.
+		{raw: "0", want: -1, says: "the retention-pin alarm is off"},
+		{raw: "-5m", want: -1, says: "the retention-pin alarm is off"},
+		// Garbage falls back loudly. Silently ignoring it would leave the user
+		// believing a tripwire they set is in force.
+		{raw: "soon", want: DefaultPinAlarmAge, says: "is not a duration"},
+	} {
+		t.Run(fmt.Sprintf("%q", tc.raw), func(t *testing.T) {
+			if tc.raw == "" {
+				t.Setenv(PinAlarmAgeEnv, "")
+			} else {
+				t.Setenv(PinAlarmAgeEnv, tc.raw)
+			}
+			var said []string
+			got := PinAlarmAgeFromEnv(func(format string, args ...interface{}) {
+				said = append(said, fmt.Sprintf(format, args...))
+			})
+			if got != tc.want {
+				t.Errorf("%q = %s, want %s", tc.raw, got, tc.want)
+			}
+			whole := strings.Join(said, "\n")
+			if tc.says == "" {
+				if whole != "" {
+					t.Errorf("an unset knob said %q; a default nobody asked to change is not news", whole)
+				}
+				return
+			}
+			if !strings.Contains(whole, tc.says) {
+				t.Errorf("said %q, want it to carry %q", whole, tc.says)
+			}
+		})
+	}
+}
+
+// A bus built with the resolved value keeps it, including the off switch — the
+// path every caller actually takes.
+func TestNewCarriesAResolvedPinAlarmAge(t *testing.T) {
+	t.Setenv(PinAlarmAgeEnv, "0")
+	b := New(Options{PinAlarmAge: PinAlarmAgeFromEnv(nil)})
+	if b.pinAlarmAge >= 0 {
+		t.Errorf("a bus built with the off switch has pinAlarmAge %s, want it negative", b.pinAlarmAge)
+	}
+}
+
+// The tripwire is printed so a reader can check the value they set against the
+// one in force. Rounding it away defeats that; rounding the observed age does not.
+func TestTheMessageNamesTheTripwireExactly(t *testing.T) {
+	for _, tc := range []struct {
+		threshold time.Duration
+		want      string
+	}{
+		{threshold: time.Hour, want: "past the 1h tripwire"},
+		{threshold: 90 * time.Second, want: "past the 1m30s tripwire"},
+		{threshold: 45 * time.Second, want: "past the 45s tripwire"},
+		{threshold: 90 * time.Minute, want: "past the 1h30m tripwire"},
+	} {
+		got := PinMessage(Pin{Consumer: "app:x", Age: 11 * time.Minute, Threshold: tc.threshold})
+		if !strings.Contains(got, tc.want) {
+			t.Errorf("a %s tripwire reads %q, want it to carry %q", tc.threshold, got, tc.want)
+		}
+	}
+}

--- a/internal/bus/status.go
+++ b/internal/bus/status.go
@@ -54,6 +54,41 @@ const (
 	// DefaultRetryCap (2m) apart, so a healthy consumer — even one retrying —
 	// advances well inside this. 5 minutes is 2.5x past the retry cap.
 	StallAge = 5 * time.Minute
+
+	// DefaultPinAlarmAge is how long an enabled consumer may pin the retention
+	// floor before the pin is called an outage rather than the system working.
+	//
+	// Retention never trims past an enabled consumer's cursor, so a consumer that
+	// is enabled and not consuming makes the log grow for as long as the condition
+	// lasts. Nothing in attn ends that on its own: auto-disable fires only on
+	// app-attributed failures, so a parked runtime holds the floor until a person
+	// restarts it.
+	//
+	// The tripwire has to sit past every stall attn resolves BY ITSELF, or it
+	// cries wolf on the system healing. Those are all measured:
+	//
+	//	5s     delivery poll interval (DefaultPollInterval)
+	//	2m     the cap a failing handler retries at (DefaultRetryCap)
+	//	2m02s  a crash-looping supervised child reaching its park (measured live)
+	//	16m0s  an app's 15-minute auto-disable clock firing (measured live; the
+	//	       window is checked at the next delivery and backoff had stretched)
+	//
+	// One hour is 3.75x past the longest of them. What that patience costs is the
+	// log written while nobody is looking, measured over 9.5 days of Victor's
+	// production bus (333,064 facts, 25.2MB, 76 bytes/fact):
+	//
+	//	1,467 facts    111KB   mean hour
+	//	2,700 facts    211KB   busiest day's mean hour (2026-08-09)
+	//	10,121 facts   786KB   busiest hour measured
+	//
+	// Under a megabyte on a 62MB database — noise, and the price of never firing
+	// on something that was about to fix itself.
+	//
+	// This is not a second definition of "stalled". HealthConsumerStalled and
+	// HealthConsumerLagging already report a consumer that is not advancing, at
+	// StallAge, for someone reading the page. This says something else: it is an
+	// hour later, it is still stuck, and it is the one holding the log open.
+	DefaultPinAlarmAge = time.Hour
 )
 
 // ProducerRow is what the Store seam hands back for one fact class: the raw
@@ -127,6 +162,46 @@ type ConsumerStatus struct {
 	// HoldsRetentionFloor marks the enabled consumer whose cursor is the floor
 	// retention stops at — the one pinning the log.
 	HoldsRetentionFloor bool
+	// PinAlarm marks that pin as past DefaultPinAlarmAge: no longer the system
+	// working, but an outage holding the log open.
+	PinAlarm bool
+	// PinnedBytes is what the backlog above its cursor holds, and is read only
+	// for a consumer whose pin is alarming — it is the harm number, and summing
+	// it costs a range scan nobody should pay for a healthy bus.
+	PinnedBytes int64
+}
+
+// Pin is one alarming retention pin, for a caller that wants the finding without
+// the rest of the snapshot. Everything a message needs is here, already read.
+type Pin struct {
+	Consumer string
+	// Cursor is the pinned position. It is what tells one episode from the next:
+	// while the consumer is stuck the cursor cannot move, and when it moves the
+	// episode is over.
+	Cursor int64
+	// Events and Bytes are what the log is holding above that cursor.
+	Events int64
+	Bytes  int64
+	// OldestUnreadAt stamps the oldest event it has not read, and Age is how long
+	// that event has waited.
+	OldestUnreadAt time.Time
+	Age            time.Duration
+	// Threshold is the tripwire this crossed, carried so a message can name the
+	// limit beside the observed value.
+	Threshold time.Duration
+}
+
+// pinAlarmed is the whole predicate, in one place, so the snapshot both surfaces
+// render and the alarm the daemon notifies on can never disagree about which
+// consumer is at fault.
+func pinAlarmed(c ConsumerStatus, now time.Time, threshold time.Duration) bool {
+	if threshold <= 0 || !c.Enabled || !c.HoldsRetentionFloor || c.Lag <= 0 {
+		return false
+	}
+	if c.OldestUnreadAt.IsZero() {
+		return false
+	}
+	return now.Sub(c.OldestUnreadAt) >= threshold
 }
 
 // Health levels, ordered by how much they want attention.
@@ -171,6 +246,8 @@ type Status struct {
 	Delivering bool
 	// RetentionWindow is the age past which retention drops events.
 	RetentionWindow time.Duration
+	// PinAlarmAge is the tripwire a retention pin has to cross to be reported.
+	PinAlarmAge time.Duration
 
 	Producers []Producer
 	Consumers []ConsumerStatus
@@ -208,6 +285,7 @@ func (b *Bus) Status() (Status, error) {
 		Earliest:        earliest,
 		Delivering:      b.delivering(),
 		RetentionWindow: b.retention,
+		PinAlarmAge:     b.pinAlarmAge,
 	}
 	for _, p := range producers {
 		out.Rows += p.Events
@@ -260,6 +338,12 @@ func (b *Bus) Status() (Status, error) {
 			entry.Live = true
 			entry.Stalled = d.stallReason()
 		}
+		if pinAlarmed(entry, now, b.pinAlarmAge) {
+			entry.PinAlarm = true
+			if n, err := b.store.PendingBytes(c.Cursor); err == nil {
+				entry.PinnedBytes = n
+			}
+		}
 		out.Consumers = append(out.Consumers, entry)
 	}
 
@@ -304,20 +388,16 @@ func health(s Status, now time.Time) []Health {
 		}
 	}
 	for _, c := range s.Consumers {
-		// A consumer legitimately holding the floor a little back is the system
-		// working. It is worth saying only when it is also the reason old events
-		// survive: it has fallen behind the retention window itself.
-		if !c.HoldsRetentionFloor || c.OldestUnreadAt.IsZero() {
-			continue
-		}
-		age := now.Sub(c.OldestUnreadAt)
-		if age <= s.RetentionWindow {
+		// A consumer holding the floor a little back is the system working, and
+		// saying so every time would make the finding meaningless. It is worth
+		// reporting once the pin is past the tripwire — see DefaultPinAlarmAge for
+		// why an hour, and for what the wait costs.
+		if !c.PinAlarm {
 			continue
 		}
 		out = append(out, Health{
 			Level: HealthWarn, Kind: HealthRetentionPinned, Subject: c.Name,
-			Message: fmt.Sprintf("consumer %s pins the retention floor at seq %d: its oldest unread event is %s old, past the %s window, so nothing below it can be trimmed",
-				c.Name, c.Cursor, roundDuration(age), roundDuration(s.RetentionWindow)),
+			Message: pinMessage(c.pin(now, s.PinAlarmAge)),
 		})
 	}
 	for _, p := range s.Producers {
@@ -334,6 +414,79 @@ func health(s Status, now time.Time) []Health {
 	})
 	return out
 }
+
+// pin lifts the finding out of a consumer row. Only meaningful once PinAlarm is
+// set: PinnedBytes is not read for anyone else.
+func (c ConsumerStatus) pin(now time.Time, threshold time.Duration) Pin {
+	return Pin{
+		Consumer:       c.Name,
+		Cursor:         c.Cursor,
+		Events:         c.Lag,
+		Bytes:          c.PinnedBytes,
+		OldestUnreadAt: c.OldestUnreadAt,
+		Age:            now.Sub(c.OldestUnreadAt),
+		Threshold:      threshold,
+	}
+}
+
+// pinMessage names what is held, how long it has been held, and the tripwire it
+// crossed — everything needed to act on it without reading this code. What to DO
+// about it is deliberately not here: the way out depends on what the consumer is,
+// which this package does not know.
+func pinMessage(p Pin) string {
+	return fmt.Sprintf("consumer %s has pinned the retention floor at seq %d for %s, past the %s tripwire: nothing below it can be trimmed, and the log is holding %s (%s) it has not read",
+		p.Consumer, p.Cursor, roundDuration(p.Age), limitDuration(p.Threshold),
+		events(p.Events), humanBytes(p.Bytes))
+}
+
+// PinAlarms reports every consumer whose retention pin is past the tripwire, and
+// is the cheap way to ask: a handful of indexed reads over the consumer table and
+// the log's ends, rather than Status's walk of every row (209ms at 945k,
+// measured). It is what the recurring check runs, on a bus that is almost always
+// healthy and should cost nothing to confirm.
+func (b *Bus) PinAlarms() ([]Pin, error) {
+	if b.store == nil || b.pinAlarmAge <= 0 {
+		return nil, nil
+	}
+	now := b.now()
+	_, head, err := b.store.Bounds()
+	if err != nil {
+		return nil, fmt.Errorf("reading log bounds: %w", err)
+	}
+	consumers, err := b.store.ListConsumers()
+	if err != nil {
+		return nil, fmt.Errorf("listing consumers: %w", err)
+	}
+	floor := retentionFloorName(consumers)
+	var out []Pin
+	for _, c := range consumers {
+		entry := ConsumerStatus{
+			Name:                c.Name,
+			Cursor:              c.Cursor,
+			Lag:                 max64(head-c.Cursor, 0),
+			Enabled:             c.Enabled,
+			HoldsRetentionFloor: c.Name == floor,
+		}
+		if entry.Lag > 0 {
+			if t, ok, err := b.store.EventTimeAt(c.Cursor + 1); err == nil && ok {
+				entry.OldestUnreadAt = t
+			}
+		}
+		if !pinAlarmed(entry, now, b.pinAlarmAge) {
+			continue
+		}
+		if n, err := b.store.PendingBytes(c.Cursor); err == nil {
+			entry.PinnedBytes = n
+		}
+		out = append(out, entry.pin(now, b.pinAlarmAge))
+	}
+	return out, nil
+}
+
+// PinMessage renders a finding the same way the status page's health entry does,
+// so the notification a user gets and the page they open to check it say the same
+// thing about the same pin.
+func PinMessage(p Pin) string { return pinMessage(p) }
 
 // surgeMessage names the number, the tripwire it crossed, and the window — the
 // three things an agent needs to act on it without reading this code.
@@ -415,6 +568,19 @@ func humanCount(n int64) string {
 	return out
 }
 
+// humanBytes renders a size at the scale a reader thinks in, matching how `attn
+// bus status` prints the log's own totals.
+func humanBytes(n int64) string {
+	switch {
+	case n >= 1<<20:
+		return fmt.Sprintf("%.1f MB", float64(n)/(1<<20))
+	case n >= 1<<10:
+		return fmt.Sprintf("%.1f KB", float64(n)/(1<<10))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}
+
 // roundDuration renders a span the way someone says it out loud, so a message
 // reads "24h" and "3d" rather than "24h0m0s" and "72h0m0s".
 func roundDuration(d time.Duration) string {
@@ -430,6 +596,29 @@ func roundDuration(d time.Duration) string {
 		return fmt.Sprintf("%.0fm", d.Minutes())
 	default:
 		return fmt.Sprintf("%.0fs", d.Seconds())
+	}
+}
+
+// limitDuration renders a configured limit exactly, where roundDuration renders
+// an observation. Nobody needs the seconds on an eleven-minute wait, but a limit
+// rounded to "2m" when it was set to 1m30s names a number the reader cannot check
+// their own value against — and checking it is the only reason it is printed.
+func limitDuration(d time.Duration) string {
+	d = d.Round(time.Second)
+	h, m, s := int(d/time.Hour), int(d%time.Hour/time.Minute), int(d%time.Minute/time.Second)
+	switch {
+	case h > 0 && m == 0 && s == 0:
+		return fmt.Sprintf("%dh", h)
+	case h > 0 && s == 0:
+		return fmt.Sprintf("%dh%dm", h, m)
+	case h > 0:
+		return fmt.Sprintf("%dh%dm%ds", h, m, s)
+	case m > 0 && s == 0:
+		return fmt.Sprintf("%dm", m)
+	case m > 0:
+		return fmt.Sprintf("%dm%ds", m, s)
+	default:
+		return fmt.Sprintf("%ds", s)
 	}
 }
 

--- a/internal/daemon/bus.go
+++ b/internal/daemon/bus.go
@@ -479,7 +479,12 @@ func (d *Daemon) ensureEventBus() {
 	if d.store != nil {
 		backing = d.newSQLBusStore()
 	}
-	d.eventBus = bus.New(bus.Options{Store: backing, Log: d.logf, Compactable: CompactableFacts})
+	d.eventBus = bus.New(bus.Options{
+		Store:       backing,
+		Log:         d.logf,
+		Compactable: CompactableFacts,
+		PinAlarmAge: d.busPinAlarmAge(),
+	})
 	d.busUnsubscribe = d.eventBus.Subscribe(bus.All, d.projectToClients)
 	d.subscribeDocumentFacts()
 	d.subscribeAgentConversationFacts()

--- a/internal/daemon/bus_pin_alarm.go
+++ b/internal/daemon/bus_pin_alarm.go
@@ -1,0 +1,188 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/apps"
+	"github.com/victorarias/attn/internal/bus"
+	"github.com/victorarias/attn/internal/jobs"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// The event log never trims past an enabled consumer's cursor, which is the
+// right rule and also means a consumer that is enabled and not consuming makes
+// the log grow for as long as the condition lasts. Until now the only way to
+// notice was to go and look — `attn bus status`, or the event bus settings page.
+//
+// This is the half that does not wait to be looked at. `internal/bus` decides
+// what counts as a pin worth reporting (DefaultPinAlarmAge carries the receipt);
+// this file decides when to say it out loud, and what to tell the user to do.
+
+const (
+	// busPinAlarmKind is the recurring check on the job queue, where every
+	// periodic duty in attn runs.
+	busPinAlarmKind    = "bus_pin_alarm"
+	busPinAlarmTimeout = 30 * time.Second
+
+	// notificationKindBusPinned marks the notification a crossing writes.
+	notificationKindBusPinned = "bus_retention_pinned"
+
+	// busPinAlarmMinInterval floors the derived check interval. Below a minute the
+	// queue would be doing work far faster than a pin can meaningfully change.
+	busPinAlarmMinInterval = time.Minute
+)
+
+// busPinAlarmInterval derives how often to look from the window being watched.
+// A check less frequent than a quarter of its own tripwire reports an outage
+// long after the tripwire named it; more frequent than that buys nothing, since
+// the condition it watches is measured in hours. At the default hour this is a
+// quarter-hour tick doing four indexed reads.
+func busPinAlarmInterval(age time.Duration) time.Duration {
+	if interval := age / 4; interval > busPinAlarmMinInterval {
+		return interval
+	}
+	return busPinAlarmMinInterval
+}
+
+// busPinAlarmAge is the tripwire this daemon watches, resolved the same way
+// every other process that renders the finding resolves it.
+//
+// Resolved once: the bus and the recurring check that watches it are wired at
+// different moments and must agree, and a value read twice is also announced
+// twice in a log someone reads to find out what the limit is. The resolver never
+// returns zero — off is negative — so zero means "not resolved yet".
+func (d *Daemon) busPinAlarmAge() time.Duration {
+	d.busPinMu.Lock()
+	defer d.busPinMu.Unlock()
+	if d.busPinAge == 0 {
+		d.busPinAge = bus.PinAlarmAgeFromEnv(d.logf)
+	}
+	return d.busPinAge
+}
+
+// busPinEpisode is one consumer's position against the alarm, held for as long
+// as the pin lasts.
+//
+// It is in memory, for the same reason the app stall clock is (see appStall): it
+// tracks a condition that is happening now. A daemon restart genuinely does start
+// the observation over — the consumer gets a fresh window against a daemon that
+// has also just restarted — and a daemon restarting more often than the check
+// interval never reaches the second observation, so a crash loop cannot turn into
+// a stream of notifications.
+type busPinEpisode struct {
+	// cursor is the pinned position, and is what tells one episode from the next.
+	// While the consumer is stuck its cursor cannot move; when it moves, whatever
+	// was wrong is over and the next pin is a new episode that may notify again.
+	cursor int64
+	// notified is set once this episode has been announced. One notification per
+	// episode: a durable row per tick, for a condition that can last days, is
+	// noise that would teach the user to ignore the feed.
+	notified bool
+}
+
+// busPinAlarmHandler is the recurring check. It reports what it saw so a run
+// doing nothing and a run that is not happening look different in the task list.
+func (d *Daemon) busPinAlarmHandler(_ context.Context, _ *jobs.Job) (any, error) {
+	if d.eventBus == nil {
+		return map[string]any{"pinned": 0}, nil
+	}
+	pins, err := d.eventBus.PinAlarms()
+	if err != nil {
+		return nil, fmt.Errorf("checking the event log's retention floor: %w", err)
+	}
+	notified := d.recordBusPins(pins)
+	return map[string]any{"pinned": len(pins), "notified": notified}, nil
+}
+
+// recordBusPins advances the episode state and announces the crossings, and is
+// the whole one-notification-per-episode rule.
+//
+// A pin is announced on the SECOND consecutive check that finds the same
+// consumer stuck at the same cursor. The confirmation is what makes the alarm
+// trustworthy across a suspend: on wake, a consumer's oldest unread event is as
+// old as the sleep, and the delivery loop has not polled yet — one look cannot
+// tell that from an outage, but two looks a whole interval apart can, because by
+// then the cursor has moved.
+func (d *Daemon) recordBusPins(pins []bus.Pin) int {
+	d.busPinMu.Lock()
+	defer d.busPinMu.Unlock()
+
+	if d.busPinEpisodes == nil {
+		d.busPinEpisodes = map[string]*busPinEpisode{}
+	}
+	// A consumer that is no longer pinning has no episode: the condition cleared,
+	// and a later one is allowed to speak again.
+	seen := make(map[string]bool, len(pins))
+	for _, p := range pins {
+		seen[p.Consumer] = true
+	}
+	for name := range d.busPinEpisodes {
+		if !seen[name] {
+			delete(d.busPinEpisodes, name)
+		}
+	}
+
+	notified := 0
+	for _, p := range pins {
+		episode := d.busPinEpisodes[p.Consumer]
+		if episode == nil || episode.cursor != p.Cursor {
+			d.busPinEpisodes[p.Consumer] = &busPinEpisode{cursor: p.Cursor}
+			continue
+		}
+		if episode.notified {
+			continue
+		}
+		episode.notified = true
+		d.notifyBusPin(p)
+		notified++
+	}
+	return notified
+}
+
+// notifyBusPin writes the durable warning and puts it on the bus so an open app
+// updates without waiting for something else to re-push the feed.
+func (d *Daemon) notifyBusPin(p bus.Pin) {
+	d.logf("bus: %s", bus.PinMessage(p))
+	if d.store == nil {
+		return
+	}
+	record, err := d.store.AddNotification(store.NotificationRecord{
+		Kind: notificationKindBusPinned,
+		// The log keeps every pinned event and nothing is lost, so this is not an
+		// emergency. It also never ends on its own, which is why it is said at all.
+		Severity:   store.NotificationWarning,
+		Title:      fmt.Sprintf("Event log held open by %s", p.Consumer),
+		Body:       busPinNotificationBody(p),
+		Detail:     fmt.Sprintf("oldest unread event: seq %d, %s", p.Cursor+1, p.OldestUnreadAt.UTC().Format(time.RFC3339)),
+		SourceKind: "bus_consumer",
+		SourceID:   p.Consumer,
+	}, time.Now())
+	if err != nil {
+		d.logf("notifications: add bus-pin notification for %s: %v", p.Consumer, err)
+		return
+	}
+	d.publishFact(FactNotificationCreated, record.ID, nil)
+}
+
+// busPinNotificationBody is the bus's own sentence about the pin, followed by
+// the way out. Agents read errors and users read notifications; this has to let
+// either one act without opening the code.
+//
+// The finding is not restated here. It is the same string `attn bus status` and
+// the settings page print, so the notification a user gets and the page they open
+// to check it can never describe one pin differently.
+//
+// The advice is chosen from the consumer's NAME, not from any runtime state: a
+// name is true whatever is wrong behind it, and the check must keep working when
+// the reason a consumer stopped is something nobody has thought of yet.
+func busPinNotificationBody(p bus.Pin) string {
+	way := fmt.Sprintf("`attn bus status` shows why it stopped; `attn bus disable %s` releases the log if you do not need it to catch up.", p.Consumer)
+	if name, ok := strings.CutPrefix(p.Consumer, apps.ConsumerPrefix); ok {
+		way = fmt.Sprintf("This is the %s app. `attn app status %s` and `attn app runtime status` show why it stopped — a parked runtime is the usual cause, and `attn app runtime restart` starts it again. `attn bus disable %s` releases the log instead.",
+			name, name, p.Consumer)
+	}
+	return bus.PinMessage(p) + ". " + way
+}

--- a/internal/daemon/bus_pin_alarm_test.go
+++ b/internal/daemon/bus_pin_alarm_test.go
@@ -1,0 +1,308 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/bus"
+	"github.com/victorarias/attn/internal/logging"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// The alarm's whole job is to be believed. A durable row per tick for a
+// condition that can last days would teach the user to ignore the feed, and a
+// row that never comes is the state this exists to end. These pin the rule
+// between the two: once per episode, and a new episode may speak again.
+
+func pinAlarmDaemon() *Daemon {
+	return &Daemon{store: store.New()}
+}
+
+func samplePin(consumer string, cursor int64) bus.Pin {
+	return bus.Pin{
+		Consumer:       consumer,
+		Cursor:         cursor,
+		Events:         412,
+		Bytes:          31_000,
+		OldestUnreadAt: time.Date(2026, 8, 11, 9, 0, 0, 0, time.UTC),
+		Age:            3 * time.Hour,
+		Threshold:      time.Hour,
+	}
+}
+
+func unread(t *testing.T, d *Daemon) []store.NotificationRecord {
+	t.Helper()
+	list, err := d.store.ListNotifications()
+	if err != nil {
+		t.Fatalf("list notifications: %v", err)
+	}
+	return list
+}
+
+// One look cannot tell an outage from a machine that just woke up: on wake the
+// oldest unread event is as old as the sleep and the delivery loop has not
+// polled yet. Two looks a whole interval apart can, because by then the cursor
+// has moved. So the first sighting never notifies.
+func TestFirstSightingOfAPinDoesNotNotify(t *testing.T) {
+	d := pinAlarmDaemon()
+
+	if n := d.recordBusPins([]bus.Pin{samplePin("app:ticketwatch", 900)}); n != 0 {
+		t.Fatalf("notified %d on the first sighting, want 0", n)
+	}
+	if list := unread(t, d); len(list) != 0 {
+		t.Fatalf("wrote %d notification(s) on the first sighting", len(list))
+	}
+}
+
+// Confirmed at the same cursor, it is said once — and stays said once however
+// long the condition lasts.
+func TestConfirmedPinNotifiesExactlyOnce(t *testing.T) {
+	d := pinAlarmDaemon()
+	pin := samplePin("app:ticketwatch", 900)
+
+	d.recordBusPins([]bus.Pin{pin})
+	if n := d.recordBusPins([]bus.Pin{pin}); n != 1 {
+		t.Fatalf("notified %d on the confirming sighting, want 1", n)
+	}
+	// The condition holds for another ten checks; the feed does not grow.
+	for i := 0; i < 10; i++ {
+		if n := d.recordBusPins([]bus.Pin{pin}); n != 0 {
+			t.Fatalf("re-notified while the same episode was held (check %d)", i+2)
+		}
+	}
+	list := unread(t, d)
+	if len(list) != 1 {
+		t.Fatalf("wrote %d notification(s) for one episode, want 1", len(list))
+	}
+	if list[0].Severity != store.NotificationWarning {
+		t.Errorf("severity = %q, want warning: the log keeps every pinned event, nothing is lost", list[0].Severity)
+	}
+	if list[0].SourceKind != "bus_consumer" || list[0].SourceID != "app:ticketwatch" {
+		t.Errorf("source = %s/%s, want the consumer it is about", list[0].SourceKind, list[0].SourceID)
+	}
+}
+
+// A cleared condition ends the episode. When it comes back it is a new outage
+// and the user has to hear about it — silence here is how the second one goes
+// unnoticed.
+func TestClearedThenRecrossedPinNotifiesAgain(t *testing.T) {
+	d := pinAlarmDaemon()
+	first := samplePin("app:ticketwatch", 900)
+
+	d.recordBusPins([]bus.Pin{first})
+	d.recordBusPins([]bus.Pin{first})
+	// The consumer caught up: nothing is pinning.
+	if n := d.recordBusPins(nil); n != 0 {
+		t.Fatalf("notified on a cleared condition")
+	}
+	// It stalls again, further along the log.
+	second := samplePin("app:ticketwatch", 4200)
+	if n := d.recordBusPins([]bus.Pin{second}); n != 0 {
+		t.Fatalf("a new episode notified on its first sighting")
+	}
+	if n := d.recordBusPins([]bus.Pin{second}); n != 1 {
+		t.Fatalf("notified %d for the second episode, want 1", n)
+	}
+	if list := unread(t, d); len(list) != 2 {
+		t.Fatalf("wrote %d notification(s) for two episodes, want 2", len(list))
+	}
+}
+
+// A cursor that moved is a consumer that read something: whatever was wrong is
+// over, even if it is stuck again by the next check. Confirmation is against the
+// same position, never merely against the same name.
+func TestMovedCursorRestartsTheConfirmation(t *testing.T) {
+	d := pinAlarmDaemon()
+
+	d.recordBusPins([]bus.Pin{samplePin("notifier", 100)})
+	if n := d.recordBusPins([]bus.Pin{samplePin("notifier", 140)}); n != 0 {
+		t.Fatalf("a moved cursor was treated as a confirmation of the old position")
+	}
+	if n := d.recordBusPins([]bus.Pin{samplePin("notifier", 140)}); n != 1 {
+		t.Fatalf("the new position was never confirmed")
+	}
+}
+
+// Two consumers can be stuck at once, and each is its own episode.
+func TestEpisodesAreTrackedPerConsumer(t *testing.T) {
+	d := pinAlarmDaemon()
+	a, b := samplePin("app:one", 10), samplePin("app:two", 20)
+
+	d.recordBusPins([]bus.Pin{a})
+	// b appears one check later, so it is not confirmed when a is.
+	if n := d.recordBusPins([]bus.Pin{a, b}); n != 1 {
+		t.Fatalf("notified %d, want only the confirmed one", n)
+	}
+	if n := d.recordBusPins([]bus.Pin{a, b}); n != 1 {
+		t.Fatalf("notified %d, want the second one now that it is confirmed", n)
+	}
+}
+
+// The user reads a notification and an agent reads an error; the same text has
+// to let either act. It names what is held, the tripwire it crossed, and a
+// command that ends it.
+func TestPinNotificationCarriesTheFindingAndTheWayOut(t *testing.T) {
+	body := busPinNotificationBody(samplePin("app:ticketwatch", 900))
+
+	for _, want := range []string{
+		"app:ticketwatch", // who
+		"3h",              // how long it has held
+		"1h",              // the tripwire it crossed
+		"seq 900",         // where the floor is stuck
+		"412 events",      // what is held
+		"30.3 KB",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body is missing %q:\n%s", want, body)
+		}
+	}
+	// An app consumer gets the app way out, including the parked-runtime case
+	// that is the usual cause.
+	for _, want := range []string{"attn app status ticketwatch", "attn app runtime restart", "attn bus disable app:ticketwatch"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body is missing the way out %q:\n%s", want, body)
+		}
+	}
+}
+
+// The advice is chosen from the consumer's name, so a consumer that is not an
+// app is never told to restart the app runtime.
+func TestNonAppPinNotificationOffersTheBusWayOut(t *testing.T) {
+	body := busPinNotificationBody(samplePin("notifier", 12))
+
+	if strings.Contains(body, "app runtime") {
+		t.Errorf("a non-app consumer was told to restart the app runtime:\n%s", body)
+	}
+	for _, want := range []string{"attn bus status", "attn bus disable notifier"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body is missing %q:\n%s", want, body)
+		}
+	}
+}
+
+// A check less frequent than a quarter of its own tripwire reports an outage
+// long after the tripwire named it; one that runs every second buys nothing on
+// a condition measured in hours.
+func TestPinAlarmIntervalTracksTheTripwire(t *testing.T) {
+	for _, tc := range []struct {
+		age  time.Duration
+		want time.Duration
+	}{
+		{bus.DefaultPinAlarmAge, 15 * time.Minute},
+		{4 * time.Hour, time.Hour},
+		{2 * time.Minute, time.Minute},  // floored
+		{10 * time.Second, time.Minute}, // floored
+	} {
+		if got := busPinAlarmInterval(tc.age); got != tc.want {
+			t.Errorf("interval for a %s tripwire = %s, want %s", tc.age, got, tc.want)
+		}
+	}
+}
+
+// The daemon wires the tripwire in two places — the bus it builds and the
+// recurring check that watches it — and they have to be the same number. Reading
+// it once is also what keeps the log from announcing the limit twice at every
+// boot. (Where the number itself comes from is internal/bus's own test.)
+func TestTheDaemonResolvesTheTripwireOnce(t *testing.T) {
+	t.Setenv(bus.PinAlarmAgeEnv, "90s")
+	logPath := filepath.Join(t.TempDir(), "daemon.log")
+	logger, err := logging.New(logPath)
+	if err != nil {
+		t.Fatalf("new test logger: %v", err)
+	}
+	defer logger.Close()
+	d := &Daemon{logger: logger}
+
+	first := d.busPinAlarmAge()
+	if first != 90*time.Second {
+		t.Fatalf("tripwire = %s, want the 90s the environment asked for", first)
+	}
+	if got := d.busPinAlarmAge(); got != first {
+		t.Errorf("second read = %s, want the same %s the bus was built with", got, first)
+	}
+	written, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read the daemon log: %v", err)
+	}
+	if got := strings.Count(string(written), "retention-pin alarm set to"); got != 1 {
+		t.Errorf("the tripwire was announced %d times, want once:\n%s", got, written)
+	}
+}
+
+// The wiring, end to end on a real store and a real bus: a consumer row whose
+// cursor sits under an aged log becomes a durable warning after the confirming
+// check, and nothing before it. Every piece above this tests one link; this is
+// the one that fails when the handler is reading the wrong bus.
+func TestPinAlarmHandlerNotifiesFromARealLog(t *testing.T) {
+	t.Setenv(bus.PinAlarmAgeEnv, "1h")
+	d := &Daemon{store: store.New()}
+	d.ensureEventBus()
+
+	old := time.Now().Add(-3 * time.Hour)
+	for i := 0; i < 4; i++ {
+		if _, err := d.store.AppendBusEvent(store.BusEvent{
+			Name: "session.state.changed", Subject: "s1", Payload: `{"state":"idle"}`,
+		}, old); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+	}
+	if err := d.store.SaveBusConsumer(store.BusConsumer{
+		Name: "app:ticketwatch", Cursor: 1, Enabled: true,
+	}, old); err != nil {
+		t.Fatalf("save consumer: %v", err)
+	}
+
+	if _, err := d.busPinAlarmHandler(t.Context(), nil); err != nil {
+		t.Fatalf("first check: %v", err)
+	}
+	if list := unread(t, d); len(list) != 0 {
+		t.Fatalf("the first check notified: %+v", list)
+	}
+	if _, err := d.busPinAlarmHandler(t.Context(), nil); err != nil {
+		t.Fatalf("confirming check: %v", err)
+	}
+	list := unread(t, d)
+	if len(list) != 1 {
+		t.Fatalf("wrote %d notification(s), want 1", len(list))
+	}
+	if !strings.Contains(list[0].Title, "app:ticketwatch") {
+		t.Errorf("title does not name the consumer: %q", list[0].Title)
+	}
+	// The finding is measured, not guessed: three unread events above seq 1.
+	if !strings.Contains(list[0].Body, "3 events") {
+		t.Errorf("body does not carry what is held: %q", list[0].Body)
+	}
+}
+
+// A healthy bus must cost nothing to confirm and say nothing at all — the check
+// runs on every daemon forever, and a tripwire working code never feels.
+func TestPinAlarmHandlerIsSilentOnAHealthyBus(t *testing.T) {
+	t.Setenv(bus.PinAlarmAgeEnv, "1h")
+	d := &Daemon{store: store.New()}
+	d.ensureEventBus()
+
+	if _, err := d.store.AppendBusEvent(store.BusEvent{Name: "ticket.updated", Subject: "t"}, time.Now()); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if err := d.store.SaveBusConsumer(store.BusConsumer{
+		Name: "app:ticketwatch", Cursor: 1, Enabled: true,
+	}, time.Now()); err != nil {
+		t.Fatalf("save consumer: %v", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		result, err := d.busPinAlarmHandler(t.Context(), nil)
+		if err != nil {
+			t.Fatalf("check %d: %v", i, err)
+		}
+		if counts, ok := result.(map[string]any); !ok || counts["pinned"] != 0 {
+			t.Fatalf("check %d reported %+v, want nothing pinned", i, result)
+		}
+	}
+	if list := unread(t, d); len(list) != 0 {
+		t.Fatalf("a healthy bus produced %+v", list)
+	}
+}

--- a/internal/daemon/bus_store.go
+++ b/internal/daemon/bus_store.go
@@ -125,6 +125,10 @@ func (a *sqlBusStore) EventTimeAt(seq int64) (time.Time, bool, error) {
 	return a.store.BusEventTimeAt(seq)
 }
 
+func (a *sqlBusStore) PendingBytes(above int64) (int64, error) {
+	return a.store.BusPendingBytes(above)
+}
+
 func busConsumerFromRow(r store.BusConsumer) bus.Consumer {
 	return bus.Consumer{
 		Name:      r.Name,

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -370,6 +370,12 @@ type Daemon struct {
 	// failing on an event. See appStall.
 	appStallMu sync.Mutex
 	appStalls  map[string]*appStall
+	// busPinEpisodes is the retention-pin alarm's position, one entry per consumer
+	// that is currently holding the event log open. See busPinEpisode.
+	busPinMu       sync.Mutex
+	busPinEpisodes map[string]*busPinEpisode
+	// busPinAge is the resolved tripwire; see busPinAlarmAge.
+	busPinAge time.Duration
 	// appWatchers are the open `app_watch` connections `attn app dev` renders.
 	appWatcherMu sync.Mutex
 	appWatchers  map[*appWatcher]struct{}

--- a/internal/daemon/workspace_keeper.go
+++ b/internal/daemon/workspace_keeper.go
@@ -291,6 +291,19 @@ func (d *Daemon) startJobQueue() {
 		); err != nil {
 			d.logf("apps: register invocation retention tick: %v", err)
 		}
+		// The event log's retention floor is the fourth. A consumer that stops
+		// consuming grows the log for as long as it lasts and nothing else ever
+		// says so, so the check is only skipped when it is deliberately turned off.
+		if age := d.busPinAlarmAge(); age > 0 {
+			if err := runner.RegisterCron(
+				busPinAlarmKind,
+				busPinAlarmInterval(age),
+				d.busPinAlarmHandler,
+				jobs.HandlerConfig{Timeout: busPinAlarmTimeout},
+			); err != nil {
+				d.logf("bus: register retention-pin alarm tick: %v", err)
+			}
+		}
 		if err := runner.RegisterCron(
 			automationScheduleKind,
 			automationScheduleInterval,

--- a/internal/daemon/ws_bus.go
+++ b/internal/daemon/ws_bus.go
@@ -110,6 +110,7 @@ func fillBusStatusResult(out *protocol.BusStatusResultMessage, s bus.Status) {
 	out.RecentWindowSeconds = bus.RecentWindow.Seconds()
 	out.BaselineWindowSeconds = bus.BaselineWindow.Seconds()
 	out.SurgeRatePerHour = bus.SurgeRatePerHour
+	out.PinAlarmSeconds = s.PinAlarmAge.Seconds()
 
 	out.Producers = make([]protocol.BusProducerStatus, 0, len(s.Producers))
 	for _, p := range s.Producers {
@@ -140,6 +141,8 @@ func fillBusStatusResult(out *protocol.BusStatusResultMessage, s bus.Status) {
 			Stalled:             c.Stalled,
 			OldestUnreadAt:      formatBusStamp(c.OldestUnreadAt),
 			HoldsRetentionFloor: c.HoldsRetentionFloor,
+			PinAlarm:            c.PinAlarm,
+			PinnedBytes:         int(c.PinnedBytes),
 		})
 	}
 	out.Health = make([]protocol.BusHealthEntry, 0, len(s.Health))

--- a/internal/jobs/cron.go
+++ b/internal/jobs/cron.go
@@ -80,15 +80,24 @@ func (r *Runner) armCronKind(kind string, interval time.Duration) {
 // alone: re-arming every boot would starve a daemon restarted more often than the
 // interval. A terminal record is revived — a build that missed the registration
 // killed it as unknown-kind, and nothing else selects it.
+//
+// A record scheduled FURTHER OUT than the current interval allows is not on
+// schedule, it is on an old one — the interval was shortened since it was armed,
+// and left alone it would keep the previous configuration forever. Pulling it in
+// never pushes a fire out, so it cannot starve the entry it is fixing.
 func (r *Runner) writeCronEntry(kind string, interval time.Duration) error {
 	existing, err := r.GetByKey(kind, CronKey)
 	if err != nil {
 		return fmt.Errorf("read cron entry: %w", err)
 	}
 	if existing != nil && !existing.State.Terminal() {
-		return nil
-	}
-	if existing != nil {
+		wait := existing.ScheduledAt.Sub(r.now())
+		if wait <= interval {
+			return nil
+		}
+		r.log("jobs: cron %s was armed for %s out, past its %s interval; pulling it in",
+			kind, wait.Round(time.Second), interval)
+	} else if existing != nil {
 		r.log("jobs: cron entry for %s was %s (%s); reviving it", kind, existing.State, existing.LastError)
 	}
 	// Enqueue coalesces, so a revive resets that row rather than minting a second.

--- a/internal/jobs/cron_test.go
+++ b/internal/jobs/cron_test.go
@@ -422,3 +422,86 @@ func TestCronFiringDoesNotReportAChange(t *testing.T) {
 		}
 	})
 }
+
+// The interval is configuration, and a record armed under the old one is not on
+// schedule — it is on a schedule nobody asked for any more. Shortening the
+// interval has to take effect, or the knob that sets it is half inert.
+func TestShorteningTheIntervalPullsAnArmedEntryIn(t *testing.T) {
+	store := newMemStore()
+	clock := newFakeClock()
+	opts := func() Options {
+		return Options{Store: store, Now: clock.now, PollInterval: testPoll, Log: func(string, ...interface{}) {}}
+	}
+	noop := func(context.Context, *Job) (any, error) { return nil, nil }
+
+	first := New(opts())
+	if err := first.RegisterCron(cronKind, time.Hour, noop, HandlerConfig{}); err != nil {
+		t.Fatalf("register cron: %v", err)
+	}
+	mustStart(t, first)
+	armed, err := first.CronEntry(cronKind)
+	if err != nil || armed == nil {
+		t.Fatalf("cron entry: %v (%+v)", err, armed)
+	}
+	first.Stop()
+
+	// Same kind, a minute apart now.
+	second := New(opts())
+	if err := second.RegisterCron(cronKind, time.Minute, noop, HandlerConfig{}); err != nil {
+		t.Fatalf("re-register cron: %v", err)
+	}
+	mustStart(t, second)
+	t.Cleanup(second.Stop)
+
+	after, err := second.CronEntry(cronKind)
+	if err != nil || after == nil {
+		t.Fatalf("cron entry after restart: %v (%+v)", err, after)
+	}
+	if !after.ScheduledAt.Before(armed.ScheduledAt) {
+		t.Fatalf("a shortened interval left the fire at %s (was %s)", after.ScheduledAt, armed.ScheduledAt)
+	}
+	if wait := after.ScheduledAt.Sub(clock.now()); wait > time.Minute {
+		t.Fatalf("next fire is %s out, past the new %s interval", wait, time.Minute)
+	}
+	// Coalescing means it is still the one recurring record, not a second one.
+	if after.ID != armed.ID {
+		t.Fatalf("pulling the entry in minted a second cron record (%s then %s)", armed.ID, after.ID)
+	}
+}
+
+// The mirror of the rule above: a LENGTHENED interval must not push an armed
+// fire out, and a daemon restarted more often than its interval must still tick.
+func TestLengtheningTheIntervalLeavesAnArmedEntryAlone(t *testing.T) {
+	store := newMemStore()
+	clock := newFakeClock()
+	opts := func() Options {
+		return Options{Store: store, Now: clock.now, PollInterval: testPoll, Log: func(string, ...interface{}) {}}
+	}
+	noop := func(context.Context, *Job) (any, error) { return nil, nil }
+
+	first := New(opts())
+	if err := first.RegisterCron(cronKind, time.Hour, noop, HandlerConfig{}); err != nil {
+		t.Fatalf("register cron: %v", err)
+	}
+	mustStart(t, first)
+	armed, err := first.CronEntry(cronKind)
+	if err != nil || armed == nil {
+		t.Fatalf("cron entry: %v (%+v)", err, armed)
+	}
+	first.Stop()
+
+	second := New(opts())
+	if err := second.RegisterCron(cronKind, 6*time.Hour, noop, HandlerConfig{}); err != nil {
+		t.Fatalf("re-register cron: %v", err)
+	}
+	mustStart(t, second)
+	t.Cleanup(second.Stop)
+
+	after, err := second.CronEntry(cronKind)
+	if err != nil || after == nil {
+		t.Fatalf("cron entry after restart: %v (%+v)", err, after)
+	}
+	if !after.ScheduledAt.Equal(armed.ScheduledAt) {
+		t.Fatalf("a lengthened interval moved the next fire from %s to %s", armed.ScheduledAt, after.ScheduledAt)
+	}
+}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "231"
+const ProtocolVersion = "232"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1286,6 +1286,12 @@ type BusConsumerStatus struct {
 	// OldestUnreadAt corresponds to the JSON schema field "oldest_unread_at".
 	OldestUnreadAt string `json:"oldest_unread_at"`
 
+	// PinAlarm corresponds to the JSON schema field "pin_alarm".
+	PinAlarm bool `json:"pin_alarm"`
+
+	// PinnedBytes corresponds to the JSON schema field "pinned_bytes".
+	PinnedBytes int `json:"pinned_bytes"`
+
 	// Stalled corresponds to the JSON schema field "stalled".
 	Stalled string `json:"stalled"`
 
@@ -1415,6 +1421,9 @@ type BusStatusResultMessage struct {
 
 	// OldestAt corresponds to the JSON schema field "oldest_at".
 	OldestAt string `json:"oldest_at"`
+
+	// PinAlarmSeconds corresponds to the JSON schema field "pin_alarm_seconds".
+	PinAlarmSeconds float64 `json:"pin_alarm_seconds"`
 
 	// Producers corresponds to the JSON schema field "producers".
 	Producers []BusProducerStatus `json:"producers"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -2179,6 +2179,14 @@ model BusConsumerStatus {
   oldest_unread_at: string;
   // Its cursor is the floor retention stops at — it is pinning the log.
   holds_retention_floor: boolean;
+  // That pin is past `pin_alarm_seconds`: no longer the system working, but an
+  // outage holding the log open. The matching `retention_pinned` health entry
+  // carries the sentence to render.
+  pin_alarm: boolean;
+  // What the backlog above its cursor weighs. Read only for a consumer whose
+  // pin is alarming, so `pin_alarm` is what separates "holding nothing" from
+  // "not measured".
+  pinned_bytes: safeint;
 }
 
 // One thing wrong, said in a whole sentence. A client renders `message`; it does
@@ -2213,6 +2221,9 @@ model BusStatusResultMessage {
   recent_window_seconds: float64;
   baseline_window_seconds: float64;
   surge_rate_per_hour: float64;
+  // How long an enabled consumer may pin the retention floor before the pin is
+  // reported. Carried so a client shows the limit beside the observed value.
+  pin_alarm_seconds: float64;
   producers: BusProducerStatus[];
   consumers: BusConsumerStatus[];
   health: BusHealthEntry[];

--- a/internal/store/bus.go
+++ b/internal/store/bus.go
@@ -382,6 +382,32 @@ func (s *Store) BusProducers(cutoffs []time.Time) ([]BusProducer, error) {
 	return out, rows.Err()
 }
 
+// BusPendingBytes sums what the log holds above a cursor — one consumer's
+// backlog, weighed the same way BusProducers weighs the whole log so the two
+// numbers are comparable.
+//
+// It walks the seq primary key over the backlog alone, so it costs in proportion
+// to what is being held rather than to the log. Only asked about a consumer
+// already known to be pinning retention past its tripwire: a healthy bus never
+// runs it.
+func (s *Store) BusPendingBytes(above int64) (int64, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return 0, nil
+	}
+	var bytes int64
+	err := s.db.QueryRow(`
+		SELECT COALESCE(SUM(LENGTH(name) + LENGTH(subject) + LENGTH(payload) + LENGTH(source) + LENGTH(created_at)), 0)
+		FROM bus_events WHERE seq > ?
+	`, above).Scan(&bytes)
+	if err != nil {
+		return 0, err
+	}
+	return bytes, nil
+}
+
 // BusEventTimeAt returns the timestamp of the first event at or above seq, and
 // whether one exists. Both callers ask an age question — how old the log's tail
 // is, and how long a consumer's oldest unread event has been waiting — and both


### PR DESCRIPTION
Retention never trims past an **enabled** consumer's cursor. That is the right
rule — a durable consumer must not lose events — and it also means a consumer
that is enabled and not consuming holds the log open for as long as the
condition lasts. Nothing in attn ends that on its own: auto-disable fires only
on app-attributed failures, so a parked runtime pins the floor until a person
restarts it. Until now the only way to notice was to go and look.

This makes the condition say itself.

## What it does

A recurring check on the durable job queue watches the retention floor. When an
enabled consumer has held it past the tripwire, one **warning** notification is
written naming the consumer, how much it is holding (events + bytes), how long
it has held it, the tripwire it crossed, and the way out:

> **Event log held open by app:ticketwatch**
> consumer app:ticketwatch has pinned the retention floor at seq 417 for 9m,
> past the 1m30s tripwire: nothing below it can be trimmed, and the log is
> holding 147 events (8.7 KB) it has not read. This is the ticketwatch app.
> `attn app status ticketwatch` and `attn app runtime status` show why it
> stopped — a parked runtime is the usual cause, and `attn app runtime restart`
> starts it again. `attn bus disable app:ticketwatch` releases the log instead.

That sentence is one string, shared. `attn bus status` tags the consumer
`(PINNING 3.0 KB)` where it used to only say `(retention floor)`, and the event
bus settings page shows a red `Pinning 8.7 KB` pill beside the same WARNING
finding. The alarm and the page you open to check it cannot describe one pin
differently.

The advice is picked from the consumer's **name**, not from any runtime state:
a name stays true whatever is wrong behind it, so the check keeps working when
the reason a consumer stopped is something nobody has thought of yet.

**Once per episode, not once per tick.** An episode is keyed by the pinned
cursor. A moved cursor proves the consumer read something and ends it; a later
pin may speak again. Live, four notifications covered ~25 minutes of continuous
pinning under a one-minute check interval.

Nothing is dropped and nothing is switched off on the consumer's behalf. The log
keeps every pinned event; this only makes the condition visible.

## The tripwire, and its receipt

`DefaultPinAlarmAge = 1h`.

Production has zero durable bus consumers, so there is no consumer-lag history
to measure. What *can* be measured is the longest stall attn resolves **by
itself** — the tripwire has to sit past all of them or it cries wolf on the
system healing:

| self-healing stall | measured |
|---|---|
| delivery poll interval (`DefaultPollInterval`) | 5s |
| failing-handler retry cap (`DefaultRetryCap`) | 2m |
| supervised child crash-looping to its park | 2m02s |
| an app's 15-minute auto-disable clock firing | 16m0s |

One hour is **3.75x** the longest of them.

What that patience costs is the log written while nobody is looking, measured
over 9.5 days of a copy of the production bus (333,064 facts, 25.2MB, 76
bytes/fact):

| window | facts | bytes |
|---|---|---|
| mean hour | 1,467 | 111KB |
| busiest day's mean hour (2026-08-09) | 2,700 | 211KB |
| busiest hour measured | 10,121 | 786KB |

Under a megabyte on a 62MB database — noise, and the price of never firing on
something that was about to fix itself.

The check itself is cheap: `Bus.PinAlarms()` does a handful of indexed reads
rather than `Status()`'s full-log walk (209ms at 945k rows, measured), and only
weighs a backlog for a consumer already known to be alarming. The check interval
is derived as tripwire/4, floored at a minute — a quarter-hour tick by default.

`ATTN_BUS_PIN_ALARM_AGE` moves the tripwire (a duration, or `0` to turn it off).
It is resolved inside `internal/bus`, so the daemon that warns and the CLI that
reads the same database cannot disagree about where the line is.

## Not a second definition of "stalled"

`HealthConsumerStalled` already reports a consumer that is not advancing, at
`StallAge`, for someone reading the page. This says something else: it is an
hour later, it is still stuck, and it is the one holding the log open.

## Suspend does not cry wolf

On wake, a consumer's oldest unread event is as old as the sleep and the
delivery loop has not polled yet — one look cannot tell that from an outage.
So the notification needs the condition on **two consecutive checks at the same
cursor**; by the second look a healthy consumer has moved. The DB-only
predicate the CLI and settings page render stays single-look, because a page
someone is reading is a question they asked.

Episode state is in memory, following `appStall`: it tracks a condition
happening now, a restart legitimately restarts the observation, and since a cron
entry's first fire is one interval after start and notifying needs two sightings,
a crash-looping daemon cannot produce a stream of notifications.

## One fix beyond the feature

`writeCronEntry` left an on-schedule record alone, so a cron entry armed under a
longer interval kept that schedule forever — shortening an interval was inert.
Found live: the alarm's own entry stayed on a 15-minute schedule after the
tripwire was moved. It now pulls an over-scheduled entry in (never pushes a fire
out, so it cannot starve the entry it is fixing), and says so.

## Live verification

Throwaway `pinalarm` profile, tripwire set to 90s via the knob. The profile ran
this branch at protocol 230; the two bumps since are pure renumbering around
siblings that took 230 and 231, with no schema change.
The app runtime's host binary was swapped for an `exit 1` script so
`app:ticketwatch` froze with real traffic behind it.

- **silent below the line** — at 56s of oldest-unread, `attn bus status` showed
  only `app:ticketwatch (retention floor)`, no tag, no notification
- **the crossing** — `bus: consumer app:ticketwatch has pinned the retention
  floor at seq 417 for 3m, past the 1m30s tripwire...`, one durable warning row
- **CLI** — `app:ticketwatch (PINNING 3.0 KB)` plus the WARN finding
- **settings page** — red `Pinning 8.7 KB` pill beside the WARNING finding
- **notification** — warning row in the app's feed
- **the way out** — restoring the runtime let the consumer catch up; the tag
  reverted to `(retention floor)`, the finding cleared, and no further
  notification was written
- **the cron fix** — `jobs: cron bus_pin_alarm was armed for 3m56s out, past its
  1m0s interval; pulling it in`

![pinalarm-clip](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/593db0d0923e16147075e68f342d747fecc8b305/delegate-bus-pin-alarm-45c75b4e/pinalarm-clip.gif)

[Full-quality recording (mp4)](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/593db0d0923e16147075e68f342d747fecc8b305/delegate-bus-pin-alarm-45c75b4e/pinalarm-clip.mp4)

## Surfaces walked

CLI (`attn bus status` table + `--json`), daemon and app (protocol fields, the
settings page), protocol (`main.tsp` → regenerated, ProtocolVersion **232** —
main took 230 and 231 while this was in flight), docs (`docs/glossary.md` gains "The
retention floor, and the pin alarm"; `AGENTS.md` event-bus section), changelog
fragment. No migration. Linux needs nothing Darwin-only. Plugins and the SDK do
not touch this surface.

https://claude.ai/code/session_01KfvctPXiMGzL7NjeTZWs3W
