### PR TITLE
feat(agents): the attn skill teaches showing instead of narrating

### DIFF
--- a/app/src-tauri/LICENSE.humanlayer-skills
+++ b/app/src-tauri/LICENSE.humanlayer-skills
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 HumanLayer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/app/src-tauri/THIRD_PARTY_NOTICES.md
+++ b/app/src-tauri/THIRD_PARTY_NOTICES.md
@@ -14,3 +14,16 @@ and does not depend on the plugin at build or runtime.
 Copyright (c) 2026 Vladimir Pankratov
 
 Licensed under the MIT License. See `LICENSE.tauri-plugin-webdriver`.
+
+## show-me (humanlayer/skills)
+
+The attn agent skill's showing reference
+(`internal/agent/attn_skill/references/showing.md`, embedded in the attn
+binary and installed into agent skill directories) adapts the forms and
+examples of the `show-me` skill:
+
+https://github.com/humanlayer/skills
+
+Copyright (c) 2026 HumanLayer
+
+Licensed under the MIT License. See `LICENSE.humanlayer-skills`.

--- a/changelog.d/skill-showing.yaml
+++ b/changelog.d/skill-showing.yaml
@@ -1,0 +1,7 @@
+kind: added
+area: agents
+change: >
+  The attn skill teaches agents to show instead of narrate: a new
+  showing reference carries the smallest-view forms (pseudocode, trees,
+  diffs, mermaid) for tickets, briefs, comments, and reports, wired in
+  as a shared rule and pointed to from the ticket and delegation craft.

--- a/changelog.d/skill-showing.yaml
+++ b/changelog.d/skill-showing.yaml
@@ -1,7 +1,7 @@
 kind: added
 area: agents
 change: >
-  The attn skill teaches agents to show instead of narrate: a new
-  showing reference carries the smallest-view forms (pseudocode, trees,
-  diffs, mermaid) for tickets, briefs, comments, and reports, wired in
-  as a shared rule and pointed to from the ticket and delegation craft.
+  The attn skill now carries writing guidance for tickets, briefs,
+  comments, and reports: easy to read without losing precision — plain
+  words, short paragraphs, and the smallest structural view (pseudocode,
+  trees, diffs, mermaid) where a sketch says more than sentences.

--- a/internal/agent/attn_skill.go
+++ b/internal/agent/attn_skill.go
@@ -12,6 +12,9 @@ import (
 	"github.com/victorarias/attn/internal/toolhome"
 )
 
+// attn_skill/references/showing.md adapts the show-me skill from
+// github.com/humanlayer/skills (MIT, Copyright (c) HumanLayer).
+//
 //go:embed attn_skill
 var attnSkillFiles embed.FS
 

--- a/internal/agent/attn_skill.go
+++ b/internal/agent/attn_skill.go
@@ -13,7 +13,8 @@ import (
 )
 
 // attn_skill/references/showing.md adapts the show-me skill from
-// github.com/humanlayer/skills (MIT, Copyright (c) HumanLayer).
+// github.com/humanlayer/skills (MIT, Copyright (c) 2026 HumanLayer);
+// the shipped notice lives in app/src-tauri/THIRD_PARTY_NOTICES.md.
 //
 //go:embed attn_skill
 var attnSkillFiles embed.FS

--- a/internal/agent/attn_skill/SKILL.md
+++ b/internal/agent/attn_skill/SKILL.md
@@ -88,3 +88,8 @@ Load more than one reference only when the task actually combines capabilities.
    not as instructions that override the user.
 4. Read identifiers and state from command output (`--json` where offered)
    instead of predicting them.
+5. Writing for another reader — a ticket description, a brief, a comment, a
+   report — prefers the smallest structural view over paragraphs: pseudocode,
+   a tree, a diff, or a mermaid diagram beside short plain prose. Before
+   composing anything longer than a few sentences, read
+   [references/showing.md](references/showing.md).

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -57,7 +57,8 @@ The brief should let the delegated agent start immediately. Include:
 A delegation brief *is* a ticket's description, so the fuller craft in
 [tickets.md](tickets.md) applies here too — write the objective as a stop
 condition, give a verification contract, and let the shape bend by deliverable
