### PR TITLE
test(bus): fail when a projection stops writing to the wire

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -495,7 +495,12 @@ consumer — runs the matching entry in `wireProjections`
 (`internal/daemon/bus.go`) to produce the wire traffic, often a snapshot
 re-push. Every state-change broadcast goes through it;
 `TestWireTrafficComesFromProjections` fails on a new one that does not, and
-carries the enumerated exception list.
+carries the enumerated exception list. Its mirror,
+`TestEveryProjectedFactReachesTheWire`, publishes every fact that has a
+projection and reads the bytes the hub sent, so a projection that stops sending
+— or sends the wrong event — fails too. Both are driven by the live table: a new
+projection is covered without touching either test, and a fact reaching no
+projection has to name the consumer that does read it.
 
 - A fact without a subject is a snapshot invalidation, not a fact. If the
   producer does not know the entity id, that is the bug to fix — change the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -498,9 +498,10 @@ re-push. Every state-change broadcast goes through it;
 carries the enumerated exception list. Its mirror,
 `TestEveryProjectedFactReachesTheWire`, publishes every fact that has a
 projection and reads the bytes the hub sent, so a projection that stops sending
-— or sends the wrong event — fails too. Both are driven by the live table: a new
-projection is covered without touching either test, and a fact reaching no
-projection has to name the consumer that does read it.
+— or sends the wrong event — fails too. Both are driven by the live
+table, so a new projection cannot go unnoticed: it needs a one-line fixture
+naming the events it sends, the test fails by name until it has one, and a fact
+reaching no projection has to name the consumer that does read it.
 
 - A fact without a subject is a snapshot invalidation, not a fact. If the
   producer does not know the entity id, that is the bug to fix — change the

--- a/changelog.d/wire-join-every-projection-proved.yaml
+++ b/changelog.d/wire-join-every-projection-proved.yaml
@@ -1,0 +1,15 @@
+kind: internal
+area: testing
+change: >
+  The daemon's fact-to-wire join is now proved for every projection at once.
+  A projection could stop sending and nothing failed: three features assert
+  against a broadcast hook that fires just before the real send, so deleting
+  the send left the whole package green — measured, by deleting the garden
+  snapshot push and again the ticket board push. TestEveryProjectedFactReachesTheWire
+  publishes each fact that has a projection and reads the bytes the hub
+  actually put on the wire, asserting the exact set of events it produced. It
+  is driven by the live projection table and the fact constants themselves, so
+  a projection added later is covered without anyone editing the test; a fact
+  that reaches no projection has to say why. This is the missing half of
+  TestWireTrafficComesFromProjections, which only ever caught traffic that
+  skipped the bus.

--- a/docs/plans/2026-08-01-ext-a1-event-bus.md
+++ b/docs/plans/2026-08-01-ext-a1-event-bus.md
@@ -339,3 +339,70 @@ CLI, app and daemon.
   `setting.changed` fact and one `settings_updated` carrying
   `changed_key=auto_settle_enabled`, while the startup tailscale and backup
   facts pushed settings with no changed key, as before.
