### PR TITLE
fix(agent-msg): one address book, and delivery that reports what happened

### DIFF
--- a/changelog.d/agent-msg-confirmed-delivery.yaml
+++ b/changelog.d/agent-msg-confirmed-delivery.yaml
@@ -1,0 +1,11 @@
+kind: fixed
+area: cli
+change: >
+  `attn agent msg` now says a message was delivered only once the target
+  actually picked it up. A session with something in front of its prompt — a
+  dialog, an overlay, a composer that does not have focus yet — reports the
+  same not-busy title as one waiting for input, and silently swallowed the
+  message while the sender was told it landed. Delivery now waits for the
+  target to start the turn the message asked for, presses Enter once more if
+  the text is sitting unsent, and otherwise keeps the message queued and says
+  so, so it lands on the target's next state change instead of disappearing.

--- a/changelog.d/claude-peer-messaging-off.yaml
+++ b/changelog.d/claude-peer-messaging-off.yaml
@@ -1,0 +1,10 @@
+kind: changed
+area: agents
+change: >
+  Claude sessions launched by attn no longer carry Claude Code's own
+  cross-session messaging tools. They offered a second address book — visible
+  only to Claude sessions, naming each one after its working directory rather
+  than the name you gave it — so an agent asked to message another agent found
+  the wrong list. `attn agent list` and `attn agent msg` remain the way across,
+  and they reach codex sessions too. Set ATTN_CLAUDE_PEER_MESSAGING=1 to launch
+  with Claude's tools back.

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -110,8 +110,12 @@ func (c *Claude) BuildCommand(opts SpawnOpts) *exec.Cmd {
 	// only attn's is left standing. Denying removes the tools from the launched
 	// agent's tool list rather than failing the call (measured: 31 tools -> 29,
 	// both absent from the session's init event).
+	// One element per rule, the documented form: a single joined element parses
+	// the same today, but a claude that tightened parsing would leave the deny
+	// inert with every test still green.
 	if enabled, _ := boolEnv("ATTN_CLAUDE_PEER_MESSAGING"); !enabled {
-		args = append(args, "--disallowed-tools", strings.Join(claudePeerTools, " "))
+		args = append(args, "--disallowed-tools")
+		args = append(args, claudePeerTools...)
 	}
 
 	if model := strings.TrimSpace(opts.Model); model != "" {

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -43,6 +43,10 @@ const (
 	claudeTranscriptFreshnessSkew = 5 * time.Second
 )
 
+// Claude Code's own cross-session messaging tools, suppressed at launch by
+// BuildCommand.
+var claudePeerTools = []string{"ListAgents", "SendMessage"}
+
 func init() {
 	Register(&Claude{})
 }
@@ -97,6 +101,17 @@ func (c *Claude) BuildCommand(opts SpawnOpts) *exec.Cmd {
 		args = append(args, "--append-system-prompt", guidance)
 	} else if instructions := hooks.AgentInstructions(opts.WorkspaceContextPath, opts.InjectWorkflowGuidance); instructions != "" {
 		args = append(args, "--append-system-prompt", instructions)
+	}
+
+	// Claude Code publishes its own address book, keyed on each session's working
+	// directory and visible only to other Claude Code sessions; attn's own
+	// (`attn agent list` / `attn agent msg`) names every session as the user named
+	// it and reaches codex too. An agent holding both messages the wrong one, so
+	// only attn's is left standing. Denying removes the tools from the launched
+	// agent's tool list rather than failing the call (measured: 31 tools -> 29,
+	// both absent from the session's init event).
+	if enabled, _ := boolEnv("ATTN_CLAUDE_PEER_MESSAGING"); !enabled {
+		args = append(args, "--disallowed-tools", strings.Join(claudePeerTools, " "))
 	}
 
 	if model := strings.TrimSpace(opts.Model); model != "" {

--- a/internal/agent/peer_messaging_test.go
+++ b/internal/agent/peer_messaging_test.go
@@ -15,11 +15,14 @@ func TestClaudeBuildCommand_DeniesPeerMessagingTools(t *testing.T) {
 		Executable: "claude",
 	})
 	i := slices.Index(cmd.Args, "--disallowed-tools")
-	if i < 0 || i+1 >= len(cmd.Args) {
+	if i < 0 {
 		t.Fatalf("args = %#v, want --disallowed-tools", cmd.Args)
 	}
-	if got := cmd.Args[i+1]; got != "ListAgents SendMessage" {
-		t.Fatalf("--disallowed-tools = %q, want %q", got, "ListAgents SendMessage")
+	// One element per rule, the form the flag documents. A joined
+	// "ListAgents SendMessage" parses the same on 2.1.228, but a claude that
+	// tightened parsing would leave the deny inert with this test still green.
+	if got := cmd.Args[i+1:]; len(got) != 2 || got[0] != "ListAgents" || got[1] != "SendMessage" {
+		t.Fatalf("--disallowed-tools = %#v, want two elements ListAgents, SendMessage", got)
 	}
 }
 

--- a/internal/agent/peer_messaging_test.go
+++ b/internal/agent/peer_messaging_test.go
@@ -1,0 +1,66 @@
+package agent
+
+import (
+	"slices"
+	"testing"
+)
+
+// attn's own messaging (`attn agent list` / `attn agent msg`) is the address
+// book; Claude Code's peer tools are a second, claude-only one keyed on the
+// working directory, so a launched agent never gets them.
+func TestClaudeBuildCommand_DeniesPeerMessagingTools(t *testing.T) {
+	cmd := (&Claude{}).BuildCommand(SpawnOpts{
+		SessionID:  "sess-1",
+		CWD:        "/tmp/project",
+		Executable: "claude",
+	})
+	i := slices.Index(cmd.Args, "--disallowed-tools")
+	if i < 0 || i+1 >= len(cmd.Args) {
+		t.Fatalf("args = %#v, want --disallowed-tools", cmd.Args)
+	}
+	if got := cmd.Args[i+1]; got != "ListAgents SendMessage" {
+		t.Fatalf("--disallowed-tools = %q, want %q", got, "ListAgents SendMessage")
+	}
+}
+
+// Everything after "--" is the initial prompt, so a flag appended past it would
+// be typed at the agent instead of read by it.
+func TestClaudeBuildCommand_DenyPrecedesInitialPrompt(t *testing.T) {
+	cmd := (&Claude{}).BuildCommand(SpawnOpts{
+		SessionID:     "sess-1",
+		CWD:           "/tmp/project",
+		Executable:    "claude",
+		InitialPrompt: "get to work",
+	})
+	deny := slices.Index(cmd.Args, "--disallowed-tools")
+	sep := slices.Index(cmd.Args, "--")
+	if deny < 0 || sep < 0 || deny > sep {
+		t.Fatalf("args = %#v, want --disallowed-tools before the -- prompt separator", cmd.Args)
+	}
+}
+
+func TestClaudeBuildCommand_PeerMessagingEnvRestoresTools(t *testing.T) {
+	t.Setenv("ATTN_CLAUDE_PEER_MESSAGING", "1")
+	cmd := (&Claude{}).BuildCommand(SpawnOpts{
+		SessionID:  "sess-1",
+		CWD:        "/tmp/project",
+		Executable: "claude",
+	})
+	if slices.Contains(cmd.Args, "--disallowed-tools") {
+		t.Fatalf("args = %#v, want no --disallowed-tools with ATTN_CLAUDE_PEER_MESSAGING=1", cmd.Args)
+	}
+}
+
+// Only Claude Code has these tools; the other drivers must not grow the flag.
+func TestOtherDriversHaveNoPeerMessagingDeny(t *testing.T) {
+	for _, driver := range []Driver{&Codex{}, &Copilot{}} {
+		cmd := driver.BuildCommand(SpawnOpts{
+			SessionID:  "sess-1",
+			CWD:        "/tmp/project",
+			Executable: driver.DefaultExecutable(),
+		})
+		if slices.Contains(cmd.Args, "--disallowed-tools") {
+			t.Fatalf("%s args = %#v, want no --disallowed-tools", driver.Name(), cmd.Args)
+		}
+	}
+}

--- a/internal/daemon/agent_msg.go
+++ b/internal/daemon/agent_msg.go
@@ -173,16 +173,39 @@ func (d *Daemon) deliverAgentMessage(record store.AgentMessage) error {
 	taken, disarm := d.armAgentMessageTaken(record.TargetSessionID)
 	defer disarm()
 
-	if err := d.typeDoorbell(record.TargetSessionID, d.composeAgentMessage(sender, record)); err != nil {
+	// A row typed into a composer once and never taken is still sitting in it.
+	// Submitting that is the whole redelivery: typing it again would stack a
+	// second copy, and a target stuck behind a dialog would collect one per
+	// state change until it cleared and read them all.
+	if d.agentMessageAwaitsSubmit(record.ID) && agentMessageTakenWindow > 0 {
+		if err := d.submitDoorbell(record.TargetSessionID); err != nil {
+			return err
+		}
+		if awaitSignal(taken, agentMessageTakenWindow) {
+			return d.stampAgentMessageDelivered(record.ID)
+		}
+		d.logf("agent msg still unsubmitted after enter; retyping: id=%s", record.ID)
+	}
+
+	composer, err := d.typeDoorbellRoute(record.TargetSessionID, d.composeAgentMessage(sender, record))
+	if err != nil {
 		return err
 	}
 	if confirmable && !d.awaitAgentMessageTaken(record.TargetSessionID, taken) {
+		if composer {
+			d.noteAgentMessageAwaitsSubmit(record.ID)
+		}
 		return errDoorbellNotTaken
 	}
-	if err := d.store.MarkAgentMessageDelivered(record.ID, time.Now()); err != nil {
+	return d.stampAgentMessageDelivered(record.ID)
+}
+
+func (d *Daemon) stampAgentMessageDelivered(id string) error {
+	d.forgetAgentMessageAwaitsSubmit(id)
+	if err := d.store.MarkAgentMessageDelivered(id, time.Now()); err != nil {
 		// The words already landed; failing to stamp would redeliver them, which
 		// is worse than losing the receipt.
-		d.logf("agent msg delivered but not stamped: id=%s err=%v", record.ID, err)
+		d.logf("agent msg delivered but not stamped: id=%s err=%v", id, err)
 	}
 	return nil
 }
@@ -199,7 +222,10 @@ func (d *Daemon) awaitAgentMessageTaken(sessionID string, taken <-chan struct{})
 		return true
 	}
 	d.logf("agent msg not taken within %s; pressing enter again: session=%s", agentMessageTakenWindow, sessionID)
-	if err := d.writePTY(sessionID, []byte("\r")); err != nil {
+	// Through submitDoorbell rather than a raw write: the wait is long enough for
+	// a dialog to have opened over the composer since the paste, and that is the
+	// one target Enter must not reach.
+	if err := d.submitDoorbell(sessionID); err != nil {
 		d.logf("agent msg re-submit failed: session=%s err=%v", sessionID, err)
 		return false
 	}
@@ -243,6 +269,31 @@ func (d *Daemon) armAgentMessageTaken(sessionID string) (<-chan struct{}, func()
 			delete(d.agentMessageTaken, sessionID)
 		}
 	}
+}
+
+// The rows whose paste reached a composer and was not taken. Memory only, and
+// deliberately: after a restart nothing can know what is still sitting in a
+// target's composer, and retyping is the safe assumption. Bounded by the
+// per-target queue cap, and every stamped delivery clears its own entry.
+func (d *Daemon) noteAgentMessageAwaitsSubmit(id string) {
+	d.agentMessageMu.Lock()
+	defer d.agentMessageMu.Unlock()
+	if d.agentMessagesAwaitingSubmit == nil {
+		d.agentMessagesAwaitingSubmit = make(map[string]bool)
+	}
+	d.agentMessagesAwaitingSubmit[id] = true
+}
+
+func (d *Daemon) agentMessageAwaitsSubmit(id string) bool {
+	d.agentMessageMu.Lock()
+	defer d.agentMessageMu.Unlock()
+	return d.agentMessagesAwaitingSubmit[id]
+}
+
+func (d *Daemon) forgetAgentMessageAwaitsSubmit(id string) {
+	d.agentMessageMu.Lock()
+	defer d.agentMessageMu.Unlock()
+	delete(d.agentMessagesAwaitingSubmit, id)
 }
 
 // noteAgentMessageTaken is the receipt side: a target that starts working has

--- a/internal/daemon/agent_msg.go
+++ b/internal/daemon/agent_msg.go
@@ -30,6 +30,25 @@ const (
 	agentMessageQueueCap     = 50
 )
 
+// agentMessageTakenWindow is how long a delivery waits for its target to start
+// the turn it asked for.
+//
+// A PTY write returning says the bytes reached the terminal, not that the agent
+// read them: a session showing a modal, an overlay, or a composer that does not
+// have focus yet reports the same settled title as one waiting at its prompt,
+// and swallows the paste whole. Submitting a message always starts a turn, so
+// `working` is the receipt; without it the row stays queued for the drain and
+// the sender is told so. Measured end to end against Claude Code 2.1.228 on a
+// live session: 181ms and 187ms once warm, 1.06s for the first message to a
+// freshly spawned target. This is a tripwire well past that, not a budget — a
+// healthy delivery never feels it, and the cost of it being too small is a
+// redelivery, not a lost message. It is a package var only so tests can drop
+// it to zero, which trusts the write as the daemon did before.
+var agentMessageTakenWindow = 3 * time.Second
+
+// errDoorbellNotTaken is a delivery whose target never picked it up.
+var errDoorbellNotTaken = errors.New("doorbell typed but the target did not take it")
+
 // agentMessageGuardVerdict is empty when a message is accepted. Otherwise it is
 // the sentence the sender is told: which limit it hit, that limit's value, and
 // what it asked for. An agent can act on that; "refused" alone it cannot.
@@ -135,16 +154,30 @@ func agentMessageQueuedDetail(err error) string {
 	if errors.Is(err, errDoorbellBlockedByApproval) {
 		return "queued (target is waiting on an approval — lands when the approval clears)"
 	}
+	if errors.Is(err, errDoorbellNotTaken) {
+		return fmt.Sprintf(
+			"queued (typed it, but the target did not start a turn within %s — something in front of its prompt ate it; lands on its next state change)",
+			agentMessageTakenWindow)
+	}
 	return "queued (target is not taking input right now — lands when it is running again; don't wait for a reply)"
 }
 
-// deliverAgentMessage types one message into its target and stamps the row.
-// Shared by the send path and the redelivery drain so a queued message and a
-// live one land identically.
+// deliverAgentMessage types one message into its target, confirms the target
+// took it, and stamps the row. Shared by the send path and the redelivery drain
+// so a queued message and a live one land identically.
 func (d *Daemon) deliverAgentMessage(record store.AgentMessage) error {
 	sender := d.store.Get(record.SenderSessionID)
+	target := d.store.Get(record.TargetSessionID)
+	confirmable := target != nil && string(target.State) != protocol.StateWorking
+
+	taken, disarm := d.armAgentMessageTaken(record.TargetSessionID)
+	defer disarm()
+
 	if err := d.typeDoorbell(record.TargetSessionID, d.composeAgentMessage(sender, record)); err != nil {
 		return err
+	}
+	if confirmable && !d.awaitAgentMessageTaken(record.TargetSessionID, taken) {
+		return errDoorbellNotTaken
 	}
 	if err := d.store.MarkAgentMessageDelivered(record.ID, time.Now()); err != nil {
 		// The words already landed; failing to stamp would redeliver them, which
@@ -152,6 +185,79 @@ func (d *Daemon) deliverAgentMessage(record store.AgentMessage) error {
 		d.logf("agent msg delivered but not stamped: id=%s err=%v", record.ID, err)
 	}
 	return nil
+}
+
+// awaitAgentMessageTaken waits for the target to start the turn the message
+// asked for. A composer that never took the Enter gets one more — the paste is
+// still sitting in it, so pressing again submits it, while repasting would
+// double the text. Only a target that takes neither is reported queued.
+func (d *Daemon) awaitAgentMessageTaken(sessionID string, taken <-chan struct{}) bool {
+	if agentMessageTakenWindow <= 0 {
+		return true
+	}
+	if awaitSignal(taken, agentMessageTakenWindow) {
+		return true
+	}
+	d.logf("agent msg not taken within %s; pressing enter again: session=%s", agentMessageTakenWindow, sessionID)
+	if err := d.writePTY(sessionID, []byte("\r")); err != nil {
+		d.logf("agent msg re-submit failed: session=%s err=%v", sessionID, err)
+		return false
+	}
+	return awaitSignal(taken, agentMessageTakenWindow)
+}
+
+func awaitSignal(signal <-chan struct{}, window time.Duration) bool {
+	timer := time.NewTimer(window)
+	defer timer.Stop()
+	select {
+	case <-signal:
+		return true
+	case <-timer.C:
+		return false
+	}
+}
+
+// armAgentMessageTaken registers interest in a target's next turn before the
+// doorbell is typed, so a target that starts working between the write and the
+// wait is still seen. The returned func always runs; nothing else clears it.
+func (d *Daemon) armAgentMessageTaken(sessionID string) (<-chan struct{}, func()) {
+	signal := make(chan struct{})
+	d.agentMessageMu.Lock()
+	if d.agentMessageTaken == nil {
+		d.agentMessageTaken = make(map[string][]chan struct{})
+	}
+	d.agentMessageTaken[sessionID] = append(d.agentMessageTaken[sessionID], signal)
+	d.agentMessageMu.Unlock()
+
+	return signal, func() {
+		d.agentMessageMu.Lock()
+		defer d.agentMessageMu.Unlock()
+		waiters := d.agentMessageTaken[sessionID]
+		for i, waiter := range waiters {
+			if waiter == signal {
+				d.agentMessageTaken[sessionID] = append(waiters[:i], waiters[i+1:]...)
+				break
+			}
+		}
+		if len(d.agentMessageTaken[sessionID]) == 0 {
+			delete(d.agentMessageTaken, sessionID)
+		}
+	}
+}
+
+// noteAgentMessageTaken is the receipt side: a target that starts working has
+// taken whatever was typed into it. Called from applyState for every cause.
+func (d *Daemon) noteAgentMessageTaken(sessionID, state string) {
+	if state != protocol.StateWorking {
+		return
+	}
+	d.agentMessageMu.Lock()
+	waiters := d.agentMessageTaken[sessionID]
+	delete(d.agentMessageTaken, sessionID)
+	d.agentMessageMu.Unlock()
+	for _, waiter := range waiters {
+		close(waiter)
+	}
 }
 
 // composeAgentMessage builds what the target actually reads. The format is the

--- a/internal/daemon/agent_msg_taken_test.go
+++ b/internal/daemon/agent_msg_taken_test.go
@@ -51,6 +51,54 @@ func TestAgentMsgQueuesWhenTheTargetNeverTakesIt(t *testing.T) {
 	}
 }
 
+// A message typed into a composer and never taken is still sitting in it, so
+// the drain submits it rather than pasting a second copy. Repasting is how a
+// target stuck behind a dialog collects one copy per state change and then
+// reads the same message N times when it clears.
+func TestAgentMsgRedeliveryPressesEnterRatherThanRepasting(t *testing.T) {
+	withAgentMessageTakenWindow(t, 50*time.Millisecond)
+	d, doorbell := newAgentMsgDaemon(t)
+	addCharacterizationSession(t, d, "sender-session-id", protocol.SessionAgentClaude, protocol.SessionStateIdle)
+	addCharacterizationSession(t, d, "target-session-id", protocol.SessionAgentClaude, protocol.SessionStateIdle)
+
+	resp := callAgentMsg(t, d, "target-session-id", "sender-session-id", "the epic is green")
+	if result := resp.AgentMsgResult; result == nil || result.Status != protocol.AgentMsgStatusQueued {
+		t.Fatalf("result = %+v, want queued", result)
+	}
+
+	drained := make(chan int, 1)
+	d.agentMessageDrainHook = func(_ string, delivered int) { drained <- delivered }
+	go func() {
+		// The drain's Enter is what lets this delivery confirm; without the state
+		// change it would report not-taken again.
+		<-time.After(20 * time.Millisecond)
+		d.applyState(sessionStateChange{
+			sessionID: "target-session-id",
+			state:     protocol.StateWorking,
+			cause:     liveSignal{},
+		})
+	}()
+	if !d.applyState(sessionStateChange{
+		sessionID: "target-session-id",
+		state:     protocol.StateIdle,
+		cause:     liveSignal{},
+	}) {
+		t.Fatal("applyState did not apply")
+	}
+
+	select {
+	case delivered := <-drained:
+		if delivered != 1 {
+			t.Fatalf("drain delivered %d, want 1", delivered)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("the drain never ran")
+	}
+	if prompts := doorbell.pasted(); len(prompts) != 1 {
+		t.Fatalf("pasted %d times, want 1 — the redelivery retyped the message: %q", len(prompts), prompts)
+	}
+}
+
 // The confirmed path: the target starts working, so the message is delivered
 // and nothing stays queued behind it.
 func TestAgentMsgDeliversWhenTheTargetStartsWorking(t *testing.T) {

--- a/internal/daemon/agent_msg_taken_test.go
+++ b/internal/daemon/agent_msg_taken_test.go
@@ -1,0 +1,119 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// withAgentMessageTakenWindow restores confirmation for one test; TestMain
+// zeroes it so the fake PTY, which never reports working, does not time out
+// every delivery in the package.
+func withAgentMessageTakenWindow(t *testing.T, window time.Duration) {
+	t.Helper()
+	previous := agentMessageTakenWindow
+	agentMessageTakenWindow = window
+	t.Cleanup(func() { agentMessageTakenWindow = previous })
+}
+
+// The bug this exists for: a PTY write returning proves the bytes reached the
+// terminal, not that the agent read them. A session with a modal in front of
+// its composer eats the paste while reporting the same settled title as one
+// waiting at its prompt, and the sender used to be told "delivered".
+func TestAgentMsgQueuesWhenTheTargetNeverTakesIt(t *testing.T) {
+	withAgentMessageTakenWindow(t, 50*time.Millisecond)
+	d, doorbell := newAgentMsgDaemon(t)
+	addCharacterizationSession(t, d, "sender-session-id", protocol.SessionAgentClaude, protocol.SessionStateIdle)
+	addCharacterizationSession(t, d, "target-session-id", protocol.SessionAgentClaude, protocol.SessionStateIdle)
+
+	resp := callAgentMsg(t, d, "target-session-id", "sender-session-id", "did the migration land?")
+	result := resp.AgentMsgResult
+	if result == nil || result.Status != protocol.AgentMsgStatusQueued {
+		t.Fatalf("result = %+v, want queued", result)
+	}
+	if !strings.Contains(result.Detail, "did not start a turn") {
+		t.Fatalf("detail does not say what happened: %q", result.Detail)
+	}
+	// Typed once, then Enter pressed again rather than the text pasted twice: the
+	// paste may be sitting in the composer, and a second paste would double it.
+	if prompts := doorbell.pasted(); len(prompts) != 1 {
+		t.Fatalf("pasted %d times, want 1: %q", len(prompts), prompts)
+	}
+
+	queued, err := d.store.UndeliveredAgentMessages("target-session-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(queued) != 1 {
+		t.Fatalf("unconfirmed message is not queued for the drain: %+v", queued)
+	}
+}
+
+// The confirmed path: the target starts working, so the message is delivered
+// and nothing stays queued behind it.
+func TestAgentMsgDeliversWhenTheTargetStartsWorking(t *testing.T) {
+	withAgentMessageTakenWindow(t, 2*time.Second)
+	d, _ := newAgentMsgDaemon(t)
+	addCharacterizationSession(t, d, "sender-session-id", protocol.SessionAgentClaude, protocol.SessionStateIdle)
+	addCharacterizationSession(t, d, "target-session-id", protocol.SessionAgentClaude, protocol.SessionStateIdle)
+
+	typed := make(chan struct{})
+	d.ptyBackend = &fakeSpawnBackend{onInput: func(sessionID string, _ []byte) {
+		if sessionID == "target-session-id" {
+			select {
+			case <-typed:
+			default:
+				close(typed)
+			}
+		}
+	}}
+	go func() {
+		<-typed
+		d.applyState(sessionStateChange{
+			sessionID: "target-session-id",
+			state:     protocol.StateWorking,
+			cause:     liveSignal{},
+		})
+	}()
+
+	resp := callAgentMsg(t, d, "target-session-id", "sender-session-id", "rebase when you surface")
+	result := resp.AgentMsgResult
+	if result == nil || result.Status != protocol.AgentMsgStatusDelivered {
+		t.Fatalf("result = %+v, want delivered", result)
+	}
+	queued, err := d.store.UndeliveredAgentMessages("target-session-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(queued) != 0 {
+		t.Fatalf("a confirmed delivery is still queued: %+v", queued)
+	}
+}
+
+// A target already mid-turn queues the paste in its composer and answers when
+// the turn ends — no new turn opens, so there is nothing to confirm. Waiting
+// for one would report queued and redeliver, doubling the message.
+func TestAgentMsgToAWorkingTargetDoesNotWaitForConfirmation(t *testing.T) {
+	withAgentMessageTakenWindow(t, time.Hour)
+	d, doorbell := newAgentMsgDaemon(t)
+	addCharacterizationSession(t, d, "sender-session-id", protocol.SessionAgentClaude, protocol.SessionStateIdle)
+	addCharacterizationSession(t, d, "target-session-id", protocol.SessionAgentClaude, protocol.SessionStateWorking)
+
+	done := make(chan protocol.Response, 1)
+	go func() { done <- callAgentMsg(t, d, "target-session-id", "sender-session-id", "when you land, ping me") }()
+
+	select {
+	case resp := <-done:
+		result := resp.AgentMsgResult
+		if result == nil || result.Status != protocol.AgentMsgStatusDelivered {
+			t.Fatalf("result = %+v, want delivered", result)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("a message to a working target waited for a turn that cannot open")
+	}
+	if prompts := doorbell.pasted(); len(prompts) != 1 {
+		t.Fatalf("pasted %d times, want 1: %q", len(prompts), prompts)
+	}
+}

--- a/internal/daemon/chief_of_staff.go
+++ b/internal/daemon/chief_of_staff.go
@@ -162,29 +162,52 @@ func (d *Daemon) nudgeChiefOfStaff(prompt string) bool {
 // composed and never the user's half-typed line. Always a bounded,
 // user-initiated delivery — never arbitrary streamed content.
 func (d *Daemon) typeDoorbell(sessionID, prompt string) error {
+	_, err := d.typeDoorbellRoute(sessionID, prompt)
+	return err
+}
+
+// typeDoorbellRoute is typeDoorbell with the route it took. composer is true
+// only for the paste, the one route that can leave a prompt sitting unsubmitted
+// in a target; a host session and a plugin driver each take the whole message or
+// fail, with nothing left behind to press Enter on.
+func (d *Daemon) typeDoorbellRoute(sessionID, prompt string) (composer bool, err error) {
 	d.doorbellMu.Lock()
 	defer d.doorbellMu.Unlock()
 	session := d.store.Get(sessionID)
 	if session == nil || !isNudgeDeliveryAllowed(string(session.State)) {
-		return errDoorbellBlockedByApproval
+		return false, errDoorbellBlockedByApproval
 	}
 	if d.isHostSession(sessionID) {
-		return d.deliverToHostSession(sessionID, hostsession.DeliverySteer, prompt)
+		return false, d.deliverToHostSession(sessionID, hostsession.DeliverySteer, prompt)
 	}
 	if delivered, err := d.deliverDoorbellViaPluginDriver(session, prompt); delivered {
-		return err
+		return false, err
 	}
 	input := make([]byte, 0, len(bracketedPasteStart)+len(prompt)+len(bracketedPasteEnd))
 	input = append(input, bracketedPasteStart...)
 	input = append(input, prompt...)
 	input = append(input, bracketedPasteEnd...)
-	return d.withPTYWriteFence(sessionID, func() error {
+	return true, d.withPTYWriteFence(sessionID, func() error {
 		if err := d.ptyBackend.Input(context.Background(), sessionID, input); err != nil {
 			return err
 		}
 		time.Sleep(doorbellSubmitDelay)
 		return d.ptyBackend.Input(context.Background(), sessionID, []byte("\r"))
 	})
+}
+
+// submitDoorbell presses Enter into a target that already has a doorbell's
+// paste sitting in its composer, which is not the same act as typing one: the
+// words are already there, and pasting them again would leave two copies. The
+// gate is the same, because a session that cannot take input must not be poked.
+func (d *Daemon) submitDoorbell(sessionID string) error {
+	d.doorbellMu.Lock()
+	defer d.doorbellMu.Unlock()
+	session := d.store.Get(sessionID)
+	if session == nil || !isNudgeDeliveryAllowed(string(session.State)) {
+		return errDoorbellBlockedByApproval
+	}
+	return d.writePTY(sessionID, []byte("\r"))
 }
 
 // maybeAssignChiefOnSpawn assigns the chief-of-staff role at a session's first

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -240,11 +240,12 @@ type Daemon struct {
 	// Which sessions owe an agent-message delivery, and which are draining one
 	// right now. The first keeps the state-report path off the database when
 	// nothing is queued, which is nearly always — see agent_msg.go.
-	agentMessageMu        sync.Mutex
-	queuedAgentMessages   map[string]bool
-	drainingAgentMessages map[string]bool
-	agentMessageTaken     map[string][]chan struct{}
-	agentMessageDrainHook func(sessionID string, delivered int) // tests only; nil in production
+	agentMessageMu              sync.Mutex
+	queuedAgentMessages         map[string]bool
+	drainingAgentMessages       map[string]bool
+	agentMessageTaken           map[string][]chan struct{}
+	agentMessagesAwaitingSubmit map[string]bool
+	agentMessageDrainHook       func(sessionID string, delivered int) // tests only; nil in production
 	// stateTrace is the diagnostic ring of state observations behind
 	// `attn state explain`. Lazily built so a directly-constructed test daemon
 	// traces without an init site.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -243,6 +243,7 @@ type Daemon struct {
 	agentMessageMu        sync.Mutex
 	queuedAgentMessages   map[string]bool
 	drainingAgentMessages map[string]bool
+	agentMessageTaken     map[string][]chan struct{}
 	agentMessageDrainHook func(sessionID string, delivered int) // tests only; nil in production
 	// stateTrace is the diagnostic ring of state observations behind
 	// `attn state explain`. Lazily built so a directly-constructed test daemon

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -110,6 +110,12 @@ func TestMain(m *testing.M) {
 	// TestTypeDoorbellDelaysEnterAfterThePaste restores a delay to pin the gap.
 	doorbellSubmitDelay = 0
 
+	// Same reason for the other half of a delivery: a fake PTY never reports
+	// working, so confirmation would time out on every send. Zero trusts the
+	// write, which is what the daemon did before confirmation existed —
+	// TestAgentMsgQueuesWhenTheTargetNeverTakesIt restores a window to pin it.
+	agentMessageTakenWindow = 0
+
 	// Plugin-process helper subprocesses (TestDaemonPluginProcessHelper,
 	// TestPluginDriverFixtureProcess) re-exec this same test binary with a
 	// single -test.run and rely on ATTN_SOCKET_PATH being the exact value

--- a/internal/daemon/session_state.go
+++ b/internal/daemon/session_state.go
@@ -170,6 +170,10 @@ func (d *Daemon) applyState(change sessionStateChange) bool {
 	if profile.broadcast {
 		d.broadcastSessionStateChanged(change.sessionID)
 	}
+	// A target that starts working has taken what was typed into it; this is the
+	// receipt a delivery in flight is waiting on. Before the drain, so a message
+	// still being confirmed is not counted as one owed.
+	d.noteAgentMessageTaken(change.sessionID, change.state)
 	// Last, and only for a target that owes one: a message that could not be
 	// typed when it was sent has no other rail back.
 	d.drainAgentMessagesAfterStateChange(change.sessionID, change.state)


### PR DESCRIPTION
Two fixes to agents reaching each other, found together: an agent asked to
"message keel" answered from the wrong address book, and the message it sent
never arrived while the sender was told it had.

## Claude's rival address book

Claude Code publishes its own list of sessions in `~/.claude/sessions/<pid>.json`
— one file per live Claude process, written by that process about itself. Its
`ListAgents`/`SendMessage` tools read it, and nothing else on the machine knows
it exists. Two properties make it wrong for attn:

- The name is `nameSource: "derived"` — derived from the session's **working
  directory**. Renaming a session in the attn app writes `sessions.label` and
  never reaches that file, so a session the user calls `Keel` is published as
  `attn-sunny-meerkat-fe`.
- Codex sessions appear in it nowhere, so it can never be attn's messaging
  system whatever we wire into it.

attn's own — `attn agent list`, `attn agent peek`, `attn agent msg` — reads
attn's sessions table, shows the name the user gave, and is cross-harness by
construction (`docs/plans/2026-08-08-converse-and-observe.md` studied Claude's
version as prior art and kept its own for exactly that reason).

So launched claude sessions now deny both tools. Denying **removes them from
the agent's tool list** rather than failing the call — measured 31 tools → 29,
both absent from the session's `type:"system"` init event. `ATTN_CLAUDE_PEER_MESSAGING=1`
launches with them back.

This does not unpublish attn sessions from `~/.claude/sessions/`, so a `claude`
running outside attn can still message in. That door is left open deliberately.

## Delivery reported from the write, not from the target

`attn agent msg` stamped a message delivered as soon as the PTY write returned.
A write returning says the bytes reached the terminal, not that the agent read
them: a session with a dialog or an overlay in front of its composer reports the
same settled title as one waiting at its prompt (`at_prompt` means "the agent's
own title says it is not busy" — it says nothing about focus), swallows the
paste whole, and the sender is told `delivered`.

Observed live: a message reported `delivered` sat unsent; a second message
later submitted both together.

Submitting a message always starts a turn, so `working` is the receipt. A
delivery now arms a waiter before typing and waits for it:

- confirmed → delivered, as before;
- unconfirmed → one more Enter (the paste may be sitting in the composer, and
  repasting would double the text), then the row stays queued for the existing
  drain and the sender is told which happened and why. The drain presses Enter
  first for the same reason, and only retypes if that Enter does not take
  either — which is what a target that discarded the paste needs;
- a target already mid-turn is exempt — it queues the paste and answers when
  its turn ends, no new turn opens, and waiting for one would redeliver.

`agentMessageTakenWindow` is 3s against measured 181ms/187ms warm and 1.06s for
the first message to a freshly spawned target — a tripwire, not a budget, and
the cost of it being too small is a redelivery, not a lost message.

## Verification

Live, on a throwaway `peermsg` profile installed from this branch (reaped after):

- the spawned claude process argv carries `--disallowed-tools ListAgents SendMessage`;
- that session, asked over `attn agent msg`, answered
  `ToolSearch("select:SendMessage")` → *"No matching deferred tools found"* —
  the deterministic check, because its first self-report claimed `SendMessage:
  PRESENT` by reading the word inside the Agent tool's description;
- three live deliveries after the fix: `delivered` in 1062ms, 181ms, 187ms.

Re-verified on the review head on a throwaway `msgfix` profile (reaped after),
two claude sessions created through the app:

- healthy path: `delivered` in 170ms and 632ms;
- stopped target: `SIGSTOP` on the target's claude (its pid read from the
  daemon's own worker registry, never matched by pattern), then a message.
  Reported `queued: typed it, but the target did not start a turn within 3s`;
- `SIGCONT`, then the next state change ran the drain. The daemon log carries
  the whole decision: `agent msg still unsubmitted after enter; retyping`. One
  copy of the message reached the screen, answered once, and the row is
  `delivered`. A stopped claude discards the buffered paste rather than holding
  it — so the Enter-first assumption is right to be provisional, and the retype
  behind it is what makes the message arrive at all.

Unit: `internal/agent/peer_messaging_test.go` (flag emitted by default, env var
suppresses it, codex/copilot never grow it, flag precedes the `--` prompt
separator) and `internal/daemon/agent_msg_taken_test.go` (queued when never
taken, delivered when the target starts working, no wait for a working target).
The queued test is mutation-verified: without the confirmation it reports
`Status:delivered`. Full `internal/daemon` and `internal/agent` packages green.

Surfaces walked: CLI (`attn agent msg` is the surface), daemon+app (delivery is
daemon-side; no protocol change, no wire shape moved), Linux (pure Go), docs
(two changelog fragments). No plugin/SDK surface — plugin drivers have their own
delivery path and are untouched.

https://claude.ai/code/session_019jBoiN1aSc9QjEFwNYgczC