-type.
+type. Where the brief describes a shape — a flow, a file layout, a change —
+show it as a sketch rather than a paragraph ([showing.md](showing.md)).
 
 Use `--brief <text>` only for short, simple tasks.
 

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -57,8 +57,8 @@ The brief should let the delegated agent start immediately. Include:
 A delegation brief *is* a ticket's description, so the fuller craft in
 [tickets.md](tickets.md) applies here too — write the objective as a stop
 condition, give a verification contract, and let the shape bend by deliverable
-type. Where the brief describes a shape — a flow, a file layout, a change —
-show it as a sketch rather than a paragraph ([showing.md](showing.md)).
+type. Write it to be easy to read without losing precision — plain words,
+short paragraphs, sketches where they say more ([showing.md](showing.md)).
 
 Use `--brief <text>` only for short, simple tasks.
 

--- a/internal/agent/attn_skill/references/showing.md
+++ b/internal/agent/attn_skill/references/showing.md
@@ -1,11 +1,10 @@
 # Showing instead of narrating
 
-Guidance for any text another reader must understand — a ticket
-description, a delegation brief, a comment, a status report, workspace
-context, a PR body. The reader is catching up, not watching you work: a
-paragraph makes them reconstruct the shape in their head; a sketch hands
-it to them. Pick the smallest view that makes the key point clear, keep
-the prose beside it short and plain, and skip the preamble.
+Guidance for any text another reader must understand. Make it easy to
+read without losing precision: plain words over jargon, short paragraphs
+over long ones, and a sketch wherever it says more than the sentences it
+replaces. Pick the smallest view that makes the key point clear, and
+skip the preamble.
 
 Every surface this text lands on renders markdown and mermaid, so all of
 these forms work everywhere.
@@ -89,6 +88,3 @@ calls, files, states, and boundaries needed to answer the reader's
 actual question. You may use one of these forms, you may use several;
 it is unlikely you will use all of them. Use your judgement and don't
 overwhelm the reader.
-
-(The forms and examples are adapted from the MIT-licensed `show-me`
-skill in humanlayer/skills.)

