### PR TITLE
fix(annotations): align across rendered links

### DIFF
--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -1167,6 +1167,12 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         totalRows: () => terminal.getScrollbackLength() + terminal.rows,
         rowText: (row) => selectionLineAtBufferRow(row, 0, terminal.cols),
         rowTextRange: (row, startCol, endCol) => selectionLineAtBufferRow(row, startCol, endCol),
+        hyperlinkUri: (row, col) => {
+          const history = terminal.getScrollbackLength();
+          return row < history
+            ? scrollbackHyperlinkUri(terminal, row, col)
+            : hyperlinkUriAt(terminal, row - history, col);
+        },
       };
     }, [selectionLineAtBufferRow]);
 

--- a/app/src/utils/terminalAnnotations.gate.test.ts
+++ b/app/src/utils/terminalAnnotations.gate.test.ts
@@ -367,4 +367,46 @@ describe('anchorForSelection', () => {
     expect(anchor!.messageKey).toBe('turn-1');
     expect(older.slice(anchor!.start, anchor!.end)).toContain('retry wrapper');
   });
+
+  it('accepts agent prose after a Markdown link was rendered as a shortened path', () => {
+    const markdown = 'Evidence: [source](/Users/tester/src/services-pilot/a/b/Source.java:19). '
+      + 'The conclusion after the source remains annotatable.';
+    const rows = [
+      '• Evidence: a/b/Source.java:19.',
+      '  The conclusion after the source remains annotatable.',
+    ];
+    const store = new TerminalAnnotationStore();
+    store.setMessages([{ key: 'turn-1', markdown }]);
+    const grid = new FakeGrid(rows);
+    const startCol = rows[1].indexOf('conclusion');
+
+    const anchor = store.anchorForSelection(grid, {
+      startRow: 1,
+      startCol,
+      endRow: 1,
+      endCol: startCol + 'conclusion after the source'.length,
+    });
+
+    expect(anchor).not.toBeNull();
+    expect(anchor!.quote).toBe('conclusion after the source');
+  });
+
+  it('keeps the containment gate on reverse selection after sparse alignment', () => {
+    const markdown = 'Evidence: [source](/Users/tester/src/services-pilot/a/b/Source.java:19). '
+      + 'The conclusion after the source remains annotatable.';
+    const store = new TerminalAnnotationStore();
+    store.setMessages([{ key: 'turn-1', markdown }]);
+    const grid = new FakeGrid([
+      '• Evidence: a/b/Source.java:19.',
+      '› conclusion after the source please',
+    ]);
+    const startCol = grid.rows[1].indexOf('conclusion');
+
+    expect(store.anchorForSelection(grid, {
+      startRow: 1,
+      startCol,
+      endRow: 1,
+      endCol: startCol + 'conclusion after the source'.length,
+    })).toBeNull();
+  });
 });

--- a/app/src/utils/terminalAnnotations.ts
+++ b/app/src/utils/terminalAnnotations.ts
@@ -26,6 +26,9 @@ export interface MessageRowAccess {
   // Text between two code-unit columns: the gate reads exactly the cells a wash
   // would cover, so sideways drift is caught.
   rowTextRange(bufferRow: number, startCol: number, endCol: number): string;
+  // Hidden OSC 8 target for a cell. Optional because plain terminal rows and
+  // test grids have no hyperlink metadata; visible text remains sufficient.
+  hyperlinkUri?(bufferRow: number, col: number): string | null;
 }
 
 // One assistant message that can be annotated.