+
+## Proving the join, both directions (2026-08-12)
+
+`TestWireTrafficComesFromProjections` only ever closed one direction: it fails a
+function that reaches the hub *without* a fact behind it. Nothing failed a
+projection whose push disappeared. Measured with `go test -overlay`: delete the
+`broadcastMessage` call from the garden snapshot projection and
+`go test ./internal/daemon` is green in 147s; do the same to the ticket board's
+and it is green in 130s.
+
+What made it invisible is a shape, not a feature. A projection whose message is
+its own top-level type (not a `WebSocketEvent`) is unobservable through the
+hub's `broadcastListener`, so garden, the ticket board and the workflow run all
+grew a test-only broadcast hook that fires immediately before the real send.
+Every assertion in those features reads the hook. Delete the send, keep the
+hook, and nothing notices — and each new feature copies the shape.
+
+`TestEveryProjectedFactReachesTheWire` (`internal/daemon/bus_wire_join_test.go`)
+is the mirror. For each fact that a `wireProjections` entry matches, it builds a
+daemon with a seeded session, workspace, layout and presentation, taps
+`wsHub.wireTap` — which sees the marshalled bytes of all five send paths, and no
+hook — publishes that one fact, and asserts the **exact set** of `event` names
+that reached the wire.
+
+Three properties make it hold without maintenance:
+
+- The fact vocabulary is parsed out of `bus.go` (`Fact…` constants) and the
+  projection table is read at runtime, so a new fact under an existing wildcard
+  (`ticket.*`, `pr.*`, `garden.*`) is covered with no edit at all.
+- A projected fact with no fixture fails by name, and a fixture whose fact no
+  longer exists fails as stale. Most fixtures are one line — 26 of the 41
+  projections push correctly against a bare daemon and a bare fact, so a subject
+  or payload appears only where the projection genuinely needs one.
+- A declared fact matched by *no* projection must be listed in
+  `factsWithoutWire` with the consumer that does read it — the same enumerated
+  exception discipline `wireSenderExceptions` uses. Without it, a projection
+  deleted by accident is indistinguishable from a fact that never had one.
+
+**The assertion is the event name, and deliberately nothing deeper.** It has to
+be at least that deep: publishing `workspace.context.changed` with no payload
+decodes to a zero value and pushes a message with an *empty* event field, which
+"pushed something" would accept — and the event name is precisely what
+copy-pasting a projection gets wrong. It should not go deeper here, because
+payload bytes already belong to the wire-trace goldens and to each feature's own
+tests; one table owning every feature's payload would rot on the first field
+added and be regenerated rather than read.
+
+Receipts, all `go test ./internal/daemon -count=1`:
+
+| run | result |
+| --- | --- |
+| garden push deleted, this test absent | ok, 146.9s |
+| garden push deleted, this test present | FAIL — `garden.planted` put nothing on the wire |
+| ticket board push deleted, this test absent | ok, 129.5s |
+| ticket board push deleted, this test present | FAIL — every `ticket.*` fact put nothing on the wire |
+| unmutated | ok, 185.0s |
+
+The third hook-shaped feature, `workflow_broadcast.go`, turned out to be covered
+already: deleting its send fails `TestWireTraceProducerGolden`, because a
+workflow run is one of the producers that golden drives. That is the difference
+between a hand-maintained producer list and a table-complete one — garden was
+merged without an entry in it, and nothing noticed.
+
+Four mutations of the mechanism itself, to show the guard is not vacuous: a
+removed fixture, a fixture for a fact that does not exist, a fixture declaring
+the wrong event, and a deleted `wireProjections` entry each fail with a message
+naming what to fix.

--- a/docs/plans/2026-08-01-ext-a1-event-bus.md
+++ b/docs/plans/2026-08-01-ext-a1-event-bus.md
@@ -371,9 +371,10 @@ Three properties make it hold without maintenance:
   remembering this test exists.
 - Being seen is what makes it loud: a projected fact with no fixture fails by
   name, saying what to add, and a fixture whose fact no longer exists fails as
-  stale. The fixture is one line for 40 of the 79 facts, because 26 of the 41
-  projections push correctly against a bare daemon and a bare fact; a subject or
-  payload appears only where the projection genuinely needs one.
+  stale. That fixture is a single line — no subject, no payload — for 41 of the
+  79 facts, which is 14 of the 41 projection entries covered whole. A subject or
+  payload appears only where the projection re-reads an entity or decodes a
+  body.
 - A declared fact matched by *no* projection must be listed in
   `factsWithoutWire` with the consumer that does read it — the same enumerated
   exception discipline `wireSenderExceptions` uses. Without it, a projection

--- a/docs/plans/2026-08-01-ext-a1-event-bus.md
+++ b/docs/plans/2026-08-01-ext-a1-event-bus.md
@@ -366,12 +366,14 @@ that reached the wire.
 Three properties make it hold without maintenance:
 
 - The fact vocabulary is parsed out of `bus.go` (`Fact…` constants) and the
-  projection table is read at runtime, so a new fact under an existing wildcard
-  (`ticket.*`, `pr.*`, `garden.*`) is covered with no edit at all.
-- A projected fact with no fixture fails by name, and a fixture whose fact no
-  longer exists fails as stale. Most fixtures are one line — 26 of the 41
-  projections push correctly against a bare daemon and a bare fact, so a subject
-  or payload appears only where the projection genuinely needs one.
+  projection table is read at runtime, so a new fact — including one that falls
+  under an existing wildcard like `ticket.*` — is *seen* without anyone
+  remembering this test exists.
+- Being seen is what makes it loud: a projected fact with no fixture fails by
+  name, saying what to add, and a fixture whose fact no longer exists fails as
+  stale. The fixture is one line for 40 of the 79 facts, because 26 of the 41
+  projections push correctly against a bare daemon and a bare fact; a subject or
+  payload appears only where the projection genuinely needs one.
 - A declared fact matched by *no* projection must be listed in
   `factsWithoutWire` with the consumer that does read it — the same enumerated
   exception discipline `wireSenderExceptions` uses. Without it, a projection

