### PR TITLE
fix(delegate): validate models and checkout placement

### DIFF
--- a/changelog.d/delegate-admission-and-placement.yaml
+++ b/changelog.d/delegate-admission-and-placement.yaml
@@ -1,0 +1,12 @@
+kind: fixed
+area: cli
+change: >
+  Delegation now rejects unknown built-in model identifiers before launch and
+  resolves supported aliases through the same catalog as preflight. Workspace
+  placement no longer silently chooses a different repository when
+  --no-worktree is used: the source checkout remains authoritative unless
+  --cwd explicitly selects another checkout, and conflicting Git locations
+  report both resolved repositories before any agent starts.
+symptom: >
+  A shorthand model could pass preflight but select an unintended fallback, or
+  --workspace --no-worktree could start an agent in another repository.

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -742,18 +742,18 @@ task source:
   --ticket <id>               adopt an existing ticket and use its description
   --confirm                   take over a ticket with a non-orphan assignee
 
-placement:
-  (no flags)                 add a pane to the source workspace; Git repositories
-                             get a new worktree automatically
-  --new-workspace            create a workspace using the source directory
-  --workspace <id>           add a pane to an existing workspace
-  --cwd <path>               create a workspace at an existing directory
-  --worktree <branch>        choose the new worktree's branch
-  --no-worktree              reuse the resolved checkout instead
+workspace placement (where the pane appears):
+  (no flags)                 add a pane to the source workspace
+  --new-workspace            create a workspace for the delegated pane
+  --workspace <id>           add a pane to an existing workspace; this does not
+                             choose that workspace's repository
+  --cwd <path>               create a workspace and use this checkout/repository
 