@@ -222,7 +225,7 @@ export class TerminalAnnotationStore {
 
     let { base, end, local } = this.searchWindow(lastSpan, totalRows);
     let rows = readRows(base, end);
-    let alignment = alignMessage(markdown, rows, base);
+    let alignment = alignMessage(markdown, rows, base, access.hyperlinkUri);
 
     // Widen to the whole buffer on a miss, or on an edge hit — the message
     // probably continues outside the window.
@@ -235,7 +238,7 @@ export class TerminalAnnotationStore {
       end = totalRows;
       local = false;
       rows = readRows(base, end);
-      alignment = alignMessage(markdown, rows, base);
+      alignment = alignMessage(markdown, rows, base, access.hyperlinkUri);
     }
 
     const entry: AlignmentCache = {
@@ -320,7 +323,13 @@ export class TerminalAnnotationStore {
       if (!alignment) continue;
       const span = offsetsForSelection(alignment, selection);
       if (!span) continue;
-      return { messageKey: key, start: span.start, end: span.end, quote: markdown.slice(span.start, span.end) };
+      const quote = markdown.slice(span.start, span.end);
+      const rows = rowsForOffsets(alignment, span.start, span.end);
+      const painted = rows
+        .map((range) => access.rowTextRange(range.row, range.startCol, range.endCol))
+        .join('\n');
+      if (!quotesAnchor(quote, painted)) continue;
+      return { messageKey: key, start: span.start, end: span.end, quote };
     }
     return null;
   }

--- a/app/src/utils/terminalMessageAlign.projection.test.ts
+++ b/app/src/utils/terminalMessageAlign.projection.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from 'vitest';
 import {
   alignMessage,
   CONFIDENT_ROW,
-  normalizedWords,
   offsetsForSelection,
   quotesAnchor,
   rowConfidence,
   rowsForOffsets,
+  tokenizeMarkdown,
 } from './terminalMessageAlign';
 
 // Renders markdown the way an agent TUI does: a marker glyph on the first row,
@@ -75,6 +75,11 @@ function anchorOffsets(markdown: string, phrase: string) {
 
 function textAt(rows: readonly string[], rowBase: number, ranges: { row: number; startCol: number; endCol: number }[]) {
   return ranges.map((range) => rows[range.row - rowBase].slice(range.startCol, range.endCol)).join('\n');
+}
+
+// Word-space form: markdown and grid text differ by exactly what is stripped.
+function normalizedWords(text: string): string {
+  return tokenizeMarkdown(text).map((token) => token.norm).join(' ');
 }
 
 describe('rowsForOffsets', () => {
@@ -170,6 +175,34 @@ describe('rowsForOffsets', () => {
       LINKED_MESSAGE.slice(target.start, target.end),
       textAt(LINKED_ROWS, 0, ranges),
     )).toBe(true);
+  });
+
+  it('keeps links with the same basename distinct by their parent directory', () => {
+    const markdown = 'Compare [one](/repo/alpha/Shared.java:42) with '
+      + '[two](/repo/beta/Shared.java:42), then keep reading.';
+    const rows = [
+      '• Compare alpha/Shared.java:42 with beta/Shared.java:42, then keep reading.',
+    ];
+    const alignment = alignMessage(markdown, rows);
+
+    for (const target of ['/repo/alpha/Shared.java:42', '/repo/beta/Shared.java:42']) {
+      const offsets = anchorOffsets(markdown, target);
+      const ranges = rowsForOffsets(alignment, offsets.start, offsets.end);
+      expect(ranges).toHaveLength(1);
+      expect(textAt(rows, 0, ranges)).toContain(target.split('/').slice(-2).join('/'));
+    }
+  });
+
+  it('does not treat a basename match under the wrong directory as a path anchor', () => {
+    const markdown = 'Before [source](/repo/right/Shared.java:42), the middle and after stay mapped.';
+    const rows = ['• Before wrong/Shared.java:42, the middle and after stay mapped.'];
+    const alignment = alignMessage(markdown, rows);
+    const target = anchorOffsets(markdown, '/repo/right/Shared.java:42');
+    const after = anchorOffsets(markdown, 'middle and after stay mapped');
+
+    expect(rowsForOffsets(alignment, target.start, target.end)).toEqual([]);
+    expect(rowsForOffsets(alignment, after.start, after.end)).not.toEqual([]);
+    expect(quotesAnchor('/repo/right/Shared.java:42', 'wrong/Shared.java:42')).toBe(false);
   });
 
   it('prefers an exact visible link label when OSC 8 also exposes its target', () => {

--- a/app/src/utils/terminalMessageAlign.projection.test.ts
+++ b/app/src/utils/terminalMessageAlign.projection.test.ts
@@ -38,6 +38,28 @@ const MESSAGE = 'A soft line wrap moves overflowing text onto the next visual li
 
 const ANCHOR = 'visual line without inserting a real';
 
+const LINKED_MESSAGE = [
+  'The paths below are genuine rejection evidence from the agent.',
+  '',
+  'Examples: [pipeline routing](/Users/tester/src/services-pilot/audiobook-ingestion/ais-pipeline-1/FileProcessingService.java:118), '
+    + '[audio validation](/Users/tester/src/services-pilot/audiobook-ingestion/ais-audio-choreography/AudioServiceImpl.java:227), '
+    + '[image validation](/Users/tester/src/services-pilot/audiobook-ingestion/ais-image-choreography/ImageServiceImpl.java:88), '
+    + '[ZIP handling](/Users/tester/src/services-pilot/audiobook-ingestion/ais-zip-choreography/UnpackerImpl.java:176).',
+  '',
+  'The conclusion after those rendered links must remain independently annotatable.',
+].join('\n');
+
+const LINKED_ROWS = [
+  '• The paths below are genuine rejection evidence from the agent.',
+  '',
+  '  Examples: audiobook-ingestion/ais-pipeline-1/FileProcessingService.java:118,',
+  '  audiobook-ingestion/ais-audio-choreography/AudioServiceImpl.java:227,',
+  '  audiobook-ingestion/ais-image-choreography/ImageServiceImpl.java:88,',
+  '  audiobook-ingestion/ais-zip-choreography/UnpackerImpl.java:176.',
+  '',
+  '  The conclusion after those rendered links must remain independently annotatable.',
+];
+
 // The message with its head scrolled off, under a user turn whose tail repeats
 // the words immediately preceding the visible head.
 const DECOY_ABOVE = [
@@ -123,6 +145,52 @@ describe('rowsForOffsets', () => {
     // Those words are only on the user's row now. Resolving them there would
     // paint a wash over the user's own text and attribute it to the agent.
     expect(rowsForOffsets(alignment, start, end).map((r) => r.row)).not.toContain(0);
+  });
+
+  it('keeps prose on both sides of a run of rendered Markdown links', () => {
+    const alignment = alignMessage(LINKED_MESSAGE, LINKED_ROWS);
+    const before = anchorOffsets(LINKED_MESSAGE, 'genuine rejection evidence');
+    const after = anchorOffsets(LINKED_MESSAGE, 'conclusion after those rendered links');
+
+    expect(rowsForOffsets(alignment, before.start, before.end)).not.toEqual([]);
+    expect(rowsForOffsets(alignment, after.start, after.end)).not.toEqual([]);
+  });
+
+  it('maps a shortened visible path back to the Markdown link destination', () => {
+    const alignment = alignMessage(LINKED_MESSAGE, LINKED_ROWS);
+    const target = anchorOffsets(
+      LINKED_MESSAGE,
+      '/Users/tester/src/services-pilot/audiobook-ingestion/ais-audio-choreography/AudioServiceImpl.java:227',
+    );
+    const ranges = rowsForOffsets(alignment, target.start, target.end);
+
+    expect(ranges).toHaveLength(1);
+    expect(textAt(LINKED_ROWS, 0, ranges)).toContain('AudioServiceImpl.java:227');
+    expect(quotesAnchor(
+      LINKED_MESSAGE.slice(target.start, target.end),
+      textAt(LINKED_ROWS, 0, ranges),
+    )).toBe(true);
+  });
+
+  it('prefers an exact visible link label when OSC 8 also exposes its target', () => {
+    const markdown = 'See [implementation](/Users/tester/src/Thing.java:44) for the invariant.';
+    const rows = ['• See implementation for the invariant.'];
+    const alignment = alignMessage(
+      markdown,
+      rows,
+      0,
+      (_row, col) => (col >= rows[0].indexOf('implementation') ? 'file:///Users/tester/src/Thing.java:44' : null),
+    );
+    const startCol = rows[0].indexOf('implementation');
+    const span = offsetsForSelection(alignment, {
+      startRow: 0,
+      startCol,
+      endRow: 0,
+      endCol: startCol + 'implementation'.length,
+    });
+
+    expect(span).not.toBeNull();
+    expect(markdown.slice(span!.start, span!.end)).toBe('implementation');
   });
 
   it('seeds on the message even when the row above echoes its opening words', () => {

--- a/app/src/utils/terminalMessageAlign.ts
+++ b/app/src/utils/terminalMessageAlign.ts
@@ -61,7 +61,6 @@ function normalizeWord(word: string): string {
 
 const MARKDOWN_LINK_RE = /\[([^\]\n]+)\]\(([^)\n]+)\)/g;
 const TRAILING_PATH_NOISE_RE = /[),.;:!?]+$/;
-const LINE_COLUMN_SUFFIX_RE = /:\d{1,7}(?::\d{1,7})?$/;
 
 function decodeTarget(value: string): string {
   const trimmed = value.trim().replace(/^<|>$/g, '');
@@ -74,10 +73,12 @@ function decodeTarget(value: string): string {
 }
 
 // Renderer-independent identities for a path or URL. Codex commonly turns an
-// absolute Markdown destination into a shorter visible repository path; the
-// basename and final two components survive both forms. These are candidates,
-// not proof — uniqueness, monotonicity, row confidence, and the containment
-// gate still decide whether a match is usable.
+// absolute Markdown destination into a shorter visible repository path. At
+// least the final directory and filename must survive: a basename alone is too
+// weak to split alignment or satisfy containment when repositories commonly
+// repeat names such as index.ts. These are candidates, not proof — uniqueness,
+// monotonicity, row confidence, and the containment gate still decide whether a
+// match is usable.
 function targetAliases(value: string): string[] {
   let target = decodeTarget(value).replace(TRAILING_PATH_NOISE_RE, '');
   if (!target.includes('/') && !/^[a-z][a-z0-9+.-]*:/i.test(target)) return [];
@@ -87,11 +88,6 @@ function targetAliases(value: string): string[] {
   const aliases = new Set<string>([`target:${target}`]);
   const withoutQuery = target.replace(/[?#].*$/, '');
   const parts = withoutQuery.split('/').filter(Boolean);
-  const basename = parts[parts.length - 1];
-  if (basename) {
-    aliases.add(`path:${basename}`);
-    aliases.add(`path:${basename.replace(LINE_COLUMN_SUFFIX_RE, '')}`);
-  }
   if (parts.length >= 2) aliases.add(`path2:${parts.slice(-2).join('/')}`);
   return [...aliases];
 }
@@ -193,13 +189,6 @@ export function tokenizeRows(
     }
   }
   return out;
-}
-
-// Word-space form: markdown and grid text differ by exactly what is stripped.
-export function normalizedWords(text: string): string {
-  return tokenizeMarkdown(text)
-    .map((t) => t.norm)
-    .join(' ');
 }
 
 // --- pairing ---------------------------------------------------------------

--- a/app/src/utils/terminalMessageAlign.ts
+++ b/app/src/utils/terminalMessageAlign.ts
@@ -11,6 +11,7 @@
 // One word of the markdown; offsets are UTF-16 code units into the ORIGINAL.
 export interface SrcToken {
   norm: string;
+  aliases: string[];
   start: number;
   end: number;
 }
@@ -21,12 +22,19 @@ export interface SrcToken {
 // bounds but never which rows resolve.
 export interface GridToken {
   norm: string;
+  aliases: string[];
   row: number;
   col: number;
   endCol: number;
   // The first prose token after an assistant marker. This breaks an otherwise
   // exact tie when the user's prompt quotes the response it requests.
   assistantLead: boolean;
+  explicitUser: boolean;
+}
+
+interface MatchToken {
+  norm: string;
+  aliases: readonly string[];
 }
 
 // Markdown syntax and TUI chrome, stripped from both sides before comparison.
@@ -36,6 +44,7 @@ const CUT_CHARS = new Set([
   ...'⏺✻❯⎿·•▪●○',
 ]);
 const ASSISTANT_MARKERS = new Set(['⏺', '•']);
+const USER_MARKERS = new Set(['❯', '›']);
 
 function isSpace(ch: string): boolean {
   return /\s/.test(ch);
@@ -50,30 +59,110 @@ function normalizeWord(word: string): string {
   return out;
 }
 
-export function tokenizeMarkdown(markdown: string): SrcToken[] {
-  const out: SrcToken[] = [];
+const MARKDOWN_LINK_RE = /\[([^\]\n]+)\]\(([^)\n]+)\)/g;
+const TRAILING_PATH_NOISE_RE = /[),.;:!?]+$/;
+const LINE_COLUMN_SUFFIX_RE = /:\d{1,7}(?::\d{1,7})?$/;
+
+function decodeTarget(value: string): string {
+  const trimmed = value.trim().replace(/^<|>$/g, '');
+  const withoutFileScheme = trimmed.replace(/^file:\/\/(?:localhost)?/i, '');
+  try {
+    return decodeURIComponent(withoutFileScheme);
+  } catch {
+    return withoutFileScheme;
+  }
+}
+
+// Renderer-independent identities for a path or URL. Codex commonly turns an
+// absolute Markdown destination into a shorter visible repository path; the
+// basename and final two components survive both forms. These are candidates,
+// not proof — uniqueness, monotonicity, row confidence, and the containment
+// gate still decide whether a match is usable.
+function targetAliases(value: string): string[] {
+  let target = decodeTarget(value).replace(TRAILING_PATH_NOISE_RE, '');
+  if (!target.includes('/') && !/^[a-z][a-z0-9+.-]*:/i.test(target)) return [];
+  target = target.replace(/\\/g, '/').replace(/\/+$/, '');
+  if (!target) return [];
+
+  const aliases = new Set<string>([`target:${target}`]);
+  const withoutQuery = target.replace(/[?#].*$/, '');
+  const parts = withoutQuery.split('/').filter(Boolean);
+  const basename = parts[parts.length - 1];
+  if (basename) {
+    aliases.add(`path:${basename}`);
+    aliases.add(`path:${basename.replace(LINE_COLUMN_SUFFIX_RE, '')}`);
+  }
+  if (parts.length >= 2) aliases.add(`path2:${parts.slice(-2).join('/')}`);
+  return [...aliases];
+}
+
+function tokenKeys(token: MatchToken): readonly string[] {
+  return [token.norm, ...token.aliases];
+}
+
+function tokensMatch(left: MatchToken, right: MatchToken): boolean {
+  const rightKeys = new Set(tokenKeys(right));
+  return tokenKeys(left).some((key) => rightKeys.has(key));
+}
+
+function pushWords(out: SrcToken[], text: string, base: number): void {
   let i = 0;
-  while (i < markdown.length) {
-    if (isSpace(markdown[i])) {
+  while (i < text.length) {
+    if (isSpace(text[i])) {
       i += 1;
       continue;
     }
     let j = i;
-    while (j < markdown.length && !isSpace(markdown[j])) j += 1;
-    const norm = normalizeWord(markdown.slice(i, j));
-    if (norm) out.push({ norm, start: i, end: j });
+    while (j < text.length && !isSpace(text[j])) j += 1;
+    const raw = text.slice(i, j);
+    const norm = normalizeWord(raw);
+    if (norm) out.push({ norm, aliases: targetAliases(raw), start: base + i, end: base + j });
     i = j;
   }
+}
+
+export function tokenizeMarkdown(markdown: string): SrcToken[] {
+  const out: SrcToken[] = [];
+  let cursor = 0;
+  for (const match of markdown.matchAll(MARKDOWN_LINK_RE)) {
+    const start = match.index ?? 0;
+    pushWords(out, markdown.slice(cursor, start), cursor);
+
+    const label = match[1];
+    const target = match[2].trim().split(/\s+['"]/)[0];
+    const labelStart = start + 1;
+    pushWords(out, label, labelStart);
+
+    const targetInMatch = match[0].indexOf(match[2]);
+    const targetStart = start + targetInMatch + match[2].indexOf(target);
+    const norm = normalizeWord(target);
+    if (norm) {
+      out.push({
+        norm,
+        aliases: targetAliases(target),
+        start: targetStart,
+        end: targetStart + target.length,
+      });
+    }
+    cursor = start + match[0].length;
+  }
+  pushWords(out, markdown.slice(cursor), cursor);
   return out;
 }
 
 // `rowBase` is the buffer row of `rows[0]`, so tokens carry absolute rows.
-export function tokenizeRows(rows: readonly string[], rowBase = 0): GridToken[] {
+export function tokenizeRows(
+  rows: readonly string[],
+  rowBase = 0,
+  hyperlinkUriAt?: (row: number, col: number) => string | null,
+): GridToken[] {
   const out: GridToken[] = [];
   for (let r = 0; r < rows.length; r += 1) {
     const row = rows[r];
     const firstNonSpace = row.search(/\S/);
-    const assistantRow = firstNonSpace >= 0 && ASSISTANT_MARKERS.has(row[firstNonSpace]);
+    const marker = firstNonSpace >= 0 ? row[firstNonSpace] : '';
+    const assistantRow = ASSISTANT_MARKERS.has(marker);
+    const userRow = USER_MARKERS.has(marker);
     let emitted = 0;
     let i = 0;
     while (i < row.length) {
@@ -83,14 +172,20 @@ export function tokenizeRows(rows: readonly string[], rowBase = 0): GridToken[] 
       }
       let j = i;
       while (j < row.length && !isSpace(row[j])) j += 1;
-      const norm = normalizeWord(row.slice(i, j));
+      const raw = row.slice(i, j);
+      const norm = normalizeWord(raw);
       if (norm) {
+        const aliases = new Set(targetAliases(raw));
+        const uri = hyperlinkUriAt?.(rowBase + r, i);
+        if (uri) targetAliases(uri).forEach((alias) => aliases.add(alias));
         out.push({
           norm,
+          aliases: [...aliases],
           row: rowBase + r,
           col: i,
           endCol: j,
           assistantLead: assistantRow && emitted === 0,
+          explicitUser: userRow,
         });
         emitted += 1;
       }
@@ -125,9 +220,9 @@ function resync(
   gi: number,
 ): { si: number; gi: number; cost: number } | null {
   for (let d = 1; d <= RESYNC_WINDOW; d += 1) {
-    if (si + d < src.length && src[si + d].norm === grid[gi].norm) return { si: si + d, gi, cost: d };
-    if (gi + d < grid.length && src[si].norm === grid[gi + d].norm) return { si, gi: gi + d, cost: d };
-    if (si + d < src.length && gi + d < grid.length && src[si + d].norm === grid[gi + d].norm) {
+    if (si + d < src.length && tokensMatch(src[si + d], grid[gi])) return { si: si + d, gi, cost: d };
+    if (gi + d < grid.length && tokensMatch(src[si], grid[gi + d])) return { si, gi: gi + d, cost: d };
+    if (si + d < src.length && gi + d < grid.length && tokensMatch(src[si + d], grid[gi + d])) {
       return { si: si + d, gi: gi + d, cost: d };
     }
   }
@@ -137,27 +232,102 @@ function resync(
 function seedScore(src: readonly SrcToken[], grid: readonly GridToken[], gi: number): number {
   let score = 0;
   for (let d = 0; d < SEED_LOOKAHEAD && d < src.length && gi + d < grid.length; d += 1) {
-    if (src[d].norm === grid[gi + d].norm) score += 1;
+    if (tokensMatch(src[d], grid[gi + d])) score += 1;
   }
   return score;
 }
 
-function positionsByNorm(tokens: readonly { norm: string }[]): Map<string, number[]> {
+function positionsByKey(tokens: readonly MatchToken[]): Map<string, number[]> {
   const out = new Map<string, number[]>();
   for (let i = 0; i < tokens.length; i += 1) {
-    const at = out.get(tokens[i].norm);
-    if (at) at.push(i);
-    else out.set(tokens[i].norm, [i]);
+    for (const key of new Set(tokenKeys(tokens[i]))) {
+      const at = out.get(key);
+      if (at) at.push(i);
+      else out.set(key, [i]);
+    }
   }
   return out;
+}
+
+// Unique identities on both sides are hard anchors. Their longest monotone
+// chain divides the message into independent alignment islands, so an arbitrary
+// renderer substitution (a Markdown link becoming a path, for example) leaves
+// a sparse hole rather than cutting off everything after it.
+function monotoneAnchors(src: readonly SrcToken[], grid: readonly GridToken[]): TokenPair[] {
+  const srcPositions = positionsByKey(src);
+  const gridPositions = positionsByKey(grid);
+  type Candidate = TokenPair & { strength: number; score: number; previous: number };
+  const uniquePairs = new Map<string, Candidate>();
+  for (const [key, srcAt] of srcPositions) {
+    if (srcAt.length !== 1) continue;
+    const gridAt = gridPositions.get(key);
+    if (!gridAt || gridAt.length !== 1) continue;
+    const pair = { srcIdx: srcAt[0], gridIdx: gridAt[0] };
+    const strength = src[pair.srcIdx].norm === grid[pair.gridIdx].norm ? 2 : 1;
+    const pairKey = `${pair.srcIdx}:${pair.gridIdx}`;
+    const previous = uniquePairs.get(pairKey);
+    if (!previous || strength > previous.strength) {
+      uniquePairs.set(pairKey, { ...pair, strength, score: 0, previous: -1 });
+    }
+  }
+
+  const candidates = [...uniquePairs.values()].sort(
+    (a, b) => a.srcIdx - b.srcIdx || a.gridIdx - b.gridIdx || b.strength - a.strength,
+  );
+  if (candidates.length === 0) return [];
+
+  // Fenwick maximum over grid positions: query(gridIdx) sees only positions
+  // strictly before gridIdx. Updates are delayed for one source-index batch so
+  // a chain cannot use two alternative identities of the same source token.
+  const fenwick = Array.from(
+    { length: grid.length + 1 },
+    () => ({ score: 0, candidate: -1 }),
+  );
+  const query = (exclusive: number) => {
+    let best = { score: 0, candidate: -1 };
+    for (let at = exclusive; at > 0; at -= at & -at) {
+      if (fenwick[at].score > best.score) best = fenwick[at];
+    }
+    return best;
+  };
+  const update = (position: number, value: { score: number; candidate: number }) => {
+    for (let at = position; at < fenwick.length; at += at & -at) {
+      if (value.score > fenwick[at].score) fenwick[at] = value;
+    }
+  };
+
+  const pairWeight = 2 * candidates.length + 1;
+  let bestCandidate = -1;
+  for (let batchStart = 0; batchStart < candidates.length;) {
+    let batchEnd = batchStart + 1;
+    while (batchEnd < candidates.length && candidates[batchEnd].srcIdx === candidates[batchStart].srcIdx) {
+      batchEnd += 1;
+    }
+    for (let i = batchStart; i < batchEnd; i += 1) {
+      const prior = query(candidates[i].gridIdx);
+      candidates[i].previous = prior.candidate;
+      candidates[i].score = prior.score + pairWeight + candidates[i].strength;
+      if (bestCandidate < 0 || candidates[i].score > candidates[bestCandidate].score) bestCandidate = i;
+    }
+    for (let i = batchStart; i < batchEnd; i += 1) {
+      update(candidates[i].gridIdx + 1, { score: candidates[i].score, candidate: i });
+    }
+    batchStart = batchEnd;
+  }
+
+  const chain: TokenPair[] = [];
+  for (let at = bestCandidate; at >= 0; at = candidates[at].previous) {
+    chain.push({ srcIdx: candidates[at].srcIdx, gridIdx: candidates[at].gridIdx });
+  }
+  return chain.reverse();
 }
 
 // Finds where the message sits in the grid using words unique on BOTH sides:
 // each pins one (src, grid) pair, and the true position is the offset most
 // agree on. Seeding on opening words fails when the head has scrolled away.
 function findSeed(src: readonly SrcToken[], grid: readonly GridToken[]): { si: number; gi: number } | null {
-  const srcPositions = positionsByNorm(src);
-  const gridPositions = positionsByNorm(grid);
+  const srcPositions = positionsByKey(src);
+  const gridPositions = positionsByKey(grid);
 
   const anchors: { si: number; gi: number }[] = [];
   const offsetVotes = new Map<number, number>();
@@ -194,7 +364,7 @@ function findSeed(src: readonly SrcToken[], grid: readonly GridToken[]): { si: n
   let bestScore = 0;
   let bestAssistantLead = false;
   for (let j = 0; j < grid.length; j += 1) {
-    if (grid[j].norm !== src[0].norm) continue;
+    if (!tokensMatch(src[0], grid[j])) continue;
     const score = seedScore(src, grid, j);
     const assistantLead = grid[j].assistantLead;
     if (score > bestScore || (score === bestScore && assistantLead && !bestAssistantLead)) {
@@ -206,6 +376,50 @@ function findSeed(src: readonly SrcToken[], grid: readonly GridToken[]): { si: n
   return gi >= 0 ? { si: 0, gi } : null;
 }
 
+function greedySegment(
+  src: readonly SrcToken[],
+  grid: readonly GridToken[],
+  srcStart: number,
+  srcEnd: number,
+  gridStart: number,
+  gridEnd: number,
+): TokenPair[] {
+  const pairs: TokenPair[] = [];
+  let si = srcStart;
+  let gi = gridStart;
+  let gaps = 0;
+  const gapBudget = Math.max(RESYNC_WINDOW, Math.ceil((srcEnd - srcStart) * 0.5));
+  while (si < srcEnd && gi < gridEnd) {
+    if (tokensMatch(src[si], grid[gi])) {
+      pairs.push({ srcIdx: si, gridIdx: gi });
+      si += 1;
+      gi += 1;
+      continue;
+    }
+    let next: { si: number; gi: number; cost: number } | null = null;
+    for (let d = 1; d <= RESYNC_WINDOW; d += 1) {
+      if (si + d < srcEnd && tokensMatch(src[si + d], grid[gi])) {
+        next = { si: si + d, gi, cost: d };
+        break;
+      }
+      if (gi + d < gridEnd && tokensMatch(src[si], grid[gi + d])) {
+        next = { si, gi: gi + d, cost: d };
+        break;
+      }
+      if (si + d < srcEnd && gi + d < gridEnd && tokensMatch(src[si + d], grid[gi + d])) {
+        next = { si: si + d, gi: gi + d, cost: d };
+        break;
+      }
+    }
+    if (!next) break;
+    gaps += next.cost;
+    if (gaps > gapBudget) break;
+    si = next.si;
+    gi = next.gi;
+  }
+  return pairs;
+}
+
 // Pairs the two token streams by walking both directions in lockstep from the
 // seed. Monotone by construction, so a bad seed shows up as a low match ratio
 // rather than a wrong span. Greedy O(n+m), not an LCS: repeated words can pair
@@ -213,6 +427,20 @@ function findSeed(src: readonly SrcToken[], grid: readonly GridToken[]): { si: n
 // before anything is painted.
 export function pairTokens(src: readonly SrcToken[], grid: readonly GridToken[]): TokenPair[] {
   if (src.length === 0 || grid.length === 0) return [];
+  const anchors = monotoneAnchors(src, grid);
+  if (anchors.length > 0) {
+    const pairs: TokenPair[] = [];
+    let srcStart = 0;
+    let gridStart = 0;
+    for (const anchor of anchors) {
+      pairs.push(...greedySegment(src, grid, srcStart, anchor.srcIdx, gridStart, anchor.gridIdx));
+      pairs.push(anchor);
+      srcStart = anchor.srcIdx + 1;
+      gridStart = anchor.gridIdx + 1;
+    }
+    pairs.push(...greedySegment(src, grid, srcStart, src.length, gridStart, grid.length));
+    return pairs;
+  }
   const seed = findSeed(src, grid);
   if (!seed) return [];
 
@@ -224,7 +452,7 @@ export function pairTokens(src: readonly SrcToken[], grid: readonly GridToken[])
   let gi = seed.gi;
   let gaps = 0;
   while (si >= 0 && gi >= 0) {
-    if (src[si].norm === grid[gi].norm) {
+    if (tokensMatch(src[si], grid[gi])) {
       before.push({ srcIdx: si, gridIdx: gi });
       si -= 1;
       gi -= 1;
@@ -232,11 +460,11 @@ export function pairTokens(src: readonly SrcToken[], grid: readonly GridToken[])
     }
     let resynced = false;
     for (let d = 1; d <= RESYNC_WINDOW && !resynced; d += 1) {
-      if (si - d >= 0 && src[si - d].norm === grid[gi].norm) {
+      if (si - d >= 0 && tokensMatch(src[si - d], grid[gi])) {
         si -= d; gaps += d; resynced = true;
-      } else if (gi - d >= 0 && src[si].norm === grid[gi - d].norm) {
+      } else if (gi - d >= 0 && tokensMatch(src[si], grid[gi - d])) {
         gi -= d; gaps += d; resynced = true;
-      } else if (si - d >= 0 && gi - d >= 0 && src[si - d].norm === grid[gi - d].norm) {
+      } else if (si - d >= 0 && gi - d >= 0 && tokensMatch(src[si - d], grid[gi - d])) {
         si -= d; gi -= d; gaps += d; resynced = true;
       }
     }
@@ -250,7 +478,7 @@ export function pairTokens(src: readonly SrcToken[], grid: readonly GridToken[])
   gi = seed.gi + 1;
   gaps = 0;
   while (si < src.length && gi < grid.length) {
-    if (src[si].norm === grid[gi].norm) {
+    if (tokensMatch(src[si], grid[gi])) {
       after.push({ srcIdx: si, gridIdx: gi });
       si += 1;
       gi += 1;
@@ -281,6 +509,7 @@ export interface PlacedWord {
 export interface RowAlignment {
   row: number;
   words: PlacedWord[];
+  explicitUser: boolean;
   // Rows below CONFIDENT_ROW are ignored when bounding and resolving.
   matched: number;
   total: number;
@@ -310,9 +539,10 @@ export function alignMessage(
   markdown: string,
   rows: readonly string[],
   rowBase = 0,
+  hyperlinkUriAt?: (row: number, col: number) => string | null,
 ): MessageAlignment {
   const src = tokenizeMarkdown(markdown);
-  const grid = tokenizeRows(rows, rowBase);
+  const grid = tokenizeRows(rows, rowBase, hyperlinkUriAt);
   const pairs = pairTokens(src, grid);
 
   const totals = new Map<number, number>();
@@ -324,7 +554,13 @@ export function alignMessage(
     const srcToken = src[pair.srcIdx];
     let row = aligned.get(gridToken.row);
     if (!row) {
-      row = { row: gridToken.row, words: [], matched: 0, total: totals.get(gridToken.row) ?? 0 };
+      row = {
+        row: gridToken.row,
+        words: [],
+        explicitUser: gridToken.explicitUser,
+        matched: 0,
+        total: totals.get(gridToken.row) ?? 0,
+      };
       aligned.set(gridToken.row, row);
     }
     row.words.push({
@@ -342,7 +578,7 @@ export function alignMessage(
   let previousStart = -1;
   for (const row of [...aligned.keys()].sort((a, b) => a - b)) {
     const entry = aligned.get(row)!;
-    if (rowConfidence(entry) < CONFIDENT_ROW) continue;
+    if (entry.explicitUser || rowConfidence(entry) < CONFIDENT_ROW) continue;
     const start = entry.words[0].start;
     if (firstRow < 0) firstRow = row;
     lastRow = row;
@@ -379,7 +615,7 @@ export function rowsForOffsets(
 ): RowRange[] {
   const out: RowRange[] = [];
   for (const [row, entry] of alignment.rows) {
-    if (rowConfidence(entry) < CONFIDENT_ROW) continue;
+    if (entry.explicitUser || rowConfidence(entry) < CONFIDENT_ROW) continue;
     let startCol = Number.POSITIVE_INFINITY;
     let endCol = -1;
     for (const word of entry.words) {
@@ -411,7 +647,7 @@ export function offsetsForSelection(
   let end = -1;
   for (const [row, entry] of alignment.rows) {
     if (row < selection.startRow || row > selection.endRow) continue;
-    if (rowConfidence(entry) < CONFIDENT_ROW) continue;
+    if (entry.explicitUser || rowConfidence(entry) < CONFIDENT_ROW) continue;
     const lowCol = row === selection.startRow ? selection.startCol : 0;
     const highCol = row === selection.endRow ? selection.endCol : Number.POSITIVE_INFINITY;
     for (const word of entry.words) {
@@ -433,9 +669,17 @@ export function offsetsForSelection(
 // make a wash disappear for a frame. Containment holds in either direction: a
 // reflow moves words between rows, so the resolved rows can cover more or less.
 export function quotesAnchor(anchoredText: string, paintedText: string): boolean {
-  const want = normalizedWords(anchoredText);
-  if (!want) return false;
-  const got = normalizedWords(paintedText);
-  if (!got) return false;
-  return got.includes(want) || want.includes(got);
+  const want = tokenizeMarkdown(anchoredText);
+  if (want.length === 0) return false;
+  const got = tokenizeRows(paintedText.split('\n'));
+  if (got.length === 0) return false;
+
+  const contains = (whole: readonly MatchToken[], part: readonly MatchToken[]): boolean => {
+    if (part.length > whole.length) return false;
+    for (let start = 0; start <= whole.length - part.length; start += 1) {
+      if (part.every((token, index) => tokensMatch(token, whole[start + index]))) return true;
+    }
+    return false;
+  };
+  return contains(got, want) || contains(want, got);
 }

--- a/changelog.d/wily-tapir-terminal-annotation-links.yaml
+++ b/changelog.d/wily-tapir-terminal-annotation-links.yaml
@@ -1,0 +1,10 @@
+kind: fixed
+area: terminal annotations
+change: >
+  Completed agent answers remain annotatable across Markdown links that the
+  terminal renders as labels or shortened file paths, instead of becoming
+  unannotatable after the first rewritten link.
+symptom: >
+  In a long Codex answer with source links, only one portion of the agent's last
+  message could be annotated. Selecting other agent-written prose incorrectly
+  said that only what the agent wrote could be annotated.

--- a/docs/plans/2026-08-12-terminal-annotation-rendered-links.md
+++ b/docs/plans/2026-08-12-terminal-annotation-rendered-links.md
@@ -57,8 +57,9 @@ type AlignmentToken = {
 ```
 
 Hyperlink metadata is optional. Plain text still aligns, and a shortened path
-falls back to conservative basename/suffix identities. URI matches are stronger
-when the TUI emitted OSC 8.
+falls back to a conservative suffix containing at least the final directory and
+filename. A basename alone is not enough evidence to split alignment or pass
+containment. URI matches are stronger when the TUI emitted OSC 8.
 
 ## Implementation
 

--- a/docs/plans/2026-08-12-terminal-annotation-rendered-links.md
+++ b/docs/plans/2026-08-12-terminal-annotation-rendered-links.md
@@ -1,0 +1,87 @@
+# Terminal annotation alignment across rendered links
+
+Status: complete.
+
+## Goal
+
+Keep a completed assistant message annotatable when an agent TUI renders its
+Markdown links as labels, shortened paths, or OSC 8 hyperlinks. A rendering
+substitution may leave the link itself unmatched, but it must not cut off the
+ordinary prose before or after it.
+
+## Architecture
+
+```text
+Current
+  transcript Markdown + terminal rows
+    -> one seed on one token-index diagonal
+      -> greedy walk stops at a renderer substitution
+        -> one annotatable fragment; the rest looks like TUI text
+
+Target
+  transcript Markdown
+    -> prose tokens + link label/target alternatives with source offsets
+  terminal rows
+    -> visible tokens + optional OSC 8 target/path aliases
+  both token streams
+    -> monotone chain of high-confidence anchors
+      -> locally fill the spans between anchors
+        -> sparse row alignment across renderer substitutions
+          -> selection containment gate
+
+Tests
+  real Codex-style Markdown/path rendering fixture
+    -> alignMessage / offsetsForSelection
+      -> TerminalAnnotationStore.anchorForSelection
+```
+
+The external interface remains Markdown offsets in a stable assistant message.
+`terminalMessageAlign` absorbs rendering variation; `AnnotatedTerminal`, the
+daemon message window, and persisted annotation records do not learn about
+Codex link syntax.
+
+## Interfaces
+
+```ts
+type MessageRowAccess = {
+  rowText(row): string
+  rowTextRange(row, startCol, endCol): string
+  hyperlinkUri?(row, col): string | null
+}
+
+type AlignmentToken = {
+  norm: string
+  aliases: string[]       // URI and path identities, when present
+  source or grid position // unchanged provenance
+}
+```
+
+Hyperlink metadata is optional. Plain text still aligns, and a shortened path
+falls back to conservative basename/suffix identities. URI matches are stronger
+when the TUI emitted OSC 8.
+
+## Implementation
+
+- [x] Add a Codex regression where several local-file links render as shortened
+      paths and prove selections before, on, and after them.
+- [x] Parse Markdown links into label and destination tokens without changing
+      their source-offset provenance.
+- [x] Replace the single-diagonal seed with a monotone chain of unique token
+      anchors, retaining bounded local resynchronization inside each span.
+- [x] Expose optional Ghostty hyperlink targets through `MessageRowAccess` and
+      use them as token aliases without scanning idle terminals.
+- [x] Apply the existing containment predicate before accepting a new reverse
+      selection, not only before painting an existing annotation.
+- [x] Run focused alignment/store tests, the full frontend suite, TypeScript,
+      and the packaged app scenario in an isolated profile.
+
+## Decisions
+
+- Keep the existing alignment interface deep: provider rendering knowledge
+  stays inside tokenization and matching rather than leaking into callers.
+- Long substitutions create sparse holes. Raising the four-token resync window
+  would increase cross-turn false matches without representing links correctly.
+- OSC 8 is evidence, not a requirement. Missing hyperlink metadata degrades to
+  conservative text/path matching.
+- The containment gate remains authoritative. Better recall must never turn a
+  refusal into an annotation on the user's prompt or TUI chrome.


### PR DESCRIPTION
## Intent

Long Codex answers can contain Markdown links whose absolute targets are rendered in the terminal as shorter paths. The annotation projection previously used one greedy token alignment; the first rewritten link could stop alignment, making later agent-written prose fail with the generic ownership refusal.

## Summary

- Parse Markdown link labels and destinations into source-offset-preserving tokens, then match them to visible path suffixes or OSC 8 URI metadata.
- Build a monotone chain from unique anchors and fill each local segment, so one renderer substitution leaves a sparse hole instead of truncating the rest of the answer.
- Preserve the reverse-selection and paint-containment gates, and explicitly exclude user-prompt rows.
- Add Codex-style multi-link regressions, a design note, and a changelog fragment.

## Verification

- `pnpm --dir app test` — 2,721 passed, 15 skipped.
- `pnpm --dir app exec tsc --noEmit`.
- Pre-commit frontend build.
- `pnpm --dir app run e2e` — 196 passed, 1 skipped.
- Packaged isolated app, bundled preflight, and the real Codex terminal-annotation scenario — passed; the annotation survived an app relaunch and a second turn.
- Production-snapshot replay — the visible assistant tail aligned from source offsets 5,876–9,638 instead of only 8,069–9,638; mean alignment time was 0.79 ms over 200 runs.