--- a/internal/daemon/bus_wire_join_test.go
+++ b/internal/daemon/bus_wire_join_test.go
@@ -1,0 +1,532 @@
+package daemon
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// The other half of the wire boundary. TestWireTrafficComesFromProjections says
+// only a projection may write to the wire; this says every fact with a
+// projection actually writes, and writes the events it is meant to.
+//
+// The defect that was invisible without it: a projection whose feature tests
+// assert against a broadcast hook fires the hook, then sends. Delete the send
+// and keep the hook and the whole package still passes — measured, by deleting
+// the garden snapshot push and running `go test ./internal/daemon` green.
+//
+// So the observation point here is wsHub.wireTap, which sees the marshalled
+// bytes of every send path, and never a hook.
+
+// wireFixture is how one fact is made real: what it is about, what it carries,
+// and the complete set of wire events publishing it must produce.
+//
+// Everything is optional except events. A fact whose projection re-pushes a
+// whole list needs no subject and no payload at all, which is most of them.
+type wireFixture struct {
+	// events is every `event` name the publish must put on the wire, in any
+	// order. Exact, not "at least": a second projection entry that matched the
+	// same fact by accident would double-push, and that is a defect too.
+	events []string
+	// subject names the entity the fact is about. Defaults to a subject nothing
+	// resolves, which is correct for a snapshot projection and wrong for one
+	// that re-reads the entity — and the test says which when it fails.
+	subject func(*wireWorld) string
+	// payload is the fact's body, for the projections that decode one.
+	payload func(*wireWorld) any
+}
+
+// wireFixtures is the whole fact -> wire-event contract, and the only place this
+// test needs editing. A fact that gains a projection and no entry here fails by
+// name; an entry whose fact no longer exists fails as stale.
+var wireFixtures = map[string]wireFixture{
+	// Sessions. Everything but the unregister re-reads the session the subject
+	// names, so the seeded session is the subject.
+	FactSessionStateChanged: {
+		events:  []string{protocol.EventSessionStateChanged},
+		subject: (*wireWorld).session,
+	},
+	FactSessionRegistered: {
+		events:  []string{protocol.EventSessionRegistered},
+		subject: (*wireWorld).session,
+	},
+	FactSessionReregistered: {
+		events:  []string{protocol.EventSessionStateChanged},
+		subject: (*wireWorld).session,
+	},
+	FactSessionRenamed: {
+		events:  []string{protocol.EventSessionStateChanged},
+		subject: (*wireWorld).session,
+	},
+	FactSessionPinChanged: {
+		events:  []string{protocol.EventSessionStateChanged},
+		subject: (*wireWorld).session,
+	},
+	FactSessionCapChanged: {
+		events:  []string{protocol.EventSessionStateChanged},
+		subject: (*wireWorld).session,
+	},
+	FactSessionActivityChanged: {
+		events:  []string{protocol.EventSessionStateChanged},
+		subject: (*wireWorld).session,
+	},
+	FactSessionConversationChanged: {
+		events:  []string{protocol.EventSessionStateChanged},
+		subject: (*wireWorld).session,
+	},
+	FactSessionWorkspaceChanged: {
+		events:  []string{protocol.EventSessionStateChanged},
+		subject: (*wireWorld).session,
+	},
+	FactSessionTodosChanged: {
+		events:  []string{protocol.EventSessionTodosUpdated},
+		subject: (*wireWorld).session,
+	},
+	FactSessionUnregistered: {
+		// The session is gone by then, so it rides in the payload.
+		events:  []string{protocol.EventSessionUnregistered},
+		subject: (*wireWorld).session,
+		payload: func(w *wireWorld) any { return w.d.sessionForBroadcast(w.d.store.Get(w.sessionID)) },
+	},
+	FactSessionRespawned: {
+		events:  []string{protocol.EventRuntimeRespawned},
+		subject: (*wireWorld).session,
+	},
+	FactSessionPTYResized: {
+		events:  []string{protocol.EventPtyResized},
+		subject: (*wireWorld).session,
+		payload: func(*wireWorld) any { return ptyGeometry{Cols: 80, Rows: 24} },
+	},
+	FactSessionPTYExited: {
+		events:  []string{protocol.EventSessionExited},
+		subject: (*wireWorld).session,
+		payload: func(*wireWorld) any { return ptyExit{ExitCode: 0} },
+	},
+
+	// The six facts whose only visible effect is one session-list push.
+	FactSessionTerminated:       {events: []string{protocol.EventSessionsUpdated}},
+	FactSessionBranchChanged:    {events: []string{protocol.EventSessionsUpdated}},
+	FactSessionChiefRoleChanged: {events: []string{protocol.EventSessionsUpdated}},
+	FactSessionReconciled:       {events: []string{protocol.EventSessionsUpdated}},
+	FactWorktreeSessionsRemoved: {events: []string{protocol.EventSessionsUpdated}},
+	FactEndpointSessionsChanged: {events: []string{protocol.EventSessionsUpdated}},
+
+	// Workspaces. The registry is the authority, so the subject must be a
+	// workspace it holds.
+	FactWorkspaceRegistered: {
+		events:  []string{protocol.EventWorkspaceRegistered},
+		subject: (*wireWorld).workspace,
+	},
+	FactWorkspaceReregistered: {
+		events:  []string{protocol.EventWorkspaceStateChanged},
+		subject: (*wireWorld).workspace,
+	},
+	FactWorkspaceRenamed: {
+		events:  []string{protocol.EventWorkspaceStateChanged},
+		subject: (*wireWorld).workspace,
+	},
+	FactWorkspaceStatusChanged: {
+		events:  []string{protocol.EventWorkspaceStateChanged},
+		subject: (*wireWorld).workspace,
+	},
+	FactWorkspaceMuteChanged: {
+		events:  []string{protocol.EventWorkspaceStateChanged},
+		subject: (*wireWorld).workspace,
+	},
+	FactWorkspacePinChanged: {
+		events:  []string{protocol.EventWorkspaceStateChanged},
+		subject: (*wireWorld).workspace,
+	},
+	FactWorkspaceRankChanged: {
+		events:  []string{protocol.EventWorkspaceStateChanged},
+		subject: (*wireWorld).workspace,
+	},
+	FactWorkspaceSessionAssociated: {
+		events:  []string{protocol.EventWorkspaceStateChanged},
+		subject: (*wireWorld).workspace,
+	},
+	FactWorkspaceSessionDissociated: {
+		events:  []string{protocol.EventWorkspaceStateChanged},
+		subject: (*wireWorld).workspace,
+	},
+	FactWorkspaceUnregistered: {
+		events:  []string{protocol.EventWorkspaceUnregistered},
+		subject: (*wireWorld).workspace,
+		payload: func(w *wireWorld) any {
+			snapshot, _ := w.d.workspaces.snapshot(w.workspaceID)
+			return snapshot
+		},
+	},
+	FactWorkspaceLayoutChanged: {
+		events:  []string{protocol.EventWorkspaceLayoutUpdated},
+		subject: (*wireWorld).workspace,
+		payload: func(w *wireWorld) any { return w.layout() },
+	},
+	FactWorkspaceLayoutRepublished: {
+		// Nothing changed, so the projection reads the layout back itself.
+		events:  []string{protocol.EventWorkspaceLayout},
+		subject: (*wireWorld).workspace,
+	},
+	FactWorkspaceContextChanged: {
+		events:  []string{protocol.EventWorkspaceContextChanged},
+		subject: (*wireWorld).workspace,
+		payload: func(w *wireWorld) any {
+			return protocol.WorkspaceContextChangedMessage{
+				Event:       protocol.EventWorkspaceContextChanged,
+				WorkspaceID: w.workspaceID,
+				Revision:    1,
+			}
+		},
+	},
+
+	// Tickets and the garden: every fact re-pushes the whole list.
+	FactTicketCreated:       {events: []string{protocol.EventTicketsUpdated}},
+	FactTicketStatusChanged: {events: []string{protocol.EventTicketsUpdated}},
+	FactTicketCommented:     {events: []string{protocol.EventTicketsUpdated}},
+	FactTicketAssigned:      {events: []string{protocol.EventTicketsUpdated}},
+	FactTicketAttached:      {events: []string{protocol.EventTicketsUpdated}},
+	FactTicketChanged:       {events: []string{protocol.EventTicketsUpdated}},
+	FactGardenPlanted:       {events: []string{protocol.EventGardenSeedsUpdated}},
+
+	// PRs and their mute lists.
+	FactPRAppeared:       {events: []string{protocol.EventPRsUpdated}},
+	FactPRUpdated:        {events: []string{protocol.EventPRsUpdated}},
+	FactPRDisappeared:    {events: []string{protocol.EventPRsUpdated}},
+	FactPRMuteChanged:    {events: []string{protocol.EventPRsUpdated}},
+	FactPRVisited:        {events: []string{protocol.EventPRsUpdated}},
+	FactPRHeatChanged:    {events: []string{protocol.EventPRsUpdated}},
+	FactPRDetailsChanged: {events: []string{protocol.EventPRsUpdated}},
+	FactRepoMuteChanged:  {events: []string{protocol.EventReposUpdated}},
+	FactAuthorMuteChanged: {
+		events: []string{protocol.EventAuthorsUpdated},
+	},
+
+	// Worktrees and git.
+	FactWorktreeCreated: {
+		events:  []string{protocol.EventWorktreeCreated},
+		subject: (*wireWorld).worktree,
+		payload: func(w *wireWorld) any { return protocol.Worktree{Path: w.worktreePath} },
+	},
+	FactWorktreeDeleted: {
+		// No payload: the wire event has only ever carried the path, which is
+		// the subject.
+		events:  []string{protocol.EventWorktreeDeleted},
+		subject: (*wireWorld).worktree,
+	},
+	FactWorktreeListReconciled: {
+		events:  []string{protocol.EventWorktreesUpdated},
+		subject: (*wireWorld).worktree,
+		payload: func(w *wireWorld) any { return []protocol.Worktree{{Path: w.worktreePath}} },
+	},
+	FactGitOperationStarted: {
+		events:  []string{protocol.EventGitOperationStarted},
+		subject: func(*wireWorld) string { return "operation-1" },
+		payload: func(*wireWorld) any { return gitOperationFixture("operation-1") },
+	},
+	FactGitOperationFinished: {
+		events:  []string{protocol.EventGitOperationFinished},
+		subject: func(*wireWorld) string { return "operation-1" },
+		payload: func(*wireWorld) any { return gitOperationFixture("operation-1") },
+	},
+
+	// GitHub plumbing.
+	FactRateLimited: {
+		events:  []string{protocol.EventRateLimited},
+		subject: func(*wireWorld) string { return "core" },
+		payload: func(*wireWorld) any { return rateLimitWindow{ResetAt: "2026-08-12T00:00:00Z"} },
+	},
+	FactGitHubHostAdded:   {events: []string{protocol.EventGitHubHostsUpdated}},
+	FactGitHubHostRemoved: {events: []string{protocol.EventGitHubHostsUpdated}},
+
+	// Endpoints.
+	FactEndpointAdded:   {events: []string{protocol.EventEndpointsUpdated}},
+	FactEndpointRemoved: {events: []string{protocol.EventEndpointsUpdated}},
+	FactEndpointChanged: {events: []string{protocol.EventEndpointsUpdated}},
+	FactEndpointStatusChanged: {
+		events:  []string{protocol.EventEndpointStatusChanged},
+		payload: func(*wireWorld) any { return protocol.EndpointInfo{ID: "endpoint-1", Status: "connected"} },
+	},
+
+	// Plugins. Four of them re-push settings too, because they change which
+	// agents are available; that second entry is part of the contract.
+	FactPluginInstalled:        {events: []string{protocol.EventPluginsUpdated}},
+	FactPluginUninstalled:      {events: []string{protocol.EventPluginsUpdated}},
+	FactPluginPriorityChanged:  {events: []string{protocol.EventPluginsUpdated}},
+	FactPluginConnected:        {events: []string{protocol.EventPluginsUpdated}},
+	FactPluginHealthChanged:    {events: []string{protocol.EventPluginsUpdated}},
+	FactPluginDisconnected:     {events: []string{protocol.EventPluginsUpdated, protocol.EventSettingsUpdated}},
+	FactPluginDriverRegistered: {events: []string{protocol.EventSettingsUpdated}},
+	FactBackupWritten:          {events: []string{protocol.EventSettingsUpdated}},
+	FactTailscaleServeChanged:  {events: []string{protocol.EventSettingsUpdated}},
+	FactSettingChanged:         {events: []string{protocol.EventSettingsUpdated}},
+
+	// Everything else with a panel of its own.
+	FactNotificationCreated: {events: []string{protocol.EventNotificationsUpdated}},
+	FactNotificationRead:    {events: []string{protocol.EventNotificationsUpdated}},
+	FactAutomationChanged:   {events: []string{protocol.EventAutomationsChanged}},
+	FactTaskChanged:         {events: []string{protocol.EventTasksChanged}},
+	FactNotebookFileChanged: {
+		events:  []string{protocol.EventNotebookChanged},
+		subject: func(*wireWorld) string { return "note.md" },
+	},
+	FactWorkflowRunUpdated: {
+		events:  []string{protocol.EventWorkflowRunUpdated},
+		subject: func(*wireWorld) string { return "run-1" },
+		payload: func(*wireWorld) any {
+			return &protocol.WorkflowRun{RunID: "run-1", Status: protocol.WorkflowRunStatusRunning}
+		},
+	},
+	FactPresentationAdded: {
+		events:  []string{protocol.EventPresentationAdded},
+		subject: (*wireWorld).presentation,
+	},
+	FactPresentationUpdated: {
+		events:  []string{protocol.EventPresentationUpdated},
+		subject: (*wireWorld).presentation,
+	},
+}
+
+// factsWithoutWire are the declared facts that deliberately produce no WebSocket
+// traffic. Same discipline as wireSenderExceptions: an entry is a design
+// decision, and the reason is the point of writing it down. Without this list a
+// projection deleted by accident would look exactly like a fact that never had
+// one.
+var factsWithoutWire = map[string]string{
+	FactDocumentChanged:              "consumed by the live-query fan-out in documents.go, not by WebSocket clients",
+	FactDocumentCollectionRemoved:    "same consumer as document.changed; ends the subscriptions that read the collection",
+	FactDocumentCollectionRedeclared: "same consumer again; a redeclare that drops a queried field ends live queries at redeclare time",
+	FactAppEnabledChanged:            "the app registry has no UI surface; the consumer is the runtime's dispatch loop",
+	FactAppRemoved:                   "same: the runtime has to stop dispatching to an app the CLI uninstalled",
+	FactAppVersionChanged:            "same: the runtime reloads handlers on an apply or a rollback",
+	FactAppRuntimeChanged:            "supervision state is read back from the supervisor (`attn app runtime status`), never from a copy",
+}
+
+// TestEveryProjectedFactReachesTheWire publishes each fact that has a projection
+// and asserts the wire saw exactly the events that fact is contracted to
+// produce. Table-complete in both directions, so it covers a projection written
+// next month without anyone remembering this file exists.
+func TestEveryProjectedFactReachesTheWire(t *testing.T) {
+	facts := declaredFactNames(t)
+
+	for _, fact := range facts {
+		if !factIsProjected(fact) {
+			if _, known := factsWithoutWire[fact]; !known {
+				t.Errorf("fact %q has no projection and no entry in factsWithoutWire.\n"+
+					"If it should reach clients, add a wireProjections entry (internal/daemon/bus.go). "+
+					"If it deliberately produces no WebSocket traffic, say so in factsWithoutWire "+
+					"with the consumer that does read it.", fact)
+			}
+			continue
+		}
+		if _, wired := factsWithoutWire[fact]; wired {
+			t.Errorf("fact %q is listed in factsWithoutWire but a projection matches it", fact)
+			continue
+		}
+		fixture, ok := wireFixtures[fact]
+		if !ok {
+			t.Errorf("fact %q is projected but has no wireFixture.\n"+
+				"Add one naming the wire events publishing it must produce; give it a subject "+
+				"or a payload only if the projection needs one to do its work.", fact)
+			continue
+		}
+		t.Run(fact, func(t *testing.T) {
+			w := newWireWorld(t)
+			subject := "no-such-entity"
+			if fixture.subject != nil {
+				subject = fixture.subject(w)
+			}
+			var payload any
+			if fixture.payload != nil {
+				payload = fixture.payload(w)
+			}
+
+			w.trace.Clear()
+			w.d.publishFact(fact, subject, payload)
+
+			got := sortedStrings(w.trace.EventNames())
+			want := sortedStrings(fixture.events)
+			if equalStrings(got, want) {
+				return
+			}
+			if len(got) == 0 {
+				t.Fatalf("publishing %q put nothing on the wire; its projection is contracted to send %v.\n"+
+					"Either the projection stopped sending — which is the defect this test exists for — "+
+					"or it needs a subject or payload the fixture does not give it.", fact, want)
+			}
+			t.Fatalf("publishing %q put %v on the wire, want %v", fact, got, want)
+		})
+	}
+
+	for fact := range wireFixtures {
+		if !factIsDeclared(facts, fact) {
+			t.Errorf("wireFixtures has an entry for %q, which is not a declared fact constant in bus.go", fact)
+		}
+	}
+	for fact := range factsWithoutWire {
+		if !factIsDeclared(facts, fact) {
+			t.Errorf("factsWithoutWire has an entry for %q, which is not a declared fact constant in bus.go", fact)
+		}
+	}
+}
+
+// wireWorld is one daemon with enough state that a projection re-reading the
+// entity its fact names finds something. Everything a fixture can point at is
+// built up front: a fixture picks, it does not construct.
+type wireWorld struct {
+	t              *testing.T
+	d              *Daemon
+	trace          *WireTrace
+	sessionID      string
+	workspaceID    string
+	presentationID string
+	worktreePath   string
+}
+
+func newWireWorld(t *testing.T) *wireWorld {
+	t.Helper()
+	dir := t.TempDir()
+	d := NewForTesting(filepath.Join(dir, "attn.sock"))
+	trace := &WireTrace{}
+	d.wsHub.wireTap = trace.record
+
+	w := &wireWorld{t: t, d: d, trace: trace}
+
+	w.sessionID = "wire-session"
+	d.store.Add(&protocol.Session{
+		ID:        w.sessionID,
+		Directory: dir,
+		State:     protocol.SessionStateIdle,
+		Agent:     protocol.SessionAgentClaude,
+	})
+
+	w.workspaceID = "wire-workspace"
+	client := newWorkspaceProtocolTestClient()
+	d.handleRegisterWorkspace(client, &protocol.RegisterWorkspaceMessage{
+		Cmd:       protocol.CmdRegisterWorkspace,
+		ID:        w.workspaceID,
+		Title:     "wire",
+		Directory: dir,
+	})
+	// Same ordering the app uses: register the workspace, then put the session
+	// in a pane. A workspace without a layout is not a state the app produces.
+	d.handleWorkspaceLayoutAddSessionPane(client, &protocol.WorkspaceLayoutAddSessionPaneMessage{
+		Cmd:         protocol.CmdWorkspaceLayoutAddSessionPane,
+		WorkspaceID: w.workspaceID,
+		PaneID:      protocol.Ptr("wire-pane"),
+		SessionID:   w.sessionID,
+	})
+	if _, err := d.ensureWorkspaceLayout(w.workspaceID); err != nil {
+		t.Fatalf("seed workspace layout: %v", err)
+	}
+
+	w.worktreePath = filepath.Join(dir, "worktree")
+
+	pres, err := d.store.CreatePresentation(w.sessionID, nil, "wire", "diff", dir, time.Now())
+	if err != nil {
+		t.Fatalf("seed presentation: %v", err)
+	}
+	w.presentationID = pres.ID
+
+	return w
+}
+
+func (w *wireWorld) session() string      { return w.sessionID }
+func (w *wireWorld) workspace() string    { return w.workspaceID }
+func (w *wireWorld) presentation() string { return w.presentationID }
+func (w *wireWorld) worktree() string     { return w.worktreePath }
+
+func (w *wireWorld) layout() *protocol.WorkspaceLayout {
+	layout, err := w.d.protocolWorkspaceLayout(w.workspaceID)
+	if err != nil {
+		w.t.Fatalf("read seeded layout: %v", err)
+	}
+	return layout
+}
+
+// gitOperationFixture is the one payload a fixture has to build rather than
+// pick: the daemon keeps no git-operation registry, so the fact is the only
+// record of the operation.
+func gitOperationFixture(id string) protocol.GitOperation {
+	return protocol.GitOperation{
+		ID:     id,
+		Kind:   protocol.GitOperationKindDeleteWorktree,
+		Status: protocol.GitOperationStatusRunning,
+	}
+}
+
+// factIsProjected reports whether any wireProjections entry would run for it.
+func factIsProjected(fact string) bool {
+	for _, p := range wireProjections() {
+		if p.filter.Matches(fact) {
+			return true
+		}
+	}
+	return false
+}
+
+func factIsDeclared(facts []string, fact string) bool {
+	for _, f := range facts {
+		if f == fact {
+			return true
+		}
+	}
+	return false
+}
+
+// declaredFactNames reads the fact vocabulary out of bus.go rather than
+// re-listing it here: a new Fact… constant is picked up by parsing, so the only
+// way to add a fact this test does not see is to stop declaring it as one.
+func declaredFactNames(t *testing.T) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "bus.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse bus.go: %v", err)
+	}
+	var names []string
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			values, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range values.Names {
+				if !strings.HasPrefix(name.Name, "Fact") || i >= len(values.Values) {
+					continue
+				}
+				lit, ok := values.Values[i].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				value, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					t.Fatalf("read %s: %v", name.Name, err)
+				}
+				names = append(names, value)
+			}
+		}
+	}
+	if len(names) == 0 {
+		t.Fatal("no Fact… constants found in bus.go — this test would pass vacuously")
+	}
+	sort.Strings(names)
+	return names
+}
+
+func sortedStrings(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
+}


