### PR TITLE
docs(agents): a comment claims only what this commit does

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,8 +377,9 @@ forgets that position and `--since <RFC3339>` replays from an instant.
   comment claims only what this commit does: describing the design you
   intend, then shipping the part in scope, quietly turns the comment into a
   lie. An unbuilt intention belongs in the plan doc or as a named gap in the
-  PR body, never in a comment. Godoc on an exported symbol is one line. A package header is a few lines plus a
-  link to the design doc, never a retelling of it. Never narrate the next line
+  PR body, never in a comment. Godoc on an exported symbol is one line. A
+  package header is a few lines plus a link to the design doc, never a
+  retelling of it. Never narrate the next line
   or argue that the change is correct: that talk belongs in the PR, and a
   comment addressed to the reviewer is a defect.
 - Conventional commit titles with a scope, in plain language:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -373,8 +373,11 @@ forgets that position and `--since <RFC3339>` replays from an instant.
   high-refresh displays, beside agents that run all day — a permanent repaint
   loop is a battery and thermal bug no test will catch.
 - Comments state what the code cannot show — a constraint, an invariant, a
-  measured receipt — in one or two lines, and move when the code moves. Godoc
-  on an exported symbol is one line. A package header is a few lines plus a
+  measured receipt — in one or two lines, and move when the code moves. A
+  comment claims only what this commit does: describing the design you
+  intend, then shipping the part in scope, quietly turns the comment into a
+  lie. An unbuilt intention belongs in the plan doc or as a named gap in the
+  PR body, never in a comment. Godoc on an exported symbol is one line. A package header is a few lines plus a
   link to the design doc, never a retelling of it. Never narrate the next line
   or argue that the change is correct: that talk belongs in the PR, and a
   comment addressed to the reviewer is a defect.

--- a/changelog.d/comments-claim-this-commit.yaml
+++ b/changelog.d/comments-claim-this-commit.yaml
@@ -1,0 +1,6 @@
+kind: internal
+area: docs
+change: >
+  The agent guide's comment discipline now says a comment claims only
+  what this commit does — an intended-but-unbuilt design goes in the
+  plan doc or the PR body, never in a comment.


### PR DESCRIPTION
The agent guide's comment-discipline bullet said what a comment is for — a constraint, an invariant, a measured receipt — but never that the claim must be true of the commit that carries it. That gap has a measured incentive, not just a hypothetical one: an agent writes the comment for the design it intends, ships the part that was in scope, and the comment silently becomes a claim about code that does not exist. Two instances of that class shipped in garden slice 1 (#867) — an id comment promising a mint-again retry nothing implemented (caught in review, became a real fix) and a log line promising a panel behavior no consumer rendered (caught by a post-merge adversarial review).

One addition to the bullet: a comment claims only what this commit does; an unbuilt intention belongs in the plan doc or as a named gap in the PR body, never in a comment.

Docs and changelog fragment only; no behavior changes.

https://claude.ai/code/session_012Bu5dMFLdBfrEo4WmQkF53