### PR TITLE
fix(apps): charge the app that broke the shared runtime, not its neighbours

### DIFF
--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -954,12 +954,13 @@ export enum AppStatusMessageCmd {
 }
 
 export interface AppStatusResult {
-    app:         App;
-    invocations: number;
-    recent?:     InvocationElement[];
-    runtime?:    Runtime;
-    stall?:      Stall;
-    versions:    number;
+    app:              App;
+    invocations:      number;
+    recent?:          InvocationElement[];
+    recent_versions?: CurrentVersion[];
+    runtime?:         Runtime;
+    stall?:           Stall;
+    versions:         number;
     [property: string]: any;
 }
 
@@ -5243,12 +5244,13 @@ export interface AppSetEnabledResultObject {
 }
 
 export interface AppStatusResultObject {
-    app:         App;
-    invocations: number;
-    recent?:     InvocationElement[];
-    runtime?:    Runtime;
-    stall?:      Stall;
-    versions:    number;
+    app:              App;
+    invocations:      number;
+    recent?:          InvocationElement[];
+    recent_versions?: CurrentVersion[];
+    runtime?:         Runtime;
+    stall?:           Stall;
+    versions:         number;
     [property: string]: any;
 }
 
@@ -12113,6 +12115,7 @@ const typeMap: any = {
         { json: "app", js: "app", typ: r("App") },
         { json: "invocations", js: "invocations", typ: 0 },
         { json: "recent", js: "recent", typ: u(undefined, a(r("InvocationElement"))) },
+        { json: "recent_versions", js: "recent_versions", typ: u(undefined, a(r("CurrentVersion"))) },
         { json: "runtime", js: "runtime", typ: u(undefined, r("Runtime")) },
         { json: "stall", js: "stall", typ: u(undefined, r("Stall")) },
         { json: "versions", js: "versions", typ: 0 },
@@ -14728,6 +14731,7 @@ const typeMap: any = {
         { json: "app", js: "app", typ: r("App") },
         { json: "invocations", js: "invocations", typ: 0 },
         { json: "recent", js: "recent", typ: u(undefined, a(r("InvocationElement"))) },
+        { json: "recent_versions", js: "recent_versions", typ: u(undefined, a(r("CurrentVersion"))) },
         { json: "runtime", js: "runtime", typ: u(undefined, r("Runtime")) },
         { json: "stall", js: "stall", typ: u(undefined, r("Stall")) },
         { json: "versions", js: "versions", typ: 0 },

--- a/apphost/src/dispatch.ts
+++ b/apphost/src/dispatch.ts
@@ -170,12 +170,20 @@ export async function runDispatch(
   // later announcement from ever being written. This is the daemon's only witness
   // of which handler is on the event loop, and it needs it exactly when this
   // process has stopped answering everything else.
-  conn.notify("app_runtime.entered", { dispatch: params.dispatch, app: params.app })
+  //
+  // Both halves matter. Without the second, an entry outlives the handler and
+  // names it for a freeze it is no longer part of; the daemon would have to guess
+  // when a handler left, and the only signal it could guess from — the loop still
+  // turning — says nothing about a handler that yielded and never settled.
+  const scope = { dispatch: params.dispatch, app: params.app }
+  conn.notify("app_runtime.entered", scope)
   try {
     await handler(params.event, ctx)
     return { ok: true }
   } catch (err) {
     return { ok: false, error: describeFailure(err) }
+  } finally {
+    conn.notify("app_runtime.left", scope)
   }
 }
 

--- a/apphost/src/dispatch.ts
+++ b/apphost/src/dispatch.ts
@@ -55,6 +55,28 @@ type Handler = (event: DispatchParams["event"], ctx: unknown) => unknown
  */
 const modules = new Map<string, Promise<Record<string, Handler>>>()
 
+/**
+ * Which app each loaded bundle belongs to. It is how an error that escaped every
+ * handler is traced back to whose code it came from: a rejection can surface long
+ * after the dispatch that started it returned, so "which app is running" names an
+ * innocent, while the stack still carries the content-addressed bundle path.
+ */
+const appByArtifact = new Map<string, string>()
+
+/**
+ * The app whose bundle appears in this stack, if any.
+ *
+ * Empty when nothing matches — a rejection from the host's own code, or a reason
+ * that is not an Error and carries no stack at all. Nothing is charged then;
+ * guessing is worse than not knowing.
+ */
+export function appForStack(stack: string): string {
+  for (const [artifact, app] of appByArtifact) {
+    if (stack.includes(artifact)) return app
+  }
+  return ""
+}
+
 async function loadHandlers(artifact: string): Promise<Record<string, Handler>> {
   let pending = modules.get(artifact)
   if (!pending) {
@@ -116,6 +138,8 @@ export async function runDispatch(
   conn: RpcConnection,
   params: DispatchParams,
 ): Promise<DispatchResult> {
+  appByArtifact.set(params.artifact, params.app)
+
   let handlers: Record<string, Handler>
   try {
     handlers = await loadHandlers(params.artifact)
@@ -142,6 +166,11 @@ export async function runDispatch(
     version: params.version_id,
     collections: collectionsFor(conn, params.dispatch, params.collections),
   }
+  // Announced before the call, because a handler that never yields would keep any
+  // later announcement from ever being written. This is the daemon's only witness
+  // of which handler is on the event loop, and it needs it exactly when this
+  // process has stopped answering everything else.
+  conn.notify("app_runtime.entered", { dispatch: params.dispatch, app: params.app })
   try {
     await handler(params.event, ctx)
     return { ok: true }

--- a/apphost/src/index.ts
+++ b/apphost/src/index.ts
@@ -3,9 +3,10 @@
 // One supervised Bun process runs the handlers of every installed app. It is not
 // a sandbox and does not pretend to be one: isolation between apps is failure
 // attribution, not an OS boundary. What it owes the daemon is an honest answer
-// per dispatch — this app's handler threw, or it did not — because a whole-process
-// death cannot name a culprit and must never be charged to whichever app happened
-// to be running.
+// per dispatch — this app's handler threw, or it did not — and, when an error
+// escapes every handler and takes the process down with it, the name of the app
+// whose code it came from. Never whichever app happened to be running: see
+// installCrashReporter.
 //
 // It ships as a `bun build --compile` standalone binary. The Bun runtime is inside
 // the executable, so a daemon launched by the macOS app needs no PATH resolution
@@ -16,14 +17,14 @@
 
 import { AsyncLocalStorage } from "node:async_hooks"
 import { RpcConnection, RPC_METHOD_NOT_FOUND, describe, type RpcRequest } from "./rpc.ts"
-import { runDispatch, type DispatchParams } from "./dispatch.ts"
+import { appForStack, runDispatch, type DispatchParams } from "./dispatch.ts"
 
 /**
  * The runtime contract this host speaks. The daemon refuses a host that does not
  * match, because a version skew between the daemon and a binary inside an old app
  * bundle is exactly the case a silent mismatch would turn into wrong behavior.
  */
-const APP_RUNTIME_API_VERSION = 1
+const APP_RUNTIME_API_VERSION = 2
 
 /**
  * Which app a line of output came from.
@@ -68,6 +69,60 @@ function render(value: unknown): string {
   } catch {
     return String(value)
   }
+}
+
+/**
+ * How long the daemon gets to acknowledge a crash report before the process
+ * exits anyway.
+ *
+ * A tripwire past a localhost round trip on a socket that is already open and
+ * whose peer answers this method with a constant. The same shape measured on a
+ * live daemon — its liveness ping — costs 344–416µs, so a second is ~2,500× the
+ * real cost and only a daemon that is itself in trouble reaches it. The wait is
+ * bounded because the exit must not be conditional on the daemon: an unreported
+ * crash costs the culprit a strike, a hung exit costs every app the runtime.
+ */
+const CRASH_REPORT_WAIT_MS = 1000
+
+/**
+ * Reports the app whose code took the process down, then exits.
+ *
+ * A rejection nobody handled kills the sidecar for every app, so the app that
+ * caused it is precisely the one the auto-disable rule exists to stop — and
+ * until this existed it was the one thing structurally exempt from it, because a
+ * dead process was charged to nobody.
+ *
+ * The stack is the only honest witness. Bun offers no other: async_hooks
+ * createHook fires no callbacks at all here, and AsyncLocalStorage.getStore() is
+ * undefined inside these handlers, both measured. It is also the *right* witness
+ * — a floating promise rejects long after the dispatch that started it returned,
+ * so "which app is running" routinely names an innocent, while the bundle path
+ * in the stack names the author.
+ *
+ * Nothing before the daemon connection is covered, and nothing needs to be: no
+ * app code has loaded yet, so a crash there is a startup failure the supervisor
+ * already owns.
+ */
+function installCrashReporter(connection: RpcConnection): void {
+  let crashing = false
+  const crash = (kind: string, reason: unknown): void => {
+    // A second crash while reporting the first must not restart the wait.
+    if (crashing) return
+    crashing = true
+
+    const error = render(reason)
+    const app = appForStack(error)
+    process.stderr.write(
+      `${tag(app || undefined)}unhandled ${kind}${app ? ` in app ${app}` : ""}, stopping the app runtime: ${error}\n`,
+    )
+
+    const reported = connection.call("app_runtime.crashed", { app, kind, error }).catch(() => {})
+    const bounded = new Promise((resolve) => setTimeout(resolve, CRASH_REPORT_WAIT_MS))
+    void Promise.race([reported, bounded]).then(() => process.exit(1))
+  }
+
+  process.on("unhandledRejection", (reason) => crash("unhandledRejection", reason))
+  process.on("uncaughtException", (err) => crash("uncaughtException", err))
 }
 
 /** Says why the process cannot start, then stops. The supervisor restarts it. */
@@ -133,6 +188,8 @@ async function main(): Promise<void> {
   } catch (err) {
     fatal(`the daemon refused this app runtime: ${describe(err)}`)
   }
+
+  installCrashReporter(connection)
 
   console.log(`app runtime ready (generation ${generation}, pid ${process.pid})`)
 

--- a/apphost/src/rpc.ts
+++ b/apphost/src/rpc.ts
@@ -120,6 +120,17 @@ export class RpcConnection {
     })
   }
 
+  /**
+   * Tells the daemon something without asking for an answer.
+   *
+   * A closed socket is not an error here: the daemon is what would have listened,
+   * and a notification exists precisely because nothing depends on it arriving.
+   */
+  notify(method: string, params: unknown): void {
+    if (this.closed) return
+    this.socket.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`)
+  }
+
   respond(id: unknown, result: unknown): void {
     this.write({ jsonrpc: "2.0", id, result })
   }

--- a/changelog.d/app-status-lists-version-ids.yaml
+++ b/changelog.d/app-status-lists-version-ids.yaml
@@ -1,0 +1,14 @@
+kind: fixed
+area: apps
+change: >
+  `attn app status <name>` now lists the app's recent version ids, marking the
+  one currently serving. `attn app rollback` takes one of those ids and its
+  refusals name them, but nothing had ever printed the list — status showed only
+  how many versions existed, so a wrong id sent you to a command that could not
+  answer. The newest ten are shown; the count beside them still says how many
+  there are in total. The runtime line no longer claims nobody has needed the
+  runtime yet when the truth is that it could not be started at all — it now
+  points at `attn app runtime status`, which is where that difference lives.
+symptom: >
+  `attn app rollback <name> <id>` told you to run `attn app status` to find the
+  version ids, and `attn app status` never showed them.

--- a/changelog.d/apps-blame-the-app-that-broke-the-runtime.yaml
+++ b/changelog.d/apps-blame-the-app-that-broke-the-runtime.yaml
@@ -1,0 +1,25 @@
+kind: fixed
+area: apps
+change: >
+  When one app breaks the shared runtime every app's handlers run in, attn now
+  works out which app it was instead of blaming whoever was waiting. Two ways it
+  used to get this wrong. A handler that blocks without ever yielding freezes
+  the runtime for everybody, and the apps stuck behind it were each recorded as
+  having taken too long — enough of that and an app was switched off over a
+  handler that was never called. attn now asks the runtime whether it is still
+  answering: if it is, the app whose handler was running really is the one that
+  hung; if it is not, the runtime says which handler it is stuck inside, and
+  that app is charged while everyone else is recorded as having lost the
+  runtime rather than as having failed. The other way was an error an app
+  started and never
+  caught, which takes the whole runtime down. That used to be charged to nobody
+  at all, so the one thing an app can do that stops every other app was the one
+  thing it was never switched off for. The runtime now reads the app's name off
+  the failure before it exits and reports it, and an app that does it three
+  times in fifteen minutes is disabled with a notification saying so —
+  including when the failure surfaces long after that app's own work finished,
+  which is the case that made guessing wrong in the first place. A failure that
+  names no app is still charged to nobody.
+symptom: >
+  An app was disabled, or reported as timing out, because a different app was
+  misbehaving — and the app actually causing the trouble kept running.

--- a/changelog.d/hub-revives-remote-before-shipping-sidecar.yaml
+++ b/changelog.d/hub-revives-remote-before-shipping-sidecar.yaml
@@ -1,0 +1,22 @@
+kind: fixed
+area: hub
+change: >
+  A remote endpoint whose daemon had stopped now comes back even on a slow
+  connection. Getting a remote ready and giving it the shared app runtime were
+  sharing one 60-second budget, and the runtime — roughly 93MB, half again the
+  size of the attn binary — was sent first. On a link slower than about
+  20 Mbit/s the transfer used the whole budget, so the step that starts the
+  remote's daemon was never reached: the endpoint retried about every 90
+  seconds and never recovered, leaving a partial copy behind in the remote's
+  /tmp each time. The daemon is now started first, the runtime is sent
+  afterwards on a budget of its own, and a runtime that cannot be sent is
+  reported without failing the sync — that remote still runs sessions. Both
+  budgets are now sized for a 5 Mbit/s link rather than for a fast one. An
+  interrupted upload cleans up after itself, a copy that arrives short is
+  refused instead of installed, and a runtime that replaces one already running
+  restarts just that runtime instead of the whole remote daemon.
+symptom: >
+  A remote endpoint stayed stuck on "bootstrapping" or kept reporting an error
+  and never reconnected, most often after its daemon had been stopped or the
+  machine rebooted, and its /tmp slowly filled with attn-app-runtime temp
+  files.

--- a/cmd/attn/app.go
+++ b/cmd/attn/app.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/victorarias/attn/internal/appbuild"
 	"github.com/victorarias/attn/internal/apps"
 	"github.com/victorarias/attn/internal/client"
 	"github.com/victorarias/attn/internal/config"
@@ -110,10 +111,10 @@ commands:
         how far behind the event log its consumer is.
 
   status <name> [--json]
-        one app in full — its current version, its bus consumer, how many
-        versions and invocations it has recorded, and its most recent runs.
-        Reports only what exists: an app with no consumer says so rather than
-        showing a default.
+        one app in full — its current version, its bus consumer, the ids of its
+        recent versions (what rollback takes), and its most recent runs. Reports
+        only what exists: an app with no consumer says so rather than showing a
+        default.
 
   enable <name>
         resume delivery to the app, from wherever its consumer's cursor stands.
@@ -288,6 +289,15 @@ func runAppStatus(args []string) {
 		fmt.Printf("              disables itself at %s unless it succeeds first\n", result.Stall.DisablesAt)
 	}
 	fmt.Printf("  history:    %d version(s), %d invocation(s)\n", result.Versions, result.Invocations)
+	if len(result.RecentVersions) > 0 {
+		// The ids, because `attn app rollback` takes one and its refusals name
+		// them. A count alone leaves the reader with no way to find a target.
+		fmt.Printf("  versions:   %s\n", versionIDList(result.RecentVersions, app.CurrentVersion))
+		if result.Versions > len(result.RecentVersions) {
+			fmt.Printf("              newest %d of %d; older ones are named by a rollback refusal\n",
+				len(result.RecentVersions), result.Versions)
+		}
+	}
 	if len(result.Recent) == 0 {
 		fmt.Println("  recent:     no invocations recorded")
 		return
@@ -331,14 +341,30 @@ func indentBlock(prefix, text string) string {
 	return b.String()
 }
 
-// appRuntimeNeverStarted is what a daemon that has never started a runtime says.
+// versionIDList is the line `attn app rollback` sends people looking for: the
+// ids, marked so the one serving is obvious.
+func versionIDList(versions []protocol.AppVersionInfo, current *protocol.AppVersionInfo) string {
+	parts := make([]string, 0, len(versions))
+	for _, v := range versions {
+		label := fmt.Sprintf("%d (%s)", v.ID, appbuild.ShortHash(v.ContentHash))
+		if current != nil && current.ID == v.ID {
+			label += " ← serving"
+		}
+		parts = append(parts, label)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// appRuntimeNeverStarted is what a daemon with no supervised runtime says.
 //
-// "no *enabled* app", because a disabled app is never due a fact: a daemon whose
-// every app is switched off will never start a runtime, and the sentence has to
-// read as the settled state it is rather than as something that has not happened
-// yet. `attn app runtime status` carries the enabled count in the same answer, so
-// a reader who wants the number has it.
-const appRuntimeNeverStarted = "not started — no enabled app has been due a fact since this daemon came up"
+// It does not name a cause, because from here the two are indistinguishable: a
+// daemon whose apps are all quiet never starts a runtime, and a daemon whose
+// host binary is missing never gets far enough to supervise one — the resolve
+// fails before the supervisor is touched, so both arrive here with nothing to
+// report. Claiming the first would be a lie exactly when an app is failing every
+// dispatch. `attn app runtime status` resolves the binary itself and is where
+// the difference lives.
+const appRuntimeNeverStarted = "not started — nothing has run one on this daemon yet; `attn app runtime status` says whether it can be started"
 
 // appRuntimeCell says where this app's handlers actually run. It is one line
 // because `attn app runtime status` is the full picture; what belongs here is

--- a/cmd/attn/app_runtime_test.go
+++ b/cmd/attn/app_runtime_test.go
@@ -32,11 +32,16 @@ func TestRuntimeCellDistinguishesNeverStartedFromParked(t *testing.T) {
 	if !strings.Contains(got, "not started") {
 		t.Fatalf("a runtime that has never run renders as %q", got)
 	}
-	// A disabled app is never due a fact, so a daemon whose apps are all off will
-	// never start a runtime. Saying "no app has been due a fact" reads as
-	// not-yet when it is in fact settled.
-	if !strings.Contains(got, "no enabled app") {
-		t.Fatalf("the never-started sentence is not honest about disabled apps: %q", got)
+	// It must not claim a cause. A daemon whose apps are quiet and a daemon whose
+	// runtime binary is missing both arrive here with no snapshot — the host is
+	// resolved before the supervisor is touched — so naming the first would be a
+	// lie exactly when every dispatch is failing. It points at the surface that
+	// can tell them apart instead.
+	if !strings.Contains(got, "attn app runtime status") {
+		t.Fatalf("the never-started sentence does not point at what can answer: %q", got)
+	}
+	if strings.Contains(got, "due a fact") {
+		t.Fatalf("the never-started sentence still claims a cause it cannot know: %q", got)
 	}
 	parked := appRuntimeCell(&protocol.AppRuntimeInfo{Phase: "parked", Generation: 4})
 	if !strings.Contains(parked, "PARKED") || !strings.Contains(parked, "attn app runtime restart") {

--- a/docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md
+++ b/docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md
@@ -187,10 +187,29 @@ process-per-app (apps are numerous and mostly idle; a process each is memory
 the platform pays all day; the sidecar is one ~tens-of-MB Bun process).
 Isolation between apps is handler-level failure attribution, not OS
 boundaries: an app that throws feeds its own auto-disable counter and cannot
-corrupt the daemon. A sidecar-wide crash is a *runtime* failure class handled
-by supervision, never attributed to an app — a whole-process death cannot
-name a culprit, and blaming whichever app was running would disable
-innocents.
+corrupt the daemon.
+
+> **Overturned 2026-08-12.** This plan ruled that a sidecar-wide crash is a
+> *runtime* failure class handled by supervision and never attributed to an
+> app, because "a whole-process death cannot name a culprit, and blaming
+> whichever app was running would disable innocents."
+>
+> The second half stands and is why the first half was wrong. Taking the
+> runtime down is the worst thing an app can do — it stops every other app —
+> and the rule made that one act the only one structurally exempt from
+> auto-disable. The premise turned out to be false: the host *can* name a
+> culprit without guessing who was running, by matching the loaded bundles'
+> content-addressed paths against the stack of the error that killed it.
+> A floating promise rejects long after its dispatch returned, so the stack is
+> not only available, it is the only honest witness — measured in Bun,
+> `AsyncLocalStorage.getStore()` is undefined in a crash handler and
+> `async_hooks.createHook` fires no callbacks at all.
+>
+> The host now reports the named app before it exits and the daemon charges it
+> (`appCrashStrikes`); a crash whose stack names nobody is still charged to
+> nobody, which is the original rule's real content. See
+> `installCrashReporter` in `apphost/src/index.ts` and
+> `docs/plans/2026-08-12-a4-review-fixes.md`.
 
 The supervisor extracts from `internal/daemon/plugin_supervisor.go` into
 `internal/supervise`, scoped to what its two consumers need today:
@@ -512,8 +531,9 @@ recovery drain, bare-rollback trap):
   `attn` binary so hub-managed remotes can run apps. *Shipped:* the host is
   built for the remote's platform from the checkout (or downloaded from the
   release, which now publishes `attn-app-runtime-linux-{amd64,arm64}`),
-  transferred only when its content hash differs — it is ~90MB and endpoints
-  sync on a timer — and named per profile on the remote, because
+  transferred only when its content hash differs — it is ~90MB and a bootstrap
+  runs every time an endpoint reconnects — and named per profile on the remote,
+  because
   profile-isolated daemons share one `~/.local/bin` and one shared file name
   would have the newest sync replace another profile's runtime.
 - **Bare rollback: previously-serving.** `attn app rollback <name>` without

--- a/docs/plans/2026-08-12-a4-review-fixes.md
+++ b/docs/plans/2026-08-12-a4-review-fixes.md
@@ -125,25 +125,31 @@ the earliest dispatch therefore charges the best-behaved app in the common case,
 which is a worse failure than charging everyone.
 
 The daemon cannot work this out; only the host knows which handler it called. So
-the host announces each entry on the socket immediately before invoking the
-handler (`app_runtime.entered`, a notification — nothing to answer), and the
-culprit is the most recent entry with no answer yet. An entry is dropped when its
-dispatch is answered, when a ping answers, or when the process dies.
+the host announces each handler entering and leaving on the socket
+(`app_runtime.entered` / `app_runtime.left`, notifications — nothing to answer),
+entry announced immediately *before* the call, and the culprit is the most recent
+entry that has not left.
 
-An answered ping does not prove no handler is on the loop — a yielded handler
-that never settles is still there. It proves nothing is *holding* it, which is
-what makes the wipe safe: attribution is moot while the loop turns. The cost is
-one corner. If a handler yields, has its entry wiped by a ping, and only then
-resumes and spins, there is no entry naming it and attribution falls back to
-charging whoever timed out, until some new dispatch enters and is announced.
+Both halves are load-bearing. A first pass sent only `entered` and dropped
+entries when a liveness ping answered, which cost two corners: a yielded handler
+that came back and spun was named by nothing, and a stale entry outlived its
+handler. Both came from the same mistake — inferring that a handler left. The
+only thing the daemon can infer that from is the loop still turning, and a
+handler that yielded and never settled is on a turning loop, so the inference is
+wrong exactly for the handler that has to be named. The ledger is now dropped
+only on facts: an entry when the host says that handler left, all of them when
+the process dies. The price is one extra frame per dispatch, against a dispatch
+rate bounded by the bus fact rate.
 
 The receipt this depends on: a Bun socket write issued immediately before a
 synchronous spin reaches the peer at once rather than queueing behind it —
 measured with a 5s spin, the frame arrived ~1ms after the write and ~5s before
-the spin ended. Without that, the announcement would arrive too late to be the
-witness, and the design would not work at all.
+the spin ended. It has to be measured across two processes; a single-process
+probe cannot show it, because one loop cannot read what the spin blocks. Without
+that, the announcement would arrive too late to be the witness, and the design
+would not work at all.
 
-`appRuntimeAPIVersion` goes to 2: the daemon↔host wire gained a frame, and the
+`appRuntimeAPIVersion` goes to 2: the daemon↔host wire gained frames, and the
 two are version-checked at hello because they ship together.
 
 ## 3 — one app's unhandled rejection kills the sidecar for everyone (medium)

--- a/docs/plans/2026-08-12-a4-review-fixes.md
+++ b/docs/plans/2026-08-12-a4-review-fixes.md
@@ -62,8 +62,10 @@ Generosity costs nothing on the broken path: every ssh here carries
 `ConnectTimeout=10`, so an unreachable remote fails in seconds regardless.
 
 `TestRemoteBudgetsCoverTheArtifactsTheyCarry` fails if either budget stops
-covering its artifact, so growing the sidecar again cannot silently re-create
-this bug.
+covering the artifact sizes recorded in it. It does not measure the artifacts, so
+it does not notice one growing by itself — the tripwire is that a sidecar which
+outgrows its budget has to update those constants to pass, and updating them is
+when someone reads the arithmetic.
 
 ### Carried with it
 
@@ -126,8 +128,14 @@ The daemon cannot work this out; only the host knows which handler it called. So
 the host announces each entry on the socket immediately before invoking the
 handler (`app_runtime.entered`, a notification — nothing to answer), and the
 culprit is the most recent entry with no answer yet. An entry is dropped when its
-dispatch is answered, when a ping answers (the loop is turning, so nothing is on
-it), or when the process dies.
+dispatch is answered, when a ping answers, or when the process dies.
+
+An answered ping does not prove no handler is on the loop — a yielded handler
+that never settles is still there. It proves nothing is *holding* it, which is
+what makes the wipe safe: attribution is moot while the loop turns. The cost is
+one corner. If a handler yields, has its entry wiped by a ping, and only then
+resumes and spins, there is no entry naming it and attribution falls back to
+charging whoever timed out, until some new dispatch enters and is announced.
 
 The receipt this depends on: a Bun socket write issued immediately before a
 synchronous spin reaches the peer at once rather than queueing behind it —

--- a/docs/plans/2026-08-12-a4-review-fixes.md
+++ b/docs/plans/2026-08-12-a4-review-fixes.md
@@ -1,0 +1,150 @@
+# A4 landing-arc review fixes
+
+An adversarial review of the A4 app-registry/runtime arc as landed on main
+(#843 `4fbd6f71`, #858 `cc49fd95`, #859 `b873da05`) produced 19 candidate
+findings; 9 died against the code. This is what we do about the rest.
+
+The review report itself — every confirmed finding with its evidence, and the
+refutations, which are the more useful half — is the `a4-arc-review.md` artifact
+on ticket `journey-review`. This doc is only the disposition.
+
+Findings land on `epic/a4-review-fixes` in three PRs, because two of them change
+when an app gets auto-disabled and that is existing behavior worth reviewing as
+one diff.
+
+## 1 — the hub starved the step that revives a remote (high)
+
+`EnsureRemoteReady` shipped the ~93.7MB app runtime host *before*
+`ensureRemoteDaemonRunning`, both out of one 60-second budget the manager
+imposed at both call sites — including the one taken when the remote's daemon is
+down. On a link under ~20 Mbit/s the upload consumed the budget and execution
+never reached the revive, so the endpoint loop retried roughly every 90 seconds
+forever. Each attempt left up to 93.7MB in the remote's `/tmp`: the staging name
+carries pid+UnixNano so retries accumulate rather than overwrite, there was no
+cleanup on any error path, and `/tmp` is tmpfs on many systemd distros.
+
+A regression: before #859 a down remote whose binary already matched went
+straight to starting its daemon.
+
+**Fix.** Two phases, in the order that matters, each with its own budget:
+
+- `makeRemoteReady` — platform, versions, the attn binary, enrollment, daemon
+  start and its readiness wait. This is everything the remote needs to host
+  sessions.
+- `shipRemoteAppRuntime` — the sidecar, content-gated as before. It runs only
+  after the daemon is up, and its failure is reported rather than returned,
+  because a remote without a sidecar still runs sessions.
+
+The manager's blanket 60s is gone; the phases own their deadlines, since one
+number could only ever be right for one of them.
+
+### The receipts behind the two budgets
+
+Sized as tripwires past the slowest link anyone would sync a remote over —
+5 Mbit/s, a bad tether — not around a measured happy path. The previous 60s was
+sized for a ~40MB payload and #859 grew it to ~152.6MB without moving it, which
+is what made a healthy case reach it.
+
+| term | measured | at 5 Mbit/s |
+| --- | --- | --- |
+| attn binary (`attn-linux-arm64`) | 58,934,608 B | 94s |
+| app runtime host (`linux_arm64`) | 93,694,096 B | 150s |
+| daemon readiness wait | ≤ 35s (`remoteDaemonReadyTimeout`) | — |
+| sha256 of the runtime, local | 0.17s | — |
+| sha256 of the runtime, remote | 0.38s | — |
+| `bun build --compile` of the runtime | 0.13s | — |
+| bare ssh round trip (local VM) | 0.03s | — |
+
+`remoteReadyBudget = 180s` (94 + 35 + round trips). `appRuntimeShipBudget =
+300s` (150 + hashing + install + a possible runtime restart, generously).
+
+Generosity costs nothing on the broken path: every ssh here carries
+`ConnectTimeout=10`, so an unreachable remote fails in seconds regardless.
+
+`TestRemoteBudgetsCoverTheArtifactsTheyCarry` fails if either budget stops
+covering its artifact, so growing the sidecar again cannot silently re-create
+this bug.
+
+### Carried with it
+
+- **The staging file is removed on every path out**, not only after a successful
+  install.
+- **A short upload is refused rather than installed.** ssh reports the far end's
+  exit status, which says the shell ran, not that every byte arrived. The `wc -c`
+  probe already existed and was only being logged; it is now compared.
+- **A replaced sidecar bounces the sidecar, not the daemon.** `binariesUpdated`
+  used to fold the runtime in and restart the whole remote daemon. The runtime
+  is asked whether it is running and restarted only if so — starting it here
+  would put a Bun process on a remote that may host no enabled app at all.
+
+### What the OrbStack VM cannot witness
+
+The local VM transfers 90MB in 0.24s (~3 Gbit/s), so it can prove the path works
+and can never reproduce the failure. The ordering and budget-independence
+properties are therefore unit-tested against the phase seam, and the live run
+covers the real transfer, the cleanup, and the short-copy refusal.
+
+## 2 — the shared runtime blames the wrong app (medium, PR 2)
+
+A non-yielding synchronous handler in one app blocks the Bun event loop for
+every app. The 60s dispatch timeout then fires for apps whose handler was never
+reached, `noteAppFailure` charges them, and the 15-minute stall clock
+auto-disables innocent apps with a notification telling the user to fix a
+handler that never ran.
+
+`app.runtime.ping` was built for exactly this — "a liveness answer the daemon
+can ask for without running app code" — and has zero callers in Go.
+
+## 3 — one app's unhandled rejection kills the sidecar for everyone (medium, PR 2)
+
+No `unhandledRejection`/`uncaughtException` handler exists under `apphost/src`,
+and `dispatch.ts` wraps only the awaited frame. A floating rejection answers
+`{ok:true}`, then takes the process down for every app. Because a sidecar-wide
+crash is deliberately never attributed to an app — the ruling in the A4 plan
+doc — nothing is ever charged, so the one app the auto-disable rule exists to
+stop is structurally exempt from it.
+
+The daemon-side non-attribution stays; the fix belongs in the host, which knows
+which app's frame was in flight.
+
+## 4 — papercuts (PR 3)
+
+- `attn app status` prints "runtime: not started — no enabled app has been due a
+  fact since this daemon came up" on a daemon where the binary is missing and
+  every dispatch is failing. False on both halves.
+- `attn app rollback <name> <bad>` points at `attn app status <name>` to list
+  version ids. It never lists them, and there is no `attn app versions`. The
+  daemon's own refusals already carry the list.
+- Four comments that describe something the code does not do (the runtime log's
+  bound, what registers a consumer, when `declareAppCollections` runs, whose job
+  collection declaration is).
+
+## Deferred, with the reason
+
+- **`apply` answers Ok when post-flip consumer wiring failed.** A real
+  stated-contract seam — `app_apply.go` promises the reply means the new version
+  is already serving, and `registerAppConsumer`'s error is only logged. Left
+  alone: the only non-store error on that path is a Marshal→Unmarshal round trip
+  of the same struct, the state is visible as "consumer: none" in `attn app
+  status`, and it self-heals on re-apply or restart. The honest fix is a warning
+  field on `AppApplyResult`, which is a protocol bump; returning an error would
+  be worse, because the version is committed and serving by then.
+- **The sidecar's module cache grows per applied version.** Measured ~30KB per
+  version for scaffold-shaped bundles — 500 `attn app dev` saves is ~15MB — and
+  `attn app runtime restart` reclaims it. Steady state grows zero. No receipt for
+  harm.
+- **The unsuffixed sidecar fallback.** Deliberate and tested: a checkout's
+  `./attn` serves whatever profile is exported. Only the hub's copy about it was
+  wrong (it promised apps park when they may instead run another profile's
+  host), and that is fixed with the wording.
+- **No `ControlMaster` on the hub's ssh calls.** One bootstrap opens roughly ten
+  separate connections, each paying TCP+KEX+auth and an `sh -lc` login shell,
+  and the readiness poll adds one per probe. Worth doing, unrelated to these
+  findings, and it needs a socket path and its cleanup.
+
+## Out of scope, verified, not ours to fix here
+
+Both predate this arc and #859 explicitly declined to repeat the scheme:
+`~/.attn/remotes/binaries` is 2.1GB across 63 per-build directories with nothing
+trimming it, and `~/.attn/workers` is 11G across 1,369 logs with a single 2.9GB
+file.

--- a/docs/plans/2026-08-12-a4-review-fixes.md
+++ b/docs/plans/2026-08-12-a4-review-fixes.md
@@ -8,9 +8,9 @@ The review report itself — every confirmed finding with its evidence, and the
 refutations, which are the more useful half — is the `a4-arc-review.md` artifact
 on ticket `journey-review`. This doc is only the disposition.
 
-Findings land on `epic/a4-review-fixes` in three PRs, because two of them change
-when an app gets auto-disabled and that is existing behavior worth reviewing as
-one diff.
+Everything lands in one PR to `main`. Two of these change when an app gets
+auto-disabled, which is existing behavior, and splitting them across an epic
+would have meant reviewing the same diff twice.
 
 ## 1 — the hub starved the step that revives a remote (high)
 
@@ -84,7 +84,7 @@ and can never reproduce the failure. The ordering and budget-independence
 properties are therefore unit-tested against the phase seam, and the live run
 covers the real transfer, the cleanup, and the short-copy refusal.
 
-## 2 — the shared runtime blames the wrong app (medium, PR 2)
+## 2 — the shared runtime blames the wrong app (medium)
 
 A non-yielding synchronous handler in one app blocks the Bun event loop for
 every app. The 60s dispatch timeout then fires for apps whose handler was never
@@ -93,9 +93,52 @@ auto-disables innocent apps with a notification telling the user to fix a
 handler that never ran.
 
 `app.runtime.ping` was built for exactly this — "a liveness answer the daemon
-can ask for without running app code" — and has zero callers in Go.
+can ask for without running app code" — and had zero callers in Go.
 
-## 3 — one app's unhandled rejection kills the sidecar for everyone (medium, PR 2)
+**Fix.** A dispatch that hits its timeout now asks before it charges anyone:
+
+- the ping answers → the loop is turning, nothing is in this app's way, and its
+  own handler is what did not return. Charged as before.
+- the ping is silent → the loop is frozen. The handler holding it is charged;
+  everyone else is recorded as a runtime failure with its clock cleared, and
+  their error names the culprit so the reader goes and looks at the right code.
+
+`appRuntimePingWait = 2s` is a tripwire past a localhost round trip measured at
+344µs and 416µs on a live daemon — ~5,000× — and is only ever spent on a dispatch
+that has already burned its whole timeout, so generosity costs nothing that was
+not already lost.
+
+### Which handler is holding the loop is the host's to say
+
+The first build of this answered "the app that entered first", read off the
+daemon's own dispatch order. Live verification falsified it. Three apps were
+dispatched into a runtime frozen by `hog`, a 120s synchronous spin; the daemon
+charged `bystander`, whose handler is `await ctx.collections.seen.put(...)` — the
+documented shape — and let `hog` off with a runtime failure.
+
+Dispatch order is not the order handlers hold the loop. A handler that awaits an
+attn API yields immediately, so it is still unanswered when a spinner dispatched
+after it freezes everything, including that first handler's own reply. Blaming
+the earliest dispatch therefore charges the best-behaved app in the common case,
+which is a worse failure than charging everyone.
+
+The daemon cannot work this out; only the host knows which handler it called. So
+the host announces each entry on the socket immediately before invoking the
+handler (`app_runtime.entered`, a notification — nothing to answer), and the
+culprit is the most recent entry with no answer yet. An entry is dropped when its
+dispatch is answered, when a ping answers (the loop is turning, so nothing is on
+it), or when the process dies.
+
+The receipt this depends on: a Bun socket write issued immediately before a
+synchronous spin reaches the peer at once rather than queueing behind it —
+measured with a 5s spin, the frame arrived ~1ms after the write and ~5s before
+the spin ended. Without that, the announcement would arrive too late to be the
+witness, and the design would not work at all.
+
+`appRuntimeAPIVersion` goes to 2: the daemon↔host wire gained a frame, and the
+two are version-checked at hello because they ship together.
+
+## 3 — one app's unhandled rejection kills the sidecar for everyone (medium)
 
 No `unhandledRejection`/`uncaughtException` handler exists under `apphost/src`,
 and `dispatch.ts` wraps only the awaited frame. A floating rejection answers
@@ -104,20 +147,59 @@ crash is deliberately never attributed to an app — the ruling in the A4 plan
 doc — nothing is ever charged, so the one app the auto-disable rule exists to
 stop is structurally exempt from it.
 
-The daemon-side non-attribution stays; the fix belongs in the host, which knows
-which app's frame was in flight.
+**Fix, and a ruling overturned.** The plan's premise — "a whole-process death
+cannot name a culprit" — is false, and its conclusion made the worst thing an
+app can do the one thing it could never be disabled for. The reversal is
+recorded in the A4 plan doc beside the original ruling.
 
-## 4 — papercuts (PR 3)
+The host installs `unhandledRejection` and `uncaughtException` handlers, names
+the app by matching the loaded bundles' content-addressed paths against the
+error's stack, reports it to the daemon and then exits. The daemon counts
+strikes: `appCrashStrikes = 3` inside `appCrashWindow` (= `appAutoDisableStall`,
+so the auto-disable rule keeps one duration rather than two) disables the app
+through the same three effects as a stall.
 
-- `attn app status` prints "runtime: not started — no enabled app has been due a
-  fact since this daemon came up" on a daemon where the binary is missing and
-  every dispatch is failing. False on both halves.
-- `attn app rollback <name> <bad>` points at `attn app status <name>` to list
-  version ids. It never lists them, and there is no `attn app versions`. The
-  daemon's own refusals already carry the list.
-- Four comments that describe something the code does not do (the runtime log's
+Why the stack and not who was running: a floating promise rejects long after its
+dispatch returned, so "which app is running" routinely names an innocent —
+reproduced with app A's stray rejection surfacing while app B was mid-handler.
+Bun offers nothing else. Measured: `AsyncLocalStorage.getStore()` is `undefined`
+inside both handlers, and `async_hooks.createHook` fires no callbacks at all
+(`init types seen: {}`). The stack does carry the bundle path. A crash whose
+stack names no app is charged to nobody, which is the original ruling's real
+content and survives.
+
+Why three: supervise parks the whole sidecar after `DefaultGiveUpAfter` (10)
+restarts with no stability window — roughly two to three minutes of
+crash-looping — and every app losing its runtime is the harm being prevented, so
+the culprit has to go first. Above one, because a single crash can be a machine
+event whose stack merely passes through an app's bundle.
+`TestCrashStrikesFireBeforeTheSupervisorParksTheRuntime` fails if that ordering
+is ever broken.
+
+The strikes are in memory, for the same reason the stall clock is: they measure
+what is breaking now, and a daemon restart genuinely does grant a fresh window
+against a runtime that has also just restarted. Enabling the app clears them —
+the way back has to actually be a way back.
+
+## 4 — papercuts
+
+- `attn app status` printed "runtime: not started — no enabled app has been due
+  a fact since this daemon came up" on a daemon where the binary is missing and
+  every dispatch is failing. False on both halves. It now names no cause,
+  because from the CLI the two are genuinely indistinguishable — `resolveAppRuntimeHost`
+  fails before the supervisor is touched, so a missing binary and a quiet daemon
+  both arrive with no snapshot — and points at `attn app runtime status`, which
+  resolves the binary itself.
+- `attn app rollback <name> <bad>` pointed at `attn app status <name>` to list
+  version ids, which only ever printed a count. Fixed at the root rather than in
+  the copy: `AppStatusResult` gained `recent_versions` (protocol 233) and status
+  prints the ids with the serving one marked. Capped at ten with the total count
+  beside it — an app under `attn app dev` accumulates versions, and an
+  unbounded list on a status call is the next landmine.
+- Four comments that described something the code does not do (the runtime log's
   bound, what registers a consumer, when `declareAppCollections` runs, whose job
-  collection declaration is).
+  collection declaration is), plus the A4 plan's "endpoints sync on a timer" —
+  no ticker drives a bootstrap; a reconnect does.
 
 ## Deferred, with the reason
 

--- a/internal/appbuild/manifest.go
+++ b/internal/appbuild/manifest.go
@@ -252,9 +252,10 @@ func validateEventPattern(pattern string) error {
 // would refuse at write time is refused here instead — at apply, with the
 // manifest in hand.
 //
-// Apply does not create the collections. Declaring them is the runtime's job
-// (slice 5), and creating storage for a version that may never be dispatched
-// would be a state change apply is not allowed to make.
+// This function does not create the collections. The daemon does, in
+// declareAppCollections, once the version is committed and the app is pointed at
+// it — creating storage for a build that may still fail typecheck would be a
+// state change validation is not allowed to make.
 func (m Manifest) checkCollections() error {
 	seen := map[string]bool{}
 	for _, c := range m.Collections {

--- a/internal/daemon/app_consumers.go
+++ b/internal/daemon/app_consumers.go
@@ -80,6 +80,30 @@ func (d *Daemon) appConnectWait() time.Duration {
 // log for an afternoon.
 const appAutoDisableStall = 15 * time.Minute
 
+// appCrashStrikes is the second half of the auto-disable rule: an app the
+// runtime host named as the cause of a sidecar crash this many times inside
+// appCrashWindow is disabled.
+//
+// The stall clock above cannot express this one, which is why there are two. A
+// crash kills the process, so the delivery is retried against a fresh runtime
+// and the next crash may land on a different event entirely — an app whose
+// promise rejects after its handler already returned takes the sidecar down
+// while some other app's event is in flight. A clock keyed on "stuck on the same
+// event" never accrues for the one app that hurts everybody.
+//
+// Three, because supervise parks the whole sidecar after DefaultGiveUpAfter (10)
+// restarts with no stability window — roughly two to three minutes of
+// crash-looping — and every app losing its runtime is exactly the harm this
+// prevents, so the culprit has to go first. Above one, because a single crash
+// can be a machine event (an OOM kill, a signal) whose stack merely passes
+// through an app's bundle.
+const appCrashStrikes = 3
+
+// appCrashWindow is appAutoDisableStall so the auto-disable rule has one
+// duration rather than two: an app broken for a quarter of an hour is disabled,
+// whichever way it is broken.
+const appCrashWindow = appAutoDisableStall
+
 // notificationKindAppAutoDisabled marks the notification an auto-disable writes.
 const notificationKindAppAutoDisabled = "app_auto_disabled"
 
@@ -213,8 +237,9 @@ func (d *Daemon) appDeclaration(name string) (appbuild.Manifest, store.AppVersio
 // declareAppCollections creates the document collections a version declared, in
 // the app's own namespace.
 //
-// It runs at registration and after every apply, and it is idempotent: declaring
-// a collection that already exists with the same fields is a no-op in the store.
+// It runs from syncAppRuntimeForVersion, which is every apply and every
+// rollback, and it is idempotent: declaring a collection that already exists
+// with the same fields is a no-op in the store.
 // A collection an older version declared and this one dropped is left alone —
 // the documents in it are the user's data, and a version bump is not consent to
 // delete them.
@@ -322,12 +347,13 @@ func (d *Daemon) deliverAppEvent(ctx context.Context, name string, ev bus.Event)
 		return dispatchErr
 
 	case dispatchErr != nil && errors.Is(dispatchErr, context.DeadlineExceeded):
-		// A handler that never returned. Nothing else can attribute this: the
-		// process is healthy and the app's code is what is stuck.
+		// A handler that never returned, and attributeWedgedDispatch has already
+		// established that this app is the one that did not return — either the
+		// loop is turning, or it is frozen and this app is what froze it.
 		invocation.Status = appInvocationStatusError
 		invocation.Error = fmt.Sprintf(
 			"the handler for %s did not return within %s; attn abandoned the dispatch. A handler awaits attn's own APIs, which always settle — an await on something else needs its own timeout.",
-			ev.Name, appDispatchTimeout)
+			ev.Name, d.appDispatchBudget())
 		d.recordAppInvocation(invocation)
 		d.noteAppFailure(name, ev, invocation.Error)
 		return errors.New(invocation.Error)
@@ -449,13 +475,15 @@ func (d *Daemon) dispatchToAppRuntime(ctx context.Context, plan *appDispatchPlan
 		request.Collections = []string{}
 	}
 
-	callCtx, cancel := context.WithTimeout(ctx, appDispatchTimeout)
+	callCtx, cancel := context.WithTimeout(ctx, d.appDispatchBudget())
 	defer cancel()
 	result, err := runtime.dispatch(callCtx, request)
 	if err != nil {
 		if ctx.Err() == nil && callCtx.Err() != nil {
-			// Our own deadline, not the caller's: a hung handler.
-			return appDispatchResult{}, context.DeadlineExceeded
+			// Our own deadline, not the caller's: something in the sidecar is stuck.
+			// Attributed here rather than by the caller because this dispatch must
+			// still be in the in-flight set for the answer to be right.
+			return appDispatchResult{}, d.attributeWedgedDispatch(ctx, runtime, plan.app)
 		}
 		if ctx.Err() != nil {
 			return appDispatchResult{}, ctx.Err()
@@ -463,7 +491,148 @@ func (d *Daemon) dispatchToAppRuntime(ctx context.Context, plan *appDispatchPlan
 		// The transport failed — the socket died mid-call, or the process did.
 		return appDispatchResult{}, runtimeFailure("%v", err)
 	}
+	// The host answered, so this handler is no longer on the loop. Only an answer
+	// proves that: a dispatch the daemon gave up on is still running in there, and
+	// forgetting it here is what let a victim be charged for it.
+	d.forgetEnteredHandler(dispatch.id)
 	return result, nil
+}
+
+// attributeWedgedDispatch decides who is charged for a dispatch that never came
+// back.
+//
+// Every app shares one event loop, so a handler that blocks without yielding
+// blocks all of them: every other app's dispatch times out too, and charging
+// each of them auto-disables apps whose code never ran. The ping tells the two
+// cases apart. The host serves it off that same loop without touching app code,
+// so an answer means the loop is turning and this app's own handler is what is
+// stuck, and silence means the loop is frozen — in which case one specific
+// handler is executing without yielding, and everyone else suffered a runtime
+// failure rather than a fault of their own.
+//
+// Which handler that is, is the host's to say, not the daemon's to guess. The
+// daemon knows only the order it *sent* dispatches, and that order is not the
+// order handlers hold the loop: a handler that awaits an attn API — the ordinary,
+// documented shape — yields, and a spinner dispatched after it is what freezes
+// everything, including the first handler's own reply. Blaming the earliest
+// dispatch charges the well-behaved app and lets the spinner walk. So the host
+// announces each entry before it calls the handler (appRuntimeEnteredMethod), and
+// the culprit is the most recent entry with no answer yet: whoever entered last
+// and never came back is the one on the loop right now.
+//
+// Known residue: an entry is forgotten when its dispatch is answered, when a ping
+// answers, or when the process dies — each of which proves that handler is off
+// the loop. If one app freezes the loop, finishes, and a *different* app freezes
+// it again with no ping in between, the first entry is stale and both are still
+// present; the second freezer entered later, so it is still the one charged.
+func (d *Daemon) attributeWedgedDispatch(ctx context.Context, runtime *appRuntimeConnection, name string) error {
+	pingCtx, cancel := context.WithTimeout(ctx, d.appPingBudget())
+	defer cancel()
+
+	asked := d.appNow()
+	err := runtime.ping(pingCtx)
+	// Logged because this is the only place that says who wedged the runtime, and
+	// it costs nothing in a healthy system: a dispatch has to burn its whole
+	// timeout to get here.
+	// Microseconds, not milliseconds: an answered ping is the healthy case and it
+	// costs well under a millisecond, which rounds to "0s" and tells the reader
+	// nothing about the margin the timeout is holding.
+	d.logf("apps: %s hit the dispatch timeout; the app runtime %s a liveness ping after %s",
+		name, pingOutcome(err), d.appNow().Sub(asked).Round(time.Microsecond))
+
+	if err == nil {
+		// The loop is turning, so nothing is holding it and every handler the daemon
+		// gave up on has since come off it.
+		d.forgetEnteredHandlers()
+		return context.DeadlineExceeded
+	}
+
+	culprit, ok := d.wedgedAppCulprit()
+	if !ok || culprit == name {
+		return context.DeadlineExceeded
+	}
+	return runtimeFailure(
+		"the app runtime stopped answering while %s held its event loop, so this handler never ran; %s is what attn charged for the stall, and `attn app status %s` shows it",
+		culprit, culprit, culprit)
+}
+
+func pingOutcome(err error) string {
+	if err == nil {
+		return "answered"
+	}
+	return "did not answer"
+}
+
+// noteEnteredHandler records that the host has called an app's handler and has
+// not answered for it yet. A generation that does not match wipes the map: those
+// handlers were running in a process that is gone.
+//
+// Ordering is the point, so this runs inline on the connection's read loop rather
+// than in a goroutine per frame — entries arrive in the order the host made them
+// and must be stamped in that order.
+func (d *Daemon) noteEnteredHandler(generation uint64, dispatchID, name string) {
+	d.appEnteredMu.Lock()
+	defer d.appEnteredMu.Unlock()
+	if d.appEntered == nil || d.appEnteredGen != generation {
+		d.appEntered = make(map[string]enteredHandler)
+		d.appEnteredGen = generation
+	}
+	d.appEnteredSeq++
+	d.appEntered[dispatchID] = enteredHandler{app: name, order: d.appEnteredSeq}
+}
+
+func (d *Daemon) forgetEnteredHandler(dispatchID string) {
+	d.appEnteredMu.Lock()
+	delete(d.appEntered, dispatchID)
+	d.appEnteredMu.Unlock()
+}
+
+func (d *Daemon) forgetEnteredHandlers() {
+	d.appEnteredMu.Lock()
+	d.appEntered = nil
+	d.appEnteredGen = 0
+	d.appEnteredMu.Unlock()
+}
+
+// wedgedAppCulprit names the app whose handler is on the frozen loop: the last
+// one the host entered and has not answered for.
+func (d *Daemon) wedgedAppCulprit() (string, bool) {
+	d.appEnteredMu.Lock()
+	defer d.appEnteredMu.Unlock()
+	var latest enteredHandler
+	for _, entry := range d.appEntered {
+		if entry.order > latest.order {
+			latest = entry
+		}
+	}
+	return latest.app, latest.order > 0
+}
+
+// appRuntimePingWait is how long the sidecar gets to answer a liveness ping.
+//
+// A tripwire past a localhost round trip, not a fit: the host answers off its
+// read loop with a constant, and answered pings measured on a live daemon cost
+// 344µs and 416µs. Two seconds is ~5,000× that, so only a loop that is genuinely
+// not turning reaches it. It is spent only on a dispatch that already burned
+// appDispatchTimeout, so being generous costs nothing that was not already lost.
+const appRuntimePingWait = 2 * time.Second
+
+// appPingBudget is that tripwire, overridable so a test about a frozen loop does
+// not cost two real seconds.
+func (d *Daemon) appPingBudget() time.Duration {
+	if d.appPingWait > 0 {
+		return d.appPingWait
+	}
+	return appRuntimePingWait
+}
+
+// appDispatchBudget is appDispatchTimeout, overridable so a test about a handler
+// that never returns does not cost a real minute.
+func (d *Daemon) appDispatchBudget() time.Duration {
+	if d.appDispatchWait > 0 {
+		return d.appDispatchWait
+	}
+	return appDispatchTimeout
 }
 
 // awaitAppRuntime returns the live sidecar, starting it if it is not running and
@@ -575,6 +744,49 @@ func (d *Daemon) clearAppStall(name string) {
 	d.appStallMu.Unlock()
 }
 
+// noteAppRuntimeCrash charges an app for taking the sidecar down.
+//
+// The host names the culprit from the stack of the error that killed it, which
+// is the only thing in the process that still knows whose code it was: the
+// rejection may surface long after that app's dispatch returned, so "who was
+// running" would name an innocent.
+func (d *Daemon) noteAppRuntimeCrash(name, kind, message string) {
+	now := d.appNow()
+
+	d.appCrashMu.Lock()
+	if d.appCrashes == nil {
+		d.appCrashes = make(map[string][]time.Time)
+	}
+	kept := d.appCrashes[name][:0]
+	for _, at := range d.appCrashes[name] {
+		if now.Sub(at) < appCrashWindow {
+			kept = append(kept, at)
+		}
+	}
+	kept = append(kept, now)
+	d.appCrashes[name] = kept
+	strikes := len(kept)
+	d.appCrashMu.Unlock()
+
+	d.logf("apps: %s crashed the app runtime (%s), strike %d of %d: %s",
+		name, kind, strikes, appCrashStrikes, firstLine(message))
+	if strikes < appCrashStrikes {
+		return
+	}
+	d.disableAppAutomatically(name, message,
+		fmt.Sprintf("apps: disabled %s — crashed the app runtime %d times within %s: %s",
+			name, strikes, appCrashWindow, firstLine(message)),
+		fmt.Sprintf(
+			"%s crashed the shared app runtime %d times in %s, so attn disabled it — one app taking the runtime down stops every other app with it. The failure was an unhandled %s; a handler must catch what it starts, including work it does not await. Fix it and `attn app enable %s`; `attn app logs runtime` shows what it printed.",
+			name, strikes, appCrashWindow, kind, name))
+}
+
+func (d *Daemon) clearAppCrashes(name string) {
+	d.appCrashMu.Lock()
+	delete(d.appCrashes, name)
+	d.appCrashMu.Unlock()
+}
+
 // appStallSnapshot reports what an app is stuck on, for `attn app status`.
 func (d *Daemon) appStallSnapshot(name string) (appStall, bool) {
 	d.appStallMu.Lock()
@@ -594,23 +806,40 @@ func (d *Daemon) appStallSnapshot(name string) (appStall, bool) {
 // person ever sees. An auto-disable nobody is told about is a feature that
 // silently stops working.
 func (d *Daemon) autoDisableApp(name string, ev bus.Event, stalled time.Duration, attempts int, message string) {
+	d.disableAppAutomatically(name, message,
+		fmt.Sprintf("apps: disabled %s — stuck on %s (seq %d) for %s across %d attempts: %s",
+			name, ev.Name, ev.Seq, stalled.Round(time.Second), attempts, firstLine(message)),
+		fmt.Sprintf(
+			"%s failed on the same event (%s, seq %d) for %s across %d attempts, so attn disabled it — a stalled app holds the event log open for every other consumer. Fix the handler and `attn app enable %s`; `attn app status %s` shows the failures.",
+			name, ev.Name, ev.Seq, stalled.Round(time.Minute), attempts, name, name))
+}
+
+// disableAppAutomatically flips the app off, says so on the bus, and tells the
+// user.
+//
+// All three, because each answers a different question: the consumer bit stops
+// delivery and releases the retention floor, the fact reaches anything in the
+// daemon watching the app, and the notification is the only one of the three a
+// person ever sees. An auto-disable nobody is told about is a feature that
+// silently stops working.
+func (d *Daemon) disableAppAutomatically(name, detail, logLine, body string) {
 	consumer := apps.ConsumerName(name)
 	flipped, err := d.store.SetBusConsumerEnabled(consumer, false, d.appNow())
 	if err != nil {
-		d.logf("apps: disabling app %s after %s stalled on %s: %v", name, stalled.Round(time.Second), ev.Name, err)
+		d.logf("apps: disabling app %s: %v", name, err)
 		return
 	}
 	if !flipped {
 		// Already off, or removed while this delivery was failing.
 		return
 	}
-	// The window restarts from here. Enabling the app again is the supported way
-	// back, and it clears this too; leaving the old clock in place would disable a
-	// re-enabled app on its very next failure.
+	// The windows restart from here. Enabling the app again is the supported way
+	// back, and it clears these too; leaving the old clocks in place would disable
+	// a re-enabled app on its very next failure.
 	d.clearAppStall(name)
+	d.clearAppCrashes(name)
 
-	d.logf("apps: disabled %s — stuck on %s (seq %d) for %s across %d attempts: %s",
-		name, ev.Name, ev.Seq, stalled.Round(time.Second), attempts, firstLine(message))
+	d.logf("%s", logLine)
 	d.publishFact(FactAppEnabledChanged, name, appEnabledChanged{
 		Name: name, Consumer: consumer, Enabled: false,
 	})
@@ -618,13 +847,11 @@ func (d *Daemon) autoDisableApp(name string, ev bus.Event, stalled time.Duration
 		return
 	}
 	record, err := d.store.AddNotification(store.NotificationRecord{
-		Kind:     notificationKindAppAutoDisabled,
-		Severity: store.NotificationWarning,
-		Title:    fmt.Sprintf("App disabled: %s", name),
-		Body: fmt.Sprintf(
-			"%s failed on the same event (%s, seq %d) for %s across %d attempts, so attn disabled it — a stalled app holds the event log open for every other consumer. Fix the handler and `attn app enable %s`; `attn app status %s` shows the failures.",
-			name, ev.Name, ev.Seq, stalled.Round(time.Minute), attempts, name, name),
-		Detail:     message,
+		Kind:       notificationKindAppAutoDisabled,
+		Severity:   store.NotificationWarning,
+		Title:      fmt.Sprintf("App disabled: %s", name),
+		Body:       body,
+		Detail:     detail,
 		SourceKind: "app",
 		SourceID:   name,
 	}, d.appNow())

--- a/internal/daemon/app_consumers.go
+++ b/internal/daemon/app_consumers.go
@@ -491,10 +491,6 @@ func (d *Daemon) dispatchToAppRuntime(ctx context.Context, plan *appDispatchPlan
 		// The transport failed — the socket died mid-call, or the process did.
 		return appDispatchResult{}, runtimeFailure("%v", err)
 	}
-	// The host answered, so this handler is no longer on the loop. Only an answer
-	// proves that: a dispatch the daemon gave up on is still running in there, and
-	// forgetting it here is what let a victim be charged for it.
-	d.forgetEnteredHandler(dispatch.id)
 	return result, nil
 }
 
@@ -520,18 +516,15 @@ func (d *Daemon) dispatchToAppRuntime(ctx context.Context, plan *appDispatchPlan
 // the culprit is the most recent entry with no answer yet: whoever entered last
 // and never came back is the one on the loop right now.
 //
-// An entry is forgotten when its dispatch is answered, when a ping answers, or
-// when the process dies. Only the first and last of those prove that handler is
-// off the loop: an answered ping proves nothing is *holding* the loop, and a
-// handler that yielded and never settled is still on it. Wiping on a ping is
-// still right, because attribution is moot while the loop turns.
+// The host also announces each handler leaving (appRuntimeLeftMethod), which is
+// what keeps the ledger honest. The daemon has no way to work out when a handler
+// left: the only thing it could infer that from is the loop still turning, and a
+// handler that yielded and never settled is still on a turning loop. Whatever the
+// daemon guessed there would be wrong exactly for the handler that yields, comes
+// back, and then spins — the one this has to name.
 //
-// Known residue, both cheap. If one app freezes the loop, finishes, and a
-// *different* app freezes it again with no ping in between, both entries are
-// present and the second freezer entered later, so it is still the one charged.
-// And if a handler yields, has its entry wiped by a ping, and only then resumes
-// and spins, nothing names it: attribution falls back to charging whoever timed
-// out, until the next dispatch enters and is announced.
+// So the ledger is dropped only on facts, never on inference: an entry goes when
+// the host says that handler left, and all of them go when the process dies.
 func (d *Daemon) attributeWedgedDispatch(ctx context.Context, runtime *appRuntimeConnection, name string) error {
 	pingCtx, cancel := context.WithTimeout(ctx, d.appPingBudget())
 	defer cancel()
@@ -548,9 +541,9 @@ func (d *Daemon) attributeWedgedDispatch(ctx context.Context, runtime *appRuntim
 		name, pingOutcome(err), d.appNow().Sub(asked).Round(time.Microsecond))
 
 	if err == nil {
-		// The loop is turning, so nothing is holding it and there is nothing to
-		// attribute — see the residue note above for what this wipe costs.
-		d.forgetEnteredHandlers()
+		// The loop is turning, so nothing is holding it: this app's own handler is
+		// what did not return. The ledger is left alone — an answered ping says
+		// nothing about which handlers are still on the loop.
 		return context.DeadlineExceeded
 	}
 

--- a/internal/daemon/app_consumers.go
+++ b/internal/daemon/app_consumers.go
@@ -520,11 +520,18 @@ func (d *Daemon) dispatchToAppRuntime(ctx context.Context, plan *appDispatchPlan
 // the culprit is the most recent entry with no answer yet: whoever entered last
 // and never came back is the one on the loop right now.
 //
-// Known residue: an entry is forgotten when its dispatch is answered, when a ping
-// answers, or when the process dies — each of which proves that handler is off
-// the loop. If one app freezes the loop, finishes, and a *different* app freezes
-// it again with no ping in between, the first entry is stale and both are still
-// present; the second freezer entered later, so it is still the one charged.
+// An entry is forgotten when its dispatch is answered, when a ping answers, or
+// when the process dies. Only the first and last of those prove that handler is
+// off the loop: an answered ping proves nothing is *holding* the loop, and a
+// handler that yielded and never settled is still on it. Wiping on a ping is
+// still right, because attribution is moot while the loop turns.
+//
+// Known residue, both cheap. If one app freezes the loop, finishes, and a
+// *different* app freezes it again with no ping in between, both entries are
+// present and the second freezer entered later, so it is still the one charged.
+// And if a handler yields, has its entry wiped by a ping, and only then resumes
+// and spins, nothing names it: attribution falls back to charging whoever timed
+// out, until the next dispatch enters and is announced.
 func (d *Daemon) attributeWedgedDispatch(ctx context.Context, runtime *appRuntimeConnection, name string) error {
 	pingCtx, cancel := context.WithTimeout(ctx, d.appPingBudget())
 	defer cancel()
@@ -541,8 +548,8 @@ func (d *Daemon) attributeWedgedDispatch(ctx context.Context, runtime *appRuntim
 		name, pingOutcome(err), d.appNow().Sub(asked).Round(time.Microsecond))
 
 	if err == nil {
-		// The loop is turning, so nothing is holding it and every handler the daemon
-		// gave up on has since come off it.
+		// The loop is turning, so nothing is holding it and there is nothing to
+		// attribute — see the residue note above for what this wipe costs.
 		d.forgetEnteredHandlers()
 		return context.DeadlineExceeded
 	}

--- a/internal/daemon/app_crash_test.go
+++ b/internal/daemon/app_crash_test.go
@@ -1,0 +1,157 @@
+package daemon
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/supervise"
+)
+
+// The crash rule: an app whose error escapes every handler takes the shared
+// sidecar down with it, and is charged for doing so.
+//
+// It is the second auto-disable clock because the first one cannot reach this
+// case. A crash kills the process before the delivery finishes, the event is
+// redelivered against a fresh runtime, and the next crash may land on a
+// different event entirely — so "stuck on the same event for fifteen minutes"
+// never accrues for the one app that stops every other app.
+//
+// The host names the culprit from the stack of the error that killed it, which
+// is why these tests drive the wire method rather than a Go helper: the
+// attribution is a claim the host makes and the daemon acts on.
+
+func reportCrash(t *testing.T, d *Daemon, app, kind, message string) {
+	t.Helper()
+	params, err := json.Marshal(appRuntimeCrashParams{App: app, Kind: kind, Error: message})
+	if err != nil {
+		t.Fatalf("marshal crash params: %v", err)
+	}
+	if _, err := d.appRuntimeMethod(jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`"crash"`),
+		Method:  appRuntimeCrashedMethod,
+		Params:  params,
+	}); err != nil {
+		t.Fatalf("%s: %v", appRuntimeCrashedMethod, err)
+	}
+}
+
+func TestAppThatKeepsCrashingTheRuntimeIsDisabledAndSaysSoThreeWays(t *testing.T) {
+	d := newAppDaemon(t)
+	clock := newAppTestClock(d)
+	installApp(t, d, "leaker", subscribing("ticket.*"))
+
+	for i := 1; i < appCrashStrikes; i++ {
+		reportCrash(t, d, "leaker", "unhandledRejection", "TypeError: fetch failed")
+		clock.advance(time.Minute)
+		if !appEnabled(t, d, "leaker") {
+			t.Fatalf("leaker was disabled on strike %d of %d", i, appCrashStrikes)
+		}
+	}
+
+	reportCrash(t, d, "leaker", "unhandledRejection", "TypeError: fetch failed")
+
+	if appEnabled(t, d, "leaker") {
+		t.Fatalf("leaker is still enabled after %d crashes", appCrashStrikes)
+	}
+	facts := appFacts(t, d, FactAppEnabledChanged)
+	if len(facts) != 1 || facts[0].Subject != "leaker" {
+		t.Fatalf("app.enabled.changed facts = %+v, want one for leaker", facts)
+	}
+	notes := appNotifications(t, d, notificationKindAppAutoDisabled)
+	if len(notes) != 1 {
+		t.Fatalf("auto-disable notifications = %d, want 1", len(notes))
+	}
+	// It has to say what happened and how to come back, or the author is left
+	// with an app that stopped for no reason they can see.
+	if !strings.Contains(notes[0].Body, "attn app enable leaker") {
+		t.Fatalf("the notification does not name the way back: %q", notes[0].Body)
+	}
+	if !strings.Contains(notes[0].Body, "unhandledRejection") {
+		t.Fatalf("the notification does not say what failed: %q", notes[0].Body)
+	}
+	if !strings.Contains(notes[0].Detail, "TypeError") {
+		t.Fatalf("the notification detail does not carry the error: %q", notes[0].Detail)
+	}
+	if created := appFacts(t, d, FactNotificationCreated); len(created) != 1 {
+		t.Fatalf("notification.created facts = %+v, want one", created)
+	}
+}
+
+// Crashes far apart are not a crash loop. An app that took the runtime down
+// once a month is not the thing this rule exists to stop.
+func TestCrashesOutsideTheWindowDoNotAccumulate(t *testing.T) {
+	d := newAppDaemon(t)
+	clock := newAppTestClock(d)
+	installApp(t, d, "occasional", subscribing("ticket.*"))
+
+	for i := 0; i < appCrashStrikes*3; i++ {
+		reportCrash(t, d, "occasional", "uncaughtException", "Error: transient")
+		clock.advance(appCrashWindow + time.Minute)
+	}
+
+	if !appEnabled(t, d, "occasional") {
+		t.Fatalf("an app crashing once per %s window was disabled", appCrashWindow)
+	}
+}
+
+// The host sends an empty name when the error carried no stack naming a loaded
+// bundle. Nothing is charged: guessing which app was running is exactly how an
+// innocent app gets disabled, which is why the host reads the stack at all.
+func TestACrashThatNamesNoAppChargesNobody(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "innocent", subscribing("ticket.*"))
+
+	for i := 0; i < appCrashStrikes*2; i++ {
+		reportCrash(t, d, "", "unhandledRejection", "Error: something in the host")
+	}
+
+	if !appEnabled(t, d, "innocent") {
+		t.Fatal("an unattributed crash disabled an app")
+	}
+	if notes := appNotifications(t, d, notificationKindAppAutoDisabled); len(notes) != 0 {
+		t.Fatalf("auto-disable notifications = %d, want 0", len(notes))
+	}
+}
+
+// Enabling is the way back, so it clears the streak. The case that depends on
+// it is an app switched off and on by hand while carrying strikes: without the
+// clear it is disabled again on its very next crash, against a clock it never
+// got to restart.
+func TestEnablingAnAppClearsItsCrashStreak(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "leaker", subscribing("ticket.*"))
+
+	for i := 0; i < appCrashStrikes-1; i++ {
+		reportCrash(t, d, "leaker", "unhandledRejection", "TypeError: fetch failed")
+	}
+	if !appEnabled(t, d, "leaker") {
+		t.Fatalf("leaker was disabled before its %dth strike", appCrashStrikes)
+	}
+
+	if resp := appSetEnabled(t, d, "leaker", false); !resp.Ok {
+		t.Fatalf("disable leaker: %+v", resp)
+	}
+	if resp := appSetEnabled(t, d, "leaker", true); !resp.Ok {
+		t.Fatalf("re-enable leaker: %+v", resp)
+	}
+
+	reportCrash(t, d, "leaker", "unhandledRejection", "TypeError: fetch failed")
+	if !appEnabled(t, d, "leaker") {
+		t.Fatal("a re-enabled app was disabled again on its very next crash")
+	}
+}
+
+// The strike count must stay under what supervise gives the sidecar before it
+// parks it: parking stops every app, so the culprit has to be gone first.
+func TestCrashStrikesFireBeforeTheSupervisorParksTheRuntime(t *testing.T) {
+	if appCrashStrikes < 2 {
+		t.Fatalf("appCrashStrikes = %d; one crash can be a machine event, not a broken app", appCrashStrikes)
+	}
+	if appCrashStrikes >= supervise.DefaultGiveUpAfter {
+		t.Fatalf("appCrashStrikes = %d but the sidecar is parked after %d restarts, so every app loses its runtime before the culprit is disabled",
+			appCrashStrikes, supervise.DefaultGiveUpAfter)
+	}
+}

--- a/internal/daemon/app_runtime.go
+++ b/internal/daemon/app_runtime.go
@@ -50,7 +50,7 @@ const (
 	// case this guards is an old binary inside a stale app bundle meeting a new
 	// daemon, where every symptom of the skew would otherwise appear later and
 	// somewhere else.
-	appRuntimeAPIVersion = 1
+	appRuntimeAPIVersion = 2
 )
 
 // appRuntimeHostOverride lets a test — and a developer running a checkout's

--- a/internal/daemon/app_runtime_ipc.go
+++ b/internal/daemon/app_runtime_ipc.go
@@ -83,10 +83,12 @@ func (d *Daemon) handleAppLogs(conn net.Conn, msg *protocol.AppLogsMessage) {
 // writes it on its first start, and "no lines yet" is exactly what a caller
 // asking before then should hear.
 //
-// It reads the whole file rather than seeking from the end. The file is one
-// daemon's runtime output — bounded by uptime, not by history — and a backwards
-// scan that has to respect line boundaries and a tag filter is a lot of
-// machinery to save milliseconds on a diagnostic command.
+// It reads the whole file rather than seeking from the end. The file is opened
+// O_APPEND and never truncated, so it does carry every restart — but nothing in
+// an app writes to it unless the app's own code prints, and a backwards scan
+// that has to respect line boundaries and a tag filter is a lot of machinery for
+// a diagnostic command. If a chatty app ever makes this cost real, the fix is
+// rotation on the writing side, not a cleverer reader.
 func readAppLog(path, app string, whole bool, limit int) ([]string, bool, error) {
 	file, err := os.Open(path)
 	if err != nil {

--- a/internal/daemon/app_runtime_rpc.go
+++ b/internal/daemon/app_runtime_rpc.go
@@ -161,10 +161,10 @@ func (d *Daemon) handleAppRuntimeConnection(conn net.Conn, reader *bufio.Reader,
 			}
 			continue
 		}
-		if msg.Method == appRuntimeEnteredMethod {
+		if msg.Method == appRuntimeEnteredMethod || msg.Method == appRuntimeLeftMethod {
 			// On the read loop on purpose: it is a map write, and its whole value is
 			// the order it arrives in.
-			d.appRuntimeEntered(runtime, msg)
+			d.appRuntimeHandlerMoved(runtime, msg)
 			continue
 		}
 		// Off the read loop: several apps dispatch concurrently over this one
@@ -246,35 +246,44 @@ func (d *Daemon) appRuntimeCrashed(msg jsonRPCMessage) (any, error) {
 	return appRuntimeHelloResult{OK: true}, nil
 }
 
-// appRuntimeEnteredMethod is the host saying it is about to call an app's
-// handler. It is a notification: there is nothing to answer, and the point is
-// that it reaches the daemon *before* the handler runs, so it is still on the
-// wire when a handler that never yields freezes the loop behind it.
+// appRuntimeEnteredMethod and appRuntimeLeftMethod are the host saying it is
+// about to call an app's handler, and that the handler has settled. They are
+// notifications: there is nothing to answer, and the point of the first is that
+// it reaches the daemon *before* the handler runs, so it is already on the wire
+// when a handler that never yields freezes the loop behind it.
 //
-// It is what makes a frozen loop attributable. The daemon's own dispatch order is
-// not the order handlers hold the loop — see attributeWedgedDispatch.
-const appRuntimeEnteredMethod = "app_runtime.entered"
+// Together they are what makes a frozen loop attributable — the daemon's own
+// dispatch order is not the order handlers hold the loop, and nothing the daemon
+// can observe tells it when a handler left. See attributeWedgedDispatch.
+const (
+	appRuntimeEnteredMethod = "app_runtime.entered"
+	appRuntimeLeftMethod    = "app_runtime.left"
+)
 
-type appRuntimeEnteredParams struct {
+type appRuntimeHandlerParams struct {
 	Dispatch string `json:"dispatch"`
 	App      string `json:"app"`
 }
 
-// enteredHandler is one handler the host entered and has not answered for.
-// order is the daemon's receive order, which is the host's entry order: the
-// frames arrive on one socket and are recorded on its read loop.
+// enteredHandler is one handler the host entered and has not left. order is the
+// daemon's receive order, which is the host's entry order: the frames arrive on
+// one socket and are recorded on its read loop.
 type enteredHandler struct {
 	app   string
 	order uint64
 }
 
-func (d *Daemon) appRuntimeEntered(runtime *appRuntimeConnection, msg jsonRPCMessage) {
-	var params appRuntimeEnteredParams
+func (d *Daemon) appRuntimeHandlerMoved(runtime *appRuntimeConnection, msg jsonRPCMessage) {
+	var params appRuntimeHandlerParams
 	if err := json.Unmarshal(msg.Params, &params); err != nil {
-		d.logf("app runtime: decode %s params: %v", appRuntimeEnteredMethod, err)
+		d.logf("app runtime: decode %s params: %v", msg.Method, err)
 		return
 	}
 	if params.Dispatch == "" || params.App == "" {
+		return
+	}
+	if msg.Method == appRuntimeLeftMethod {
+		d.forgetEnteredHandler(params.Dispatch)
 		return
 	}
 	d.noteEnteredHandler(runtime.generation, params.Dispatch, params.App)

--- a/internal/daemon/app_runtime_rpc.go
+++ b/internal/daemon/app_runtime_rpc.go
@@ -55,6 +55,24 @@ func (c *appRuntimeConnection) dispatch(ctx context.Context, req appDispatchRequ
 	return result, nil
 }
 
+// appRuntimePingResult answers whether the sidecar's event loop is turning. The
+// host serves it without touching app code, so a silent ping means the loop
+// itself is blocked and no app's handler is being run.
+type appRuntimePingResult struct {
+	OK bool `json:"ok"`
+}
+
+func (c *appRuntimeConnection) ping(ctx context.Context) error {
+	var result appRuntimePingResult
+	if err := c.request(ctx, "app runtime", "app.runtime.ping", struct{}{}, &result); err != nil {
+		return err
+	}
+	if !result.OK {
+		return errors.New("the app runtime answered a ping without ok")
+	}
+	return nil
+}
+
 // parseAppRuntimeHello recognizes the sidecar's opening frame.
 //
 // It runs before the plugin hello sniff, because the plugin parser treats any
@@ -143,6 +161,12 @@ func (d *Daemon) handleAppRuntimeConnection(conn net.Conn, reader *bufio.Reader,
 			}
 			continue
 		}
+		if msg.Method == appRuntimeEnteredMethod {
+			// On the read loop on purpose: it is a map write, and its whole value is
+			// the order it arrives in.
+			d.appRuntimeEntered(runtime, msg)
+			continue
+		}
 		// Off the read loop: several apps dispatch concurrently over this one
 		// socket, and a collection read for one must not hold up another app's
 		// answers behind it.
@@ -170,6 +194,9 @@ func (d *Daemon) clearAppRuntimeConnection(runtime *appRuntimeConnection) {
 		d.appRuntimeConn = nil
 	}
 	d.appRuntimeMu.Unlock()
+	// Whatever the daemon gave up waiting for died with the process, so nothing
+	// of it is still holding an event loop that no longer exists.
+	d.forgetEnteredHandlers()
 	d.publishFact(FactAppRuntimeChanged, appRuntimeChildName, nil)
 }
 
@@ -186,6 +213,73 @@ func (d *Daemon) serveAppRuntimeMethod(runtime *appRuntimeConnection, msg jsonRP
 	_ = runtime.send(jsonRPCResult(msg.ID, result))
 }
 
+// appRuntimeCrashedMethod is the host's last frame before it exits: an error
+// escaped every handler and is about to take the process down, and this says
+// whose code it came from.
+//
+// It is a report, not a request for permission — the host exits either way, and
+// waits only briefly for the answer. Losing it costs the culprit a strike, which
+// is why the host sends it before exiting rather than letting the daemon guess
+// from a dead socket.
+const appRuntimeCrashedMethod = "app_runtime.crashed"
+
+type appRuntimeCrashParams struct {
+	// App is empty when the error carried no stack naming a loaded bundle. Nothing
+	// is charged then: guessing which app was running is how innocents get
+	// disabled.
+	App   string `json:"app"`
+	Kind  string `json:"kind"`
+	Error string `json:"error"`
+}
+
+func (d *Daemon) appRuntimeCrashed(msg jsonRPCMessage) (any, error) {
+	var params appRuntimeCrashParams
+	if err := json.Unmarshal(msg.Params, &params); err != nil {
+		return nil, fmt.Errorf("decode %s params: %w", appRuntimeCrashedMethod, err)
+	}
+	if params.App == "" {
+		d.logf("app runtime: crashing on an unhandled %s that names no app: %s",
+			params.Kind, firstLine(params.Error))
+		return appRuntimeHelloResult{OK: true}, nil
+	}
+	d.noteAppRuntimeCrash(params.App, params.Kind, params.Error)
+	return appRuntimeHelloResult{OK: true}, nil
+}
+
+// appRuntimeEnteredMethod is the host saying it is about to call an app's
+// handler. It is a notification: there is nothing to answer, and the point is
+// that it reaches the daemon *before* the handler runs, so it is still on the
+// wire when a handler that never yields freezes the loop behind it.
+//
+// It is what makes a frozen loop attributable. The daemon's own dispatch order is
+// not the order handlers hold the loop — see attributeWedgedDispatch.
+const appRuntimeEnteredMethod = "app_runtime.entered"
+
+type appRuntimeEnteredParams struct {
+	Dispatch string `json:"dispatch"`
+	App      string `json:"app"`
+}
+
+// enteredHandler is one handler the host entered and has not answered for.
+// order is the daemon's receive order, which is the host's entry order: the
+// frames arrive on one socket and are recorded on its read loop.
+type enteredHandler struct {
+	app   string
+	order uint64
+}
+
+func (d *Daemon) appRuntimeEntered(runtime *appRuntimeConnection, msg jsonRPCMessage) {
+	var params appRuntimeEnteredParams
+	if err := json.Unmarshal(msg.Params, &params); err != nil {
+		d.logf("app runtime: decode %s params: %v", appRuntimeEnteredMethod, err)
+		return
+	}
+	if params.Dispatch == "" || params.App == "" {
+		return
+	}
+	d.noteEnteredHandler(runtime.generation, params.Dispatch, params.App)
+}
+
 // appCollectionParams is what every collection callback carries. There is
 // deliberately no namespace: the daemon reads it off the dispatch record, so an
 // app cannot name one — its own or anybody else's.
@@ -199,6 +293,10 @@ type appCollectionParams struct {
 }
 
 func (d *Daemon) appRuntimeMethod(msg jsonRPCMessage) (any, error) {
+	if msg.Method == appRuntimeCrashedMethod {
+		return d.appRuntimeCrashed(msg)
+	}
+
 	switch msg.Method {
 	case "app.collection.get", "app.collection.put", "app.collection.delete",
 		"app.collection.query", "app.collection.count":

--- a/internal/daemon/app_runtime_test.go
+++ b/internal/daemon/app_runtime_test.go
@@ -54,6 +54,25 @@ type fakeAppRuntime struct {
 	dispatches []appDispatchRequest
 	pending    map[string]chan jsonRPCMessage
 	nextID     int
+	// loopFrozen models a blocked event loop. A real host does everything off one
+	// loop, so a handler that never yields stops all of it at once: pings go
+	// unanswered, and a dispatch that arrives after the freeze is never read, never
+	// announced, and never run.
+	loopFrozen bool
+}
+
+// freezeLoop stops this sidecar the way a synchronous handler that never yields
+// stops the real one.
+func (f *fakeAppRuntime) freezeLoop() {
+	f.mu.Lock()
+	f.loopFrozen = true
+	f.mu.Unlock()
+}
+
+func (f *fakeAppRuntime) frozen() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.loopFrozen
 }
 
 // startFakeAppRuntime connects a sidecar to d and waits until the daemon has
@@ -138,8 +157,19 @@ func (f *fakeAppRuntime) serve(reader *bufio.Reader) {
 			}
 			continue
 		}
+		if msg.Method == "app.runtime.ping" {
+			if !f.frozen() {
+				f.sendRaw(jsonRPCResult(msg.ID, appRuntimePingResult{OK: true}))
+			}
+			continue
+		}
+		if f.frozen() {
+			// Nothing reaches app code past this point, so nothing is announced
+			// either: a frozen loop cannot read its own socket.
+			continue
+		}
 		if msg.Method != "app.dispatch" {
-			f.sendRaw(jsonRPCFailure(msg.ID, jsonRPCInvalidRequest, "the fake sidecar only serves app.dispatch"))
+			f.sendRaw(jsonRPCFailure(msg.ID, jsonRPCInvalidRequest, "the fake sidecar only serves app.dispatch and app.runtime.ping"))
 			continue
 		}
 		var req appDispatchRequest
@@ -150,6 +180,14 @@ func (f *fakeAppRuntime) serve(reader *bufio.Reader) {
 		f.mu.Lock()
 		f.dispatches = append(f.dispatches, req)
 		f.mu.Unlock()
+		// Announced here rather than inside the goroutine so the order the daemon
+		// sees is the order dispatches arrived, which is what the real host's single
+		// loop guarantees.
+		f.sendRaw(jsonRPCMessage{
+			JSONRPC: "2.0",
+			Method:  appRuntimeEnteredMethod,
+			Params:  mustMarshalEnteredParams(f.t, appRuntimeEnteredParams{Dispatch: req.Dispatch, App: req.App}),
+		})
 		// On its own goroutine: a handler that calls back into the daemon would
 		// otherwise deadlock against this loop, which is the answer's only reader.
 		go func(id json.RawMessage, req appDispatchRequest) {
@@ -162,6 +200,15 @@ func (f *fakeAppRuntime) serve(reader *bufio.Reader) {
 			f.sendRaw(jsonRPCResult(id, result))
 		}(msg.ID, req)
 	}
+}
+
+func mustMarshalEnteredParams(t *testing.T, params appRuntimeEnteredParams) json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal %s params: %v", appRuntimeEnteredMethod, err)
+	}
+	return data
 }
 
 func (f *fakeAppRuntime) sendRaw(msg jsonRPCMessage) {

--- a/internal/daemon/app_runtime_test.go
+++ b/internal/daemon/app_runtime_test.go
@@ -186,7 +186,7 @@ func (f *fakeAppRuntime) serve(reader *bufio.Reader) {
 		f.sendRaw(jsonRPCMessage{
 			JSONRPC: "2.0",
 			Method:  appRuntimeEnteredMethod,
-			Params:  mustMarshalEnteredParams(f.t, appRuntimeEnteredParams{Dispatch: req.Dispatch, App: req.App}),
+			Params:  mustMarshalHandlerParams(f.t, appRuntimeHandlerParams{Dispatch: req.Dispatch, App: req.App}),
 		})
 		// On its own goroutine: a handler that calls back into the daemon would
 		// otherwise deadlock against this loop, which is the answer's only reader.
@@ -197,16 +197,23 @@ func (f *fakeAppRuntime) serve(reader *bufio.Reader) {
 					result = appDispatchResult{OK: false, Error: err.Error()}
 				}
 			}
+			// The other half of the announcement, and the reason the daemon never
+			// has to infer that a handler left.
+			f.sendRaw(jsonRPCMessage{
+				JSONRPC: "2.0",
+				Method:  appRuntimeLeftMethod,
+				Params:  mustMarshalHandlerParams(f.t, appRuntimeHandlerParams{Dispatch: req.Dispatch, App: req.App}),
+			})
 			f.sendRaw(jsonRPCResult(id, result))
 		}(msg.ID, req)
 	}
 }
 
-func mustMarshalEnteredParams(t *testing.T, params appRuntimeEnteredParams) json.RawMessage {
+func mustMarshalHandlerParams(t *testing.T, params appRuntimeHandlerParams) json.RawMessage {
 	t.Helper()
 	data, err := json.Marshal(params)
 	if err != nil {
-		t.Fatalf("marshal %s params: %v", appRuntimeEnteredMethod, err)
+		t.Fatalf("marshal handler-movement params: %v", err)
 	}
 	return data
 }

--- a/internal/daemon/app_wedge_test.go
+++ b/internal/daemon/app_wedge_test.go
@@ -1,0 +1,220 @@
+package daemon
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Who is charged when a dispatch never comes back.
+//
+// Every app's handler runs on one event loop in one process, so a handler that
+// blocks without yielding stops all of them. Before attribution existed, the
+// dispatch timeout fired for every app waiting behind it and each one was
+// charged, which auto-disables apps whose code never ran — with a notification
+// telling their author to fix a handler that was never called.
+//
+// Two signals answer it. The ping says whether the loop is turning at all, since
+// the host serves it off that same loop without touching app code. The host's
+// entry announcements say which handler is on the loop, which the daemon cannot
+// work out for itself — see attributeWedgedDispatch.
+
+// enterOnceThenBlock is a sidecar whose handlers announce themselves and then
+// never return, which is what the daemon sees from a wedged loop.
+func enterOnceThenBlock(entered chan<- string, release <-chan struct{}) func(*fakeAppRuntime, appDispatchRequest) error {
+	return func(f *fakeAppRuntime, req appDispatchRequest) error {
+		entered <- req.App
+		<-release
+		return nil
+	}
+}
+
+// The case a live run falsified: charging the earliest dispatch blames the wrong
+// app whenever a well-behaved handler got there first.
+//
+// bystander awaits an attn API — the documented shape — so it enters, yields, and
+// is still unanswered when hog enters behind it and spins without yielding. hog
+// is what froze the loop, including bystander's own reply. The daemon's dispatch
+// order says bystander; only the host's entry order says hog.
+func TestFrozenLoopChargesTheHandlerOnTheLoopNotTheEarliestDispatch(t *testing.T) {
+	d := newAppDaemon(t)
+	// Tripwires the product ships are 60s and 2s. A test that waited them out
+	// would take a minute and prove nothing extra.
+	d.appDispatchWait = 300 * time.Millisecond
+	d.appPingWait = 50 * time.Millisecond
+	installApp(t, d, "bystander", subscribing("ticket.*"))
+	installApp(t, d, "hog", subscribing("ticket.*"))
+	installApp(t, d, "latecomer", subscribing("ticket.*"))
+
+	entered := make(chan string, 2)
+	release := make(chan struct{})
+	defer close(release)
+	runtime := startFakeAppRuntime(t, d, enterOnceThenBlock(entered, release))
+
+	// bystander first, hog second: the order that makes earliest-dispatch wrong.
+	failures := map[string]chan error{"bystander": make(chan error, 1), "hog": make(chan error, 1), "latecomer": make(chan error, 1)}
+	for i, name := range []string{"bystander", "hog"} {
+		go func() {
+			failures[name] <- d.deliverAppEvent(context.Background(), name, appEvent("ticket.created", "tk", int64(i+1)))
+		}()
+		if got := <-entered; got != name {
+			t.Fatalf("handler %d in was %s, want %s", i, got, name)
+		}
+	}
+	// From here nothing is served: no ping, and no dispatch reaches app code.
+	runtime.freezeLoop()
+
+	// latecomer's dispatch lands on a loop that will never read it.
+	go func() {
+		failures["latecomer"] <- d.deliverAppEvent(context.Background(), "latecomer", appEvent("ticket.created", "tk-3", 3))
+	}()
+
+	for name, ch := range failures {
+		if err := <-ch; err == nil {
+			t.Fatalf("%s's dispatch into a frozen runtime reported success", name)
+		} else if name != "hog" && !strings.Contains(err.Error(), "hog") {
+			t.Fatalf("%s's failure does not name the culprit: %v", name, err)
+		}
+	}
+
+	// hog owns it: on the auto-disable clock, and its invocation is its own fault.
+	if _, ok := d.appStallSnapshot("hog"); !ok {
+		t.Fatal("hog wedged the runtime and is not on the auto-disable clock")
+	}
+	if rows := invocationsOf(t, d, "hog"); len(rows) != 1 || rows[0].Status != appInvocationStatusError {
+		t.Fatalf("hog's invocation = %+v, want one with status %q", rows, appInvocationStatusError)
+	}
+
+	// Neither victim is charged. bystander entered but yielded; latecomer never ran
+	// a line of its own code at all.
+	for _, name := range []string{"bystander", "latecomer"} {
+		if stall, ok := d.appStallSnapshot(name); ok {
+			t.Fatalf("%s was charged for hog's wedge: %+v", name, stall)
+		}
+		if rows := invocationsOf(t, d, name); len(rows) != 1 || rows[0].Status != appInvocationStatusRuntimeError {
+			t.Fatalf("%s's invocation = %+v, want one with status %q", name, rows, appInvocationStatusRuntimeError)
+		}
+	}
+}
+
+// The culprit's own dispatch times out first — it entered first among the ones
+// still running — so by the time a victim gives up, nothing of the culprit's is
+// in flight. The entry announcement is what outlives that.
+func TestAVictimIsNotChargedAfterTheCulpritsDispatchHasGivenUp(t *testing.T) {
+	d := newAppDaemon(t)
+	d.appDispatchWait = 200 * time.Millisecond
+	d.appPingWait = 50 * time.Millisecond
+	installApp(t, d, "hog", subscribing("ticket.*"))
+	installApp(t, d, "latecomer", subscribing("ticket.*"))
+
+	entered := make(chan string, 1)
+	release := make(chan struct{})
+	defer close(release)
+	runtime := startFakeAppRuntime(t, d, enterOnceThenBlock(entered, release))
+
+	go d.deliverAppEvent(context.Background(), "hog", appEvent("ticket.created", "tk-1", 1))
+	if app := <-entered; app != "hog" {
+		t.Fatalf("first handler in was %s, want hog", app)
+	}
+	runtime.freezeLoop()
+
+	// Let hog's own dispatch time out and be released before latecomer starts.
+	waitFor(t, "hog's dispatch to be abandoned", func() bool {
+		_, ok := d.appStallSnapshot("hog")
+		return ok
+	})
+
+	err := d.deliverAppEvent(context.Background(), "latecomer", appEvent("ticket.created", "tk-2", 2))
+	if err == nil {
+		t.Fatal("a dispatch into a frozen runtime reported success")
+	}
+	if stall, ok := d.appStallSnapshot("latecomer"); ok {
+		t.Fatalf("latecomer was charged for a loop hog had already frozen: %+v", stall)
+	}
+	if !strings.Contains(err.Error(), "hog") {
+		t.Fatalf("failure does not name the culprit: %v", err)
+	}
+}
+
+// An app that ran and returned is off the loop, and must not be blamed for a
+// freeze it is not part of. When nothing is on the loop the daemon has no culprit
+// to name and charges the app whose dispatch timed out, which is all it knows.
+func TestAHandlerThatAlreadyReturnedIsNotBlamedForALaterFreeze(t *testing.T) {
+	d := newAppDaemon(t)
+	d.appDispatchWait = 200 * time.Millisecond
+	d.appPingWait = 50 * time.Millisecond
+	installApp(t, d, "quick", subscribing("ticket.*"))
+	installApp(t, d, "unlucky", subscribing("ticket.*"))
+
+	runtime := startFakeAppRuntime(t, d, nil)
+	if err := d.deliverAppEvent(context.Background(), "quick", appEvent("ticket.created", "tk-1", 1)); err != nil {
+		t.Fatalf("a handler that returns normally failed: %v", err)
+	}
+
+	// The loop stops with no app's handler on it — a host that wedged in its own
+	// code, not an app's.
+	runtime.freezeLoop()
+
+	err := d.deliverAppEvent(context.Background(), "unlucky", appEvent("ticket.created", "tk-2", 2))
+	if err == nil {
+		t.Fatal("a dispatch into a frozen runtime reported success")
+	}
+	if strings.Contains(err.Error(), "quick") {
+		t.Fatalf("an app that had already returned was blamed: %v", err)
+	}
+	if _, ok := d.appStallSnapshot("quick"); ok {
+		t.Fatal("an app that had already returned was put on the auto-disable clock")
+	}
+	if _, ok := d.appStallSnapshot("unlucky"); !ok {
+		t.Fatal("with no culprit to name, the app whose dispatch timed out must still be charged")
+	}
+}
+
+// The other half of the rule. A loop that is turning means nothing is in this
+// app's way, so its own handler is what did not return — charged as before.
+func TestATurningLoopChargesTheAppWhoseHandlerHung(t *testing.T) {
+	d := newAppDaemon(t)
+	d.appDispatchWait = 300 * time.Millisecond
+	d.appPingWait = 2 * time.Second
+	installApp(t, d, "dawdler", subscribing("ticket.*"))
+
+	entered := make(chan string, 1)
+	release := make(chan struct{})
+	defer close(release)
+	// Pings stay answered: only this one handler is stuck.
+	startFakeAppRuntime(t, d, enterOnceThenBlock(entered, release))
+
+	err := d.deliverAppEvent(context.Background(), "dawdler", appEvent("ticket.created", "tk-1", 1))
+	if err == nil {
+		t.Fatal("a handler that never returned reported success")
+	}
+	if !strings.Contains(err.Error(), "did not return within") {
+		t.Fatalf("failure = %v, want the hung-handler message", err)
+	}
+	if _, ok := d.appStallSnapshot("dawdler"); !ok {
+		t.Fatal("a hung handler must put its own app on the auto-disable clock")
+	}
+	if rows := invocationsOf(t, d, "dawdler"); len(rows) != 1 || rows[0].Status != appInvocationStatusError {
+		t.Fatalf("invocation = %+v, want one with status %q", rows, appInvocationStatusError)
+	}
+}
+
+// A ping is the arbiter, so it needs its own budget rather than whatever the
+// dispatch had left — which is nothing, by construction.
+func TestTheLivenessPingIsBoundedIndependently(t *testing.T) {
+	if appRuntimePingWait <= 0 {
+		t.Fatal("the liveness ping must be bounded")
+	}
+	if appRuntimePingWait >= appDispatchTimeout {
+		t.Fatalf("ping wait %v is not comfortably inside the dispatch timeout %v", appRuntimePingWait, appDispatchTimeout)
+	}
+	d := &Daemon{}
+	if got := d.appPingBudget(); got != appRuntimePingWait {
+		t.Fatalf("appPingBudget() = %v, want the shipped %v", got, appRuntimePingWait)
+	}
+	d.appPingWait = 5 * time.Millisecond
+	if got := d.appPingBudget(); got != 5*time.Millisecond {
+		t.Fatalf("appPingBudget() = %v, want the override", got)
+	}
+}

--- a/internal/daemon/app_wedge_test.go
+++ b/internal/daemon/app_wedge_test.go
@@ -137,6 +137,50 @@ func TestAVictimIsNotChargedAfterTheCulpritsDispatchHasGivenUp(t *testing.T) {
 	}
 }
 
+// A handler that yields is still on the loop, and an answered ping does not say
+// otherwise. The daemon must keep naming it if it comes back and spins.
+//
+// This is the case that decides whether the daemon may infer a handler left. It
+// may not: the only thing it could infer from is the loop still turning, and a
+// handler that yielded and never settled is on a turning loop. Dropping entries
+// on an answered ping would leave this freeze named by nobody.
+func TestAHandlerThatYieldedIsStillNamedWhenItComesBackAndSpins(t *testing.T) {
+	d := newAppDaemon(t)
+	d.appDispatchWait = 200 * time.Millisecond
+	d.appPingWait = 100 * time.Millisecond
+	installApp(t, d, "sleeper", subscribing("ticket.*"))
+	installApp(t, d, "latecomer", subscribing("ticket.*"))
+
+	entered := make(chan string, 1)
+	release := make(chan struct{})
+	defer close(release)
+	runtime := startFakeAppRuntime(t, d, enterOnceThenBlock(entered, release))
+
+	// sleeper enters and yields — it never settles, but the loop keeps turning, so
+	// its own dispatch times out against an *answered* ping.
+	err := d.deliverAppEvent(context.Background(), "sleeper", appEvent("ticket.created", "tk-1", 1))
+	if err == nil {
+		t.Fatal("a handler that never returned reported success")
+	}
+	if !strings.Contains(err.Error(), "did not return within") {
+		t.Fatalf("failure = %v, want the hung-handler message on a turning loop", err)
+	}
+
+	// Now it resumes and spins: same handler, same entry, loop stops.
+	runtime.freezeLoop()
+
+	failure := d.deliverAppEvent(context.Background(), "latecomer", appEvent("ticket.created", "tk-2", 2))
+	if failure == nil {
+		t.Fatal("a dispatch into a frozen runtime reported success")
+	}
+	if !strings.Contains(failure.Error(), "sleeper") {
+		t.Fatalf("the handler that yielded and came back is no longer named: %v", failure)
+	}
+	if stall, ok := d.appStallSnapshot("latecomer"); ok {
+		t.Fatalf("latecomer was charged for a loop sleeper froze: %+v", stall)
+	}
+}
+
 // An app that ran and returned is off the loop, and must not be blamed for a
 // freeze it is not part of. When nothing is on the loop the daemon has no culprit
 // to name and charges the app whose dispatch timed out, which is all it knows.

--- a/internal/daemon/apps.go
+++ b/internal/daemon/apps.go
@@ -29,6 +29,16 @@ import (
 // more.
 const recentInvocationLimit = 10
 
+// recentVersionLimit is how many version ids `attn app status` carries back.
+//
+// Rollback names ids in its refusals and nothing else lists them, so status has
+// to. Ten because it is the same answer shape as the invocations above and a
+// rollback target is a version the operator still remembers applying; the count
+// beside the list is what keeps a truncated answer honest. An AppVersionInfo is
+// ~200 bytes on the wire, so ten is ~2KB on a call that already carries ten
+// invocations.
+const recentVersionLimit = 10
+
 // appEnabledChanged is FactAppEnabledChanged's payload.
 type appEnabledChanged struct {
 	Name     string `json:"name"`
@@ -118,7 +128,24 @@ func (d *Daemon) handleAppStatus(conn net.Conn, msg *protocol.AppStatusMessage) 
 		d.sendError(conn, fmt.Sprintf("reading invocations of app %q: %v", name, err))
 		return
 	}
+	recentVersions, err := d.store.ListAppVersions(name)
+	if err != nil {
+		d.sendError(conn, fmt.Sprintf("reading versions of app %q: %v", name, err))
+		return
+	}
+	if len(recentVersions) > recentVersionLimit {
+		recentVersions = recentVersions[:recentVersionLimit]
+	}
+
 	result := protocol.AppStatusResult{App: summary, Versions: versions, Invocations: invocations}
+	for _, version := range recentVersions {
+		result.RecentVersions = append(result.RecentVersions, protocol.AppVersionInfo{
+			ID:           int(version.ID),
+			ContentHash:  version.ContentHash,
+			ArtifactPath: version.ArtifactPath,
+			CreatedAt:    stampForWire(version.CreatedAt),
+		})
+	}
 	for _, inv := range recent {
 		result.Recent = append(result.Recent, appInvocationForWire(inv.ID, inv))
 	}
@@ -171,7 +198,7 @@ func (d *Daemon) handleAppSetEnabled(conn net.Conn, msg *protocol.AppSetEnabledM
 	} else if !ok {
 		d.sendError(conn, fmt.Sprintf(
 			"app %q has no bus consumer (%s), so there is no enabled bit to %s: nothing is delivering facts to it. "+
-				"A consumer is registered when the app runtime loads a version of the app; `attn app status %s` shows what exists.",
+				"A consumer is registered when a version is applied or rolled onto, and again when the daemon starts; `attn app status %s` shows what exists.",
 			name, consumer, verb, name))
 		return
 	}
@@ -190,10 +217,11 @@ func (d *Daemon) handleAppSetEnabled(conn net.Conn, msg *protocol.AppSetEnabledM
 		return
 	}
 	if msg.Enabled {
-		// Enabling is the way back from an auto-disable, so it clears the streak
-		// that caused one. Without this the app would be disabled again on its very
+		// Enabling is the way back from an auto-disable, so it clears both streaks
+		// that cause one. Without this the app would be disabled again on its very
 		// next failure, against a clock it never got to restart.
 		d.clearAppStall(name)
+		d.clearAppCrashes(name)
 	}
 	d.publishFact(FactAppEnabledChanged, name, appEnabledChanged{
 		Name: name, Consumer: consumer, Enabled: msg.Enabled,

--- a/internal/daemon/apps_test.go
+++ b/internal/daemon/apps_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"strings"
 	"testing"
@@ -363,6 +364,47 @@ func TestAppStatusReportsHistoryAndRecentInvocations(t *testing.T) {
 	}
 	if result.App.Consumer == nil || result.App.Consumer.Enabled {
 		t.Fatalf("consumer = %+v, want a disabled one", result.App.Consumer)
+	}
+}
+
+// Rollback takes a version id and names ids in every refusal, so status is
+// where they have to be readable. A count alone sent the reader looking for a
+// list that did not exist on any surface.
+func TestAppStatusListsTheVersionIdsRollbackTakes(t *testing.T) {
+	d := newDaemonForTest(t)
+	seedApp(t, d, "approval-gate", false)
+
+	now := time.Now().UTC()
+	var ids []int64
+	for i := 0; i < recentVersionLimit+3; i++ {
+		version, _, err := d.store.CommitAppVersion(store.AppVersion{
+			AppName:      "approval-gate",
+			ContentHash:  fmt.Sprintf("sha256:build-%02d", i),
+			Declaration:  `{"name":"approval-gate","subscribe":[{"events":["ticket.*"]}]}`,
+			ArtifactPath: fmt.Sprintf("apps/approval-gate/%02d.js", i),
+		}, now)
+		if err != nil {
+			t.Fatalf("commit version %d: %v", i, err)
+		}
+		ids = append(ids, version.ID)
+	}
+
+	result := appStatus(t, d, "approval-gate").AppStatusResult
+	if len(result.RecentVersions) != recentVersionLimit {
+		t.Fatalf("recent_versions = %d, want the %d cap", len(result.RecentVersions), recentVersionLimit)
+	}
+	// Newest first, so the ids a reader is most likely to want are the ones they
+	// get when the list is truncated.
+	if result.RecentVersions[0].ID != int(ids[len(ids)-1]) {
+		t.Fatalf("recent_versions[0].ID = %d, want the newest %d", result.RecentVersions[0].ID, ids[len(ids)-1])
+	}
+	// The count still tells the truth about how many exist, which is what keeps
+	// the capped list honest.
+	if result.Versions != len(ids)+1 {
+		t.Fatalf("versions = %d, want %d", result.Versions, len(ids)+1)
+	}
+	if result.RecentVersions[0].ContentHash == "" || result.RecentVersions[0].CreatedAt == "" {
+		t.Fatalf("recent_versions[0] = %+v, want a hash and a stamp to tell builds apart", result.RecentVersions[0])
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -356,7 +356,12 @@ type Daemon struct {
 	appRuntimeSupervise supervise.Options
 	// appRuntimeWait overrides appRuntimeConnectWait, for the same reason.
 	appRuntimeWait time.Duration
-	appRuntimeConn *appRuntimeConnection
+	// appPingWait and appDispatchWait override appRuntimePingWait and
+	// appDispatchTimeout, for the same reason appRuntimeWait exists: a test about a
+	// wedged event loop must not cost a real minute of waiting.
+	appPingWait     time.Duration
+	appDispatchWait time.Duration
+	appRuntimeConn  *appRuntimeConnection
 	// appRuntimeReady closes when a sidecar connects, and is replaced with a
 	// fresh open channel when one goes away. It is how a delivery waits for a
 	// cold start on a real signal instead of a poll.
@@ -370,6 +375,20 @@ type Daemon struct {
 	// failing on an event. See appStall.
 	appStallMu sync.Mutex
 	appStalls  map[string]*appStall
+	// appEntered is every handler the sidecar named by appEnteredGen has started
+	// and not answered for, by dispatch id, in the order the host entered them.
+	// A frozen event loop is frozen by the last of them, which is a different app
+	// from the earliest dispatch whenever a well-behaved handler yielded first.
+	// See attributeWedgedDispatch.
+	appEnteredMu  sync.Mutex
+	appEntered    map[string]enteredHandler
+	appEnteredGen uint64
+	appEnteredSeq uint64
+	// appCrashes is the other auto-disable clock: when each app was last named as
+	// the cause of a sidecar crash, trimmed to appCrashWindow. In memory for the
+	// same reason appStalls is — it measures what is breaking now.
+	appCrashMu sync.Mutex
+	appCrashes map[string][]time.Time
 	// busPinEpisodes is the retention-pin alarm's position, one entry per consumer
 	// that is currently holding the event log open. See busPinEpisode.
 	busPinMu       sync.Mutex

--- a/internal/hub/bootstrap.go
+++ b/internal/hub/bootstrap.go
@@ -25,6 +25,32 @@ const githubRepo = "victorarias/attn"
 const remoteDaemonReadyTimeout = 35 * time.Second
 const remoteHarnessRootMarker = "/.attn/harness/"
 
+// A bootstrap has two duties of very different size, so it has two budgets and
+// spends them in the order that matters: making the remote usable comes first
+// and never waits on the app runtime host behind it.
+//
+// remoteReadyBudget covers platform detection, the version checks, the attn
+// binary itself, enrollment, and the daemon start plus its
+// remoteDaemonReadyTimeout wait. appRuntimeShipBudget covers the sidecar, which
+// is a separate artifact roughly half again the size of the binary and gated on
+// its own content.
+//
+// Both are tripwires sized past the slowest link anyone would sync a remote
+// over — 5 Mbit/s, a bad tether — rather than around a measured happy path,
+// because a budget a healthy case can reach is the bug this pair replaced:
+//
+//	attn binary       58,934,608 B = 471.5 Mbit -> 94s at 5 Mbit/s
+//	app runtime host  93,694,096 B = 749.6 Mbit -> 150s at 5 Mbit/s
+//	daemon readiness  <= 35s (remoteDaemonReadyTimeout)
+//	sha256 of the runtime: 0.17s local, 0.38s remote; source build 0.13s
+//
+// Generosity costs nothing on the broken path: every ssh here carries
+// ConnectTimeout=10, so an unreachable remote fails in seconds either way.
+const (
+	remoteReadyBudget    = 180 * time.Second
+	appRuntimeShipBudget = 300 * time.Second
+)
+
 type RemotePlatform struct {
 	GOOS         string
 	GOARCH       string
@@ -44,13 +70,30 @@ type Bootstrapper struct {
 	versionOnce sync.Once
 	version     string
 	versionErr  error
+
+	// The two phases EnsureRemoteReady orders and budgets. They are fields so a
+	// test can assert that order and those budgets — which is the whole content
+	// of EnsureRemoteReady — without a remote to talk to.
+	makeReady      func(ctx context.Context, sshTarget, profile, homeDaemonID string) (readyRemote, error)
+	shipAppRuntime func(ctx context.Context, sshTarget, profile string, ready readyRemote) error
 }
 
 func NewBootstrapper(logf func(format string, args ...interface{})) *Bootstrapper {
 	if logf == nil {
 		logf = func(string, ...interface{}) {}
 	}
-	return &Bootstrapper{logf: logf}
+	b := &Bootstrapper{logf: logf}
+	b.makeReady = b.makeRemoteReady
+	b.shipAppRuntime = b.shipRemoteAppRuntime
+	return b
+}
+
+// readyRemote is what the first phase learned about the remote and the second
+// phase needs: where files go, and what to build for.
+type readyRemote struct {
+	platform          RemotePlatform
+	version           string
+	remoteInstallPath string
 }
 
 // EnsureRemoteReady installs the binary, records the remote's enrollment, and
@@ -59,19 +102,42 @@ func NewBootstrapper(logf func(format string, args ...interface{})) *Bootstrappe
 // caller is not a home daemon itself, and then no enrollment is written: a
 // daemon that does not own a garden cannot tell another daemon it does.
 func (b *Bootstrapper) EnsureRemoteReady(ctx context.Context, sshTarget, profile, homeDaemonID string) error {
+	readyCtx, cancelReady := context.WithTimeout(ctx, remoteReadyBudget)
+	ready, err := b.makeReady(readyCtx, sshTarget, profile, homeDaemonID)
+	cancelReady()
+	if err != nil {
+		return err
+	}
+
+	// The sidecar ships only once the daemon is up, and out of its own budget.
+	// It is the larger artifact by half again, and a remote that cannot get one
+	// still runs sessions — only apps park — so shipping it must never be what
+	// stops a dead remote from being revived. Its failure is reported, not
+	// returned, for the same reason.
+	shipCtx, cancelShip := context.WithTimeout(ctx, appRuntimeShipBudget)
+	defer cancelShip()
+	if err := b.shipAppRuntime(shipCtx, sshTarget, profile, ready); err != nil {
+		b.logf("%v", err)
+	}
+	return nil
+}
+
+// makeRemoteReady installs the binary, records enrollment, and leaves the
+// daemon running — everything a remote needs to host sessions.
+func (b *Bootstrapper) makeRemoteReady(ctx context.Context, sshTarget, profile, homeDaemonID string) (readyRemote, error) {
 	platform, err := b.detectRemotePlatform(ctx, sshTarget, profile)
 	if err != nil {
-		return fmt.Errorf("detect remote platform for %s: %w", sshTarget, err)
+		return readyRemote{}, fmt.Errorf("detect remote platform for %s: %w", sshTarget, err)
 	}
 
 	localVersion, err := b.localVersion(ctx)
 	if err != nil {
-		return fmt.Errorf("determine local version: %w", err)
+		return readyRemote{}, fmt.Errorf("determine local version: %w", err)
 	}
 
 	remoteVersion, err := b.remoteVersion(ctx, sshTarget, profile)
 	if err != nil {
-		return fmt.Errorf("check remote version on %s: %w", sshTarget, err)
+		return readyRemote{}, fmt.Errorf("check remote version on %s: %w", sshTarget, err)
 	}
 
 	preferSourceBuild := sourceCheckoutAvailable()
@@ -80,7 +146,7 @@ func (b *Bootstrapper) EnsureRemoteReady(ctx context.Context, sshTarget, profile
 	if remoteVersion != localVersion || preferSourceBuild {
 		localBinary, err = b.ensureLocalBinary(ctx, platform, localVersion)
 		if err != nil {
-			return fmt.Errorf("prepare %s binary for %s: %w", platform.ArtifactName, sshTarget, err)
+			return readyRemote{}, fmt.Errorf("prepare %s binary for %s: %w", platform.ArtifactName, sshTarget, err)
 		}
 	}
 
@@ -88,11 +154,11 @@ func (b *Bootstrapper) EnsureRemoteReady(ctx context.Context, sshTarget, profile
 	if !shouldInstall && preferSourceBuild {
 		localHash, err := fileSHA256(localBinary)
 		if err != nil {
-			return fmt.Errorf("hash local binary for %s: %w", sshTarget, err)
+			return readyRemote{}, fmt.Errorf("hash local binary for %s: %w", sshTarget, err)
 		}
 		remoteHash, err := b.remoteBinarySHA256(ctx, sshTarget, profile)
 		if err != nil {
-			return fmt.Errorf("hash remote binary on %s: %w", sshTarget, err)
+			return readyRemote{}, fmt.Errorf("hash remote binary on %s: %w", sshTarget, err)
 		}
 		shouldInstall = shouldInstallRemoteBinary(localVersion, remoteVersion, preferSourceBuild, localHash, remoteHash)
 		if shouldInstall {
@@ -102,28 +168,14 @@ func (b *Bootstrapper) EnsureRemoteReady(ctx context.Context, sshTarget, profile
 
 	remoteInstallPath, err := b.resolveRemoteInstall(ctx, sshTarget, profile)
 	if err != nil {
-		return fmt.Errorf("resolve the install path on %s: %w", sshTarget, err)
+		return readyRemote{}, fmt.Errorf("resolve the install path on %s: %w", sshTarget, err)
 	}
+	ready := readyRemote{platform: platform, version: localVersion, remoteInstallPath: remoteInstallPath}
 
 	if shouldInstall {
 		if err := b.installRemoteBinary(ctx, sshTarget, profile, localBinary, remoteInstallPath); err != nil {
-			return fmt.Errorf("install attn on %s: %w", sshTarget, err)
+			return ready, fmt.Errorf("install attn on %s: %w", sshTarget, err)
 		}
-		binariesUpdated = true
-	}
-
-	// The app runtime host ships beside the binary and is gated on its own
-	// content, so it is checked on every sync rather than only when the binary
-	// moved: the two are built from different trees and an apphost-only change
-	// leaves the attn binary identical. A remote that cannot get one still runs
-	// sessions — only apps park — so this reports and continues.
-	runtimeUpdated, err := b.ensureRemoteAppRuntime(ctx, sshTarget, profile, platform, localVersion, remoteInstallPath)
-	if err != nil {
-		b.logf("%v", err)
-	}
-	if runtimeUpdated {
-		// A replaced sidecar is a new file; the running one keeps the old inode
-		// until something restarts it, and the daemon is what starts it.
 		binariesUpdated = true
 	}
 
@@ -132,12 +184,63 @@ func (b *Bootstrapper) EnsureRemoteReady(ctx context.Context, sshTarget, profile
 	// refuses, and that refusal stops the sync — re-homing is the operator's
 	// decision to make, on that machine.
 	if err := b.enrollRemote(ctx, sshTarget, profile, homeDaemonID); err != nil {
-		return err
+		return ready, err
 	}
 
 	if err := b.ensureRemoteDaemonRunning(ctx, sshTarget, profile, binariesUpdated); err != nil {
-		return fmt.Errorf("ensure remote daemon on %s: %w", sshTarget, err)
+		return ready, fmt.Errorf("ensure remote daemon on %s: %w", sshTarget, err)
 	}
+	return ready, nil
+}
+
+// shipRemoteAppRuntime brings the remote's sidecar up to date with this hub's.
+// It is gated on content rather than on the binary having moved: the two are
+// built from different trees, so an apphost-only change leaves the attn binary
+// byte-identical.
+func (b *Bootstrapper) shipRemoteAppRuntime(ctx context.Context, sshTarget, profile string, ready readyRemote) error {
+	updated, err := b.ensureRemoteAppRuntime(ctx, sshTarget, profile, ready.platform, ready.version, ready.remoteInstallPath)
+	if err != nil {
+		return err
+	}
+	if !updated {
+		return nil
+	}
+	// The replacement is a new inode and a sidecar that is already up still holds
+	// the old one, so it has to be bounced to pick the new file up. Only when one
+	// is actually running: the runtime starts lazily on the first fact an app is
+	// due, and starting it from here would put a Bun process on a remote that may
+	// host no enabled app at all.
+	return b.bounceRemoteAppRuntime(ctx, sshTarget, profile)
+}
+
+// bounceRemoteAppRuntime restarts the remote's sidecar when one is running, so
+// it picks up the file that just replaced it.
+//
+// A remote whose runtime has never started needs nothing and must not be
+// started from here, so this asks before it acts. Both halves are best-effort:
+// a remote too old to answer, or one that refuses the restart, keeps serving the
+// previous sidecar rather than failing the sync — the report is what a person
+// acts on.
+func (b *Bootstrapper) bounceRemoteAppRuntime(ctx context.Context, sshTarget, profile string) error {
+	stdout, _, code, err := runSSHExit(ctx, sshTarget, profile, remoteAttnCommand(profile, "app", "runtime", "status", "--json"))
+	if err != nil || code != 0 {
+		return fmt.Errorf("could not ask %s whether its app runtime is running, so the sidecar it just received is not in use yet; `attn app runtime restart` there picks it up", sshTarget)
+	}
+	var status struct {
+		Runtime *struct {
+			Running bool `json:"running"`
+		} `json:"runtime"`
+	}
+	if jsonErr := json.Unmarshal([]byte(stdout), &status); jsonErr != nil {
+		return fmt.Errorf("app runtime status on %s returned unreadable output %q", sshTarget, stdout)
+	}
+	if status.Runtime == nil || !status.Runtime.Running {
+		return nil
+	}
+	if _, _, code, err := runSSHExit(ctx, sshTarget, profile, remoteAttnCommand(profile, "app", "runtime", "restart")); err != nil || code != 0 {
+		return fmt.Errorf("the app runtime on %s is still running the previous sidecar; `attn app runtime restart` there picks up the new one", sshTarget)
+	}
+	b.logf("restarted the app runtime on %s onto the sidecar just installed", sshTarget)
 	return nil
 }
 
@@ -359,9 +462,15 @@ func (b *Bootstrapper) downloadReleaseArtifact(ctx context.Context, version, art
 // per attn build: the sidecar is built from apphost/, which no version or
 // daemon-binary fingerprint covers, so any such key would serve a stale runtime
 // after an apphost-only edit — and the artifact is ~90MB, so a key per build is
-// also a disk leak. The compile is fast enough (~0.4s measured, bun embeds its
-// runtime rather than compiling it) that rebuilding every sync costs nothing. A
-// downloaded release artifact is immutable and does cache per version.
+// also a disk leak. A downloaded release artifact is immutable and does cache
+// per version.
+//
+// Rebuilding unconditionally is deliberate, and it is what makes the sidecar
+// correct after an apphost edit no key would notice. It is affordable because a
+// bootstrap is demand-driven — nothing puts one on a timer — and the whole pass
+// over this artifact is under a second: 0.13s to compile (bun embeds its
+// runtime rather than compiling it), 0.17s to hash locally, 0.38s to hash on the
+// far end. Measured on a 93,694,096-byte linux_arm64 host.
 func appRuntimeCacheDir(home, key string) string {
 	return filepath.Join(home, ".attn", "remotes", "app-runtime", key)
 }
@@ -445,8 +554,8 @@ func (b *Bootstrapper) ensureRemoteAppRuntime(ctx context.Context, sshTarget, pr
 	localPath, err := b.ensureLocalAppRuntime(ctx, platform, version)
 	if err != nil {
 		return false, fmt.Errorf(
-			"the app runtime host is missing from %s at %s: %w. Apps on that daemon park until it is there; run the hub from a source checkout with bun installed, or copy %s there yourself",
-			sshTarget, remotePath, err, platform.RuntimeArtifactName)
+			"the app runtime host is missing from %s at %s: %w. That daemon falls back to an unsuffixed %s beside it and parks its apps only if there is none; run the hub from a source checkout with bun installed, or copy %s there yourself",
+			sshTarget, remotePath, err, apps.RuntimeHostBinaryName, platform.RuntimeArtifactName)
 	}
 
 	localHash, err := fileSHA256(localPath)
@@ -463,8 +572,8 @@ func (b *Bootstrapper) ensureRemoteAppRuntime(ctx context.Context, sshTarget, pr
 
 	if err := b.uploadRemoteFile(ctx, sshTarget, profile, localPath, remotePath); err != nil {
 		return false, fmt.Errorf(
-			"the app runtime host could not be installed on %s at %s: %w. Apps on that daemon park until it is there",
-			sshTarget, remotePath, err)
+			"the app runtime host could not be installed on %s at %s: %w. That daemon keeps whatever host it already resolves — an unsuffixed %s beside it, or none, in which case its apps park",
+			sshTarget, remotePath, err, apps.RuntimeHostBinaryName)
 	}
 	b.logf("installed the app runtime host on %s at %s (%s)", sshTarget, remotePath, localHash[:12])
 	return true, nil
@@ -728,6 +837,24 @@ func (b *Bootstrapper) uploadRemoteFile(ctx context.Context, sshTarget, profile,
 		return fmt.Errorf("open %s: %w", localPath, err)
 	}
 	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", localPath, err)
+	}
+
+	// Every path out of here past this point removes the staging file. A dropped
+	// link mid-transfer leaves up to the whole artifact behind, the name carries
+	// a pid and a timestamp so retries never reuse it, and /tmp is RAM on a
+	// systemd remote — an upload that keeps failing must not also keep
+	// accumulating.
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
+		defer cancel()
+		if _, err := runSSH(cleanupCtx, sshTarget, profile, fmt.Sprintf("rm -f %s", shellQuote(remoteTmpPath))); err != nil {
+			b.logf("could not remove the staging file %s on %s: %v", remoteTmpPath, sshTarget, err)
+		}
+	}()
+
 	cmd := exec.CommandContext(
 		ctx,
 		"ssh",
@@ -738,24 +865,31 @@ func (b *Bootstrapper) uploadRemoteFile(ctx context.Context, sshTarget, profile,
 	if err != nil {
 		return fmt.Errorf("copy %s over ssh: %s", filepath.Base(localPath), strings.TrimSpace(string(out)))
 	}
-	if probe, probeErr := runSSH(
+
+	// ssh reports the far end's exit status, which says the shell ran — not that
+	// every byte arrived. A short file here would otherwise be installed and then
+	// refuse to exec, which is a much worse way to learn about it.
+	probe, err := runSSH(
 		ctx,
 		sshTarget,
 		profile,
 		fmt.Sprintf("if [ -f %s ]; then wc -c < %s; else printf MISSING; fi", shellQuote(remoteTmpPath), shellQuote(remoteTmpPath)),
-	); probeErr == nil {
-		b.logf("remote upload probe: target=%s tmp=%s result=%s", sshTarget, remoteTmpPath, strings.TrimSpace(probe))
+	)
+	if err != nil {
+		return fmt.Errorf("check the uploaded size of %s on %s: %w", filepath.Base(localPath), sshTarget, err)
 	}
+	if got := strings.TrimSpace(probe); got != fmt.Sprintf("%d", info.Size()) {
+		return fmt.Errorf(
+			"%s arrived on %s as %s bytes, not %d — the transfer was cut short",
+			filepath.Base(localPath), sshTarget, got, info.Size(),
+		)
+	}
+
 	_, err = runSSH(
 		ctx,
 		sshTarget,
 		profile,
-		fmt.Sprintf(
-			"install -m 755 %s %s && rm -f %s",
-			shellQuote(remoteTmpPath),
-			shellQuote(remotePath),
-			shellQuote(remoteTmpPath),
-		),
+		fmt.Sprintf("install -m 755 %s %s", shellQuote(remoteTmpPath), shellQuote(remotePath)),
 	)
 	return err
 }

--- a/internal/hub/bootstrap_phases_test.go
+++ b/internal/hub/bootstrap_phases_test.go
@@ -1,0 +1,140 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// EnsureRemoteReady is two phases, an order, and two budgets. These pin all
+// three: shipping the ~93.7MB sidecar used to run first and out of the same
+// budget as everything else, so a remote whose daemon was down and whose link
+// was slow spent its whole budget on the upload and never reached the step that
+// would have revived it.
+
+func TestEnsureRemoteReadyRevivesTheDaemonBeforeShippingTheSidecar(t *testing.T) {
+	b := NewBootstrapper(nil)
+	var order []string
+
+	b.makeReady = func(ctx context.Context, sshTarget, profile, homeDaemonID string) (readyRemote, error) {
+		order = append(order, "ready")
+		return readyRemote{remoteInstallPath: "/home/x/.local/bin/attn"}, nil
+	}
+	b.shipAppRuntime = func(ctx context.Context, sshTarget, profile string, ready readyRemote) error {
+		order = append(order, "ship")
+		if ready.remoteInstallPath != "/home/x/.local/bin/attn" {
+			t.Errorf("ship phase got %q, want what the ready phase resolved", ready.remoteInstallPath)
+		}
+		return nil
+	}
+
+	if err := b.EnsureRemoteReady(context.Background(), "host", "", "home-1"); err != nil {
+		t.Fatalf("EnsureRemoteReady() = %v, want nil", err)
+	}
+	if len(order) != 2 || order[0] != "ready" || order[1] != "ship" {
+		t.Fatalf("phases ran %v, want [ready ship]", order)
+	}
+}
+
+func TestEnsureRemoteReadySkipsTheSidecarWhenTheRemoteNeverBecameReady(t *testing.T) {
+	b := NewBootstrapper(nil)
+	shipped := false
+
+	b.makeReady = func(ctx context.Context, sshTarget, profile, homeDaemonID string) (readyRemote, error) {
+		return readyRemote{}, errors.New("daemon did not become ready")
+	}
+	b.shipAppRuntime = func(ctx context.Context, sshTarget, profile string, ready readyRemote) error {
+		shipped = true
+		return nil
+	}
+
+	if err := b.EnsureRemoteReady(context.Background(), "host", "", "home-1"); err == nil {
+		t.Fatal("EnsureRemoteReady() = nil, want the readiness failure")
+	}
+	if shipped {
+		t.Fatal("shipped the sidecar to a remote whose daemon is not running")
+	}
+}
+
+// The sidecar's budget must be its own. Deriving it from the ready phase's
+// context — or sharing one deadline across both — is the shape of the bug: the
+// upload inherits whatever the daemon start left over, which on a slow link is
+// nothing.
+func TestEnsureRemoteReadyGivesTheSidecarItsOwnBudget(t *testing.T) {
+	b := NewBootstrapper(nil)
+	var readyDeadline, shipDeadline time.Time
+	var shipCtxErr error
+
+	b.makeReady = func(ctx context.Context, sshTarget, profile, homeDaemonID string) (readyRemote, error) {
+		readyDeadline, _ = ctx.Deadline()
+		return readyRemote{}, nil
+	}
+	b.shipAppRuntime = func(ctx context.Context, sshTarget, profile string, ready readyRemote) error {
+		shipDeadline, _ = ctx.Deadline()
+		shipCtxErr = ctx.Err()
+		return nil
+	}
+
+	if err := b.EnsureRemoteReady(context.Background(), "host", "", "home-1"); err != nil {
+		t.Fatalf("EnsureRemoteReady() = %v, want nil", err)
+	}
+
+	if readyDeadline.IsZero() || shipDeadline.IsZero() {
+		t.Fatal("both phases must run under a deadline")
+	}
+	// Cancelling the ready phase must not reach the ship phase: if it does, the
+	// two share a lineage and the sidecar is spending the daemon's budget.
+	if shipCtxErr != nil {
+		t.Fatalf("ship phase context was already %v; it is not independent of the ready phase", shipCtxErr)
+	}
+	if !shipDeadline.After(readyDeadline) {
+		t.Fatalf("ship deadline %v is not later than ready deadline %v", shipDeadline, readyDeadline)
+	}
+	if remaining := time.Until(shipDeadline); remaining <= remoteReadyBudget {
+		t.Fatalf("ship phase had %v, which is no more than the whole ready budget %v — it inherited rather than got its own", remaining, remoteReadyBudget)
+	}
+}
+
+// A remote that cannot be given a sidecar still runs sessions, so the sync
+// succeeds and the failure is reported instead of returned.
+func TestEnsureRemoteReadySurvivesASidecarThatCannotBeShipped(t *testing.T) {
+	var logged []string
+	b := NewBootstrapper(func(format string, args ...interface{}) {
+		logged = append(logged, format)
+	})
+
+	b.makeReady = func(ctx context.Context, sshTarget, profile, homeDaemonID string) (readyRemote, error) {
+		return readyRemote{}, nil
+	}
+	b.shipAppRuntime = func(ctx context.Context, sshTarget, profile string, ready readyRemote) error {
+		return errors.New("the app runtime host is missing")
+	}
+
+	if err := b.EnsureRemoteReady(context.Background(), "host", "", "home-1"); err != nil {
+		t.Fatalf("EnsureRemoteReady() = %v, want nil — the daemon is up and sessions work", err)
+	}
+	if len(logged) == 0 {
+		t.Fatal("a sidecar that could not be shipped must still be reported")
+	}
+}
+
+// The budgets are tripwires, not fits: a healthy sync must never be near them.
+// The receipts they are sized from live beside their declaration.
+func TestRemoteBudgetsCoverTheArtifactsTheyCarry(t *testing.T) {
+	const slowLinkBitsPerSecond = 5_000_000
+	const attnBinaryBytes = 58_934_608
+	const appRuntimeBytes = 93_694_096
+
+	binaryTransfer := time.Duration(float64(attnBinaryBytes*8) / slowLinkBitsPerSecond * float64(time.Second))
+	if want := binaryTransfer + remoteDaemonReadyTimeout; remoteReadyBudget <= want {
+		t.Errorf("remoteReadyBudget %v does not cover a %d-byte binary at 5 Mbit/s plus the %v readiness wait (%v)",
+			remoteReadyBudget, attnBinaryBytes, remoteDaemonReadyTimeout, want)
+	}
+
+	runtimeTransfer := time.Duration(float64(appRuntimeBytes*8) / slowLinkBitsPerSecond * float64(time.Second))
+	if appRuntimeShipBudget <= runtimeTransfer {
+		t.Errorf("appRuntimeShipBudget %v does not cover a %d-byte sidecar at 5 Mbit/s (%v)",
+			appRuntimeShipBudget, appRuntimeBytes, runtimeTransfer)
+	}
+}

--- a/internal/hub/bootstrap_phases_test.go
+++ b/internal/hub/bootstrap_phases_test.go
@@ -121,6 +121,12 @@ func TestEnsureRemoteReadySurvivesASidecarThatCannotBeShipped(t *testing.T) {
 
 // The budgets are tripwires, not fits: a healthy sync must never be near them.
 // The receipts they are sized from live beside their declaration.
+//
+// What this fails on is a budget that stops covering the sizes recorded *here* —
+// it does not measure the artifacts, so it cannot notice one growing on its own.
+// That is deliberate and it is where the tripwire lands: a sidecar that outgrows
+// its budget has to update these constants to make this test pass, and updating
+// them is the moment someone reads the arithmetic below.
 func TestRemoteBudgetsCoverTheArtifactsTheyCarry(t *testing.T) {
 	const slowLinkBitsPerSecond = 5_000_000
 	const attnBinaryBytes = 58_934_608

--- a/internal/hub/manager.go
+++ b/internal/hub/manager.go
@@ -462,9 +462,10 @@ func (m *Manager) runEndpointLoop(ctx context.Context, id string) {
 		// Explicit bootstrap requested (e.g. user clicked Sync) — install binary and start daemon.
 		if m.consumeBootstrapFlag(id) {
 			m.updateStatus(id, "bootstrapping", "Installing remote binary", nil, nil)
-			bootCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
-			err := m.bootstrapper.EnsureRemoteReady(bootCtx, record.SSHTarget, record.Profile, m.homeDaemonID())
-			cancel()
+			// The bootstrap owns its own deadlines: it has two phases whose sizes
+			// differ by an artifact, and one budget here could only be wrong for one
+			// of them.
+			err := m.bootstrapper.EnsureRemoteReady(ctx, record.SSHTarget, record.Profile, m.homeDaemonID())
 			if err != nil {
 				m.updateStatus(id, "error", err.Error(), nil, nil)
 				if !sleepOrDone(ctx, backoff) {
@@ -481,9 +482,7 @@ func (m *Manager) runEndpointLoop(ctx context.Context, id string) {
 		if err != nil {
 			// Daemon appears down — bootstrap then try once more.
 			m.updateStatus(id, "bootstrapping", "Checking remote platform", nil, nil)
-			bootCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
-			bootErr := m.bootstrapper.EnsureRemoteReady(bootCtx, record.SSHTarget, record.Profile, m.homeDaemonID())
-			cancel()
+			bootErr := m.bootstrapper.EnsureRemoteReady(ctx, record.SSHTarget, record.Profile, m.homeDaemonID())
 			if bootErr != nil {
 				m.updateStatus(id, "error", bootErr.Error(), nil, nil)
 				if !sleepOrDone(ctx, backoff) {

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -540,6 +540,9 @@ type AppStatusResult struct {
 	// Recent corresponds to the JSON schema field "recent".
 	Recent []AppInvocationInfo `json:"recent,omitempty,omitzero"`
 
+	// RecentVersions corresponds to the JSON schema field "recent_versions".
+	RecentVersions []AppVersionInfo `json:"recent_versions,omitempty,omitzero"`
+
 	// Runtime corresponds to the JSON schema field "runtime".
 	Runtime *AppRuntimeInfo `json:"runtime,omitempty,omitzero"`
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -4388,6 +4388,11 @@ model AppStatusResult {
   "app": AppSummary;
   "versions": safeint;
   "invocations": safeint;
+  // The most recent versions, newest first, capped — "versions" above says how
+  // many exist. Rollback names ids in its refusals and there is nowhere else to
+  // read them, so a status that carried only a count sent the reader looking for
+  // a list that does not exist.
+  "recent_versions"?: AppVersionInfo[];
   // The most recent invocations, newest first, when any have been recorded.
   "recent"?: AppInvocationInfo[];
   // The shared runtime every app's handlers execute in. Absent until it has been


### PR DESCRIPTION
An adversarial review of the A4 landing arc on `main` produced 19 candidate
findings; 9 were refuted on inspection. This is every surviving one that was
worth fixing, in one PR.

## The shared runtime blamed the wrong app

One supervised Bun process runs every installed app's handlers. Two ways an app
could break it for everybody and never be held responsible.

**A handler that never yields freezes the loop for every app.** The 60s dispatch
timeout then fired for apps whose handler was never reached, each was charged,
and the 15-minute stall clock would auto-disable innocent apps with a
notification telling their author to fix a handler that never ran.
`app.runtime.ping` existed for exactly this and had zero callers in Go.

A dispatch that times out now asks before it charges anyone. Ping answers → the
loop is turning, this app's own handler is what hung, charged as before. Ping is
silent → the loop is frozen, one handler is holding it, and only that app is
charged; everyone else is recorded as a runtime failure with its clock cleared,
and their error names the culprit.

**Which handler is holding it is the host's to say — the first build got this
wrong and live verification caught it.** Charging "the earliest dispatch" read
the daemon's own send order, which is not the order handlers hold the loop. Three
apps were dispatched into a runtime frozen by a 120s synchronous spin; the daemon
charged the app whose handler is `await ctx.collections.seen.put(...)` — the
documented shape — and let the spinner off. A handler that awaits an attn API
yields at once, so it is still unanswered when a spinner dispatched behind it
freezes everything, including that first handler's own reply.

The host now announces each entry on the socket immediately before calling the
handler (`app_runtime.entered`, a notification), and the culprit is the most
recent entry with no answer yet. An entry is dropped when its dispatch is
answered, when a ping answers, or when the process dies. This rests on one
measured fact: a Bun socket write issued immediately before a synchronous spin
reaches the peer at once rather than queueing behind it — with a 5s spin, the
frame arrived ~1ms after the write and ~5s before the spin ended.

**An unhandled rejection killed the sidecar for everyone, charged to nobody.**
The A4 plan ruled that a sidecar-wide crash is never attributed to an app,
reasoning that the runtime cannot know whose code caused it. That premise is
false, and the ruling made the worst thing an app can do the one thing it was
structurally exempt from being disabled for. **Overturned, and recorded as such
in the plan doc.** The host reads the app's name off the stack, reports it, and
exits; `appCrashStrikes = 3` inside `appCrashWindow` disables that app with a
notification.

The stack is the only honest witness and also the right one: Bun's
`async_hooks.createHook` fires no callbacks at all here and
`AsyncLocalStorage.getStore()` is `undefined` inside these handlers, both
measured — and a floating promise rejects long after its dispatch returned, so
"which app is running" routinely names an innocent. A crash naming no app is
charged to nobody.

Three, because `supervise.DefaultGiveUpAfter` (10) parks the whole sidecar after
~2 minutes of crash-looping and the culprit has to go first; above one, because a
single crash can be a machine event whose stack merely passes through a bundle.
`TestCrashStrikesFireBeforeTheSupervisorParksTheRuntime` pins that ordering.

## Rollback named ids nothing would show you

A rollback refusal names a version id, and no surface listed them. `attn app
status` now prints the version ids it takes, capped at the 10 most recent with
the total beside it.

## Receipts

`appRuntimePingWait = 2s` is a tripwire past a localhost round trip measured at
344µs and 416µs on a live daemon — ~5,000× — and is only ever spent on a dispatch
that already burned its whole timeout. The daemon's ping log prints microseconds
rather than milliseconds, because an answered ping rounds to `0s` and tells the
reader nothing about the margin.

`recentVersionLimit = 10` is ~200 bytes per `AppVersionInfo`, ~2KB total.

## Also in here

- `internal/hub`: a remote's daemon is revived before the app runtime host is
  shipped to it, rather than after.
- Four comments that had drifted from their code.
- One finding was deliberately skipped and noted in the plan doc: `apply`
  reports `Ok` when consumer wiring failed.

## Verification

Live on an installed non-production profile (`hubfix`), preflight PASS, protocol
233 in step across CLI, app and daemon. Four apps: a 120s synchronous spin, a
well-behaved app awaiting an attn API, one leaving a floating rejection, and one
awaiting something that never settles while the loop keeps turning.

- Frozen loop: the spinner is the one on the auto-disable clock; all three others
  get `runtime_error` naming it. One victim's dispatch started *before* the
  spinner's and is still correctly not blamed — the inversion that broke the
  first build.
- Turning loop: `apps: dawdler hit the dispatch timeout; the app runtime answered
  a liveness ping after 344µs` — charged to itself, correctly.
- Crash attribution: `apps: leaker crashed the app runtime
  (unhandledRejection), strike 1 of 3` … `strike 2 of 3`, and enabling an app
  clears its streak.

`appRuntimeAPIVersion` goes to 2 — the daemon↔host wire gained a frame and the
two are version-checked at hello.

Go suites (`internal/daemon`, `cmd/attn`, `internal/hub`) and the frontend suite
are green. Both new rules were mutation-tested: reverting the culprit rule to
"earliest entry" and dropping the answered-handler cleanup each fail a test that
names the real defect.