### PR DESCRIPTION
## The hole

`TestWireTrafficComesFromProjections` closes one direction of the event-bus
boundary: a function that reaches the hub without a fact behind it fails.
Nothing failed a projection whose push disappeared.

Measured with `go test -overlay`, deleting only the send:

| mutation | `go test ./internal/daemon -count=1` |
| --- | --- |
| `broadcastMessage` deleted from `projectGardenSeeds` | **ok**, 146.9s |
| `broadcastMessage` deleted from `projectTicketsUpdated` | **ok**, 129.5s |

The shape is what hid it, not the feature. A projection whose message is its own
top-level type (not a `WebSocketEvent`) is invisible to the hub's
`broadcastListener`, so garden, the ticket board and the workflow run each grew a
test-only broadcast hook that fires immediately before the real send — and every
assertion in those features reads the hook. Delete the send, keep the hook, and
nothing notices. Each new feature copies the shape.

## The mirror

`TestEveryProjectedFactReachesTheWire` (`internal/daemon/bus_wire_join_test.go`).
For every fact a `wireProjections` entry matches, it builds a daemon with a
seeded session, workspace, layout and presentation, taps `wsHub.wireTap` — which
sees the marshalled bytes of all five send paths, and no hook — publishes that
one fact, and asserts the **exact set** of `event` names that reached the wire.

