### PR TITLE
docs(plans): stop pointing the garden's prose quality at the dead gate

### DIFF
--- a/changelog.d/garden-prose-pointer.yaml
+++ b/changelog.d/garden-prose-pointer.yaml
@@ -1,0 +1,6 @@
+kind: internal
+area: docs
+change: >
+  The garden plan no longer hands prose quality for crown bodies and
+  notes to the prose density gate — that design died in calibration.
+  It now points at the first-principles record of what was measured.

--- a/docs/plans/2026-08-06-the-garden-vertical-slices.md
+++ b/docs/plans/2026-08-06-the-garden-vertical-slices.md
@@ -92,8 +92,9 @@ to fix.
   `attn seed notes <id>`"), with the full list pageable and filterable.
   A silent truncation here recreates the unread bulletin board this
   surface exists to replace. Prose quality for crown bodies and notes is
-  the [density gate](2026-08-10-prose-density-gate.md)'s job, not this
-  plan's. Live queries, bus change events, and revision-checked writes
+  an open problem outside this plan's scope — the gate designed for it
+  died in calibration; what was measured is in
+  [the first-principles record](2026-08-12-plain-agent-prose-first-principles.md). Live queries, bus change events, and revision-checked writes
   come free; schema can move fast while the shape settles. Single-writer
   invariants (one active tender) are enforced in daemon code, the
   `applyState` way — not by table constraints.

--- a/docs/plans/2026-08-06-the-garden-vertical-slices.md
+++ b/docs/plans/2026-08-06-the-garden-vertical-slices.md
@@ -94,8 +94,9 @@ to fix.
   surface exists to replace. Prose quality for crown bodies and notes is
   an open problem outside this plan's scope — the gate designed for it
   died in calibration; what was measured is in
-  [the first-principles record](2026-08-12-plain-agent-prose-first-principles.md). Live queries, bus change events, and revision-checked writes
-  come free; schema can move fast while the shape settles. Single-writer
+  [the first-principles record](2026-08-12-plain-agent-prose-first-principles.md).
+  Live queries, bus change events, and revision-checked writes come
+  free; schema can move fast while the shape settles. Single-writer
   invariants (one active tender) are enforced in daemon code, the
   `applyState` way — not by table constraints.
 - **One primitive.** A **plot** is a seed with children and execution


### PR DESCRIPTION
The garden slices plan handed prose quality for crown bodies and notes to the [prose density gate](docs/plans/2026-08-10-prose-density-gate.md): "Prose quality for crown bodies and notes is the density gate's job, not this plan's." That gate died in calibration — nothing cheap predicts when a reader will ask for plainer words (measured in #863) — so the sentence promised a design that will not ship.

One-sentence repoint: prose quality there is an open problem outside the garden plan's scope, with a link to the first-principles record (`2026-08-12-plain-agent-prose-first-principles.md`, landing in #863) for what was measured. If this merges before #863 the link dangles for the gap between the two; both are docs-only and close together.

No behavior changes; docs and changelog fragment only.

https://claude.ai/code/session_012Bu5dMFLdBfrEo4WmQkF53