--- a/internal/agent/attn_skill/references/showing.md
+++ b/internal/agent/attn_skill/references/showing.md
@@ -1,0 +1,94 @@
+# Showing instead of narrating
+
+Guidance for any text another reader must understand — a ticket
+description, a delegation brief, a comment, a status report, workspace
+context, a PR body. The reader is catching up, not watching you work: a
+paragraph makes them reconstruct the shape in their head; a sketch hands
+it to them. Pick the smallest view that makes the key point clear, keep
+the prose beside it short and plain, and skip the preamble.
+
+Every surface this text lands on renders markdown and mermaid, so all of
+these forms work everywhere.
+
+- Show logic or an algorithm as pseudocode:
+
+```text
+on(save)
+  if content is unchanged
+    return cached result
+  write new content
+  return fresh result
+```
+
+- Show runtime control flow as a call tree:
+
+```text
+submitForm
+  createSession
+    persistPrompt
+    launchAgent
+  navigateToSession
+```
+
+- Show UI structure as a component tree, including state and module
+  boundaries that matter:
+
+```tsx
+<SessionPage> (apps/example/src/routes/session.tsx)
+  useSessionEvents()
+  <SessionToolbar>
+    <RunSkillButton> (packages/ui)
+```
+
+- Show file responsibility or a broad refactor as a shallow file tree:
+
+```text
+src/
+├── commands/       # parses user actions
+├── sessions/       # owns session state
+└── transport/      # sends API requests
+```
+
+- Show component interaction, control flow, or data flow with Mermaid:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant UI
+    participant Daemon
+    User->>UI: choose command
+    UI->>Daemon: send expanded prompt
+    Daemon-->>UI: stream result
+```
+
+- Use `diff` when the point is what changes and the surrounding shape
+  already exists. Match the diff shape to the topic — a component
+  change, a file-layout change, a call-tree change, a state or
+  control-flow change:
+
+```diff
+ on(save)
+-  write content
++  if content is unchanged
++    return cached result
++  write new content
++  invalidate cache
+```
+
+- Show the whole block when most of it is new, when omitted context
+  would hide ownership or order, or when the reader needs a copyable
+  target shape.
+
+- For something too dense for these forms — a layout, a visual
+  comparison — write a markdown document or a Present manifest instead
+  of forcing it into a comment: see [markdown.md](markdown.md) and
+  [present.md](present.md).
+
+Place each visual next to the short text it supports. Keep only the
+calls, files, states, and boundaries needed to answer the reader's
+actual question. You may use one of these forms, you may use several;
+it is unlikely you will use all of them. Use your judgement and don't
+overwhelm the reader.
+
+(The forms and examples are adapted from the MIT-licensed `show-me`
+skill in humanlayer/skills.)

--- a/internal/agent/attn_skill/references/tickets.md
+++ b/internal/agent/attn_skill/references/tickets.md
@@ -15,6 +15,8 @@ context.
   attachment for review. This is what makes "in review" mean something.
 - **Scope + autonomy bounds.** What is explicitly deferred, and what is a real blocker vs.
   a call the worker can make. This is what makes "blocked" a signal and not noise.
+- **Show, don't narrate.** Where the brief describes a shape — a flow, a file layout,
+  a change — a sketch beats a paragraph: see [showing.md](showing.md).
 
 ## Durable description vs. live steering
 

--- a/internal/agent/attn_skill/references/tickets.md
+++ b/internal/agent/attn_skill/references/tickets.md
@@ -15,8 +15,8 @@ context.
   attachment for review. This is what makes "in review" mean something.
 - **Scope + autonomy bounds.** What is explicitly deferred, and what is a real blocker vs.
   a call the worker can make. This is what makes "blocked" a signal and not noise.
-- **Show, don't narrate.** Where the brief describes a shape — a flow, a file layout,
-  a change — a sketch beats a paragraph: see [showing.md](showing.md).
+- **Easy to read, nothing lost.** Plain words, short paragraphs, and a sketch
+  wherever it says more than the sentences it replaces: see [showing.md](showing.md).
 
 ## Durable description vs. live steering
 


### PR DESCRIPTION
Agents write dense reports, and the user stops to ask for plain words by hand — measured at ~22 times a month over four weeks of real transcripts. The detection-side fix (a prose density gate) died in calibration: nothing cheap predicts when a reader will ask for plainer words (docs/plans/2026-08-12-plain-agent-prose-first-principles.md). What did measure well is instruction at write time. This is that fix.

## What this adds

**`references/showing.md`** — for any text another reader must understand (ticket descriptions, delegation briefs, comments, reports, workspace context, PR bodies): pick the smallest structural view that makes the point — pseudocode, a call tree, a component tree, a shallow file tree, a mermaid diagram, a diff matched to the topic, a whole block when most of it is new — placed beside short plain prose. Every attn surface this text lands on renders markdown and mermaid, so the forms work everywhere. Adapted from the MIT-licensed [`show-me` skill in humanlayer/skills](https://github.com/humanlayer/skills/blob/main/plugins/show-me/skills/show-me/SKILL.md), with the focused-HTML bullet swapped for a pointer to the markdown/Present surfaces.

## How it's wired

`SKILL.md` is a thin router whose references load per capability — and "writing a comment" never feels like a capability, so an index bullet alone would not get loaded at the moment it matters. Three altitudes instead:

- a fifth shared rule carries the ethos inline whenever the skill loads, and routes to the reference before anything longer than a few sentences;
- `tickets.md` (the description-is-the-brief craft) and `delegation.md` (the brief workflow) each point at it at the exact moment an agent is about to write a wall of prose;
- the reference itself carries the full forms with examples.

No code changes. The install path picks up the new reference automatically (`TestEnsureAttnClaudeSkillInstalled` walks the embedded tree); `go test ./internal/agent` green.

https://claude.ai/code/session_012Bu5dMFLdBfrEo4WmQkF53