Three things make it hold without maintenance:

- The fact vocabulary is parsed out of `bus.go` (`Fact…` constants) and the
  projection table is read at runtime, so a new fact — including one falling under
  an existing wildcard like `ticket.*` — is **seen** without anyone remembering
  this test exists.
- Being seen is what makes it loud: a projected fact with no fixture fails **by
  name**, saying what to add, and a fixture whose fact no longer exists fails as
  stale. That fixture is a single line — no subject, no payload — for **41 of the
  79** facts, which is **14 of the 41** projection entries covered whole. A
  subject or payload appears only where the projection re-reads an entity or
  decodes a body.

  (Corrected after review: an earlier version said "26 of the 41 projections push
  against a bare daemon and a bare fact". That came from the probe used to size
  the work — an empty world, counting anything that reached the wire, including a
  push whose event name was empty — so it did not reproduce by reading the table.
  The figures above are counted from the fixtures as written.)
- A declared fact matched by *no* projection must be listed in `factsWithoutWire`
  with the consumer that does read it — the same enumerated-exception discipline
  `wireSenderExceptions` already uses. Without it, a projection deleted by
  accident is indistinguishable from a fact that never had one.

`TestWireTrafficComesFromProjections` is untouched.

### Where the line sits: the event name, and deliberately nothing deeper