-worktree options:
-  combine with any placement (current, --workspace, or --new-workspace);
-  combining with --cwd creates a worktree of the repo at that directory
+repository placement (where the agent runs):
+  (no flags)                 create a worktree from the source checkout
+  --no-worktree              reuse the source checkout; with --workspace, only
+                             the pane moves to the target workspace
+  --worktree <branch>        choose the new worktree's branch
   --repo <path>              main repository (defaults to the repository the
                              target workspace's sessions are in)
   --from <ref>               branch or ref to start from
@@ -762,8 +762,8 @@ worktree options:
 session options:
 	--request-id <id>          stable retry key (generated and printed when omitted; op- is reserved)
   --agent <name>             configured prompt-capable built-in or plugin agent
-  --model <name>             pin the agent's model (alias or full id, e.g.
-                             "opus" or "claude-opus-4-8"; defaults to the
+  --model <name>             pin a supported model (aliases resolve to canonical
+                             ids, e.g. "opus" to "claude-opus-5"; defaults to the
                              agent's own default)
   --effort <level>           pin the agent's reasoning effort (claude: low,
                              medium, high, xhigh, max; codex: minimal, low,

--- a/cmd/attn/main_test.go
+++ b/cmd/attn/main_test.go
@@ -557,6 +557,22 @@ func TestParseDelegateArgsNoWorktree(t *testing.T) {
 	}
 }
 
+func TestParseDelegateArgsWorkspaceNoWorktreeKeepsConceptsSeparate(t *testing.T) {
+	parsed, err := parseDelegateArgs([]string{
+		"--source-session", "source-session",
+		"--brief", "Join this workspace from my current checkout",
+		"--workspace", "workspace-mixed",
+		"--no-worktree",
+		"--allow-worktree-reuse",
+	})
+	if err != nil {
+		t.Fatalf("parseDelegateArgs() error = %v", err)
+	}
+	if parsed.options.Placement != "existing_workspace" || parsed.options.WorkspaceID != "workspace-mixed" || !parsed.options.NoWorktree || !parsed.options.AllowWorktreeReuse {
+		t.Fatalf("options = %+v", parsed.options)
+	}
+}
+
 func TestParseDelegateArgsRejectsNoWorktreeOverrides(t *testing.T) {
 	for _, args := range [][]string{
 		{"--no-worktree", "--worktree", "feat/parser"},

--- a/docs/plans/2026-08-12-delegate-admission-and-placement.md
+++ b/docs/plans/2026-08-12-delegate-admission-and-placement.md
@@ -1,0 +1,36 @@
+# Stricter delegation admission and placement
+
+## Outcome
+
+`attn delegate` rejects unknown built-in model IDs before launch, resolves
+supported aliases to canonical IDs, and shares that model authority with
+`attn preflight`.
+
+Workspace placement and repository placement are independent. `--workspace`
+chooses where the pane appears. `--no-worktree` reuses the source session's
+checkout unless `--cwd` explicitly chooses another checkout. Worktree creation
+still infers a repository from existing workspace members when no repository
+override is supplied.
+
+## Boundaries
+
+- Plugin model identifiers remain driver-owned and pass through unchanged.
+- Existing Claude aliases remain accepted and resolve to current canonical IDs.
+- Conflicting explicit Git locations fail before runtime launch and name both
+  resolved repositories with correction guidance.
+- There is no post-launch model handshake, dry run, or explain mode.
+
+## Verification status
+
+- Complete package tests pass for `cmd/attn`, `internal/client`,
+  `internal/agent`, and `internal/preflight`; the focused delegation tests pass
+  in `internal/daemon`.
+- The short full-Go harness passes every package and daemon shard except the
+  app-builder tests that download TypeScript; those fail before test behavior
+  with a Spotify Artifactory `401`.
+- The freshly built CLI resolves `opus` to `claude-opus-5`, rejects `opus-5`
+  and `gpt-5.6` with canonical suggestions, and displays workspace and
+  repository placement separately in `delegate --help`.
+- An isolated packaged-app install could not complete because the same
+  Artifactory authentication failure blocked frontend dependency installation,
+  so integrated app/daemon verification was not available in this checkout.

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -84,7 +84,11 @@ Plugin agents work only when they declare delegated initial-prompt support.
 Copilot delegation is currently unsupported.
 
 `--model` and `--effort` pin the delegated agent's model and reasoning effort
-for that delegation only; omitted, the agent uses its own defaults. `--effort`
+for that delegation only; omitted, the agent uses its own defaults. Built-in
+model aliases resolve to their canonical IDs (`opus` becomes
+`claude-opus-5`), and unknown IDs fail before launch with the supported models
+and a suggestion when one is close. `attn preflight` uses this same resolver.
+`--effort`
 takes the agent's native levels (claude: low, medium, high, xhigh, max; codex:
 minimal, low, medium, high, xhigh). Agents without a native mechanism (e.g.
 copilot) reject these flags.
@@ -112,6 +116,13 @@ workspace that fits its domain rather than creating a new workspace per item.
 If no existing workspace fits: no placement flag adds the session to the
 current workspace, `--new-workspace` creates a separate workspace from the
 source directory, and `--cwd` creates one at an existing directory.
+
+Workspace placement decides where the pane appears; repository placement
+decides where the agent runs. `--workspace` never makes its recorded directory
+the checkout for `--no-worktree`: that combination reuses the source session's
+current checkout. `--cwd` is the explicit checkout override and creates a new
+workspace there. Conflicting explicit repository inputs fail before launch and
+show both resolved repositories.
 
 `attn list` marks sessions in hidden workspaces with `workspace_muted: true`.
 When the source session is the chief of staff, delegating into a muted existing

--- a/internal/agent/models.go
+++ b/internal/agent/models.go
@@ -1,0 +1,159 @@
+package agent
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type modelCatalog struct {
+	canonical []string
+	aliases   map[string]string
+}
+
+var launchModelCatalogs = map[string]modelCatalog{
+	"claude": {
+		canonical: []string{"claude-fable-5", "claude-opus-5", "claude-sonnet-4-6", "claude-haiku-4-5"},
+		aliases: map[string]string{
+			"fable":  "claude-fable-5",
+			"opus":   "claude-opus-5",
+			"sonnet": "claude-sonnet-4-6",
+			"haiku":  "claude-haiku-4-5",
+		},
+	},
+	"codex": {
+		canonical: []string{
+			"gpt-5.6-luna",
+			"gpt-5.6-terra",
+			"gpt-5.6-sol",
+			"gpt-5.5",
+			"gpt-5.4-codex",
+			"gpt-5.4",
+			"gpt-5.4-mini",
+		},
+	},
+}
+
+// ResolveLaunchModel validates a built-in agent's model pin and returns its
+// canonical identifier. Plugin and other driver-owned model names pass through.
+func ResolveLaunchModel(agent, requested string) (string, error) {
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		return "", nil
+	}
+	catalog, ok := launchModelCatalogs[strings.ToLower(strings.TrimSpace(agent))]
+	if !ok {
+		return requested, nil
+	}
+
+	normalized := strings.ToLower(requested)
+	if canonical, ok := catalog.aliases[normalized]; ok {
+		return canonical, nil
+	}
+	for _, canonical := range catalog.canonical {
+		if normalized == canonical {
+			return canonical, nil
+		}
+	}
+
+	suggestions := modelSuggestions(normalized, catalog)
+	return "", fmt.Errorf("model %q is not supported by agent %q; supported models: %s%s%s",
+		requested,
+		agent,
+		strings.Join(catalog.canonical, ", "),
+		formatModelAliases(catalog.aliases),
+		formatModelSuggestions(suggestions),
+	)
+}
+
+func modelSuggestions(requested string, catalog modelCatalog) []string {
+	var prefixMatches []string
+	for _, canonical := range catalog.canonical {
+		if strings.HasPrefix(canonical, requested+"-") {
+			prefixMatches = append(prefixMatches, canonical)
+		}
+		trimmed := strings.TrimPrefix(canonical, "claude-")
+		if requested == trimmed {
+			return []string{canonical}
+		}
+	}
+	if len(prefixMatches) > 0 {
+		return prefixMatches
+	}
+
+	type candidate struct {
+		model    string
+		distance int
+	}
+	var candidates []candidate
+	for _, canonical := range catalog.canonical {
+		distance := editDistance(requested, canonical)
+		trimmed := strings.TrimPrefix(canonical, "claude-")
+		if shorter := editDistance(requested, trimmed); shorter < distance {
+			distance = shorter
+		}
+		candidates = append(candidates, candidate{model: canonical, distance: distance})
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].distance == candidates[j].distance {
+			return candidates[i].model < candidates[j].model
+		}
+		return candidates[i].distance < candidates[j].distance
+	})
+	if len(candidates) > 0 && candidates[0].distance <= 3 {
+		return []string{candidates[0].model}
+	}
+	return nil
+}
+
+func formatModelSuggestions(suggestions []string) string {
+	switch len(suggestions) {
+	case 0:
+		return ""
+	case 1:
+		return fmt.Sprintf("; did you mean %q?", suggestions[0])
+	default:
+		quoted := make([]string, len(suggestions))
+		for index, suggestion := range suggestions {
+			quoted[index] = fmt.Sprintf("%q", suggestion)
+		}
+		return "; did you mean one of " + strings.Join(quoted, ", ") + "?"
+	}
+}
+
+func formatModelAliases(aliases map[string]string) string {
+	if len(aliases) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(aliases))
+	for alias := range aliases {
+		names = append(names, alias)
+	}
+	sort.Strings(names)
+	return " (aliases: " + strings.Join(names, ", ") + ")"
+}
+
+func editDistance(left, right string) int {
+	leftRunes, rightRunes := []rune(left), []rune(right)
+	previous := make([]int, len(rightRunes)+1)
+	for index := range previous {
+		previous[index] = index
+	}
+	for leftIndex, leftRune := range leftRunes {
+		current := make([]int, len(rightRunes)+1)
+		current[0] = leftIndex + 1
+		for rightIndex, rightRune := range rightRunes {
+			cost := 1
+			if leftRune == rightRune {
+				cost = 0
+			}
+			current[rightIndex+1] = min(
+				current[rightIndex]+1,
+				previous[rightIndex+1]+1,
+				previous[rightIndex]+cost,
+			)
+		}
+		previous = current
+	}
+	return previous[len(rightRunes)]
+}

