### PR TITLE
docs(plans): what we measured about making agent prose plain

### DIFF
--- a/changelog.d/plain-prose-first-principles.yaml
+++ b/changelog.d/plain-prose-first-principles.yaml
@@ -1,0 +1,6 @@
+kind: internal
+area: docs
+change: >
+  Recorded what four days of measurement found about making agent prose easier
+  to read: nothing cheap predicts when a reader will ask for plainer words, but
+  rewriting and then comparing the two versions does work.

--- a/docs/plans/2026-08-10-prose-density-gate.md
+++ b/docs/plans/2026-08-10-prose-density-gate.md
@@ -42,9 +42,10 @@ is pinned here:
 
 Tables that apply the 150-word floor sit on a subset of pull A: 995 messages
 with the original regex labels (43 complaints, 952 accepted), 1,042 with the
-hand-verified ones (22 complaints, 1,020 accepted). The Go and Python
-tokenizers disagree on two messages at the floor, which is why one table below
-reads 21 complaints and another 22; it never moves a result.
+hand-verified ones (22 complaints, 1,020 accepted). Two tokenizers were used
+across the scratchpad runs, one in Go and one in Python, and they disagree on
+two messages sitting exactly at the floor — the same recomputation reported 21
+complaints from one and 22 from the other. It never moves a result.
 
 **Every gated feature is a coin flip** (pull A, regex labels, 43 complaints and
 952 silently accepted; AUC 0.5 is chance):

--- a/docs/plans/2026-08-10-prose-density-gate.md
+++ b/docs/plans/2026-08-10-prose-density-gate.md
@@ -1,161 +1,488 @@
 # Plan: the prose density gate
 