It has to be at least that deep. Publishing `workspace.context.changed` with no
payload decodes to a zero value and pushes a message with an **empty** event
field — "pushed something" accepts that. And the event name is precisely what
copy-pasting a projection gets wrong, which is the failure mode this exists to
close.

It should not go deeper here. Payload bytes already belong to the wire-trace
goldens and to each feature's own tests. One table owning every feature's payload
would rot on the first field added and would be regenerated rather than read.

Asserting the *complete* set rather than "at least one" also catches the opposite
defect: a second projection entry matching the same fact and double-pushing.

## Receipts

All `go test ./internal/daemon -count=1`:

| run | result |
| --- | --- |
| garden push deleted, this test absent | ok, 146.9s |
| garden push deleted, this test present | **FAIL** — `garden.planted` put nothing on the wire |
| ticket board push deleted, this test absent | ok, 129.5s |
| ticket board push deleted, this test present | **FAIL** — every `ticket.*` fact put nothing on the wire |
| unmutated | ok, 185.0s |

The "absent" runs replace the new test file with a bare `package daemon` through
the same overlay, so before and after are measured in one tree.

```
--- FAIL: TestEveryProjectedFactReachesTheWire/garden.planted
    publishing "garden.planted" put nothing on the wire; its projection is
    contracted to send [garden_seeds_updated].
    Either the projection stopped sending — which is the defect this test exists
    for — or it needs a subject or payload the fixture does not give it.
```