--- a/internal/agent/models_test.go
+++ b/internal/agent/models_test.go
@@ -1,0 +1,47 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveLaunchModel(t *testing.T) {
+	tests := []struct {
+		name      string
+		agent     string
+		requested string
+		want      string
+		wantError []string
+	}{
+		{name: "claude alias", agent: "claude", requested: "opus", want: "claude-opus-5"},
+		{name: "claude canonical", agent: "claude", requested: "claude-opus-5", want: "claude-opus-5"},
+		{name: "plugin model", agent: "fixture", requested: "provider/custom-model", want: "provider/custom-model"},
+		{
+			name: "missing claude prefix", agent: "claude", requested: "opus-5",
+			wantError: []string{`did you mean "claude-opus-5"?`, "supported models: claude-fable-5, claude-opus-5"},
+		},
+		{
+			name: "ambiguous codex family", agent: "codex", requested: "gpt-5.6",
+			wantError: []string{"did you mean one of", `"gpt-5.6-luna"`, `"gpt-5.6-terra"`, `"gpt-5.6-sol"`},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ResolveLaunchModel(test.agent, test.requested)
+			if len(test.wantError) == 0 {
+				if err != nil || got != test.want {
+					t.Fatalf("ResolveLaunchModel(%q, %q) = %q, %v; want %q, nil", test.agent, test.requested, got, err, test.want)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ResolveLaunchModel(%q, %q) unexpectedly succeeded with %q", test.agent, test.requested, got)
+			}
+			for _, want := range test.wantError {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error = %q, want substring %q", err, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -450,10 +450,13 @@ func TestClientDelegateTicket(t *testing.T) {
 	}()
 
 	_, err = New(sockPath).Delegate("source-session", "", DelegateOptions{
-		RequestID:  "request-1",
-		TicketID:   "planned-work",
-		Confirm:    true,
-		NoWorktree: true,
+		RequestID:          "request-1",
+		TicketID:           "planned-work",
+		Confirm:            true,
+		Placement:          "existing_workspace",
+		WorkspaceID:        "workspace-mixed",
+		NoWorktree:         true,
+		AllowWorktreeReuse: true,
 	})
 	if err != nil {
 		t.Fatalf("Delegate error: %v", err)
@@ -464,6 +467,9 @@ func TestClientDelegateTicket(t *testing.T) {
 	}
 	if request.Brief != "" || protocol.Deref(request.TicketID) != "planned-work" || !protocol.Deref(request.Confirm) {
 		t.Fatalf("Delegate ticket source = %+v", request)
+	}
+	if protocol.Deref(request.Placement) != "existing_workspace" || protocol.Deref(request.WorkspaceID) != "workspace-mixed" || !protocol.Deref(request.AllowWorktreeReuse) {
+		t.Fatalf("Delegate workspace placement = %+v", request)
 	}
 }
 

--- a/internal/daemon/delegate.go
+++ b/internal/daemon/delegate.go
@@ -137,11 +137,6 @@ func (d *Daemon) resolveDelegationAgent(sourceAgent string, requested *string) (
 	return driver.Name(), nil
 }
 
-// validateDelegationModelEffort rejects --model / --effort for agents whose
-// launch command cannot apply them, so the pin fails fast at delegate time
-// instead of being silently dropped by the spawned session. Values themselves
-// are passed through (aliases, full ids, and new effort levels stay legal
-// without an allowlist to rot); the agent CLI is the authority on them.
 func (d *Daemon) validateDelegationModelEffort(agent, model, effort string) error {
 	if model == "" && effort == "" {
 		return nil
@@ -163,6 +158,48 @@ func (d *Daemon) validateDelegationModelEffort(agent, model, effort string) erro
 		return fmt.Errorf("agent %q does not support --effort", agent)
 	}
 	return nil
+}
+
+// resolveDelegationModelEffort rejects pins the selected driver cannot apply and
+// resolves built-in model aliases through the same catalog preflight uses.
+func (d *Daemon) resolveDelegationModelEffort(agent, model, effort string) (string, error) {
+	if err := d.validateDelegationModelEffort(agent, model, effort); err != nil {
+		return "", err
+	}
+	if _, plugin := d.ensurePluginRegistry().driver(agent); plugin {
+		return model, nil
+	}
+	resolvedModel, err := agentdriver.ResolveLaunchModel(agent, model)
+	if err != nil {
+		return "", err
+	}
+	return resolvedModel, nil
+}
+
+func resolveDelegationRepository(path, flagName string) (string, error) {
+	root, err := git.GetRepoRoot(path)
+	if err != nil {
+		return "", fmt.Errorf("%s %s is not in a Git repository", flagName, git.CanonicalizePath(path))
+	}
+	return git.ResolveMainRepoPath(root), nil
+}
+
+func validateDelegationRepositoryInputs(cwd string, request *protocol.DelegateWorktreeRequest) error {
+	if request == nil || strings.TrimSpace(cwd) == "" || strings.TrimSpace(protocol.Deref(request.Repo)) == "" {
+		return nil
+	}
+	cwdRepo, err := resolveDelegationRepository(cwd, "--cwd")
+	if err != nil {
+		return err
+	}
+	explicitRepo, err := resolveDelegationRepository(protocol.Deref(request.Repo), "--repo")
+	if err != nil {
+		return err
+	}
+	if git.CanonicalizePath(cwdRepo) == git.CanonicalizePath(explicitRepo) {
+		return nil
+	}
+	return fmt.Errorf("repository placement conflict: --cwd resolves to %s, but --repo resolves to %s; remove --repo to branch from --cwd, or make both flags point to the same repository", cwdRepo, explicitRepo)
 }
 
 func delegationPlacement(msg *protocol.DelegateMessage) string {
@@ -501,6 +538,9 @@ func (d *Daemon) createDelegationWorktree(baseDirectory, inferredRepo string, re
 	}
 	expectedPath = git.CanonicalizePath(expectedPath)
 	if _, statErr := os.Stat(expectedPath); statErr == nil {
+		if pathRepo, pathErr := resolveDelegationRepository(expectedPath, "--worktree-path"); pathErr == nil && git.CanonicalizePath(pathRepo) != git.CanonicalizePath(repo) {
+			return "", false, fmt.Errorf("repository placement conflict: selected repository resolves to %s, but --worktree-path resolves to %s; choose a worktree path from the selected repository or correct --repo/--cwd", repo, pathRepo)
+		}
 		wt := d.discoverWorktree(expectedPath)
 		if wt == nil || strings.TrimSpace(wt.Branch) != branch {
 			return "", false, fmt.Errorf("worktree path already exists and is not branch %q: %s", branch, expectedPath)
@@ -627,7 +667,8 @@ func (d *Daemon) delegateOperation(msg *protocol.DelegateMessage, operationID, r
 	}
 	model := strings.TrimSpace(protocol.Deref(msg.Model))
 	effort := strings.TrimSpace(strings.ToLower(protocol.Deref(msg.Effort)))
-	if err := d.validateDelegationModelEffort(agent, model, effort); err != nil {
+	model, err = d.resolveDelegationModelEffort(agent, model, effort)
+	if err != nil {
 		return nil, err
 	}
 	sessionID := reservedSessionID
@@ -776,12 +817,22 @@ func (d *Daemon) delegateOperation(msg *protocol.DelegateMessage, operationID, r
 				return nil, cwdErr
 			}
 			directory = validatedCwd
+			if repoErr := validateDelegationRepositoryInputs(directory, msg.Worktree); repoErr != nil {
+				return nil, repoErr
+			}
 		}
 		if directory == "" {
 			directory = source.Directory
 		}
 	default:
 		return nil, fmt.Errorf("unsupported placement %q", placement)
+	}
+
+	// Workspace placement decides where the pane appears. Without a worktree or
+	// explicit --cwd checkout, repository placement remains the source session's
+	// current checkout even when --workspace targets a mixed workspace.
+	if msg.Worktree == nil && strings.TrimSpace(protocol.Deref(msg.Cwd)) == "" {
+		directory = source.Directory
 	}
 
 	if err := d.applyDefaultDelegationWorktree(msg, placement, workspaceID, directory, sessionID, name); err != nil {

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -670,6 +670,50 @@ func TestDelegateThreadsModelAndEffortIntoSpawn(t *testing.T) {
 	}
 }
 
+func TestDelegateResolvesAliasAndRejectsUnknownModelBeforeSpawn(t *testing.T) {
+	t.Run("alias resolves to canonical model", func(t *testing.T) {
+		d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+		backend := &fakeSpawnBackend{}
+		_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+		consumeDelegatedPrompt(t, backend)
+
+		if _, err := d.delegate(&protocol.DelegateMessage{
+			Cmd: protocol.CmdDelegate, SourceSessionID: sourceSessionID,
+			Brief: "Use the supported alias.", Agent: protocol.Ptr("claude"), Model: protocol.Ptr("opus"),
+		}); err != nil {
+			t.Fatalf("delegate() error = %v", err)
+		}
+		spawn, ok := backend.LastSpawn()
+		if !ok || spawn.Model != "claude-opus-5" {
+			t.Fatalf("spawn = %+v, want canonical claude-opus-5", spawn)
+		}
+	})
+
+	for _, test := range []struct {
+		name, agent, model, want string
+	}{
+		{name: "claude shorthand", agent: "claude", model: "opus-5", want: "claude-opus-5"},
+		{name: "codex family", agent: "codex", model: "gpt-5.6", want: "gpt-5.6-sol"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+			backend := &fakeSpawnBackend{}
+			_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+
+			_, err := d.delegate(&protocol.DelegateMessage{
+				Cmd: protocol.CmdDelegate, SourceSessionID: sourceSessionID,
+				Brief: "Reject this model before launch.", Agent: protocol.Ptr(test.agent), Model: protocol.Ptr(test.model),
+			})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("delegate() error = %v, want guidance containing %q", err, test.want)
+			}
+			if len(backend.spawnOpts) != 1 {
+				t.Fatalf("spawn count = %d, want only source session", len(backend.spawnOpts))
+			}
+		})
+	}
+}
+
 func TestDelegateThreadsModelAndEffortIntoPluginDriver(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	backend := &fakeSpawnBackend{}
@@ -1314,7 +1358,7 @@ func TestDelegateRejectsNameMatchingSourceSession(t *testing.T) {
 func TestDelegateTargetsExistingWorkspace(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	backend := &fakeSpawnBackend{}
-	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	_, sourceSessionID, sourceDir := setupDelegationSource(t, d, backend)
 	consumeDelegatedPrompt(t, backend)
 	targetDir := t.TempDir()
 	targetWorkspaceID := "workspace-target"
@@ -1338,7 +1382,7 @@ func TestDelegateTargetsExistingWorkspace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("delegate() error = %v", err)
 	}
-	if result.WorkspaceID != targetWorkspaceID || result.Directory != targetDir {
+	if result.WorkspaceID != targetWorkspaceID || result.Directory != sourceDir {
 		t.Fatalf("result = %+v", result)
 	}
 	if workspace := d.store.GetWorkspace(targetWorkspaceID); workspace == nil || !workspace.Muted {
@@ -1349,7 +1393,7 @@ func TestDelegateTargetsExistingWorkspace(t *testing.T) {
 func TestDelegateTargetsPinnedEmptyWorkspace(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	backend := &fakeSpawnBackend{}
-	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	_, sourceSessionID, sourceDir := setupDelegationSource(t, d, backend)
 	consumeDelegatedPrompt(t, backend)
 	targetDir := t.TempDir()
 	targetWorkspaceID := "workspace-empty-pinned"
@@ -1373,7 +1417,7 @@ func TestDelegateTargetsPinnedEmptyWorkspace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("delegate() error = %v", err)
 	}
-	if result.WorkspaceID != targetWorkspaceID || result.Directory != targetDir {
+	if result.WorkspaceID != targetWorkspaceID || result.Directory != sourceDir {
 		t.Fatalf("result = %+v", result)
 	}
 	if sessions := d.store.SessionsInWorkspace(targetWorkspaceID); len(sessions) != 1 || sessions[0] != result.SessionID {
@@ -1936,6 +1980,83 @@ func TestDelegateWorktreeAmbiguousWorkspaceRepoRequiresRepo(t *testing.T) {
 			t.Fatalf("worktree created at %s despite ambiguous repository", strayPath)
 		}
 	}
+}
+
+func TestDelegateNoWorktreeReusesSourceCheckoutInMixedWorkspace(t *testing.T) {
+	root := t.TempDir()
+	sourceRepo := initDelegationRepo(t, root, "source")
+	repoA := initDelegationRepo(t, root, "repo-a")
+	repoB := initDelegationRepo(t, root, "repo-b")
+
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSourceAt(t, d, backend, sourceRepo)
+	consumeDelegatedPrompt(t, backend)
+
+	targetWorkspaceID := "workspace-mixed"
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd: protocol.CmdRegisterWorkspace, ID: targetWorkspaceID, Title: "Mixed", Directory: repoA,
+	})
+	addWorkspaceSessionAt(t, d, targetWorkspaceID, "session-a", repoA)
+	addWorkspaceSessionAt(t, d, targetWorkspaceID, "session-b", repoB)
+
+	result, err := d.delegate(&protocol.DelegateMessage{
+		Cmd: protocol.CmdDelegate, SourceSessionID: sourceSessionID,
+		Brief:     "Reuse the checkout this command was invoked from.",
+		Placement: protocol.Ptr(delegationPlacementExisting), WorkspaceID: protocol.Ptr(targetWorkspaceID),
+		AllowWorktreeReuse: protocol.Ptr(true),
+	})
+	if err != nil {
+		t.Fatalf("delegate() error = %v", err)
+	}
+	if result.WorkspaceID != targetWorkspaceID || result.Directory != sourceRepo || protocol.Deref(result.WorktreeCreated) {
+		t.Fatalf("result = %+v, want mixed workspace organization with source checkout %s", result, sourceRepo)
+	}
+}
+
+func TestDelegateRejectsConflictingRepositoryPlacement(t *testing.T) {
+	t.Run("cwd and repo", func(t *testing.T) {
+		root := t.TempDir()
+		repoA := initDelegationRepo(t, root, "repo-a")
+		repoB := initDelegationRepo(t, root, "repo-b")
+		d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+		backend := &fakeSpawnBackend{}
+		_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+
+		_, err := d.delegate(&protocol.DelegateMessage{
+			Cmd: protocol.CmdDelegate, SourceSessionID: sourceSessionID, Brief: "Conflicting repositories.",
+			Placement: protocol.Ptr(delegationPlacementNew), Cwd: protocol.Ptr(repoA),
+			Worktree: &protocol.DelegateWorktreeRequest{Repo: protocol.Ptr(repoB), Branch: "feat/conflict"},
+		})
+		if err == nil || !strings.Contains(err.Error(), repoA) || !strings.Contains(err.Error(), repoB) || !strings.Contains(err.Error(), "remove --repo") {
+			t.Fatalf("delegate() error = %v, want both repositories and correction guidance", err)
+		}
+		if len(backend.spawnOpts) != 1 {
+			t.Fatalf("spawn count = %d, want only source session", len(backend.spawnOpts))
+		}
+	})
+
+	t.Run("selected repo and existing worktree path", func(t *testing.T) {
+		root := t.TempDir()
+		repoA := initDelegationRepo(t, root, "repo-a")
+		repoB := initDelegationRepo(t, root, "repo-b")
+		pathB := filepath.Join(root, "repo-b--shared")
+		runGitDaemon(t, repoB, "worktree", "add", "-b", "feat/shared", pathB)
+		d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+		backend := &fakeSpawnBackend{}
+		_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+
+		_, err := d.delegate(&protocol.DelegateMessage{
+			Cmd: protocol.CmdDelegate, SourceSessionID: sourceSessionID, Brief: "Conflicting worktree path.",
+			Worktree: &protocol.DelegateWorktreeRequest{
+				Repo: protocol.Ptr(repoA), Branch: "feat/shared", Path: protocol.Ptr(pathB),
+			},
+			AllowWorktreeReuse: protocol.Ptr(true),
+		})
+		if err == nil || !strings.Contains(err.Error(), repoA) || !strings.Contains(err.Error(), repoB) || !strings.Contains(err.Error(), "--worktree-path") {
+			t.Fatalf("delegate() error = %v, want both repositories and --worktree-path guidance", err)
+		}
+	})
 }
 
 // TestDelegateWorktreeExplicitRepoOverridesWorkspaceSessions confirms --repo

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -119,6 +119,11 @@ func run(ctx context.Context, opts Options, p prober) Report {
 		caps := agentdriver.EffectiveCapabilities(driver)
 		if launch.Model.Value != "" && !caps.HasModelPin {
 			add(fail("launch.model", fmt.Sprintf("agent %q does not support model pins", launch.Agent.Value), "Remove --model or select an agent that supports model pins."))
+		} else if resolvedModel, err := agentdriver.ResolveLaunchModel(launch.Agent.Value, launch.Model.Value); err != nil {
+			add(fail("launch.model", err.Error(), "Choose one of the listed models or omit --model to use the agent default."))
+		} else {
+			launch.Model.Value = resolvedModel
+			report.Launch.Model.Value = resolvedModel
 		}
 		if launch.Effort.Value != "" && !caps.HasEffortPin {
 			add(fail("launch.effort", fmt.Sprintf("agent %q does not support effort pins", launch.Agent.Value), "Remove --effort or select an agent that supports effort pins."))

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -40,15 +40,39 @@ func passingProber(t *testing.T) prober {
 }
 
 func TestRunPassesWithConsistentEnvironment(t *testing.T) {
-	report := run(context.Background(), Options{Agent: "codex", Model: "gpt-test", Effort: "high", WorkingDir: t.TempDir()}, passingProber(t))
+	report := run(context.Background(), Options{Agent: "codex", Model: "gpt-5.6-sol", Effort: "high", WorkingDir: t.TempDir()}, passingProber(t))
 	if !report.OK() || report.Status != StatusPass {
 		t.Fatalf("report status = %q, checks=%+v", report.Status, report.Checks)
 	}
-	if report.Launch.Model.Value != "gpt-test" || report.Launch.Effort.Value != "high" {
+	if report.Launch.Model.Value != "gpt-5.6-sol" || report.Launch.Effort.Value != "high" {
 		t.Fatalf("launch = %+v", report.Launch)
 	}
 	assertCheck(t, report, "routing.daemon", StatusPass, "")
 	assertCheck(t, report, "protocol.app_daemon", StatusPass, "")
+}
+
+func TestRunUsesAuthoritativeModelResolution(t *testing.T) {
+	t.Run("resolves alias", func(t *testing.T) {
+		report := run(context.Background(), Options{Agent: "claude", Model: "opus", WorkingDir: t.TempDir()}, passingProber(t))
+		if !report.OK() || report.Launch.Model.Value != "claude-opus-5" {
+			t.Fatalf("report = %+v, want canonical claude-opus-5", report)
+		}
+	})
+
+	for _, test := range []struct {
+		name, agent, model, want string
+	}{
+		{name: "claude shorthand", agent: "claude", model: "opus-5", want: "claude-opus-5"},
+		{name: "codex family", agent: "codex", model: "gpt-5.6", want: "gpt-5.6-sol"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			report := run(context.Background(), Options{Agent: test.agent, Model: test.model, WorkingDir: t.TempDir()}, passingProber(t))
+			if report.OK() {
+				t.Fatalf("report unexpectedly passed: %+v", report)
+			}
+			assertCheck(t, report, "launch.model", StatusFail, test.want)
+		})
+	}
 }
 
 func TestRunReportsRootCausesAndActions(t *testing.T) {


### PR DESCRIPTION
## Intent

Delegation could pass preflight with a model identifier that the selected agent did not resolve as intended, then silently start on a fallback model. Repository placement was also coupled to workspace placement, so `--workspace --no-worktree` could reuse a checkout from an unrelated repository.

This makes both decisions explicit and rejects ambiguous input before launching an agent.

## Summary

- add one built-in model resolver shared by `preflight` and `delegate`
- resolve supported Claude aliases to canonical model IDs and reject unknown built-in IDs with supported choices and suggestions
- keep plugin model identifiers driver-owned
- make the source checkout authoritative for `--no-worktree`, including when the pane is placed with `--workspace`
- reject conflicting `--cwd`/`--repo` and existing `--worktree-path` repository inputs with both resolved locations
- clarify workspace placement versus repository/worktree placement in CLI and bundled delegation guidance
- add regression coverage for model aliases, invalid identifiers, mixed workspaces, repository conflicts, and valid worktree combinations

## Verification

- `go test ./cmd/attn ./internal/client ./internal/agent ./internal/preflight`
- focused `internal/daemon` delegation tests
- freshly built CLI checks for canonical alias resolution, invalid model rejection, and updated help output
- pre-commit Go build

The full Go harness and packaged-app install could not complete because Spotify Artifactory returned `401` while fetching TypeScript/frontend dependencies. All unaffected runnable packages and daemon shards passed.