-Agent-written prose drifts dense: long paragraphs, sentences doing three
-jobs, loaded words, nominalized mush. Guidance alone has not held — the
-comment-prose sweep (#818) measured comments ballooning from 6% to 17% of
-the diff under style guidance that forbade exactly that. Trust but verify
-(Victor, 2026-08-10): a detector reads what an agent wrote and reports,
-in the writing loop, what to simplify and where.
+## Goal
 
-The deliverable is always a **finding** — a quoted span, the objection,
-and when possible a suggested rewrite. Never a score: an agent can fix
-"this sentence does three jobs, split it"; it cannot fix "readability 32",
-and optimizing against score-shaped readability targets is documented to
-degrade the prose itself — disproportionate weight on sentence-level
-readability rewards destabilizes training and lowers simplification
-quality ([receipt](https://arxiv.org/pdf/2410.17088)), and
-Hemingway-style length rules are the interactive push toward staccato.
+Agent-written prose drifts dense, and Victor has to say so by hand. Twenty-six
+times in four weeks he replied "plain language bro" or "simpler terms please" to
+a message he had just been handed. The gate fires that nudge for him, before he
+reads the draft.
 
-## Shape
+The original two-layer design in this plan — a Vale-shaped rule engine emitting
+findings, plus a model judge — was calibrated against a corpus of those real
+complaints and did not survive. What replaced it is smaller: a deterministic
+trigger and a nudge string. See [Receipts](#receipts).
 
-Two layers. The deterministic layer owns everything countable; the judge
-owns everything semantic. The anti-gaming tripwires exist so an agent
-optimizing one layer lands in the other's findings.
+**That deterministic trigger is also dead.** Measured against every message
+Victor actually replied to rather than against the corpus that built it, it fires
+on 85% of prose he accepted without comment, and every one of its six features is
+a coin flip — as is every cheaper and smarter trigger tried after it. See
+[The trigger does not work](#the-trigger-does-not-work). What replaces it
+predicts nothing: every gated write is rewritten under the nudge and a pairwise
+verdict decides which version ships. See [Design C](#design-c-rewrite-and-verify).
 
-```mermaid
-flowchart LR
-    A[agent writes prose] --> D[deterministic layer\npure Go, free, instant]
-    A --> J[model judge\nHaiku-class, ~1¢/doc]
-    D --> F["findings: {span, rule, objection}"]
-    J --> F
-    F --> A
+## The trigger does not work
+
+Second corpus, built to answer a question the first one could not: how often does
+the gate fire on ordinary writing? Every assistant message over 120 words that
+Victor typed a reply to — 1,217 of them across 1,675 transcripts, one month —
+labelled by whether that reply complained about the prose. Only genuinely typed
+human turns count (`origin.kind == "human"`, `promptSource == "typed"`); task
+notifications, teammate relays, and compaction summaries all arrive as user turns
+and all contain words like "concise" that have nothing to do with the message
+before them. Without that filter the complaint side is ~70% machine text.
+
+**Every gated feature is a coin flip** (43 complaints, 952 silently accepted;
+AUC 0.5 is chance):
+
+| feature | AUC | mean complaint | mean silent |
+| --- | --- | --- | --- |
+| word_len_mean | 0.503 | 4.84 | 4.83 |
+| em_dash | 0.504 | 2.08 | 2.08 |
+| long_words_8 | 0.509 | 15.10 | 14.93 |
+| preposition | 0.493 | 6.07 | 6.18 |
+| sent_mean_words | 0.529 | 19.96 | 18.57 |
+| long_sents_per100 | 0.549 | 0.83 | 0.73 |
+
+**The shipped thresholds fire on 84.6% of messages Victor never complained
+about.** Recalibrated to the 90th percentile of accepted prose they fire on 38.4%
+of silent messages and 37.2% of complaints — equally on both. There is no
+operating point that is quiet and useful at the same time.
+
+Shape is no better: raw words 0.589, characters 0.572, paragraphs 0.568,
+headings/lists/tables/bold all at or below chance. Nothing cheap predicts it.
+
+**How the first corpus hid this.** Its negative side was the *revisions* — prose
+written after a complaint, on best behaviour — not ordinary writing. Thresholds
+set just above that fire on anything less careful than Victor's most careful
+prose, which is nearly everything he is sent. The 94% paired win rates were real
+and answer a different question: *is a revision plainer than the message it
+replaced?* Yes, nearly always. That is not *does density predict a complaint?*
+This plan wrote "a paired signal is not a threshold" about one feature and then
+built the whole trigger on exactly that mistake.
+
+**The labels were then hand-read and it still does not work.** The regex that
+labelled complaints matched replies about design ("a plain rename should be
+fine", "isnt that too complex"), speed, and file loading; only 22 of 49 were
+genuine writing complaints. Recomputed on the hand-verified labels, density is
+still chance (word_len_mean 0.44, long_words_8 0.50). What the clean labels
+did surface: the genuine complaints split into style complaints ("plain
+language bro", maybe a third) and comprehension failures quoting one specific
+passage that assumed unseen knowledge (the majority), and messages with
+structure draw *fewer* complaints than prose walls — fenced blocks AUC 0.19,
+tables 0.21, headings 0.33, all inverted. The weak residual signals are
+message length (raw words 0.60, paragraphs 0.60) and conversation depth
+(0.59). With 22 positives every AUC carries roughly ±0.12, so nothing here is
+confidently above chance.
+
+**Model judges and reader-context features fail too.** Scoring each message
+0-10 for "will he push back on how this is written": bare-message Haiku AUC
+0.534; gpt-5.6-luna 0.522, rating 96% of everything ≥5 — the known absolute-
+scoring failure of LLM judges. Two experiments aimed at the comprehension-
+failure species, both on the hand-verified labels: (a) a Haiku judge shown the
+user-visible conversation prefix before the message — AUC 0.568; (b)
+deterministic novel-referent density, the fraction of the message's terms
+absent from the visible conversation before it — AUC 0.49-0.50, with novel
+backtick identifiers *inverted* at 0.39 (new code terms draw fewer
+complaints). Nothing cheap — feature, judge, or context-aware — predicts the
+complaint. The most likely reading: whether Victor pushes back is not a
+property of the text; it depends on what he needed at that moment.
+
+**What survives.** The nudge. In replay it moved word-level density down in 93%
+of cases, matched Victor's own revisions, beat "please simplify" by 20-30 points,
+and never dropped a diagram or table. The half that talks to the agent works; the
+half that decides when to talk does not — and after six features, shape,
+novelty, and three judge configurations, the evidence says no cheap trigger
+exists to build. What ships instead predicts nothing: see the next section.
+
+## Design C: rewrite and verify
+
+Since no signal predicts the complaint, stop predicting. On every gated write
+(`ticket new`, `ticket comment`, `delegate`), the pipeline is:
+
+1. **Rewrite** the text under `DefaultNudge` (the agent's own model; opus in
+   every measurement here). p50 12s, max 29s.
+2. **Verify pairwise**: sonnet, `--effort low`, judges original vs rewrite in
+   *both orders*. The rewrite ships only on a double win; a flip or a loss
+   ships the original. p50 6s per pair of calls.
+3. **Fact gate**: sonnet/low answers "name one concrete thing the ORIGINAL
+   states that the REWRITE dropped, or NONE". A flagged loss ships the
+   original — fail closed. Any model error anywhere also ships the original —
+   the pipeline can only ever fail open to the text the agent already wrote.
+4. **Structure gate**: `Structure.Lost` (fenced blocks, tables, links) on the
+   rewrite ships the original. Deterministic and free. 0/200 on chat text;
+   1/98 on ticket text (a dropped link), which is why it gates rather than
+   logs.
+
+The judge prompt must be **single-axis**. The first prompt asked for plainness
+and completeness in one question and the judge resolved the tension by counting
+detail: 47-53% accuracy against Victor's own accepted revisions. Asking only
+"which reads plainer" (information-loss policed separately by step 3) moved it
+to 85-97%. Same lesson tightened the fact prompt: demand "NONE or one quote, no
+reasoning" or the checker rambles itself into self-refuting verdicts.
+
+**Effort hurts the judge.** Accuracy on the 17 ground-truth pairs falls
+monotonically with reasoning effort, in both model families — the task is a
+surface judgment, and thinking room lets the judge re-litigate the
+completeness bias the prompt removed:
+
+| judge | ships (of 17) | flips | wrong | per-call acc | p50 |
+| --- | --- | --- | --- | --- | --- |
+| sonnet/low | 16 | 1 | 0 | 97% | 4.8s |
+| sonnet/medium | 15 | 2 | 0 | 94% | 4.4s |
+| sonnet/high | 11 | 6 | 0 | 82% | 4.4s |
+| terra/low | 14 | 2 | **1** | 88% | 6.2s |
+| terra/medium | 12 | 5 | 0 | 85% | 11.2s |
+| terra/high | 12 | 4 | **1** | 82% | 8.1s |
+| haiku (any prompt) | 3 | 10 | 4 | 47% | — |
+
+Haiku is position-biased garbage (27 of 34 verdicts picked whichever side was
+labelled B); terra confidently prefers the rejected original once at two
+effort levels, which the both-orders rule cannot defend against. Sonnet's
+remaining errors are all flips — uncertainty, which ships the original.
+
+**Receipts, all on hand-verified labels and holdout data:**
+
+- *Validity* (17 pairs Victor himself adjudicated): sonnet/low ships his
+  accepted revision 16/17, never the rejected side.
+- *Safety* (100 silently-accepted messages, no prompt tuned on them): 98%
+  of rewrites win the pairwise vote — and a blind test says that is real, not
+  judge style-bias: shown 6 unlabelled pairs with sides randomized, Victor
+  picked the rewrite 6/6 (p ≈ 0.016), on messages he had accepted in their
+  original form.
+- *The nudge eats receipts, and the fix works*: the plain nudge dropped
+  numbers, file:line citations, arithmetic receipts, and hedges in 31/98
+  rewrites (tight checker). Adding "keep every number, measurement, and file
+  or line reference, and keep stated uncertainty stated" cut it to 10/97 on
+  the same sample — and the residue is phrase-level wording, not receipts,
+  with several of the 10 being checker ramble counted conservatively.
+
+**The ticket register needs the gates.** Ran offline over all 99 real ticket
+descriptions and comments ≥100 words from production (copied read-only). The
+pairwise vote still ships 97% — but the fact gate fires on 36 of those 96
+(37%, vs 10% on chat), and the catches are real: three rewrites dropped the
+*entire* ticket body and still won the plainness vote; others dropped session
+IDs, commit SHAs, file:line references, and measured receipts, and two changed
+meaning ("two 30m windows" → "about an hour"). Effective behavior on tickets:
+~60/99 rewrites ship, the rest fall back to the original, no loss reaches the
+reader. On fact-dense text the single-axis judge is safe only because the
+fact gate is behind it — the gate is load-bearing, not belt-and-braces.
+
+**What this costs**: ~20s of agent time and a few cents per gated write, on
+surfaces that see a handful of writes a day. The latency lands on the agent
+writing the ticket, never on the reader.
+
+**Rollout** (shadow mode considered and rejected — single user, offline
+register evidence above replaces it): ship live behind a `prose.pipeline`
+setting, `off | on`, default `off`; every run logs original, rewrite, verdicts
+and timings under the data dir, which is also the label corpus growing on its
+own. Fail open everywhere: missing binary, timeout (90s tripwire; measured
+max 74s total on ticket text), or any error ships the agent's original text.
+
+**Not yet done**: wire the pipeline into the three gated writes behind the
+setting, unwire the dead deterministic trigger (thresholds, `attn prose
+check`'s verdict mode, calibration tests, the refusal one-shot), and the
+remaining 14 blind pairs if tighter error bars are wanted.
+
+## Receipts
+
+Corpus: 26 moments mined from four weeks of Claude Code transcripts where Victor
+objected to an agent's prose; 17 are pure "write this plainly" complaints. Each
+case carries the message he objected to, his complaint verbatim, and the revision
+he accepted. Paired within-case, so topic and length cancel out.
+
+**The rule set this plan originally proposed does not separate dense prose from
+accepted prose.** Win rate is how often the dense side scored worse:
+
+| proposed rule | win rate |
+| --- | --- |
+| nominalizations | 59% |
+| passive voice | 57% |
+| noun strings (3+) | 50% (n=4) |
+| expletive openers | 33% — backwards |
+
+Chance is 50%; significance at n=17 needs 76%. Every rule that would have
+required a part-of-speech tagger landed in that table, which closes the tagger
+question and the CPIDR idea-density port with it.
+
+**What does separate:**
+
+| feature | dense → accepted | win rate |
+| --- | --- | --- |
+| words ≥8 chars | 13.6 → 9.8 /100w | 94% |
+| parenthetical asides | 0.74 → 0.41 /100w | 94% |
+| mean sentence length | 18.2 → 14.6 words | 88% |
+| "not just X — Y" tic | 0.28 → 0.11 /100w | 80% |
+| em-dashes | 2.00 → 1.55 /100w | 76% |
+| prepositions | 6.5 → 5.4 /100w | 76% |
+
+**A paired signal is not a threshold.** Parenthetical asides win 94% paired, yet
+the two distributions overlap so completely that a tripwire set past accepted
+prose fires on 0% of dense documents. Only word-level and length features work as
+absolute gates.
+
+**The gate, leave-one-out** (each threshold set 2% above the max of every other
+accepted document, so no document sets the bar it is judged by). Regenerate with
+`TestRecalibrate`, which runs the package's own `Measure` — the numbers can never
+drift from the shipping code. 15 pairs clear the 150-word floor:
+
+```
+long_words_8      > 14.40   fires on 5/15 dense,  1/15 accepted
+word_len_mean     >  4.77              5/15       0/15
+em_dash           >  2.24              4/15       0/15
+long_sents/100w   >  0.96              4/15       1/15
+sent_mean_words   > 19.53              4/15       0/15
+preposition       >  7.65              1/15       1/15
+
+UNION                                 12/15 (80%) 3/15 (20%)
 ```
 
-### Deterministic layer (pure Go)
+**One gate is enough.** Requiring two before firing costs 20 points of recall
+(73% → 53% in-sample) and buys nothing: the false-positive rate is already 0% at
+one gate. Three drops recall to 20%.
 
-No Python dependency, ever (Victor, 2026-08-10): anything worth adopting
-from the research gets a Go port; anything needing a real parser is cut.
+**The gate fires on long reference documents**, which nothing routes through it —
+`AGENTS.md`, `docs/glossary.md`, `docs/profiles.md` and `CHANGELOG.md` all trip,
+each marginally (16.25 against 14.40; 20.29 against 19.53) where a genuinely dense
+message misses by multiples (67.65 against 14.40). Whole-document averages over
+thousands of words mix headings, terse lists and prose, so they are a different
+distribution from the messages the thresholds were cut for. This is a limit of
+`attn prose check` pointed at a document, not of the gate on the write paths.
 
-- **Vale-shaped rule engine.** [Vale](https://vale.sh/) is a mature Go
-  prose linter — markup-aware, production-proven (Datadog, Grafana), and
-  its Vocab model (per-project accept/reject term lists) is exactly the
-  user-curated loaded-word list. Embed it or mirror its style format so
-  existing styles carry over; decided in slice 1.
-- **Rules that survive technical prose**: nominalizations and hidden verbs
-  ("give consideration to"), noun strings (3+ consecutive nouns), passive
-  voice hiding its actor, expletive openers, the reject vocabulary, and a
-  generous per-sentence length tripwire. Skipped as documented
-  staccato-machines: adverb-phobia, blanket length bans, marketing-tone
-  rules.
-- **Idea density per sentence** — the metric that says *overloaded* rather
-  than *long*: propositions per word, CPIDR-style (count verbs,
-  adjectives, adverbs, prepositions, conjunctions over a POS tag pass;
-  [receipt](https://link.springer.com/article/10.3758/BRM.40.2.540)),
-  ported to Go over a pure-Go tagger
-  ([jdkato/prose](https://pkg.go.dev/github.com/jdkato/prose)). Chopping a
-  sentence moves words but deletes no propositions, so this number cannot
-  be gamed by fragmenting.
-- **Anti-gaming pair for the length rule**: a staccato detector (runs of
-  consecutive sub-threshold sentences, sentence-length variance floor) and
-  an adjacent-sentence referent-overlap check — chopped prose loses
-  connectives and shared referents, so the cohesion check fires exactly
-  when the length check is being gamed.
-- **Cut**: composite readability formulas (blind to jargon, gameable,
-  score-shaped), surprisal/perplexity (heavy runtime, measures
-  unpredictability — which technical prose legitimately has), max
-  dependency distance (needs a real parser; the judge covers it).
+**The harness, 15 cases replayed against opus.** Each case rebuilt to the message
+Victor objected to, answered in his place, and measured:
 
-### Model judge
+```
+arm         n   judged   still trips   dropped structure   mean words
+real       15     15      0 (  0%)      3 ( 20%)            420
+generic    15      9      6 ( 67%)      3 ( 20%)            187
+mechanism  15     15      9 ( 60%)      0 (  0%)            359
+```
 
-One narrow question per call, per paragraph. The cited ground: small
-models judge adequately on narrow, closed-ended rubrics but not on
-open-ended quality ([SLMJury](https://arxiv.org/html/2606.07810)). That
-Haiku-class agreement is *sufficient* at this granularity is a working
-assumption, not a received fact — slice 2 measures it on our own corpus
-before the judge is trusted, and the criterion-scoped design is what
-makes that measurement possible per criterion.
-The reconcile classifier is the in-repo precedent: tool-less, cheap,
-deterministic harness around a small model.
+Two of those columns are traps and are recorded here so nobody reads them as
+wins. `real` scoring zero trips is **circular** — those fifteen documents are the
+accepted side that set the thresholds. And six of the generic arm's rewrites fell
+under the word floor and abstained, so its trip rate is over nine documents, not
+fifteen: shortening is not the same as clarifying, and a scoreboard that counts
+abstentions as passes rewards the wrong thing.
 
-- Criteria, one per pass: sentence doing more than one job; paragraph
-  with no through-line ("each sentence is fine, the paragraph is a
-  maze"); loaded or hedging language where a plain word exists; choppy
-  fragments that are one idea broken apart (the judge is the backstop
-  against gaming the deterministic layer).
-- Output is a capped list of `{quoted span, objection, rewrite}` — no
-  scores (leniency drift), no pairwise comparison (verbosity and position
-  bias live there). The user's reject vocabulary is injected into the
-  rubric per run.
-- Grounding for trusting the family at all: GPT-4-class readability
-  judgments correlate r≈0.75 with humans, beating every formula and
-  psycholinguistic index
-  ([Trott & Rivière 2024](https://arxiv.org/abs/2410.14028)).
+The question the `real` arm *can* answer is paired — against the message it
+replaced, did the rewrite move each feature down:
 
-## Every threshold needs a receipt
+```
+feature                 real      generic   mechanism
+long_words_8           14/15 93%  10/15 67%  14/15 93%
+word_len_mean          12/15 80%   9/15 60%  14/15 93%
+em_dash                11/15 73%   8/15 53%  12/15 80%
+sent_mean_words        13/15 87%  14/15 93%  14/15 93%
+long_sents_per100      11/15 73%  12/15 80%  11/15 73%
+preposition            11/15 73%  10/15 67%   9/15 60%
+```
 
-No number in the deterministic layer ships from this plan. Calibrate on a
-corpus labeled by Victor — prose he has judged good beside prose he has
-judged dense (the #818 before/after diffs are a ready-made seed corpus) —
-and set each tripwire past where the good prose goes. A legitimate
-sentence hitting the gate means the threshold is wrong; remeasure.
+**The two nudges do different things.** On the length features every arm ties —
+"Please simplify" makes text shorter, which is easy. On the word-level features,
+the ones the corpus said the complaints are actually about, the mechanism nudge
+matches Victor's own revisions (93% on long words) or beats them (93% against
+80% on mean word length), and the generic control trails both by 20-30 points.
 
-## Where it runs
+**The structure clause earns its place.** The generic nudge dropped tables in two
+cases and a fenced block plus tables in a third — 3/15, the same rate as Victor's
+own revisions. The mechanism nudge dropped nothing in fifteen rewrites. This is
+the concern that motivated the clause, and it is the cleanest non-circular result
+in the run.
 
-Activation is **mechanical wherever prose already passes through attn's
-hands** — the gate must not lean on the guidance channel #818 measured
-drifting. Guidance-based activation is reserved for surfaces attn never
-touches.
+**One nudge does not reliably produce prose that passes.** 60% of mechanism
+rewrites still trip. The one-shot design absorbs this — the rewrite lands
+regardless — but nobody should expect a single pass to clear the bar, and a
+future design that blocks until it does would be wrong.
 
-- **`attn prose check <file|->`** is the base verb: both layers, findings
-  to stdout, `--json` for agents, `--deterministic-only` for the free
-  tier. Everything else composes it.
-- **The ticketing system is the first wired surface** (Victor,
-  2026-08-10) — it exists on main today, no need to wait for seeds. A
-  delegation brief and a backlog ticket description are agent-written
-  prose with a named reader who cannot ask clarifying questions, which
-  makes them the highest-value place to catch density. `attn delegate`
-  and `attn ticket new` run the deterministic layer on the brief and
-  return findings alongside success, advisory: the author sees them and
-  decides; nothing is refused.
-- **Boundary moments, advisory**, for prose attn never handles: agent
-  guidance (embedded skill, crew charters) says to run the check before
-  presenting a plan doc, filing a handoff, or opening a PR whose body
-  carries real prose.
-- **Not a hard block anywhere** until the gate earns trust on real
-  drafts; promotion to CI or a pre-file hook is a later decision, taken
-  per surface.
+**Two hypotheses tested and refuted**, recorded so they are not re-proposed:
 
-## Slices
+- *Glossary discipline.* Canonical `docs/glossary.md` term usage: 53% — a coin
+  flip. Dense messages use shared vocabulary at the same rate as accepted ones.
+  What looked like a 76% signal on "coined vocabulary" turned out to be counting
+  branch names and file paths inside backticks.
+- *Findings beat a nudge.* Not refuted, but unsupported and now unnecessary: all
+  17 of Victor's bare nudges produced a revision he accepted. The nudge is not
+  the weak part, so span-level findings have no measured value to add.
 
-1. **Deterministic layer + CLI.** Rule engine decision (embed Vale vs
-   mirror its format), the technical-prose rule set, idea density port,
-   anti-gaming pair, calibration corpus and receipts, `attn prose check`.
-2. **Judge.** Criterion passes, span-anchored output, vocabulary
-   injection, cost and agreement spot-check against the corpus.
-3. **Ticket wiring.** `attn delegate` and `attn ticket new` run the
-   deterministic layer on briefs and descriptions, findings advisory in
-   the result; embedded-skill guidance for the unwired surfaces.
-4. **Garden integration** once crown bodies and notes exist ([the garden
-   plan](2026-08-06-the-garden-vertical-slices.md) points here for its
-   prose quality gate) — the same wired-surface pattern, on the garden's
-   write verbs.
+## Architecture Map
+
+```text
+Current:
+agent writes description/comment/brief
+  -> cmd/attn: runTicketNew / runTicketComment / runDelegate
+    -> internal/client: CreateTicket / CommentTicket
+      -> daemon
+
+Target:
+agent writes description/comment/brief
+  -> cmd/attn: runTicketNew / runTicketComment / runDelegate
+    -> internal/prosegate.Check(text)          # pure Go, no model, sub-ms
+       |  a refusal is already on record
+       |    -> clear it, warn on any structure the rewrite dropped, pass
+       |  trips, nothing on record
+       |    -> record it, print nudge to stderr, exit 2   # agent rewrites, re-runs
+       |  otherwise
+       v
+    -> internal/client: CreateTicket / CommentTicket
+      -> daemon
+
+Also:
+attn prose check <file|->        # same Check, --json for agents
+```
+
+The gate lives CLI-side. No protocol change, no daemon change, no
+`ProtocolVersion` bump: the CLI already owns every write path we are gating.
+
+## Data Model / Interfaces
+
+```go
+// internal/prosegate
+type Verdict struct {
+    Tripped bool
+    Gates   []GateHit  // which tripwire, its value, its threshold — for --json and logs
+    Nudge   string     // the text handed to the agent; empty when not tripped
+}
+
+type GateHit struct {
+    Name      string   // "long_words_8"
+    Value     float64
+    Threshold float64
+}
+
+func Check(text string, cfg Config) Verdict
+
+// Prose only. Fenced blocks (covers ```mermaid), tables, and command lines are
+// removed before measurement, so structure never trips a gate on its own.
+func proseOnly(markdown string) string
+
+// Structure the rewrite must not lose.
+type Structure struct {
+    FencedBlocks, Tables, Links, ListItems, Headings int
+}
+func StructureOf(markdown string) Structure
+func (before Structure) Lost(after Structure) []string  // fences, tables, links
+func (before Structure) Preserved(after Structure) bool
+```
+
+`Lost` watches three of the five counts. Headings and list items are counted but
+never reported: reorganising them is what the nudge asks for, and a warning that
+fires on every honest rewrite is one nobody reads.
+
+Config, one place, defaulting to the `/bro` wording:
+
+```go
+type Config struct {
+    Nudge      string             // default: the /bro text + "keep what carries
+                                  // information the prose cannot — diagrams,
+                                  // tables, code, commands, links. Improve them
+                                  // if you can; just don't drop them."
+    Thresholds map[string]float64 // the calibrated numbers above
+    Enabled    bool
+}
+```
+
+One-shot state, so the gate can never wedge an agent:
+
+```
+<data-dir>/prosegate/<session-id>  ->  {digest, structure} of the refused text
+```
+
+One refusal per session, not per text. The moment a refusal is on record the
+next write lands, whatever it says, and the record is cleared so the gate arms
+again for the following message. On that next write the stored structure is
+compared against what arrived: anything dropped is named on stderr, and the
+write still goes through.
+
+## Boundaries
+
+- `internal/prosegate` owns measurement, thresholds, and the nudge string. Pure
+  functions over a string; no store, no client, no daemon.
+- `cmd/attn` owns the decision to refuse and the one-shot record. It is the only
+  caller that can block a write.
+- The daemon owns nothing here. Deliberate: the gate must not become a protocol
+  concern before it has earned trust.
+- Nothing rewrites text automatically. The agent rewrites; the gate only checks.
+
+## Implementation Steps
+
+- [x] `internal/prosegate`: `proseOnly` (fences, tables, command lines),
+      tokenizer, the six gates, `Check`, thresholds as named constants carrying
+      their receipts.
+- [x] `internal/prosegate`: `StructureOf` / `Lost` / `Preserved`, with the
+      structural counts above.
+- [x] Corpus fixture + calibration test, gated behind `ATTN_PROSE_CORPUS` (the
+      corpus is real conversation text and this repo is public). A threshold edit
+      that breaks separation fails the test. Bounds are recall ≥70% and false
+      positive ≤30%; in-sample reads below the leave-one-out estimate of 80%/20%
+      because every accepted document helped set the bar it is judged against.
+      `TestRecalibrate` regenerates the numbers through the package's own
+      `Measure`, so they can never drift from the shipping code.
+- [x] `attn prose check <file|->`, `--json`.
+- [x] Wire `ticket new`, `ticket comment`, `delegate` through the gate with the
+      one-shot refusal and the dropped-structure warning.
+- [x] Harness (`TestNudgeHarness`): replays every case that clears the word floor.
+      It rebuilds the conversation up to the message Victor objected to, answers
+      in his place, and measures what comes back — three arms, `real` (the
+      revision he accepted, free), `generic` ("Please simplify.", the control the
+      mechanism has to beat), and `mechanism` (the shipped nudge). Reconstruction
+      is bounded, not a full resume: the last few turns of plain text, widened
+      until two of them are the user's, so the question being answered is inside
+      the window. It costs money and minutes, so it runs only when asked:
+
+      ```
+      ATTN_PROSE_CORPUS=…/corpus_pure.jsonl ATTN_PROSE_HARNESS=…/out \
+        go test ./internal/prosegate -run TestNudgeHarness -v -timeout 40m
+      ```
+- [x] Changelog fragment; `docs/glossary.md` entry for the prose gate.
 
 ## Decisions
 
-- **Both layers, not guidance alone** (Victor, 2026-08-10): trust but
-  verify; #818 is the receipt that guidance drifts.
-- **No Python dependency** (Victor, 2026-08-10): Go ports or cuts.
-- **Findings, never scores** (2026-08-10): the feedback contract is a
-  quoted span an agent can act on; scores drift and get gamed.
-- **Advisory before blocking** (2026-08-10): the gate reports to the
-  writing agent first; hard gates come per surface, with evidence.
-- **Tickets before seeds** (Victor, 2026-08-10): the first wired surface
-  is the ticketing system already on main, so the gate's activation never
-  waits on the garden and never rests on guidance alone.
+- **Trigger, not findings** (2026-08-11): the corpus shows Victor's bare nudge
+  worked 17/17, so the missing piece is firing it, not enriching it. Kills the
+  rule engine, the judge, span-anchored output, and the vocabulary injection.
+- **No part-of-speech tagger** (2026-08-11): every rule that needed one measured
+  at chance. Also kills the CPIDR idea-density port and the `jdkato/prose`
+  dependency (+6MB, gonum, unmaintained since 2020).
+- **Surprisal stays cut** (2026-08-11), but for a better reason than the original
+  plan gave: it is the best-evidenced predictor of reading difficulty in the
+  literature, and it still has no repair operator — "this word was unexpected"
+  tells an agent nothing to do. Runtime cost was never the real objection.
+- **Refuse once per session, not per text** (2026-08-11): keying the one-shot on
+  the text digest looked safe and was not — an agent whose rewrite still trips
+  produces a different digest, gets refused again, and trades versions with the
+  gate forever. Keying it on the record itself means the second write always
+  lands.
+- **Structure is checked, not requested** (Victor, 2026-08-11): a nudge that says
+  "be concise" will eventually delete a mermaid diagram. Counting structural
+  elements before and after makes preservation a property rather than a hope.
+- **Loss is reported, not rejected** (Victor, 2026-08-11): forbidding any edit to
+  a diagram or table is too rigid — an agent should be free to improve one. The
+  rule is about losing information, not about touching markup, and only the
+  author can tell whether a dropped table was deliberate. So the nudge asks, the
+  check watches, and the warning names what went missing without blocking.
+- **Gate lives in the CLI** (2026-08-11): the write paths are already there, so
+  this needs no protocol version bump and no daemon surface.
 
-## Open questions
+## Open Questions
 
-- Embed Vale as a library vs mirror its style format with our own engine
-  (slice 1 decides; embedding buys the ecosystem, mirroring buys control).
-- Whether the judge rides the daemon (a job kind) or stays CLI-only until
-  a surface needs it ambiently.
+- 20% of accepted prose trips the union gate, and 60% of nudged rewrites still
+  trip. Both are tolerable while the payload is a nudge that costs one rewrite;
+  neither would be tolerable in a design that blocks until the text passes.
+- Chat replies inside a session never pass through attn's hands, so the gate
+  cannot fire there — that surface stays opt-in via `attn prose check`, which is
+  the guidance channel #818 measured drifting. Accepted for now.
+- The corpus holds real conversation text and this repo is public. It lives
+  outside the tree behind `ATTN_PROSE_CORPUS`, and both the calibration test and
+  the harness skip without it — so CI never proves anything about the
+  thresholds. A redacted or synthetic fixture would fix that; nothing does today.
+- The gate reads a whole reference document as one message and trips on the
+  margins (see the receipt above). Nothing routes documents through it, but
+  `attn prose check <doc>` will nag. Either the command grows a document mode or
+  its help says plainly what it is for.
+
+## Follow-ups
+
+- Promotion from advisory-refusal to anything stricter, per surface, with
+  evidence from the harness.
+- Garden write verbs, once crown bodies exist — the same wiring, unchanged.

--- a/docs/plans/2026-08-10-prose-density-gate.md
+++ b/docs/plans/2026-08-10-prose-density-gate.md
@@ -31,8 +31,23 @@ notifications, teammate relays, and compaction summaries all arrive as user turn
 and all contain words like "concise" that have nothing to do with the message
 before them. Without that filter the complaint side is ~70% machine text.
 
-**Every gated feature is a coin flip** (43 complaints, 952 silently accepted;
-AUC 0.5 is chance):
+**Which numbers came from which pull.** Counts differ across this document and
+its successor because there were two pulls and two label sets, so every figure
+is pinned here:
+
+| pull | date | files walked | messages | complaint labels |
+| --- | --- | --- | --- | --- |
+| A | 2026-08-11 | 1,675 | 1,217 | 49 by regex, 22 after hand-reading |
+| B — adds the conversation each message was read in | 2026-08-11, later | 2,066 | 1,250 | pull A's labels, re-joined by file and line |
+
+Tables that apply the 150-word floor sit on a subset of pull A: 995 messages
+with the original regex labels (43 complaints, 952 accepted), 1,042 with the
+hand-verified ones (22 complaints, 1,020 accepted). The Go and Python
+tokenizers disagree on two messages at the floor, which is why one table below
+reads 21 complaints and another 22; it never moves a result.
+
+**Every gated feature is a coin flip** (pull A, regex labels, 43 complaints and
+952 silently accepted; AUC 0.5 is chance):
 
 | feature | AUC | mean complaint | mean silent |
 | --- | --- | --- | --- |
@@ -178,10 +193,14 @@ and timings under the data dir, which is also the label corpus growing on its
 own. Fail open everywhere: missing binary, timeout (90s tripwire; measured
 max 74s total on ticket text), or any error ships the agent's original text.
 
-**Not yet done**: wire the pipeline into the three gated writes behind the
-setting, unwire the dead deterministic trigger (thresholds, `attn prose
-check`'s verdict mode, calibration tests, the refusal one-shot), and the
-remaining 14 blind pairs if tighter error bars are wanted.
+**Never built.** Nothing routes `ticket new`, `ticket comment` or `delegate`
+through any of this; the pipeline was only ever run offline against saved text.
+Building it would mean writing it from scratch — there is no gate in the
+repository to unwire and no threshold code to delete, only the unmerged
+generation-1 branch described in
+[What was built](#what-was-built-and-where-it-is-not). The one loose measurement
+is the blind test: 6 pairs judged, 14 more available if tighter error bars are
+wanted.
 
 ## Receipts
 
@@ -404,24 +423,40 @@ write still goes through.
   concern before it has earned trust.
 - Nothing rewrites text automatically. The agent rewrites; the gate only checks.
 
-## Implementation Steps
+## What was built, and where it is not
 
-- [x] `internal/prosegate`: `proseOnly` (fences, tables, command lines),
+**None of this is in the repository.** It was written and measured in a session
+scratchpad, and the measurements above are the only thing worth keeping from it.
+Nothing below is a task list; it is a record of what the numbers were produced
+with. Unticked boxes would imply work still owed, and none is.
+
+Two generations of prose code exist, and neither is on `main`:
+
+- **Generation 1**, a rule engine — density, hidden-verb, rhythm and structure
+  rules, accept/reject vocabulary files, golden tests, corpus fixtures — lives
+  unmerged on the branch `feat/prose-check` as `internal/prose` plus
+  `cmd/attn/prose.go`. The corpus measurements killed its design; the branch
+  should be closed.
+- **Generation 2**, described below, was never committed at all. If any of it is
+  ever worth reviving it is the nudge text and the structural counter, both
+  reproduced in full in this document.
+
+- `internal/prosegate`: `proseOnly` (fences, tables, command lines),
       tokenizer, the six gates, `Check`, thresholds as named constants carrying
       their receipts.
-- [x] `internal/prosegate`: `StructureOf` / `Lost` / `Preserved`, with the
+- `internal/prosegate`: `StructureOf` / `Lost` / `Preserved`, with the
       structural counts above.
-- [x] Corpus fixture + calibration test, gated behind `ATTN_PROSE_CORPUS` (the
+- Corpus fixture + calibration test, gated behind `ATTN_PROSE_CORPUS` (the
       corpus is real conversation text and this repo is public). A threshold edit
       that breaks separation fails the test. Bounds are recall ≥70% and false
       positive ≤30%; in-sample reads below the leave-one-out estimate of 80%/20%
       because every accepted document helped set the bar it is judged against.
       `TestRecalibrate` regenerates the numbers through the package's own
       `Measure`, so they can never drift from the shipping code.
-- [x] `attn prose check <file|->`, `--json`.
-- [x] Wire `ticket new`, `ticket comment`, `delegate` through the gate with the
+- `attn prose check <file|->`, `--json`.
+- Wire `ticket new`, `ticket comment`, `delegate` through the gate with the
       one-shot refusal and the dropped-structure warning.
-- [x] Harness (`TestNudgeHarness`): replays every case that clears the word floor.
+- Harness (`TestNudgeHarness`): replays every case that clears the word floor.
       It rebuilds the conversation up to the message Victor objected to, answers
       in his place, and measures what comes back — three arms, `real` (the
       revision he accepted, free), `generic` ("Please simplify.", the control the
@@ -434,7 +469,9 @@ write still goes through.
       ATTN_PROSE_CORPUS=…/corpus_pure.jsonl ATTN_PROSE_HARNESS=…/out \
         go test ./internal/prosegate -run TestNudgeHarness -v -timeout 40m
       ```
-- [x] Changelog fragment; `docs/glossary.md` entry for the prose gate.
+- A changelog fragment and a `docs/glossary.md` entry for the prose gate were
+  drafted alongside the code and went the same way. `docs/glossary.md` on `main`
+  has no prose entry, and should not gain one until something ships.
 
 ## Decisions
 
@@ -448,11 +485,13 @@ write still goes through.
   plan gave: it is the best-evidenced predictor of reading difficulty in the
   literature, and it still has no repair operator — "this word was unexpected"
   tells an agent nothing to do. Runtime cost was never the real objection.
-- **Refuse once per session, not per text** (2026-08-11): keying the one-shot on
-  the text digest looked safe and was not — an agent whose rewrite still trips
-  produces a different digest, gets refused again, and trades versions with the
-  gate forever. Keying it on the record itself means the second write always
-  lands.
+- **The retry always lands** (2026-08-11): keying the one-shot on the text
+  digest looked safe and was not — an agent whose rewrite still trips produces a
+  different digest, gets refused again, and trades versions with the gate
+  forever. Keying it on the record itself guarantees the write after a refusal
+  goes through. Note what it does not guarantee: the gate re-arms after that
+  write, so a later message can be refused again. One refusal per message, not
+  one per session.
 - **Structure is checked, not requested** (Victor, 2026-08-11): a nudge that says
   "be concise" will eventually delete a mermaid diagram. Counting structural
   elements before and after makes preservation a property rather than a hope.

--- a/docs/plans/2026-08-12-plain-agent-prose-first-principles.md
+++ b/docs/plans/2026-08-12-plain-agent-prose-first-principles.md
@@ -1,0 +1,297 @@
+# Plain agent prose: problem statement and dead ends
+
+A step back. Everything here was measured. Nothing here is a proposal.
+
+This exists so someone can attack the problem fresh without repeating four days
+of dead ends, and without inheriting the framing that produced them.
+
+The attempt that generated these numbers is
+[2026-08-10-prose-density-gate.md](2026-08-10-prose-density-gate.md). None of it
+shipped. It is safe to throw away.
+
+## The problem
+
+Agents write densely. Jargon, hedging, nouns stacked on nouns, sentences that
+carry three ideas. The user then has to stop and ask for it again in plain
+words. The goal, as stated:
+
+> automatically make agents easier to understand without user asking
+
+Two parts of that carry weight. **Automatically** — an agent that writes plainly
+only when told has not solved anything. **Without user asking** — whatever we
+build must not need the user to notice, complain, or configure.
+
+Here is where an agent's prose becomes a lasting record, and where something
+could step in before a person reads it:
+
+- `attn ticket new` — the ticket description
+- `attn ticket comment` — a comment on a ticket
+- `attn delegate` — the brief handed to a delegated agent
+
+Chat messages inside a session are where the complaints actually happen. But
+those stream straight to a terminal, so there is no write to intercept.
+
+## What bad and good look like
+
+Both pairs below are real. Each shows a message the user objected to, what they
+said, and the revision they accepted. These pairs are the clearest statement of
+the target we have.
+
+### Pair 1 — the reply was "plain language please"
+
+Rejected:
+
+> **What landed**
+>
+> The four background kinds run on `internal/jobs`; `internal/tasks` is deleted
+> (~3,500 lines). Each kind's inputs moved from the `Subject`/`Meta` string bag
+> to a typed JSON payload, and coalescing moved from the record's identity to an
+> explicit `UniqueKey`. The wire shape is unchanged — `protocol.Task.Subject` is
+> populated from `UniqueKey` — so no protocol bump and no frontend work.
+
+Accepted:
+
+> **What I did**
+>
+> All four background jobs the daemon runs (compacting workspace context,
+> summarizing sessions, writing journal entries, reconciling tickets) now run on
+> the new queue. The old task runner is deleted. Each job carries its inputs as
+> proper structured data instead of a bag of strings.
+>
+> [...] Nothing changed on the app side. Same panel, same data, no version bump.
+
+### Pair 2 — the reply was "can uy explain iun plain langage?"
+
+Rejected:
+
+> ## The diagnosis contradicts your three-way split
+>
+> It's **options 1 and 2 combined** — and that rules out option 3
+> (correct-by-design). The workspace `directory` is not a deliberate "workspace
+> home" that merely differs from "the repo to branch from". It's a field with
+> *no invariant at all*.
+
+Accepted:
+
+> ## What went wrong
+>
+> Every workspace in attn stores a "directory" — one folder path. You'd assume it
+> means "this workspace's project folder." It doesn't mean anything that
+> reliable.
+>
+> That path gets overwritten constantly. [...] Drag a pane into a new workspace,
+> and the new one copies the *old workspace's* folder — not the folder the thing
+> you dragged actually lives in.
+
+### What actually changes between them
+
+Worth spelling out, because the obvious reading is wrong:
+
+- **The accepted version is not shorter.** Both revisions here are longer than
+  what they replaced. Compression is not the fix, and "be concise" is not the
+  instruction.
+- **Shorthand becomes things.** "The four background kinds" turns into the four
+  jobs, named. A symbol the reader would have to look up gets replaced by what
+  it points at.
+- **Headings stop being clever.** "The diagnosis contradicts your three-way
+  split" becomes "What went wrong."
+- **Every fact survives.** File paths, counts, branch names, PR numbers — all
+  still there in the accepted versions. Plainness never traded one away.
+- **The reader's question gets answered first.** The accepted versions open with
+  what happened. The rejected ones open with how the agent was thinking about it.
+
+## What we know about the complaints
+
+Where the numbers come from: every agent message over 120 words that the user
+typed a reply to. That is 1,250 messages, pulled from 2,066 transcript files
+covering about a month. Only replies a human actually typed count — task
+notifications, teammate relays, and compaction summaries all arrive as user
+turns too, and they are full of words like "concise" that have nothing to do
+with the message before them.
+
+Searching those replies for complaint words flagged 49. **Reading all 49 by hand
+left 22.** The other 27 were about design ("a plain rename should be fine"),
+speed, or scope. The word "simple" gets used constantly for things that are not
+writing. Anyone working from this data must check the labels by hand; the
+automatic version is wrong more than half the time.
+
+**The user complains about writing about 22 times a month, out of roughly 1,250
+substantial messages.** That rate is the most important number in this document.
+It caps every approach that needs a human to label things.
+
+Read the 22 and they are two different problems wearing one coat:
+
+1. **Style** — about a third. "plain language bro", "too verbose", "loaded
+   terms". This is a property of the message.
+2. **Comprehension** — the majority. They quote one specific passage and say
+   they do not understand it. "explain 20s / 5 min, what does that mean." "i
+   dont understand what you mean by 'stuffed into the settings map'." This is
+   not a property of the message. It is the gap between the message and what
+   the reader has already seen.
+
+## What was tried, and what it measured
+
+The tables use AUC. It answers one question: pick a complained-about message and
+an accepted one at random — how often does the measurement rank them correctly?
+0.5 means no better than a coin. 1.0 means perfect. With only 22 complaints to
+test against, anything between 0.5 and 0.6 could be luck.
+
+**Predicting which messages will draw a complaint. Every attempt failed.**
+
+| attempt | result |
+| --- | --- |
+| Six surface measurements (long words, sentence length, em dashes, prepositions, word length, long sentences) | AUC 0.44-0.56 |
+| Limits tuned on the first, smaller collection of pairs | fires on **84.6%** of messages nobody complained about |
+| Message shape (length, paragraphs, headings, lists, code, tables, bold) | best 0.60 (word count); structure runs *backwards* — code blocks 0.19, tables 0.21, headings 0.33 |
+| Haiku scoring the message alone, 0-10, "will they push back" | AUC 0.534 |
+| gpt-5.6-luna, same question | AUC 0.522; scores 96% of all prose at 5 or higher |
+| Haiku shown the conversation the reader had seen, then the message | AUC 0.568 |
+| How many of the message's words never appeared earlier in the conversation | AUC 0.49-0.50; new backticked identifiers run *backwards* at 0.39 |
+
+Nothing predicts it. The most likely reason is that it is not a property of the
+text at all. The same message draws a complaint on a day the reader is trying to
+decide something, and passes on a day they are not.
+
+**Why the first attempt fooled us.** We compared complained-about messages
+against the revisions that followed them — writing produced right after a
+complaint, on best behaviour. Any limit set just above that fires on everything
+less careful, which is nearly everything. The 94% success rate was real, but it
+answered a different question: is a revision plainer than what it replaced? Yes,
+almost always. That is not the same as knowing in advance which messages need
+one.
+
+**Improving prose. This part works.** The instruction is attn's `/bro` skill
+text plus two clauses about what has to survive:
+
+> Restate your last message. Stop using jargon and speak coherently. State it
+> more simply and concisely, like one human talking to another. Keep what
+> carries information the prose cannot — diagrams, tables, code, commands,
+> links. Improve them if you can; just don't drop them. Keep every number,
+> measurement, and file or line reference, and keep stated uncertainty stated —
+> a receipt or a caveat is information, not clutter.
+
+Replaying it against the real complaints: it brought word-level density down in
+93% of cases, landed where the user's own revisions landed, and beat a plain
+"please simplify" by 20 to 30 points.
+
+**Judging which of two versions is plainer. This part works, with care.** Show a
+model both versions and ask which one wins — then ask again with the sides
+swapped. Against the 17 pairs the user judged personally:
+
+| judge | picks the accepted revision | picks the rejected one | changes its mind when sides swap |
+| --- | --- | --- | --- |
+| sonnet, effort low | 16/17 | 0 | 1 |
+| sonnet, effort high | 11/17 | 0 | 6 |
+| gpt-5.6-terra, low | 14/17 | **1** | 2 |
+| haiku, any prompt | 3/17 | 4 | 10 |
+
+Two findings hide in that table. **Comparing two versions works where scoring
+one does not** — the same models asked to rate a single message 0-10 were coin
+flips. And **more thinking makes it worse**, steadily, in both model families.
+Given room to reason, the judge talks itself back into rewarding detail and
+precision, which is the very thing being complained about.
+
+The prompt mattered more than the model. A first version asking for plainness
+*and* completeness in one question scored 47-53%. Splitting it, so the judge
+ranks only plainness while a separate check watches for lost information, moved
+it to 85-97%.
+
+**The rewrite drops receipts. This is the real defect.** Run it over 100 real
+ticket descriptions and comments and numbers, `file.go:73` citations,
+arithmetic, session IDs, commit SHAs, and hedges disappear in 37% of rewrites.
+Three rewrites dropped the entire ticket body and still won the plainness
+comparison. Two changed the meaning — "two 30m windows" became "about an hour".
+Adding the receipts clause to the instruction cut losses on chat text from 31%
+to 10%, but ticket text, which is thick with identifiers, stayed at 37%.
+
+**Which model should do the rewriting: unfinished.** 40 ticket texts through six
+rewriters, each scored by the checks above. Only two rows are valid. The rest
+died on a CLI failure while being scored and were never measured.
+
+| rewriter | passes every check | plainer than the original | keeps every fact | p50 |
+| --- | --- | --- | --- | --- |
+| opus-5 | 20/40 | 40/40 | 20/40 | 16s |
+| sonnet-5 | 11/40 | 39/39 | 12/39 | 10s |
+| haiku-4.5, luna, terra, sol | not measured | — | — | 14-26s |
+
+The two valid rows agree with everything else here: rewriters are almost always
+plainer, and they lose facts about half the time on fact-dense text. Making
+prose plain is easy. Keeping the receipts is the hard part.
+
+## Where this left us
+
+The design that survived predicts nothing. Rewrite every gated write, compare
+the two versions both ways, keep whichever wins, and let a fact check and a
+structure check send it back to the original. Every layer is measured, and it
+cannot ship something worse than what the agent wrote. What is wrong with it:
+
+- It spends a model call on every write to improve maybe half of them.
+- On ticket text about 60% of writes ship the original anyway, because the
+  rewrite dropped an identifier.
+- The evidence that its output is genuinely better is thin. Six blind pairs,
+  where the user picked the rewrite 6 times out of 6 (p ≈ 0.016) — on chat
+  messages, not on ticket text.
+- It only touches three CLI surfaces.
+
+That last point deserves its own line. **Every complaint in the data happened
+somewhere this design cannot reach.** They all happened in chat. It intercepts
+ticket and delegation writes, which nobody has ever complained about.
+
+## Framings nobody has tried
+
+Starting points, not recommendations. None of these has been measured.
+
+- **Fix the writer, not the message.** Everything above steps in after the prose
+  exists. The instruction could live in the agent's standing context so the
+  first draft comes out plain. Costs nothing. Unknown: whether standing guidance
+  survives a long session — which the replay harness could measure directly.
+- **Step in when someone reads, not when an agent writes.** attn owns the
+  surface where messages get read. A message that does not land could be
+  replaced on demand, with one keystroke, instead of every message being
+  pre-chewed. That turns an unsolvable prediction problem into a one-click
+  request. The cost is that the user has to ask.
+- **Aim at comprehension, not density.** Most complaints quote a passage that
+  assumed knowledge the reader did not have. Nobody has tried to measure
+  understandability head-on — for example, whether a model given only what the
+  reader had seen can answer questions about the message.
+- **Let the agent judge its own draft before sending.** Same two-way comparison,
+  but run inside the agent's turn, where the whole conversation is available,
+  instead of at a CLI boundary that only sees the text.
+- **Accept that it is unpredictable and make repair cheap instead of
+  automatic.** A complaint costs the user four words and produces a good
+  revision 93% of the time. The manual loop may already be close to optimal, and
+  the honest answer may be to make it faster rather than remove it.
+- **Question whether those 22 complaints are the right target at all.** They are
+  the moments someone objected out loud. The messages that were read,
+  half-understood, and let go are invisible in every measurement here, and we
+  know of no way to observe them.
+
+## Constraints any solution must respect
+
+- **Latency lands on the agent, never on the reader.** Twenty seconds before a
+  ticket is written is fine. Twenty seconds before a message appears is not.
+- **It must fail open.** Any error, timeout, or missing binary ships the text the
+  agent already wrote. A prose check that can block a write is worse than any
+  dense paragraph.
+- **No shadow mode.** Ruled out — attn has one user, and spending a week logging
+  to answer a question is a week of waiting. Measuring offline against the
+  existing data and the real ticket table replaces it.
+- **Idle systems stay idle.** Nothing here may add recurring work. The pipeline
+  runs only when someone actually writes.
+- **The data stays out of the repo.** It is the user's private transcripts, and
+  this repository is public. It lives in a session scratchpad. Only the numbers
+  and the short excerpts above are committed.
+
+## Reproducing any of this
+
+The mining and experiment scripts live in the session scratchpad, not in the
+repo. Everything they produced is summarized above. The data files are
+`corpus_pure.jsonl` (17 hand-checked rejected/accepted pairs),
+`silent.jsonl.handlabel` (1,250 messages, 22 hand-checked complaints), and
+`tickets.jsonl` (136 real ticket texts, copied read-only from the production
+database).
+
+The only code in the repo is `internal/prosegate`: the instruction text, a
+tokenizer, a `Structure` counter that reports what a rewrite dropped, and a dead
+threshold check that should be deleted. Its `zz_*_test.go` files are uncommitted
+research scaffolding.

--- a/docs/plans/2026-08-12-plain-agent-prose-first-principles.md
+++ b/docs/plans/2026-08-12-plain-agent-prose-first-principles.md
@@ -6,8 +6,9 @@ This exists so someone can attack the problem fresh without repeating four days
 of dead ends, and without inheriting the framing that produced them.
 
 The attempt that generated these numbers is
-[2026-08-10-prose-density-gate.md](2026-08-10-prose-density-gate.md). None of it
-shipped. It is safe to throw away.
+[2026-08-10-prose-density-gate.md](2026-08-10-prose-density-gate.md). Its design
+is dead; that file now records the autopsy, in more detail than this one. No
+code from it shipped, and none needs reviving.
 
 ## The problem
 
@@ -103,8 +104,16 @@ Worth spelling out, because the obvious reading is wrong:
 ## What we know about the complaints
 
 Where the numbers come from: every agent message over 120 words that the user
-typed a reply to. That is 1,250 messages, pulled from 2,066 transcript files
-covering about a month. Only replies a human actually typed count — task
+typed a reply to, covering about a month. There were two pulls, hours apart, and
+the counts differ, so both are pinned here. The first walked 1,675 transcript
+files and kept 1,217 messages. The second walked 2,066 files, kept 1,250, and
+added the conversation each message was read in; it reuses the first pull's
+labels, matched by file and line. Tables that drop messages under 150 words sit
+on a subset of the first pull: 1,042 messages, of which 22 are complaints. The
+full pinning, including which table uses which label set, is in the
+[companion doc](2026-08-10-prose-density-gate.md#the-trigger-does-not-work).
+
+Only replies a human actually typed count — task
 notifications, teammate relays, and compaction summaries all arrive as user
 turns too, and they are full of words like "concise" that have nothing to do
 with the message before them.
@@ -291,7 +300,19 @@ repo. Everything they produced is summarized above. The data files are
 `tickets.jsonl` (136 real ticket texts, copied read-only from the production
 database).
 
-The only code in the repo is `internal/prosegate`: the instruction text, a
-tokenizer, a `Structure` counter that reports what a rewrite dropped, and a dead
-threshold check that should be deleted. Its `zz_*_test.go` files are uncommitted
-research scaffolding.
+**No prose code is in the repository, on `main` or anywhere else it would be
+found by looking.** Two generations exist and neither shipped:
+
+- **Generation 1** — a rule engine with density, hidden-verb, rhythm and
+  structure rules, accept/reject vocabulary files, and golden tests — sits
+  unmerged on the branch `feat/prose-check`, as `internal/prose` plus
+  `cmd/attn/prose.go`. The measurements above killed its design before it was
+  reviewed. Close the branch.
+- **Generation 2** — the six threshold checks, the rewrite instruction, the
+  one-shot refusal, and a structural counter — was never committed. It lived in
+  a session scratchpad and is gone. The only parts worth reviving are quoted in
+  full in this document: the instruction text above, and the idea of counting
+  code blocks, tables and links before and after a rewrite.
+
+So there is nothing here to delete and nothing to build on. Anyone starting
+fresh starts from the measurements, not from the code.


### PR DESCRIPTION
Agents write densely, and the user has to stop and ask for plain words by hand — about 22 times a month. This is the record of trying to fix that automatically, including everything that failed.

## What this adds

`docs/plans/2026-08-12-plain-agent-prose-first-principles.md` — a standalone problem statement, written to be read cold by someone with no prior context. It carries real rejected/accepted message pairs, every approach tried with its measurement, six framings nobody has tried, and the constraints any answer must respect.

`docs/plans/2026-08-10-prose-density-gate.md` — updated to record what killed the original design.

## The finding

**Nothing cheap predicts when a reader will ask for plainer words.** Measured against 1,250 real messages with 22 hand-checked complaints:

| approach | result (0.5 is a coin flip) |
| --- | --- |
| six surface measurements | AUC 0.44-0.56 |
| message shape | best 0.60; code blocks and tables run backwards |
| model judge scoring one message | 0.52-0.53 |
| judge shown the conversation first | 0.568 |
| words never seen earlier in the conversation | 0.49-0.50 |

The first attempt looked like it worked because it compared complained-about messages against the revisions that answered them — writing produced on best behaviour, right after a complaint. Limits set just above that fire on 85% of prose nobody objected to.

**Two things do work.** The rewrite instruction lands where the user's own revisions land (93% of cases). And comparing two versions both ways picks the accepted one 16 times out of 17 — while scoring a single message in isolation is a coin flip, and more reasoning effort makes the judge steadily worse, in both model families tested.

**The unfixed defect**: rewriting drops receipts. Numbers, `file.go:73` citations, session IDs, and hedges vanish in 37% of rewrites of real ticket text.

## Why docs only

No code ships. The gate this research was meant to produce does not exist, and the doc says the leftover scaffolding should be deleted. The measurements are the deliverable.

The underlying data stays out of the repo — it is private transcripts and this repository is public. Only the numbers and short excerpts are committed.

https://claude.ai/code/session_01LA95N1YPYEzBk1UWLPFogP