**The guard is not vacuous.** Four mutations of the mechanism itself, each
failing with a message naming what to fix: a removed fixture (`"garden.planted"
is projected but has no wireFixture`), a fixture for a fact that does not exist
(`not a declared fact constant in bus.go`), a fixture declaring the wrong event
(`put [garden_seeds_updated] on the wire, want [tickets_updated]`), and a deleted
`wireProjections` entry (`has no projection and no entry in factsWithoutWire`).

**One correction to the report this came from.** The third hook-shaped feature,
`workflow_broadcast.go`, was inferred to have the same hole and does not: deleting
its send fails `TestWireTraceProducerGolden`, because a workflow run is one of the
producers that golden drives. That is exactly the difference between a
hand-maintained producer list and a table-complete one — garden was merged without
an entry in it, and nothing noticed.

`go vet ./internal/daemon` clean; the new test passes under `-race` (3.7s).

## What a future projection author has to do

Add a one-line fixture naming the events the projection sends — and nothing else,
in the common case, because 41 of the 79 existing fixtures are exactly that one
line. There is nothing to remember: the test fails by name until the fixture is
there, and says what to supply. It is never silent.

(Corrected after review: the first version of this section claimed "nothing",
which was true of being *noticed* and not of being *covered*.)

## Live verification

Exempt: test-harness only. No production file changed — the diff is one new test
file, a changelog fragment, and two documentation edits. `wireTap` already existed
in `wsHub` for the wire-trace goldens; nothing was added to production wiring, so
there is no app-observable behavior to verify.

https://claude.ai/code/session_01S99Ao2Ckrnzw976ghoUhtX
