### PR TITLE
feat(garden): seeds relate, and the garden says what is ready

### DIFF
--- a/app/src/components/GardenPanel.css
+++ b/app/src/components/GardenPanel.css
@@ -234,6 +234,56 @@
   gap: 10px;
 }
 
+.garden-seed__ready {
+  color: var(--accent);
+  flex: none;
+  font-size: var(--font-size-xs);
+}
+
+.garden-seed__blocked {
+  color: var(--color-text-muted);
+  flex: none;
+  font-size: var(--font-size-xs);
+  white-space: nowrap;
+}
+
+.garden-seed__relations {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.garden-seed__relations li {
+  align-items: baseline;
+  display: flex;
+  gap: 8px;
+  min-width: 0;
+}
+
+.garden-seed__relation-label {
+  color: var(--color-text-muted);
+  flex: none;
+  font-size: var(--font-size-xs);
+}
+
+.garden-seed__relation-title {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.garden-seed__relation-state {
+  color: var(--color-text-tertiary);
+  flex: none;
+  font-size: var(--font-size-xs);
+  margin-left: auto;
+}
+
 .garden-seed__body {
   background: var(--color-bg-elevated);
   border-radius: 4px;

--- a/app/src/components/GardenPanel.edges.test.tsx
+++ b/app/src/components/GardenPanel.edges.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { GardenPanel } from './GardenPanel';
+import type { Seed } from '../hooks/useDaemonSocket';
+
+function seed(overrides: Partial<Seed> & { id: string; title: string }): Seed {
+  return {
+    body: '',
+    status: 'planted',
+    step_slug: overrides.title,
+    workspace_id: 'ws-1',
+    planter_session: '',
+    planter_member: '',
+    tender_session: '',
+    tender_member: '',
+    edges: [],
+    ready: false,
+    template: false,
+    gate: false,
+    vars: [],
+    rev: 1,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// Readiness is the daemon's answer — it knows which tender sessions are still
+// alive — so the panel renders `ready` rather than recomputing it. What the
+// panel does own is the reverse direction of an edge: edges are stored on the
+// seed they point from, so "who blocks me" only exists by reading the garden.
+describe('GardenPanel edges', () => {
+  const blocker = seed({ id: 's-aaa111', title: 'the blocker', ready: true });
+  const blocked = seed({
+    id: 's-bbb111',
+    title: 'the blocked one',
+    edges: [{ kind: 'part-of', to: 's-ccc111' }],
+  });
+  const crown = seed({ id: 's-ccc111', title: 'the crown' });
+
+  function chain(blockerStatus: string): Seed[] {
+    return [
+      { ...blocker, status: blockerStatus, ready: blockerStatus === 'planted', edges: [{ kind: 'blocks', to: 's-bbb111' }] },
+      blocked,
+      crown,
+    ];
+  }
+
+  it('marks the ready seed and says how many block the others', () => {
+    render(<GardenPanel isOpen onClose={vi.fn()} seedsTotal={3} seeds={chain('planted')} workspaceId="ws-1" />);
+
+    expect(screen.getByText('ready')).toBeInTheDocument();
+    expect(screen.getByText('blocked by 1')).toBeInTheDocument();
+  });
+
+  // Harvesting the blocker is the whole point of the edge: the dependent stops
+  // being blocked at the next read, with nobody clearing anything by hand.
+  it('stops counting a harvested blocker', () => {
+    const { rerender } = render(
+      <GardenPanel isOpen onClose={vi.fn()} seedsTotal={3} seeds={chain('planted')} workspaceId="ws-1" />,
+    );
+    expect(screen.getByText('blocked by 1')).toBeInTheDocument();
+
+    rerender(<GardenPanel isOpen onClose={vi.fn()} seedsTotal={3} seeds={chain('harvested')} workspaceId="ws-1" />);
+
+    expect(screen.queryByText('blocked by 1')).not.toBeInTheDocument();
+  });
+
+  it('lists a seed’s edges in both directions when opened', () => {
+    const { container } = render(
+      <GardenPanel isOpen onClose={vi.fn()} seedsTotal={3} seeds={chain('planted')} workspaceId="ws-1" />,
+    );
+
+    fireEvent.click(screen.getByText('the blocked one'));
+
+    const relations = container.querySelector('.garden-seed__relations');
+    expect(relations?.textContent).toContain('part of');
+    expect(relations?.textContent).toContain('the crown');
+    expect(relations?.textContent).toContain('blocked by');
+    expect(relations?.textContent).toContain('the blocker');
+  });
+
+  // A blocker in another workspace still blocks. The panel scopes what it lists
+  // but must read edges against the whole push, or a blocked seed reads as free.
+  it('counts a blocker from another workspace', () => {
+    const away = seed({
+      id: 's-ddd111',
+      title: 'blocker elsewhere',
+      workspace_id: 'ws-2',
+      edges: [{ kind: 'blocks', to: 's-bbb111' }],
+    });
+    render(<GardenPanel isOpen onClose={vi.fn()} seedsTotal={2} seeds={[blocked, away]} workspaceId="ws-1" />);
+
+    expect(screen.queryByText('blocker elsewhere')).not.toBeInTheDocument();
+    expect(screen.getByText('blocked by 1')).toBeInTheDocument();
+  });
+});

--- a/app/src/components/GardenPanel.lifecycle.test.tsx
+++ b/app/src/components/GardenPanel.lifecycle.test.tsx
@@ -14,6 +14,7 @@ function seed(overrides: Partial<Seed> & { id: string; title: string }): Seed {
     tender_session: '',
     tender_member: '',
     edges: [],
+    ready: false,
     template: false,
     gate: false,
     vars: [],

--- a/app/src/components/GardenPanel.scope.test.tsx
+++ b/app/src/components/GardenPanel.scope.test.tsx
@@ -14,6 +14,7 @@ function seed(overrides: Partial<Seed> & { id: string; title: string }): Seed {
     tender_session: '',
     tender_member: '',
     edges: [],
+    ready: false,
     template: false,
     gate: false,
     vars: [],

--- a/app/src/components/GardenPanel.tsx
+++ b/app/src/components/GardenPanel.tsx
@@ -54,6 +54,61 @@ function statusClass(status: string): string {
   }
 }
 
+// closedStatus is the seed statuses that stop holding anything back. A blocker
+// stops blocking the moment it is harvested or withered; a dormant one still
+// blocks, because parking is a pause, not an answer.
+function closedStatus(status: string): boolean {
+  return status === 'harvested' || status === 'withered';
+}
+
+interface Relation {
+  label: string;
+  seed: Seed;
+}
+
+interface GardenIndex {
+  byID: Map<string, Seed>;
+  // Edges pointing at a seed, already phrased from that seed's side.
+  inbound: Map<string, Relation[]>;
+  // How many open seeds block a seed.
+  blockers: Map<string, number>;
+}
+
+// indexEdges reads the whole pushed garden once. Edges are stored on the seed
+// they point from, so the reverse direction is only knowable by walking every
+// seed — per row that is a scan per row, and this panel renders the garden.
+//
+// The index is built over the unscoped push on purpose: a blocker can live in
+// another workspace, and a panel that only looked at the workspace it shows
+// would tell a blocked seed it is blocked by nothing.
+function indexEdges(seeds: Seed[]): GardenIndex {
+  const index: GardenIndex = { byID: new Map(), inbound: new Map(), blockers: new Map() };
+  for (const seed of seeds) index.byID.set(seed.id, seed);
+  for (const seed of seeds) {
+    for (const edge of seed.edges ?? []) {
+      const label = edge.kind === 'blocks' ? 'blocked by' : edge.kind === 'part-of' ? 'has part' : '';
+      if (!label) continue;
+      index.inbound.set(edge.to, [...(index.inbound.get(edge.to) ?? []), { label, seed }]);
+      if (edge.kind === 'blocks' && !closedStatus(seed.status)) {
+        index.blockers.set(edge.to, (index.blockers.get(edge.to) ?? 0) + 1);
+      }
+    }
+  }
+  return index;
+}
+
+// relationsOf lists a seed's edges in both directions.
+function relationsOf(index: GardenIndex, id: string): Relation[] {
+  const rows: Relation[] = [];
+  for (const edge of index.byID.get(id)?.edges ?? []) {
+    const other = index.byID.get(edge.to);
+    if (!other) continue;
+    if (edge.kind === 'blocks') rows.push({ label: 'blocks', seed: other });
+    if (edge.kind === 'part-of') rows.push({ label: 'part of', seed: other });
+  }
+  return rows.concat(index.inbound.get(id) ?? []);
+}
+
 // tenderOf names whoever holds the seed: the crew member if there is one,
 // because that is the name a person says, and the claiming session otherwise. A
 // session id is not pretty, but "somebody holds this" is the fact the panel owes
@@ -72,6 +127,8 @@ export function GardenPanel({ isOpen, onClose, seeds, seedsTotal, workspaceId }:
     if (showAll || !workspaceId) return seeds;
     return seeds.filter((seed) => seed.workspace_id === workspaceId);
   }, [seeds, showAll, workspaceId]);
+
+  const index = useMemo(() => indexEdges(seeds), [seeds]);
 
   if (!isOpen) return null;
 
@@ -116,6 +173,8 @@ export function GardenPanel({ isOpen, onClose, seeds, seedsTotal, workspaceId }:
         <ul className="garden-panel__list">
           {scoped.map((seed) => {
             const expanded = expandedId === seed.id;
+            const blockers = index.blockers.get(seed.id) ?? 0;
+            const relations = expanded ? relationsOf(index, seed.id) : [];
             return (
               <li
                 key={seed.id}
@@ -131,6 +190,12 @@ export function GardenPanel({ isOpen, onClose, seeds, seedsTotal, workspaceId }:
                     <span className="garden-seed__title">{seed.title}</span>
                     <span className="garden-seed__line">
                       <span className="garden-seed__state">{seed.status}</span>
+                      {seed.ready && <span className="garden-seed__ready">ready</span>}
+                      {blockers > 0 && (
+                        <span className="garden-seed__blocked">
+                          blocked by {blockers}
+                        </span>
+                      )}
                       {tenderOf(seed) && (
                         <span className="garden-seed__tender">tended by {tenderOf(seed)}</span>
                       )}
@@ -149,6 +214,18 @@ export function GardenPanel({ isOpen, onClose, seeds, seedsTotal, workspaceId }:
                       {seed.template && <span>packet</span>}
                       {seed.gate && <span>gate</span>}
                     </div>
+                    {relations.length > 0 && (
+                      <ul className="garden-seed__relations">
+                        {relations.map((relation) => (
+                          <li key={`${relation.label}:${relation.seed.id}`}>
+                            <span className="garden-seed__relation-label">{relation.label}</span>
+                            <span className="garden-seed__relation-title">{relation.seed.title}</span>
+                            <span className="garden-seed__id">{relation.seed.id}</span>
+                            <span className="garden-seed__relation-state">{relation.seed.status}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
                     {seed.body ? (
                       <pre className="garden-seed__body">{seed.body}</pre>
                     ) : (

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -234,7 +234,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '235';
+export const PROTOCOL_VERSION = '236';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentMsgMessage, AgentMsgResult, AgentMsgStatus, AgentPeekMessage, AgentPeekResult, AgentPeekScreen, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, AppApplyMessage, AppApplyResult, AppConsumerInfo, AppInvocationInfo, AppListMessage, AppListResult, AppLogsMessage, AppLogsResult, AppRemoveMessage, AppRemoveResult, AppRollbackMessage, AppRollbackResult, AppRuntimeInfo, AppRuntimeRestartMessage, AppRuntimeRestartResult, AppRuntimeStatusMessage, AppRuntimeStatusResult, AppSetEnabledMessage, AppSetEnabledResult, AppStallInfo, AppStatusMessage, AppStatusResult, AppSummary, AppVersionInfo, AppWatchMessage, AppWatchResult, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, BusConsumerStatus, BusHealthEntry, BusProducerStatus, BusSetConsumerEnabledMessage, BusSetConsumerEnabledResultMessage, BusStatusGetMessage, BusStatusResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocUndefineMessage, DocUndefineResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GardenSeedsUpdatedMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Seed, SeedEdge, SeedListMessage, SeedListResult, SeedNote, SeedNoteMessage, SeedNoteResult, SeedNotesMessage, SeedNotesResult, SeedPlantMessage, SeedPlantResult, SeedShowMessage, SeedShowResult, SeedTransitionMessage, SeedTransitionResult, SeedVar, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketRow, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentMsgMessage, AgentMsgResult, AgentMsgStatus, AgentPeekMessage, AgentPeekResult, AgentPeekScreen, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, AppApplyMessage, AppApplyResult, AppConsumerInfo, AppInvocationInfo, AppListMessage, AppListResult, AppLogsMessage, AppLogsResult, AppRemoveMessage, AppRemoveResult, AppRollbackMessage, AppRollbackResult, AppRuntimeInfo, AppRuntimeRestartMessage, AppRuntimeRestartResult, AppRuntimeStatusMessage, AppRuntimeStatusResult, AppSetEnabledMessage, AppSetEnabledResult, AppStallInfo, AppStatusMessage, AppStatusResult, AppSummary, AppVersionInfo, AppWatchMessage, AppWatchResult, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, BusConsumerStatus, BusHealthEntry, BusProducerStatus, BusSetConsumerEnabledMessage, BusSetConsumerEnabledResultMessage, BusStatusGetMessage, BusStatusResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocUndefineMessage, DocUndefineResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GardenSeedsUpdatedMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Seed, SeedEdge, SeedLinkMessage, SeedLinkResult, SeedListMessage, SeedListResult, SeedNote, SeedNoteMessage, SeedNoteResult, SeedNotesMessage, SeedNotesResult, SeedPlantMessage, SeedPlantResult, SeedReadyMessage, SeedReadyResult, SeedRelation, SeedShowMessage, SeedShowResult, SeedTransitionMessage, SeedTransitionResult, SeedVar, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketRow, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const activityStatusMessage = Convert.toActivityStatusMessage(json);
 //   const activityStatusResult = Convert.toActivityStatusResult(json);
@@ -340,6 +340,8 @@
 //   const runtimeRespawnedMessage = Convert.toRuntimeRespawnedMessage(json);
 //   const seed = Convert.toSeed(json);
 //   const seedEdge = Convert.toSeedEdge(json);
+//   const seedLinkMessage = Convert.toSeedLinkMessage(json);
+//   const seedLinkResult = Convert.toSeedLinkResult(json);
 //   const seedListMessage = Convert.toSeedListMessage(json);
 //   const seedListResult = Convert.toSeedListResult(json);
 //   const seedNote = Convert.toSeedNote(json);
@@ -349,6 +351,9 @@
 //   const seedNotesResult = Convert.toSeedNotesResult(json);
 //   const seedPlantMessage = Convert.toSeedPlantMessage(json);
 //   const seedPlantResult = Convert.toSeedPlantResult(json);
+//   const seedReadyMessage = Convert.toSeedReadyMessage(json);
+//   const seedReadyResult = Convert.toSeedReadyResult(json);
+//   const seedRelation = Convert.toSeedRelation(json);
 //   const seedShowMessage = Convert.toSeedShowMessage(json);
 //   const seedShowResult = Convert.toSeedShowResult(json);
 //   const seedTransitionMessage = Convert.toSeedTransitionMessage(json);
@@ -3003,6 +3008,7 @@ export interface SeedElement {
     id:              string;
     planter_member:  string;
     planter_session: string;
+    ready:           boolean;
     reason?:         string;
     rev:             number;
     status:          string;
@@ -5129,10 +5135,12 @@ export interface Response {
     present_open_result?:                  PresentOpenResultObject;
     prs?:                                  PRElement[];
     repos?:                                RepoElement[];
+    seed_link_result?:                     SeedLinkResultObject;
     seed_list_result?:                     SeedListResultObject;
     seed_note_result?:                     SeedNoteResultObject;
     seed_notes_result?:                    SeedNotesResultObject;
     seed_plant_result?:                    SeedPlantResultObject;
+    seed_ready_result?:                    SeedReadyResultObject;
     seed_show_result?:                     SeedShowResultObject;
     seed_transition_result?:               SeedTransitionResultObject;
     session_instructions_result?:          SessionInstructionsResultObject;
@@ -5374,6 +5382,12 @@ export interface PresentOpenResultObject {
     [property: string]: any;
 }
 
+export interface SeedLinkResultObject {
+    changed: boolean;
+    seed:    SeedElement;
+    [property: string]: any;
+}
+
 export interface SeedListResultObject {
     all:          boolean;
     seeds:        SeedElement[];
@@ -5409,10 +5423,26 @@ export interface SeedPlantResultObject {
     [property: string]: any;
 }
 
+export interface SeedReadyResultObject {
+    scope:    string;
+    scope_id: string;
+    seeds:    SeedElement[];
+    [property: string]: any;
+}
+
 export interface SeedShowResultObject {
     notes:       Note[];
     notes_total: number;
+    relations:   RelationElement[];
     seed:        SeedElement;
+    [property: string]: any;
+}
+
+export interface RelationElement {
+    label:   string;
+    seed_id: string;
+    status:  string;
+    title:   string;
     [property: string]: any;
 }
 
@@ -5693,6 +5723,7 @@ export interface Seed {
     id:              string;
     planter_member:  string;
     planter_session: string;
+    ready:           boolean;
     reason?:         string;
     rev:             number;
     status:          string;
@@ -5710,6 +5741,25 @@ export interface Seed {
 export interface SeedEdge {
     kind: string;
     to:   string;
+    [property: string]: any;
+}
+
+export interface SeedLinkMessage {
+    cmd:        SeedLinkMessageCmd;
+    kind:       string;
+    seed_id:    string;
+    to_seed_id: string;
+    unlink?:    boolean;
+    [property: string]: any;
+}
+
+export enum SeedLinkMessageCmd {
+    SeedLink = "seed_link",
+}
+
+export interface SeedLinkResult {
+    changed: boolean;
+    seed:    SeedElement;
     [property: string]: any;
 }
 
@@ -5798,6 +5848,34 @@ export interface SeedPlantResult {
     [property: string]: any;
 }
 
+export interface SeedReadyMessage {
+    all?:               boolean;
+    cmd:                SeedReadyMessageCmd;
+    plot?:              string;
+    source_session_id?: string;
+    workspace_id?:      string;
+    [property: string]: any;
+}
+
+export enum SeedReadyMessageCmd {
+    SeedReady = "seed_ready",
+}
+
+export interface SeedReadyResult {
+    scope:    string;
+    scope_id: string;
+    seeds:    SeedElement[];
+    [property: string]: any;
+}
+
+export interface SeedRelation {
+    label:   string;
+    seed_id: string;
+    status:  string;
+    title:   string;
+    [property: string]: any;
+}
+
 export interface SeedShowMessage {
     cmd:     SeedShowMessageCmd;
     seed_id: string;
@@ -5811,6 +5889,7 @@ export enum SeedShowMessageCmd {
 export interface SeedShowResult {
     notes:       Note[];
     notes_total: number;
+    relations:   RelationElement[];
     seed:        SeedElement;
     [property: string]: any;
 }
@@ -10451,6 +10530,22 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SeedEdge")), null, 2);
     }
 
+    public static toSeedLinkMessage(json: string): SeedLinkMessage {
+        return cast(JSON.parse(json), r("SeedLinkMessage"));
+    }
+
+    public static seedLinkMessageToJson(value: SeedLinkMessage): string {
+        return JSON.stringify(uncast(value, r("SeedLinkMessage")), null, 2);
+    }
+
+    public static toSeedLinkResult(json: string): SeedLinkResult {
+        return cast(JSON.parse(json), r("SeedLinkResult"));
+    }
+
+    public static seedLinkResultToJson(value: SeedLinkResult): string {
+        return JSON.stringify(uncast(value, r("SeedLinkResult")), null, 2);
+    }
+
     public static toSeedListMessage(json: string): SeedListMessage {
         return cast(JSON.parse(json), r("SeedListMessage"));
     }
@@ -10521,6 +10616,30 @@ export class Convert {
 
     public static seedPlantResultToJson(value: SeedPlantResult): string {
         return JSON.stringify(uncast(value, r("SeedPlantResult")), null, 2);
+    }
+
+    public static toSeedReadyMessage(json: string): SeedReadyMessage {
+        return cast(JSON.parse(json), r("SeedReadyMessage"));
+    }
+
+    public static seedReadyMessageToJson(value: SeedReadyMessage): string {
+        return JSON.stringify(uncast(value, r("SeedReadyMessage")), null, 2);
+    }
+
+    public static toSeedReadyResult(json: string): SeedReadyResult {
+        return cast(JSON.parse(json), r("SeedReadyResult"));
+    }
+
+    public static seedReadyResultToJson(value: SeedReadyResult): string {
+        return JSON.stringify(uncast(value, r("SeedReadyResult")), null, 2);
+    }
+
+    public static toSeedRelation(json: string): SeedRelation {
+        return cast(JSON.parse(json), r("SeedRelation"));
+    }
+
+    public static seedRelationToJson(value: SeedRelation): string {
+        return JSON.stringify(uncast(value, r("SeedRelation")), null, 2);
     }
 
     public static toSeedShowMessage(json: string): SeedShowMessage {
@@ -13528,6 +13647,7 @@ const typeMap: any = {
         { json: "id", js: "id", typ: "" },
         { json: "planter_member", js: "planter_member", typ: "" },
         { json: "planter_session", js: "planter_session", typ: "" },
+        { json: "ready", js: "ready", typ: true },
         { json: "reason", js: "reason", typ: u(undefined, "") },
         { json: "rev", js: "rev", typ: 0 },
         { json: "status", js: "status", typ: "" },
@@ -14793,10 +14913,12 @@ const typeMap: any = {
         { json: "present_open_result", js: "present_open_result", typ: u(undefined, r("PresentOpenResultObject")) },
         { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
         { json: "repos", js: "repos", typ: u(undefined, a(r("RepoElement"))) },
+        { json: "seed_link_result", js: "seed_link_result", typ: u(undefined, r("SeedLinkResultObject")) },
         { json: "seed_list_result", js: "seed_list_result", typ: u(undefined, r("SeedListResultObject")) },
         { json: "seed_note_result", js: "seed_note_result", typ: u(undefined, r("SeedNoteResultObject")) },
         { json: "seed_notes_result", js: "seed_notes_result", typ: u(undefined, r("SeedNotesResultObject")) },
         { json: "seed_plant_result", js: "seed_plant_result", typ: u(undefined, r("SeedPlantResultObject")) },
+        { json: "seed_ready_result", js: "seed_ready_result", typ: u(undefined, r("SeedReadyResultObject")) },
         { json: "seed_show_result", js: "seed_show_result", typ: u(undefined, r("SeedShowResultObject")) },
         { json: "seed_transition_result", js: "seed_transition_result", typ: u(undefined, r("SeedTransitionResultObject")) },
         { json: "session_instructions_result", js: "session_instructions_result", typ: u(undefined, r("SessionInstructionsResultObject")) },
@@ -14982,6 +15104,10 @@ const typeMap: any = {
         { json: "title", js: "title", typ: "" },
         { json: "warnings", js: "warnings", typ: u(undefined, a("")) },
     ], "any"),
+    "SeedLinkResultObject": o([
+        { json: "changed", js: "changed", typ: true },
+        { json: "seed", js: "seed", typ: r("SeedElement") },
+    ], "any"),
     "SeedListResultObject": o([
         { json: "all", js: "all", typ: true },
         { json: "seeds", js: "seeds", typ: a(r("SeedElement")) },
@@ -15007,10 +15133,22 @@ const typeMap: any = {
     "SeedPlantResultObject": o([
         { json: "seed", js: "seed", typ: r("SeedElement") },
     ], "any"),
+    "SeedReadyResultObject": o([
+        { json: "scope", js: "scope", typ: "" },
+        { json: "scope_id", js: "scope_id", typ: "" },
+        { json: "seeds", js: "seeds", typ: a(r("SeedElement")) },
+    ], "any"),
     "SeedShowResultObject": o([
         { json: "notes", js: "notes", typ: a(r("Note")) },
         { json: "notes_total", js: "notes_total", typ: 0 },
+        { json: "relations", js: "relations", typ: a(r("RelationElement")) },
         { json: "seed", js: "seed", typ: r("SeedElement") },
+    ], "any"),
+    "RelationElement": o([
+        { json: "label", js: "label", typ: "" },
+        { json: "seed_id", js: "seed_id", typ: "" },
+        { json: "status", js: "status", typ: "" },
+        { json: "title", js: "title", typ: "" },
     ], "any"),
     "SeedTransitionResultObject": o([
         { json: "seed", js: "seed", typ: r("SeedElement") },
@@ -15211,6 +15349,7 @@ const typeMap: any = {
         { json: "id", js: "id", typ: "" },
         { json: "planter_member", js: "planter_member", typ: "" },
         { json: "planter_session", js: "planter_session", typ: "" },
+        { json: "ready", js: "ready", typ: true },
         { json: "reason", js: "reason", typ: u(undefined, "") },
         { json: "rev", js: "rev", typ: 0 },
         { json: "status", js: "status", typ: "" },
@@ -15226,6 +15365,17 @@ const typeMap: any = {
     "SeedEdge": o([
         { json: "kind", js: "kind", typ: "" },
         { json: "to", js: "to", typ: "" },
+    ], "any"),
+    "SeedLinkMessage": o([
+        { json: "cmd", js: "cmd", typ: r("SeedLinkMessageCmd") },
+        { json: "kind", js: "kind", typ: "" },
+        { json: "seed_id", js: "seed_id", typ: "" },
+        { json: "to_seed_id", js: "to_seed_id", typ: "" },
+        { json: "unlink", js: "unlink", typ: u(undefined, true) },
+    ], "any"),
+    "SeedLinkResult": o([
+        { json: "changed", js: "changed", typ: true },
+        { json: "seed", js: "seed", typ: r("SeedElement") },
     ], "any"),
     "SeedListMessage": o([
         { json: "all", js: "all", typ: u(undefined, true) },
@@ -15278,6 +15428,24 @@ const typeMap: any = {
     "SeedPlantResult": o([
         { json: "seed", js: "seed", typ: r("SeedElement") },
     ], "any"),
+    "SeedReadyMessage": o([
+        { json: "all", js: "all", typ: u(undefined, true) },
+        { json: "cmd", js: "cmd", typ: r("SeedReadyMessageCmd") },
+        { json: "plot", js: "plot", typ: u(undefined, "") },
+        { json: "source_session_id", js: "source_session_id", typ: u(undefined, "") },
+        { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
+    ], "any"),
+    "SeedReadyResult": o([
+        { json: "scope", js: "scope", typ: "" },
+        { json: "scope_id", js: "scope_id", typ: "" },
+        { json: "seeds", js: "seeds", typ: a(r("SeedElement")) },
+    ], "any"),
+    "SeedRelation": o([
+        { json: "label", js: "label", typ: "" },
+        { json: "seed_id", js: "seed_id", typ: "" },
+        { json: "status", js: "status", typ: "" },
+        { json: "title", js: "title", typ: "" },
+    ], "any"),
     "SeedShowMessage": o([
         { json: "cmd", js: "cmd", typ: r("SeedShowMessageCmd") },
         { json: "seed_id", js: "seed_id", typ: "" },
@@ -15285,6 +15453,7 @@ const typeMap: any = {
     "SeedShowResult": o([
         { json: "notes", js: "notes", typ: a(r("Note")) },
         { json: "notes_total", js: "notes_total", typ: 0 },
+        { json: "relations", js: "relations", typ: a(r("RelationElement")) },
         { json: "seed", js: "seed", typ: r("SeedElement") },
     ], "any"),
     "SeedTransitionMessage": o([
@@ -17212,6 +17381,9 @@ const typeMap: any = {
     "RuntimeRespawnedMessageEvent": [
         "runtime_respawned",
     ],
+    "SeedLinkMessageCmd": [
+        "seed_link",
+    ],
     "SeedListMessageCmd": [
         "seed_list",
     ],
@@ -17223,6 +17395,9 @@ const typeMap: any = {
     ],
     "SeedPlantMessageCmd": [
         "seed_plant",
+    ],
+    "SeedReadyMessageCmd": [
+        "seed_ready",
     ],
     "SeedShowMessageCmd": [
         "seed_show",

--- a/changelog.d/garden-edges-and-ready.yaml
+++ b/changelog.d/garden-edges-and-ready.yaml
@@ -1,0 +1,17 @@
+kind: added
+area: cli
+change: >
+  Seeds now relate, and the garden answers "what can I do right now". `attn
+  seed link <a> blocks <b>` makes b wait for a, `attn seed link <b> part-of
+  <c>` puts b in the plot c crowns, and `attn seed unlink` takes either back.
+  `attn seed ready` lists what you can pick up in the workspace you are in:
+  open, nothing blocking it, nobody holding it — with `--plot <crown>`,
+  `--workspace <id>` and `--all` when you want a different scope. The answer is
+  worked out when you ask, so harvesting a blocker frees whatever was waiting
+  on it the next time anyone looks. `attn seed ls --tree` draws the plot
+  hierarchy, `attn seed show` lists a seed's edges in both directions, and the
+  garden panel marks the ready seeds and says how many blockers the others are
+  waiting on. Linking two seeds into a cycle is refused, naming both seeds and
+  the edge to remove. Agents attn launches now start knowing the garden's
+  vocabulary, the ready → tend → harvest loop, and how many seeds their
+  workspace had ready.

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -3086,6 +3086,16 @@ func runAgentDirectly(requestedAgent string) {
 			}
 		}
 	}
+	// The garden primer rides the same launch injection as the guidance above,
+	// for chief and workspace agents alike. The count comes from the daemon
+	// rather than a copy of the rule, so what an agent is primed with and what
+	// `attn seed ready` answers cannot drift apart; a refusal — an outpost, whose
+	// garden lives at its home — primes nothing rather than teaching a loop this
+	// session cannot run.
+	if ready, err := c.SeedReady(sessionID, "", nil, false); err == nil {
+		count := len(ready.Seeds)
+		opts.GardenReady = &count
+	}
 	// The daemon's worker exports ATTN_WORKFLOW_GUIDANCE_ENABLED when the
 	// workflows_enabled setting is on. This launch path is the worker process, so
 	// the env var (not a store read) carries the gate here.

--- a/cmd/attn/seed.go
+++ b/cmd/attn/seed.go
@@ -45,6 +45,10 @@ func runSeed() {
 		runSeedNote(args)
 	case "notes":
 		runSeedNotes(args)
+	case "link", "unlink":
+		runSeedLink(os.Args[2] == "unlink", args)
+	case "ready":
+		runSeedReady(args)
 	default:
 		fmt.Fprintf(os.Stderr, "seed: unknown command %q\n", os.Args[2])
 		writeSeedHelp(os.Stderr)
@@ -68,13 +72,27 @@ commands:
         on a crown that body is the plan itself. The seed is stamped with the
         workspace of the session you are in; --workspace overrides it.
 
-  ls [--all | --workspace <id>] [--json]
+  ls [--all | --workspace <id>] [--tree] [--json]
         the seeds of the workspace you are in, newest first. --all is the whole
-        garden, including seeds planted outside any workspace.
+        garden, including seeds planted outside any workspace. --tree nests each
+        seed under the crown it is part of.
+
+  ready [--plot <crown> | --workspace <id> | --all] [--json]
+        what you can tend right now, oldest first: nothing open blocks it,
+        nobody is holding it, and it is not a crown — a plot's work is its
+        children. With no flags the scope is the workspace you are in.
+
+  link <a> blocks <b> | link <a> part-of <b>
+        relate two seeds. "a blocks b" keeps b out of ready until a closes;
+        "a part-of b" puts a in b's plot, and b is then the crown. A cycle is
+        refused, naming both seeds and the edge to remove.
+
+  unlink <a> blocks <b>
+        remove the edge. Every link has one.
 
   show <id> [--json]
-        one seed: its state, who tends it, its body, and the newest notes on
-        its trail.
+        one seed: its state, who tends it, every edge that touches it in both
+        directions, its body, and the newest notes on its trail.
 
   tend <id> [--member <name>]
         claim the seed and start growing it. One tender at a time: tending a
@@ -109,7 +127,9 @@ commands:
         edit the seed and export again, never the file.
 
 flags:
-  --workspace <id>   the workspace to stamp (plant) or to list (ls)
+  --plot <crown>     scope a ready answer to one plot
+  --tree             nest a listing under its crowns
+  --workspace <id>   the workspace to stamp (plant) or to list (ls, ready)
   --member <name>    the crew member asking, recorded as planter, tender or
                      note author
   --session <id>     the session asking (defaults to ATTN_SESSION_ID)
@@ -137,6 +157,8 @@ type seedFlags struct {
 	member    *string
 	json      *bool
 	all       *bool
+	tree      *bool
+	plot      *string
 	message   *string
 	out       *string
 	limit     *int
@@ -152,6 +174,8 @@ func newSeedFlags(verb string) *seedFlags {
 		member:    fs.String("member", "", "crew member planting this seed"),
 		json:      fs.Bool("json", false, "print the result as JSON"),
 		all:       fs.Bool("all", false, "the whole garden, not one workspace"),
+		tree:      fs.Bool("tree", false, "nest seeds under the crown they are part of"),
+		plot:      fs.String("plot", "", "scope to one plot, by its crown"),
 		message:   fs.String("m", "", "the seed's body, as markdown (- reads stdin)"),
 		out:       fs.String("out", "", "file to write (- for stdout)"),
 		limit:     fs.Int("limit", 0, "how many trail entries to read"),
@@ -250,16 +274,45 @@ func runSeedList(args []string) {
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "ID\tSTATUS\tTENDER\tPLANTED\tTITLE")
-	for _, seed := range result.Seeds {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
-			seed.ID, seed.Status, orDash(firstNonEmpty(seed.TenderMember, seed.TenderSession)),
-			shortStamp(seed.CreatedAt), seed.Title)
+	for _, row := range seedRows(result.Seeds, *f.tree) {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s%s\n",
+			row.seed.ID, row.seed.Status, orDash(firstNonEmpty(row.seed.TenderMember, row.seed.TenderSession)),
+			shortStamp(row.seed.CreatedAt), strings.Repeat("  ", row.depth), row.seed.Title)
 	}
 	w.Flush()
 	if result.Total > len(result.Seeds) {
 		fmt.Printf("\nshowing the newest %d of %d seeds — one read is capped at %d. The %d not shown are the oldest; `attn seed ls --workspace <id>` reaches them in a narrower scope.\n",
 			len(result.Seeds), result.Total, len(result.Seeds), result.Total-len(result.Seeds))
 	}
+}
+
+// seedRow is one printed line: the seed and how deep it sits under its crown.
+type seedRow struct {
+	seed  protocol.Seed
+	depth int
+}
+
+// seedRows orders a listing. Flat keeps the daemon's order; --tree hands the
+// ordering to the garden package, so the CLI and a future in-app tree cannot
+// disagree about what nests under what.
+func seedRows(seeds []protocol.Seed, tree bool) []seedRow {
+	rows := make([]seedRow, 0, len(seeds))
+	if !tree {
+		for _, seed := range seeds {
+			rows = append(rows, seedRow{seed: seed})
+		}
+		return rows
+	}
+	byID := make(map[string]protocol.Seed, len(seeds))
+	domain := make([]garden.Seed, 0, len(seeds))
+	for _, seed := range seeds {
+		byID[seed.ID] = seed
+		domain = append(domain, gardenSeedFromWire(seed))
+	}
+	for _, row := range garden.Tree(domain) {
+		rows = append(rows, seedRow{seed: byID[row.Seed.ID], depth: row.Depth})
+	}
+	return rows
 }
 
 // shortStamp renders a wire timestamp for a terminal column; an unparseable one
@@ -287,9 +340,101 @@ func runSeedShow(args []string) {
 		return
 	}
 	printSeed(result.Seed)
+	if len(result.Relations) > 0 {
+		fmt.Println()
+		printRelations(result.Relations)
+	}
 	if len(result.Notes) > 0 {
 		fmt.Println()
 		printNotes(result.Notes, result.NotesTotal)
+	}
+}
+
+// printRelations renders both directions of a seed's edges. The other seed's
+// state is on the line because "blocked-by s-7k3f9m" is only actionable when the
+// reader can see whether that blocker is still open.
+func printRelations(relations []protocol.SeedRelation) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	for _, relation := range relations {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", relation.Label, relation.SeedID, relation.Status, relation.Title)
+	}
+	w.Flush()
+}
+
+// runSeedLink relates two seeds, reading `link <a> blocks <b>` as it is said out
+// loud. The daemon owns what may be linked, so a refusal here is only about the
+// shape of the command.
+func runSeedLink(unlink bool, args []string) {
+	verb := "link"
+	if unlink {
+		verb = "unlink"
+	}
+	f := newSeedFlags(verb)
+	positionals := f.parse(verb, args)
+	if len(positionals) != 3 {
+		seedFail(verb, fmt.Errorf("reads as a sentence: `attn seed %s s-7k3f9m %s s-2p4qxv`, where the kind is %s",
+			verb, garden.EdgeBlocks, strings.Join(garden.LinkableKinds, " or ")))
+	}
+	result, err := seedClient().SeedLink(positionals[0], positionals[1], positionals[2], unlink)
+	if err != nil {
+		seedFail(verb, err)
+	}
+	if *f.json {
+		writeJSON(result)
+		return
+	}
+	switch {
+	case unlink:
+		fmt.Printf("%s no longer %s %s\n", positionals[0], positionals[1], positionals[2])
+	case !result.Changed:
+		fmt.Printf("%s already %s %s\n", positionals[0], positionals[1], positionals[2])
+	default:
+		fmt.Printf("%s %s %s\n", positionals[0], positionals[1], positionals[2])
+	}
+}
+
+// runSeedReady is the flag-free question: what can I tend now. Scope comes from
+// the daemon, which knows the session, so an agent asks without naming its own
+// context.
+func runSeedReady(args []string) {
+	f := newSeedFlags("ready")
+	if positionals := f.parse("ready", args); len(positionals) != 0 {
+		seedFail("ready", fmt.Errorf("takes no arguments, got %q; scope it with --plot <crown>, --workspace <id> or --all", positionals[0]))
+	}
+	result, err := seedClient().SeedReady(f.sessionID(), strings.TrimSpace(*f.plot), f.workspaceOverride(), *f.all)
+	if err != nil {
+		seedFail("ready", err)
+	}
+	if *f.json {
+		writeJSON(result)
+		return
+	}
+	if len(result.Seeds) == 0 {
+		fmt.Printf("nothing is ready %s — `attn seed ls` shows what is planted and what holds it\n", readyScopeName(result))
+		return
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tSTATUS\tPLANTED\tTITLE")
+	for _, seed := range result.Seeds {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", seed.ID, seed.Status, shortStamp(seed.CreatedAt), seed.Title)
+	}
+	w.Flush()
+	fmt.Printf("\n%d ready %s — `attn seed tend <id>` claims one\n", len(result.Seeds), readyScopeName(result))
+}
+
+// readyScopeName says what the answer covered, so an empty answer is never read
+// as an empty garden.
+func readyScopeName(result *protocol.SeedReadyResult) string {
+	switch result.Scope {
+	case "plot":
+		return fmt.Sprintf("in the plot under %s", result.ScopeID)
+	case "workspace":
+		if result.ScopeID == "" {
+			return "outside any workspace"
+		}
+		return "in this workspace"
+	default:
+		return "in the garden"
 	}
 }
 
@@ -310,8 +455,8 @@ func printSeed(seed protocol.Seed) {
 	if seed.Reason != nil && *seed.Reason != "" {
 		fmt.Fprintf(w, "reason\t%s\n", *seed.Reason)
 	}
-	for _, edge := range seed.Edges {
-		fmt.Fprintf(w, "edge\t%s %s\n", edge.Kind, edge.To)
+	if seed.Ready {
+		fmt.Fprintf(w, "ready\tyes\n")
 	}
 	w.Flush()
 	if body := strings.TrimRight(seed.Body, "\n"); body != "" {
@@ -463,9 +608,16 @@ func runSeedExport(args []string) {
 	fmt.Printf("wrote %s from %s — edit the seed, not the file\n", absolute, result.Seed.ID)
 }
 
-// gardenSeedFromWire is the export's only need for the domain type: rendering
-// belongs to the garden package, so the CLI and a future in-app renderer cannot
-// disagree about what a crown looks like.
+// gardenSeedFromWire carries a wire seed back into the domain type, which is
+// where rendering and hierarchy live — so the CLI and a future in-app renderer
+// cannot disagree about what a crown looks like or what nests under it.
 func gardenSeedFromWire(seed protocol.Seed) garden.Seed {
-	return garden.Seed{ID: seed.ID, Title: seed.Title, Body: seed.Body}
+	out := garden.Seed{
+		ID: seed.ID, Title: seed.Title, Body: seed.Body, Status: seed.Status,
+		Edges: make([]garden.Edge, 0, len(seed.Edges)),
+	}
+	for _, edge := range seed.Edges {
+		out.Edges = append(out.Edges, garden.Edge{Kind: edge.Kind, To: edge.To})
+	}
+	return out
 }

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -431,6 +431,20 @@ closes it as abandoned. **Replanting** reopens a closed seed — a closed seed
 reopens before it moves again, which is why replant is the only verb a
 harvested seed answers.
 
+An **edge** is one typed relation between two seeds, stored on the seed it
+points from. Two kinds carry meaning today: **blocks** (`a blocks b` — b waits
+for a) and **part-of** (`b part-of c` — b is one of the crown c's children, and
+a seed sits in at most one plot). `sown-from`, `discovered-from` and
+`relates-to` are declared and inert. A cycle in either kind is refused when it
+is created, naming both seeds and the edge to remove.
+
+**Ready** is the answer to "what can I pick up right now": an open seed nothing
+blocks, nobody holds, and nothing is part of — a crown's work is its children,
+not the crown. It is computed when asked and never stored, so harvesting a
+blocker frees its dependent at the next call, with nobody clearing anything.
+`attn seed ready` scopes to the calling session's workspace unless told
+otherwise, and every attn-launched agent starts knowing its workspace's count.
+
 A **note** is one entry on a seed's trail: what happened and what was learned,
 written for whoever tends that seed next. Notes are anchored to the work and
 routed to nobody — a message with an addressee is a message, not a note — and

--- a/docs/plans/2026-08-06-the-garden-vertical-slices.md
+++ b/docs/plans/2026-08-06-the-garden-vertical-slices.md
@@ -340,26 +340,41 @@ Goal: seeds relate, and "what can I do now" is one flag-free command.
 
 Ships:
 
-- [ ] `attn seed link <a> blocks <b>` and `attn seed link <a> part-of <b>`
+- [x] `attn seed link <a> blocks <b>` and `attn seed link <a> part-of <b>`
       (typed edge list on the seed document; new kinds — `sown-from`,
       `discovered-from`, `relates-to` — are additive), with `unlink`.
-- [ ] `attn seed ready` with inferred scope: the calling session's workspace
+- [x] `attn seed ready` with inferred scope: the calling session's workspace
       by default; `--plot <crown>`, `--workspace <id>`, `--all` override.
-- [ ] `attn seed ls --tree` renders `part-of` hierarchy; `show` lists edges
+- [x] `attn seed ls --tree` renders `part-of` hierarchy; `show` lists edges
       both directions (blocks / blocked-by).
-- [ ] Harvesting a blocker makes the dependent ready at the next query (no
+- [x] Harvesting a blocker makes the dependent ready at the next query (no
       nudge yet — named later).
-- [ ] Priming, interactive side: attn-launched sessions receive the brief
+- [x] Priming, interactive side: attn-launched sessions receive the brief
       garden primer and their workspace's ready count in guidance (the
       chief-guidance injection path).
 
+Three rules decided while building this (2026-08-12):
+
+- A seed something is `part-of` is never itself ready. A crown's work is its
+  children, so a plot with open children would otherwise hand out the crown
+  and every leaf at once. A crown is finished by harvesting it, not by
+  tending it, so this holds even after its children close.
+- A seed sits in at most one plot. The second `part-of` is refused naming the
+  plot it is already in and the `unlink` that moves it, rather than making
+  "which plot is this in" a list.
+- A live tender holds its seed, and liveness is "a session this daemon still
+  knows" — including `recoverable`, which answers the open question below.
+  A tender that names only a crew member always holds: attn has no signal
+  that a person in a terminal pane walked away, and handing their seed to
+  somebody else on a guess is worse than leaving it claimed.
+
 Acceptance:
 
-- [ ] A three-seed chain (A blocks B, B part-of C) round-trips: `ready`
+- [x] A three-seed chain (A blocks B, B part-of C) round-trips: `ready`
       shows only A; harvesting A surfaces B.
-- [ ] Two sessions in different workspaces get different flag-free `ready`
+- [x] Two sessions in different workspaces get different flag-free `ready`
       answers.
-- [ ] Cycle creation is refused loudly, naming both seeds.
+- [x] Cycle creation is refused loudly, naming both seeds.
 
 ### Slice 4 — the seed axis of continuity
 
@@ -518,8 +533,13 @@ Acceptance:
   [docs/plans/2026-08-10-home-garden-crew-arc.md](2026-08-10-home-garden-crew-arc.md).
   Still to build before slice 5's dispatch acceptance can include a remote
   delegate; cross-machine syncing proper stays with the central-server arc.
-- Whether `ready` should exclude seeds whose tender session is dead vs.
-  recoverable (interacts with daemon-owned revive). Slice 3 decides.
+- ~~Whether `ready` should exclude seeds whose tender session is dead vs.
+  recoverable (interacts with daemon-owned revive). Slice 3 decides.~~ Ruled
+  2026-08-12: a session the daemon still knows holds its seed, `recoverable`
+  included — revive brings that session back to the seed it was tending, and
+  releasing it meanwhile would hand the work to somebody else while its
+  tender is on the way back. A session the daemon no longer knows releases
+  it. See slice 3's rules.
 - Crew references: free-string member names are knowingly un-validated
   until the crew primitive lands — acceptable for a single-user garden,
   revisit at the crew arc.

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -90,12 +90,10 @@ func (c *Claude) BuildCommand(opts SpawnOpts) *exec.Cmd {
 	// A chief-of-staff launch (NotebookRoot set) gets chief guidance instead
 	// of the workspace-context checkout guidance. Every other workspace agent gets
 	// its workspace-context guidance (plus workflow-trigger guidance when enabled,
-	// folded in by hooks.AgentInstructions). Non-chief agents are NOT nudged to
+	// folded in by hooks.Launch). Non-chief agents are NOT nudged to
 	// journal: the keeper narrates each workspace's own work into the journal, and
 	// the chief journals the cross-workspace layer.
-	if guidance := hooks.ChiefGuidance(opts.NotebookRoot, c.Capabilities().HasSelfMonitor); guidance != "" {
-		args = append(args, "--append-system-prompt", guidance)
-	} else if instructions := hooks.AgentInstructions(opts.WorkspaceContextPath, opts.InjectWorkflowGuidance); instructions != "" {
+	if instructions := opts.launchGuidance(c.Capabilities().HasSelfMonitor); instructions != "" {
 		args = append(args, "--append-system-prompt", instructions)
 	}
 

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -401,9 +401,12 @@ func (c *Codex) GenerateConfigOverrides(opts SpawnOpts) []string {
 		opts.SessionID,
 		opts.SocketPath,
 		opts.WrapperPath,
-		opts.WorkspaceContextPath,
-		opts.NotebookRoot,
-		opts.InjectWorkflowGuidance,
+		hooks.Launch{
+			NotebookRoot:         opts.NotebookRoot,
+			WorkspaceContextPath: opts.WorkspaceContextPath,
+			InjectWorkflow:       opts.InjectWorkflowGuidance,
+			GardenReady:          opts.GardenReady,
+		},
 	)
 	if opts.TrustWorkingDirectory {
 		overrides = append(overrides, fmt.Sprintf(`projects.%s.trust_level="trusted"`, strconv.Quote(opts.CWD)))

--- a/internal/agent/driver.go
+++ b/internal/agent/driver.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/victorarias/attn/internal/hooks"
 )
 
 // Driver is the core interface every agent must implement.
@@ -245,6 +247,24 @@ type SpawnOpts struct {
 	// TrustWorkingDirectory lets an unattended daemon-owned launch pass the
 	// driver's repository trust gate; interactive launches leave it false.
 	TrustWorkingDirectory bool
+
+	// GardenReady is how many seeds this session's workspace had ready when the
+	// launch resolved it, and nil when the daemon had no answer — no garden
+	// reachable from here. It is what the garden primer is built from.
+	GardenReady *int
+}
+
+// launchGuidance is the system-prompt block for this launch: chief guidance or
+// the workspace agent's, plus the garden primer. hasSelfMonitor is the driver's
+// own capability, which is why the driver composes rather than the caller.
+func (o SpawnOpts) launchGuidance(hasSelfMonitor bool) string {
+	return hooks.Launch{
+		NotebookRoot:         o.NotebookRoot,
+		HasSelfMonitor:       hasSelfMonitor,
+		WorkspaceContextPath: o.WorkspaceContextPath,
+		InjectWorkflow:       o.InjectWorkflowGuidance,
+		GardenReady:          o.GardenReady,
+	}.Instructions()
 }
 
 // --- Optional capability interfaces ---

--- a/internal/agent/garden_primer_test.go
+++ b/internal/agent/garden_primer_test.go
@@ -1,0 +1,33 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+// Both built-in agents are launched into the same garden, so both carry the
+// primer — and neither invents one when the daemon had no answer.
+func TestBuiltinAgentsCarryTheGardenPrimer(t *testing.T) {
+	ready := 3
+
+	claude := argvValueAfter(
+		(&Claude{}).BuildCommand(SpawnOpts{SessionID: "s", Executable: "claude", GardenReady: &ready}).Args,
+		"--append-system-prompt",
+	)
+	if !strings.Contains(claude, "attn seed ready") || !strings.Contains(claude, "3 seeds were ready") {
+		t.Fatalf("claude launch dropped the garden primer: %q", claude)
+	}
+
+	codex := strings.Join((&Codex{}).GenerateConfigOverrides(SpawnOpts{SessionID: "s", GardenReady: &ready}), "\n")
+	if !strings.Contains(codex, "attn seed ready") || !strings.Contains(codex, "3 seeds were ready") {
+		t.Fatalf("codex launch dropped the garden primer: %q", codex)
+	}
+
+	bare := argvValueAfter(
+		(&Claude{}).BuildCommand(SpawnOpts{SessionID: "s", Executable: "claude"}).Args,
+		"--append-system-prompt",
+	)
+	if strings.Contains(bare, "attn seed ready") {
+		t.Fatalf("a launch with no garden answer primed anyway: %q", bare)
+	}
+}

--- a/internal/client/garden.go
+++ b/internal/client/garden.go
@@ -110,6 +110,50 @@ func (c *Client) SeedNote(sessionID, seedID, body, member string) (*protocol.See
 	return resp.SeedNoteResult, nil
 }
 
+// SeedLink adds one edge between two seeds, or removes it when unlink is set.
+// The daemon decides what may be linked — an edge onto a seed that is not
+// planted, a second crown, a cycle — so the CLI and the app cannot disagree.
+func (c *Client) SeedLink(seedID, kind, toSeedID string, unlink bool) (*protocol.SeedLinkResult, error) {
+	msg := protocol.SeedLinkMessage{
+		Cmd: protocol.CmdSeedLink, SeedID: seedID, Kind: kind, ToSeedID: toSeedID,
+	}
+	if unlink {
+		msg.Unlink = protocol.Ptr(true)
+	}
+	resp, err := c.send(msg)
+	if err != nil {
+		return nil, err
+	}
+	if resp.SeedLinkResult == nil {
+		return nil, fmt.Errorf("the daemon accepted the edge but returned no seed")
+	}
+	return resp.SeedLinkResult, nil
+}
+
+// SeedReady asks what can be tended now. Every argument is an override: with
+// none of them the daemon scopes the answer to the calling session's workspace.
+func (c *Client) SeedReady(sessionID, plot string, workspaceID *string, all bool) (*protocol.SeedReadyResult, error) {
+	msg := protocol.SeedReadyMessage{Cmd: protocol.CmdSeedReady}
+	if sessionID != "" {
+		msg.SourceSessionID = protocol.Ptr(sessionID)
+	}
+	if plot != "" {
+		msg.Plot = protocol.Ptr(plot)
+	}
+	msg.WorkspaceID = workspaceID
+	if all {
+		msg.All = protocol.Ptr(true)
+	}
+	resp, err := c.send(msg)
+	if err != nil {
+		return nil, err
+	}
+	if resp.SeedReadyResult == nil {
+		return nil, fmt.Errorf("the daemon answered without a ready list")
+	}
+	return resp.SeedReadyResult, nil
+}
+
 // SeedNotes reads a seed's whole trail, newest first. limit 0 takes the
 // daemon's bound.
 func (c *Client) SeedNotes(seedID string, limit int) (*protocol.SeedNotesResult, error) {

--- a/internal/daemon/bus.go
+++ b/internal/daemon/bus.go
@@ -211,6 +211,11 @@ const (
 	// seed, not the note — the trail is the seed's memory of itself, and the
 	// entity anybody reads is the seed.
 	FactGardenNoted = "garden.noted"
+	// FactGardenLinked/FactGardenUnlinked: an edge was added to or removed from
+	// a seed. Subject is the seed the edge is stored on, which is the document
+	// that changed; the seed at the other end is read from that document.
+	FactGardenLinked   = "garden.linked"
+	FactGardenUnlinked = "garden.unlinked"
 
 	// App registry facts; subject is the app's name.
 	//

--- a/internal/daemon/bus_wire_join_test.go
+++ b/internal/daemon/bus_wire_join_test.go
@@ -201,6 +201,8 @@ var wireFixtures = map[string]wireFixture{
 	FactGardenWithered:      {events: []string{protocol.EventGardenSeedsUpdated}},
 	FactGardenReplanted:     {events: []string{protocol.EventGardenSeedsUpdated}},
 	FactGardenNoted:         {events: []string{protocol.EventGardenSeedsUpdated}},
+	FactGardenLinked:        {events: []string{protocol.EventGardenSeedsUpdated}},
+	FactGardenUnlinked:      {events: []string{protocol.EventGardenSeedsUpdated}},
 
 	// PRs and their mute lists.
 	FactPRAppeared:       {events: []string{protocol.EventPRsUpdated}},

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -50,6 +50,8 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdSeedTransition:             commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdSeedNote:                   commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdSeedNotes:                  commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdSeedLink:                   commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdSeedReady:                  commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdStop:                       commandMetadata(ScopeSession, false, true),
 	protocol.CmdTodos:                      commandMetadata(ScopeSession, false, true),
 	protocol.CmdFilesEdited:                commandMetadata(ScopeSession, false, true),

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2737,6 +2737,10 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleSeedNote(conn, msg.(*protocol.SeedNoteMessage))
 	case protocol.CmdSeedNotes: // wire: seed_notes
 		d.handleSeedNotes(conn, msg.(*protocol.SeedNotesMessage))
+	case protocol.CmdSeedLink: // wire: seed_link
+		d.handleSeedLink(conn, msg.(*protocol.SeedLinkMessage))
+	case protocol.CmdSeedReady: // wire: seed_ready
+		d.handleSeedReady(conn, msg.(*protocol.SeedReadyMessage))
 	case protocol.CmdStop: // wire: stop
 		d.handleStop(conn, msg.(*protocol.StopMessage))
 	case protocol.CmdTodos: // wire: todos

--- a/internal/daemon/garden.go
+++ b/internal/daemon/garden.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"slices"
 	"strings"
 	"time"
 
@@ -155,26 +156,36 @@ func (d *Daemon) readSeed(id string) (garden.Seed, docstore.Document, error) {
 	return seed, *doc, nil
 }
 
-// querySeeds reads the garden, newest first. An empty workspaceID with scoped
-// true means "the seeds that belong to no workspace", which is a real answer and
-// not the same as the whole garden.
-func (d *Daemon) querySeeds(workspaceID string, scoped bool, limit int) ([]protocol.Seed, error) {
-	q := docstore.Query{
+// gardenRead is the whole garden as one read: the seeds newest first, the
+// document each came from, and which of them are ready.
+//
+// Every surface starts here rather than querying its own scope, because an edge
+// and a readiness answer are properties of the whole graph — the seed blocking
+// this workspace's work may live in another one. Scoping happens after the read.
+type gardenRead struct {
+	seeds []garden.Seed
+	docs  map[string]docstore.Document
+	ready map[string]bool
+}
+
+// readGarden reads every seed, bounded by the same limit one push carries, and
+// decides readiness over the set. Past that bound a scoped list can be short of
+// its own count — which is the count each surface prints beside it.
+func (d *Daemon) readGarden() (gardenRead, error) {
+	read, _, err := d.runDocQuery(docstore.Query{
 		Namespace:  garden.Namespace,
 		Collection: garden.CollectionSeeds,
 		Sort:       &docstore.Sort{Field: docstore.FieldCreatedAt, Desc: true},
-		Limit:      limit,
-	}
-	if scoped {
-		q.Filters = append(q.Filters, docstore.Filter{
-			Field: "workspace_id", Op: docstore.OpEq, Value: workspaceID,
-		})
-	}
-	read, _, err := d.runDocQuery(q)
+		Limit:      gardenSnapshotLimit,
+	})
 	if err != nil {
-		return nil, err
+		return gardenRead{}, err
 	}
-	out := make([]protocol.Seed, 0, len(read.Documents))
+	out := gardenRead{
+		seeds: make([]garden.Seed, 0, len(read.Documents)),
+		docs:  make(map[string]docstore.Document, len(read.Documents)),
+		ready: map[string]bool{},
+	}
 	for _, doc := range read.Documents {
 		seed, err := garden.Decode(doc.Body)
 		if err != nil {
@@ -182,9 +193,48 @@ func (d *Daemon) querySeeds(workspaceID string, scoped bool, limit int) ([]proto
 			d.logf("garden: seed %s has an unreadable body: %v", doc.ID, err)
 			continue
 		}
-		out = append(out, seedToProtocol(seed, doc))
+		out.seeds = append(out.seeds, seed)
+		out.docs[seed.ID] = doc
+	}
+	for _, seed := range garden.Ready(out.seeds, d.sessionExists) {
+		out.ready[seed.ID] = true
 	}
 	return out, nil
+}
+
+// wire renders seeds this read holds. A seed the read did not cover — one
+// written since — still renders, without a stamp it cannot know.
+func (g gardenRead) wire(seeds []garden.Seed) []protocol.Seed {
+	out := make([]protocol.Seed, 0, len(seeds))
+	for _, seed := range seeds {
+		out = append(out, seedToProtocol(seed, g.docs[seed.ID], g.ready[seed.ID]))
+	}
+	return out
+}
+
+// inWorkspace narrows a read to one workspace. An empty workspaceID means "the
+// seeds that belong to no workspace", which is a real answer and not the same as
+// the whole garden.
+func (g gardenRead) inWorkspace(workspaceID string) []garden.Seed {
+	out := make([]garden.Seed, 0, len(g.seeds))
+	for _, seed := range g.seeds {
+		if seed.WorkspaceID == workspaceID {
+			out = append(out, seed)
+		}
+	}
+	return out
+}
+
+// gardenReady answers which seeds are tendable now, for a caller that has
+// already written and needs only to render one seed. A failed read leaves the
+// answer empty rather than failing a move that committed.
+func (d *Daemon) gardenReady() map[string]bool {
+	read, err := d.readGarden()
+	if err != nil {
+		d.logf("garden: reading the garden to decide readiness: %v", err)
+		return map[string]bool{}
+	}
+	return read.ready
 }
 
 // countSeeds is what makes a truncated read honest: every surface shows a
@@ -208,7 +258,7 @@ func (d *Daemon) countSeeds(workspaceID string, scoped bool) int {
 	return read.Count
 }
 
-func seedToProtocol(seed garden.Seed, doc docstore.Document) protocol.Seed {
+func seedToProtocol(seed garden.Seed, doc docstore.Document, ready bool) protocol.Seed {
 	out := protocol.Seed{
 		ID:             seed.ID,
 		Title:          seed.Title,
@@ -223,6 +273,7 @@ func seedToProtocol(seed garden.Seed, doc docstore.Document) protocol.Seed {
 		Edges:          make([]protocol.SeedEdge, 0, len(seed.Edges)),
 		Template:       seed.Template,
 		Gate:           seed.Gate,
+		Ready:          ready,
 		Vars:           make([]protocol.SeedVar, 0, len(seed.Vars)),
 		Rev:            int(doc.Rev),
 		CreatedAt:      doc.CreatedAt.UTC().Format(time.RFC3339),
@@ -269,14 +320,14 @@ func (d *Daemon) seedsForBroadcast() []protocol.Seed {
 	if err := d.requireHome(garden.Surface); err != nil {
 		return nil
 	}
-	seeds, err := d.querySeeds("", false, gardenSnapshotLimit)
+	read, err := d.readGarden()
 	if err != nil {
 		if !docstore.IsUndeclaredCollection(err) {
 			d.logf("garden: reading seeds for broadcast: %v", err)
 		}
 		return nil
 	}
-	return seeds
+	return read.wire(read.seeds)
 }
 
 // countSeedsForBroadcast is seedsForBroadcast's count, behind the same fence:
@@ -373,7 +424,7 @@ func (d *Daemon) handleSeedPlant(conn net.Conn, msg *protocol.SeedPlantMessage) 
 	}
 	d.sendGardenResponse(conn, protocol.Response{
 		Ok:              true,
-		SeedPlantResult: &protocol.SeedPlantResult{Seed: seedToProtocol(seed, doc)},
+		SeedPlantResult: &protocol.SeedPlantResult{Seed: seedToProtocol(seed, doc, d.gardenReady()[seed.ID])},
 	})
 }
 
@@ -466,15 +517,19 @@ func (d *Daemon) handleSeedList(conn net.Conn, msg *protocol.SeedListMessage) {
 		workspaceID = resolved
 	}
 
-	seeds, err := d.querySeeds(workspaceID, !all, gardenSnapshotLimit)
+	read, err := d.readGarden()
 	if err != nil {
 		d.sendGardenError(conn, "ls", err)
 		return
 	}
+	seeds := read.seeds
+	if !all {
+		seeds = read.inWorkspace(workspaceID)
+	}
 	d.sendGardenResponse(conn, protocol.Response{
 		Ok: true,
 		SeedListResult: &protocol.SeedListResult{
-			Seeds:       seeds,
+			Seeds:       read.wire(seeds),
 			WorkspaceID: workspaceID,
 			All:         all,
 			Total:       d.countSeeds(workspaceID, !all),
@@ -498,12 +553,220 @@ func (d *Daemon) handleSeedShow(conn net.Conn, msg *protocol.SeedShowMessage) {
 	if err != nil {
 		d.logf("garden: reading the trail of %s: %v", seed.ID, err)
 	}
+	read, err := d.readGarden()
+	if err != nil {
+		d.logf("garden: reading the garden around %s: %v", seed.ID, err)
+	}
 	d.sendGardenResponse(conn, protocol.Response{
 		Ok: true,
 		SeedShowResult: &protocol.SeedShowResult{
-			Seed: seedToProtocol(seed, doc), Notes: notes, NotesTotal: total,
+			Seed:       seedToProtocol(seed, doc, read.ready[seed.ID]),
+			Notes:      notes,
+			NotesTotal: total,
+			Relations:  gardenRelations(read, seed.ID),
 		},
 	})
+}
+
+// gardenRelations renders both directions of a seed's edges, each with the other
+// seed's title and state: "blocked-by s-7k3f9m" is only actionable when the
+// reader can see whether that blocker is still open.
+func gardenRelations(read gardenRead, id string) []protocol.SeedRelation {
+	index := make(map[string]garden.Seed, len(read.seeds))
+	for _, seed := range read.seeds {
+		index[seed.ID] = seed
+	}
+	relations := garden.Relations(read.seeds, id)
+	out := make([]protocol.SeedRelation, 0, len(relations))
+	for _, relation := range relations {
+		other := index[relation.Seed]
+		out = append(out, protocol.SeedRelation{
+			Label:  relation.Label,
+			SeedID: relation.Seed,
+			Title:  other.Title,
+			Status: other.Status,
+		})
+	}
+	return out
+}
+
+// handleSeedLink adds or removes one edge. The decision is made against the
+// whole garden — a cycle is a property of the graph — and written against the
+// revision that decision was read from, so two agents linking at once produce
+// one edge and one honest refusal rather than a lost write.
+func (d *Daemon) handleSeedLink(conn net.Conn, msg *protocol.SeedLinkMessage) {
+	verb := "link"
+	if protocol.Deref(msg.Unlink) {
+		verb = "unlink"
+	}
+	if err := d.requireHome(garden.Surface); err != nil {
+		d.sendGardenError(conn, verb, err)
+		return
+	}
+	kind, err := garden.ParseEdgeKind(msg.Kind)
+	if err != nil {
+		d.sendGardenError(conn, verb, err)
+		return
+	}
+	from := strings.TrimSpace(msg.SeedID)
+	to := strings.TrimSpace(msg.ToSeedID)
+	for _, id := range []string{from, to} {
+		if err := garden.ValidateID(id); err != nil {
+			d.sendGardenError(conn, verb, err)
+			return
+		}
+	}
+	schema, err := d.seedsCollection()
+	if err != nil {
+		d.sendGardenError(conn, verb, err)
+		return
+	}
+
+	const attempts = 3
+	for range attempts {
+		read, err := d.readGarden()
+		if err != nil {
+			d.sendGardenError(conn, verb, err)
+			return
+		}
+		var next garden.Seed
+		changed := true
+		if verb == "unlink" {
+			next, err = garden.Unlink(read.seeds, from, kind, to)
+		} else {
+			next, changed, err = garden.Link(read.seeds, from, kind, to)
+		}
+		if err != nil {
+			d.sendGardenError(conn, verb, err)
+			return
+		}
+		if !changed {
+			d.sendGardenResponse(conn, protocol.Response{
+				Ok: true,
+				SeedLinkResult: &protocol.SeedLinkResult{
+					Seed: seedToProtocol(next, read.docs[next.ID], read.ready[next.ID]), Changed: false,
+				},
+			})
+			return
+		}
+		fact := FactGardenLinked
+		if verb == "unlink" {
+			fact = FactGardenUnlinked
+		}
+		doc, err := d.writeSeed(*schema, next, read.docs[next.ID].Rev, fact)
+		if err != nil {
+			if docstore.IsConflict(err) {
+				continue
+			}
+			d.sendGardenError(conn, verb, err)
+			return
+		}
+		d.sendGardenResponse(conn, protocol.Response{
+			Ok: true,
+			SeedLinkResult: &protocol.SeedLinkResult{
+				Seed: seedToProtocol(next, doc, d.gardenReady()[next.ID]), Changed: true,
+			},
+		})
+		return
+	}
+	d.sendGardenError(conn, verb, fmt.Errorf(
+		"%s was rewritten under all %d attempts to %s it; read it again with `attn seed show %s` and decide from what it says now",
+		from, attempts, verb, from))
+}
+
+// handleSeedReady answers what can be tended now. The scope is inferred from the
+// caller — the daemon owns the session, so the flag-free form is the common one —
+// and a caller with no scope at all is refused rather than handed the seeds that
+// happen to belong to no workspace.
+func (d *Daemon) handleSeedReady(conn net.Conn, msg *protocol.SeedReadyMessage) {
+	if err := d.requireHome(garden.Surface); err != nil {
+		d.sendGardenError(conn, "ready", err)
+		return
+	}
+	read, err := d.readGarden()
+	if err != nil {
+		d.sendGardenError(conn, "ready", err)
+		return
+	}
+	ready := make([]garden.Seed, 0, len(read.ready))
+	for _, seed := range read.seeds {
+		if read.ready[seed.ID] {
+			ready = append(ready, seed)
+		}
+	}
+
+	result := &protocol.SeedReadyResult{Scope: "all"}
+	switch {
+	case protocol.Deref(msg.All):
+	case strings.TrimSpace(protocol.Deref(msg.Plot)) != "":
+		crown := strings.TrimSpace(*msg.Plot)
+		if err := garden.ValidateID(crown); err != nil {
+			d.sendGardenError(conn, "ready", err)
+			return
+		}
+		if _, _, err := d.readSeed(crown); err != nil {
+			d.sendGardenError(conn, "ready", err)
+			return
+		}
+		// The plot is walked over the whole garden, not over the ready seeds: a
+		// crown is never ready itself, so walking the ready set would lose every
+		// child whose parent it holds.
+		inPlot := map[string]bool{}
+		for _, seed := range garden.InPlot(read.seeds, crown) {
+			inPlot[seed.ID] = true
+		}
+		scoped := make([]garden.Seed, 0, len(ready))
+		for _, seed := range ready {
+			if inPlot[seed.ID] {
+				scoped = append(scoped, seed)
+			}
+		}
+		ready, result.Scope, result.ScopeID = scoped, "plot", crown
+	default:
+		sessionID := strings.TrimSpace(protocol.Deref(msg.SourceSessionID))
+		workspaceID, err := d.gardenWorkspaceFor(sessionID, msg.WorkspaceID)
+		if err != nil {
+			d.sendGardenError(conn, "ready", err)
+			return
+		}
+		if workspaceID == "" && msg.WorkspaceID == nil && sessionID == "" {
+			d.sendGardenError(conn, "ready", errors.New(
+				"there is no session to take a workspace from, so there is no default scope; pass --all for the whole garden, --workspace <id> for one, or --plot <crown> for a plot"))
+			return
+		}
+		scoped := make([]garden.Seed, 0, len(ready))
+		for _, seed := range ready {
+			if seed.WorkspaceID == workspaceID {
+				scoped = append(scoped, seed)
+			}
+		}
+		ready, result.Scope, result.ScopeID = scoped, "workspace", workspaceID
+	}
+	// Oldest first, against the newest-first order every other read uses: this is
+	// a work queue, and the seed that has waited longest is the one to hand over.
+	slices.Reverse(ready)
+	result.Seeds = read.wire(ready)
+	d.sendGardenResponse(conn, protocol.Response{Ok: true, SeedReadyResult: result})
+}
+
+// gardenReadyCount is what a launching session is primed with: how many seeds
+// its workspace has ready. It is the same answer `attn seed ready` gives with no
+// flags, so guidance and the CLI cannot disagree.
+func (d *Daemon) gardenReadyCount(workspaceID string) (int, error) {
+	if err := d.requireHome(garden.Surface); err != nil {
+		return 0, err
+	}
+	read, err := d.readGarden()
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, seed := range read.seeds {
+		if read.ready[seed.ID] && seed.WorkspaceID == workspaceID {
+			count++
+		}
+	}
+	return count, nil
 }
 
 // gardenFacts is the verb-to-fact table. One fact per transition, each naming
@@ -538,7 +801,7 @@ func (d *Daemon) handleSeedTransition(conn net.Conn, msg *protocol.SeedTransitio
 	}
 	d.sendGardenResponse(conn, protocol.Response{
 		Ok:                   true,
-		SeedTransitionResult: &protocol.SeedTransitionResult{Seed: seedToProtocol(seed, doc)},
+		SeedTransitionResult: &protocol.SeedTransitionResult{Seed: seedToProtocol(seed, doc, d.gardenReady()[seed.ID])},
 	})
 }
 

--- a/internal/daemon/garden_edges_test.go
+++ b/internal/daemon/garden_edges_test.go
@@ -1,0 +1,329 @@
+package daemon
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/garden"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// link runs one `attn seed link`/`unlink` over the pipe.
+func link(t *testing.T, d *Daemon, from, kind, to string, unlink bool) protocol.Response {
+	t.Helper()
+	msg := protocol.SeedLinkMessage{Cmd: protocol.CmdSeedLink, SeedID: from, Kind: kind, ToSeedID: to}
+	if unlink {
+		msg.Unlink = protocol.Ptr(true)
+	}
+	return gardenCall(t, func(c net.Conn) { d.handleSeedLink(c, &msg) })
+}
+
+func mustLink(t *testing.T, d *Daemon, from, kind, to string) protocol.SeedLinkResult {
+	t.Helper()
+	resp := link(t, d, from, kind, to, false)
+	if !resp.Ok {
+		t.Fatalf("link %s %s %s: %v", from, kind, to, protocol.Deref(resp.Error))
+	}
+	return *resp.SeedLinkResult
+}
+
+func ready(t *testing.T, d *Daemon, msg protocol.SeedReadyMessage) protocol.SeedReadyResult {
+	t.Helper()
+	msg.Cmd = protocol.CmdSeedReady
+	resp := gardenCall(t, func(c net.Conn) { d.handleSeedReady(c, &msg) })
+	if !resp.Ok {
+		t.Fatalf("ready: %v", protocol.Deref(resp.Error))
+	}
+	return *resp.SeedReadyResult
+}
+
+func readyIDs(result protocol.SeedReadyResult) []string {
+	out := make([]string, 0, len(result.Seeds))
+	for _, seed := range result.Seeds {
+		out = append(out, seed.ID)
+	}
+	return out
+}
+
+// The slice's acceptance, end to end: the plan's three-seed chain, the one seed
+// it leaves ready, and the dependent surfacing the moment its blocker is
+// harvested — nothing nudged, nothing cleared by hand.
+func TestGardenEdges_HarvestingABlockerSurfacesTheDependent(t *testing.T) {
+	d := newGardenDaemon(t)
+	a := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "first"})
+	b := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "second"})
+	c := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "the plot"})
+
+	mustLink(t, d, a.ID, garden.EdgeBlocks, b.ID)
+	mustLink(t, d, b.ID, garden.EdgePartOf, c.ID)
+
+	first := ready(t, d, protocol.SeedReadyMessage{SourceSessionID: protocol.Ptr("sess-a")})
+	if got := readyIDs(first); len(got) != 1 || got[0] != a.ID {
+		t.Fatalf("ready = %v, want only the unblocked seed %s", got, a.ID)
+	}
+	if first.Scope != "workspace" || first.ScopeID != "ws-1" {
+		t.Fatalf("flag-free ready scoped to %s/%s, want the session's workspace", first.Scope, first.ScopeID)
+	}
+
+	move(t, d, "sess-a", a.ID, garden.VerbTend, "", "trellis")
+	move(t, d, "sess-a", a.ID, garden.VerbHarvest, "done", "trellis")
+
+	second := ready(t, d, protocol.SeedReadyMessage{SourceSessionID: protocol.Ptr("sess-a")})
+	if got := readyIDs(second); len(got) != 1 || got[0] != b.ID {
+		t.Fatalf("after harvesting the blocker, ready = %v, want %s", got, b.ID)
+	}
+}
+
+// Readiness is computed per read and carried on the wire, so the panel renders
+// the same answer the CLI gives instead of deriving its own.
+func TestGardenEdges_ReadyRidesTheSeedOnTheWire(t *testing.T) {
+	d := newGardenDaemon(t)
+	var pushed []protocol.Seed
+	d.gardenBroadcastHook = func(seeds []protocol.Seed, _ int) { pushed = seeds }
+
+	blocker := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "blocker"})
+	blocked := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "blocked"})
+	mustLink(t, d, blocker.ID, garden.EdgeBlocks, blocked.ID)
+
+	states := map[string]bool{}
+	for _, seed := range pushed {
+		states[seed.ID] = seed.Ready
+	}
+	if len(pushed) != 2 {
+		t.Fatalf("linking pushed %d seeds, want the whole garden", len(pushed))
+	}
+	if !states[blocker.ID] || states[blocked.ID] {
+		t.Fatalf("the push carries ready=%v, want the blocker ready and the blocked one not", states)
+	}
+}
+
+// An edge is stored on one side, so `show` has to read the garden to answer the
+// other: what blocks this, and what is part of it.
+func TestGardenEdges_ShowListsBothDirections(t *testing.T) {
+	d := newGardenDaemon(t)
+	a := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "first"})
+	b := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "second"})
+	c := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "the plot"})
+	mustLink(t, d, a.ID, garden.EdgeBlocks, b.ID)
+	mustLink(t, d, b.ID, garden.EdgePartOf, c.ID)
+
+	relations := show(t, d, b.ID).Relations
+	got := map[string]string{}
+	for _, relation := range relations {
+		got[relation.Label] = relation.SeedID
+		if relation.Title == "" || relation.Status == "" {
+			t.Fatalf("relation %+v carries no title or status; a bare id is not readable", relation)
+		}
+	}
+	if got[garden.EdgePartOf] != c.ID || got["blocked-by"] != a.ID || len(relations) != 2 {
+		t.Fatalf("show relations = %+v", relations)
+	}
+
+	if got := show(t, d, a.ID).Relations; len(got) != 1 || got[0].Label != garden.EdgeBlocks || got[0].SeedID != b.ID {
+		t.Fatalf("the blocking side reads %+v, want one outbound blocks edge", got)
+	}
+}
+
+func TestGardenEdges_UnlinkPutsTheSeedBack(t *testing.T) {
+	d := newGardenDaemon(t)
+	a := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "first"})
+	b := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "second"})
+	mustLink(t, d, a.ID, garden.EdgeBlocks, b.ID)
+
+	// Linking the same edge twice is not a refusal and not a write: the garden
+	// did not move, and the caller is told so.
+	if again := mustLink(t, d, a.ID, garden.EdgeBlocks, b.ID); again.Changed {
+		t.Fatal("re-linking the same edge reported a change")
+	}
+
+	resp := link(t, d, a.ID, garden.EdgeBlocks, b.ID, true)
+	if !resp.Ok {
+		t.Fatalf("unlink: %v", protocol.Deref(resp.Error))
+	}
+	if len(resp.SeedLinkResult.Seed.Edges) != 0 {
+		t.Fatalf("unlink left %+v", resp.SeedLinkResult.Seed.Edges)
+	}
+	if got := readyIDs(ready(t, d, protocol.SeedReadyMessage{SourceSessionID: protocol.Ptr("sess-a")})); len(got) != 2 {
+		t.Fatalf("after unlinking, ready = %v, want both seeds", got)
+	}
+}
+
+func TestGardenEdges_RefusalsNameBothSeeds(t *testing.T) {
+	d := newGardenDaemon(t)
+	a := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "first"})
+	b := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "second"})
+	mustLink(t, d, a.ID, garden.EdgeBlocks, b.ID)
+
+	cycle := link(t, d, b.ID, garden.EdgeBlocks, a.ID, false)
+	if cycle.Ok {
+		t.Fatal("a blocks cycle was accepted")
+	}
+	// Loud means the caller can fix it without reading the garden: both seeds,
+	// what it would do, and the edge to remove.
+	for _, want := range []string{a.ID, b.ID, "deadlock", "attn seed unlink"} {
+		if !strings.Contains(protocol.Deref(cycle.Error), want) {
+			t.Fatalf("cycle refusal does not name %q: %s", want, protocol.Deref(cycle.Error))
+		}
+	}
+
+	kind := link(t, d, a.ID, "sort-of", b.ID, false)
+	if kind.Ok || !strings.Contains(protocol.Deref(kind.Error), "blocks and part-of") {
+		t.Fatalf("an unknown kind was not refused with the kinds that exist: %+v", kind)
+	}
+
+	missing := link(t, d, a.ID, garden.EdgeBlocks, "s-zzzzzz", false)
+	if missing.Ok || !strings.Contains(protocol.Deref(missing.Error), "s-zzzzzz") {
+		t.Fatalf("an unknown seed was not refused by name: %+v", missing)
+	}
+
+	malformed := link(t, d, a.ID, garden.EdgeBlocks, "nope", false)
+	if malformed.Ok || !strings.Contains(protocol.Deref(malformed.Error), "seed id") {
+		t.Fatalf("a malformed id was not refused by shape: %+v", malformed)
+	}
+
+	stray := link(t, d, a.ID, garden.EdgePartOf, b.ID, true)
+	if stray.Ok || !strings.Contains(protocol.Deref(stray.Error), "does not part-of") {
+		t.Fatalf("unlinking an edge that is not there was not refused: %+v", stray)
+	}
+}
+
+// Two real sessions in two workspaces. The flag-free form is the common one, so
+// what it infers has to be the caller's own workspace and nobody else's.
+func TestGardenEdges_ReadyDiffersPerSessionWorkspace(t *testing.T) {
+	d := newGardenDaemon(t)
+	d.workspaces.register("ws-2", "b", "/tmp/b", "b0", false, false)
+	now := string(protocol.TimestampNow())
+	d.store.Add(&protocol.Session{
+		ID: "sess-b", Label: "b", State: "idle",
+		StateSince: now, StateUpdatedAt: now, LastSeen: now,
+	})
+	d.workspaces.associateSession("sess-b", "ws-2", "b")
+
+	here := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "mine"})
+	there := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-b"), Title: "theirs"})
+
+	mine := ready(t, d, protocol.SeedReadyMessage{SourceSessionID: protocol.Ptr("sess-a")})
+	if got := readyIDs(mine); len(got) != 1 || got[0] != here.ID {
+		t.Fatalf("sess-a ready = %v, want %s", got, here.ID)
+	}
+	theirs := ready(t, d, protocol.SeedReadyMessage{SourceSessionID: protocol.Ptr("sess-b")})
+	if got := readyIDs(theirs); len(got) != 1 || got[0] != there.ID {
+		t.Fatalf("sess-b ready = %v, want %s", got, there.ID)
+	}
+	if theirs.ScopeID != "ws-2" {
+		t.Fatalf("sess-b scoped to %q, want ws-2", theirs.ScopeID)
+	}
+
+	// A blocker in another workspace still blocks: the edge is a property of the
+	// garden, not of the workspace the reader happens to be in.
+	mustLink(t, d, there.ID, garden.EdgeBlocks, here.ID)
+	if got := readyIDs(ready(t, d, protocol.SeedReadyMessage{SourceSessionID: protocol.Ptr("sess-a")})); len(got) != 0 {
+		t.Fatalf("ready = %v, want nothing: the only seed here is blocked from another workspace", got)
+	}
+
+	whole := ready(t, d, protocol.SeedReadyMessage{All: protocol.Ptr(true)})
+	if got := readyIDs(whole); len(got) != 1 || got[0] != there.ID || whole.Scope != "all" {
+		t.Fatalf("--all ready = %v (scope %s), want the blocker", got, whole.Scope)
+	}
+}
+
+func TestGardenEdges_ReadyScopesToAPlot(t *testing.T) {
+	d := newGardenDaemon(t)
+	crown := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "the plot"})
+	inside := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "inside"})
+	deeper := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "deeper"})
+	plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "outside"})
+	mustLink(t, d, inside.ID, garden.EdgePartOf, crown.ID)
+	mustLink(t, d, deeper.ID, garden.EdgePartOf, inside.ID)
+
+	result := ready(t, d, protocol.SeedReadyMessage{Plot: protocol.Ptr(crown.ID)})
+	// The crown and the middle seed both have children, so the leaf is the only
+	// thing in this plot anybody can pick up.
+	if got := readyIDs(result); len(got) != 1 || got[0] != deeper.ID {
+		t.Fatalf("plot ready = %v, want the one leaf %s", got, deeper.ID)
+	}
+	if result.Scope != "plot" || result.ScopeID != crown.ID {
+		t.Fatalf("plot scope = %s/%s", result.Scope, result.ScopeID)
+	}
+
+	missing := gardenCall(t, func(c net.Conn) {
+		d.handleSeedReady(c, &protocol.SeedReadyMessage{Cmd: protocol.CmdSeedReady, Plot: protocol.Ptr("s-zzzzzz")})
+	})
+	if missing.Ok || !strings.Contains(protocol.Deref(missing.Error), "s-zzzzzz") {
+		t.Fatalf("an unknown plot was not refused by name: %+v", missing)
+	}
+}
+
+// Oldest first, against the newest-first order every other read uses: ready is a
+// work queue, and the seed that has waited longest is the one to hand over.
+func TestGardenEdges_ReadyHandsOverTheOldestFirst(t *testing.T) {
+	d := newGardenDaemon(t)
+	first := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "waited longest"})
+	second := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "just planted"})
+
+	got := readyIDs(ready(t, d, protocol.SeedReadyMessage{SourceSessionID: protocol.Ptr("sess-a")}))
+	if len(got) != 2 || got[0] != first.ID || got[1] != second.ID {
+		t.Fatalf("ready order = %v, want %s before %s", got, first.ID, second.ID)
+	}
+}
+
+// A tender holds its seed only while its session is one the daemon knows. A
+// session that is gone must not park work forever.
+func TestGardenEdges_ReadyReleasesASeedWhoseSessionIsGone(t *testing.T) {
+	d := newGardenDaemon(t)
+	addGardenSession(t, d, "sess-b")
+	seed := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "held"})
+	move(t, d, "sess-b", seed.ID, garden.VerbTend, "", "")
+
+	if got := readyIDs(ready(t, d, protocol.SeedReadyMessage{SourceSessionID: protocol.Ptr("sess-a")})); len(got) != 0 {
+		t.Fatalf("ready = %v, want nothing: a live session holds the seed", got)
+	}
+
+	d.store.Remove("sess-b")
+	if got := readyIDs(ready(t, d, protocol.SeedReadyMessage{SourceSessionID: protocol.Ptr("sess-a")})); len(got) != 1 {
+		t.Fatalf("ready = %v, want the seed back once its session is gone", got)
+	}
+}
+
+// The count an agent is primed with at launch is the same answer `attn seed
+// ready` gives with no flags — one computation, so guidance and the CLI cannot
+// drift apart.
+func TestGardenEdges_LaunchPrimerCountsTheSameReady(t *testing.T) {
+	d := newGardenDaemon(t)
+	a := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "first"})
+	b := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "second"})
+	mustLink(t, d, a.ID, garden.EdgeBlocks, b.ID)
+
+	count, err := d.gardenReadyCount("ws-1")
+	if err != nil {
+		t.Fatalf("gardenReadyCount: %v", err)
+	}
+	if want := len(ready(t, d, protocol.SeedReadyMessage{SourceSessionID: protocol.Ptr("sess-a")}).Seeds); count != want {
+		t.Fatalf("primer count = %d, want %d", count, want)
+	}
+	if count != 1 {
+		t.Fatalf("primer count = %d, want 1", count)
+	}
+}
+
+// An outpost has no garden, so it must not answer these two either — and the
+// primer must hand a launching agent nothing rather than a loop it cannot run.
+func TestGardenEdges_OutpostRefusesLinkAndReady(t *testing.T) {
+	d := newEnrolledDaemon(t, "d-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	t.Cleanup(d.stopEventBus)
+	d.ensureGardenCollections()
+
+	if resp := link(t, d, "s-7k3f9m", garden.EdgeBlocks, "s-7k3f9n", false); resp.Ok {
+		t.Fatal("seed link answered on an outpost")
+	}
+	resp := gardenCall(t, func(c net.Conn) {
+		d.handleSeedReady(c, &protocol.SeedReadyMessage{Cmd: protocol.CmdSeedReady, All: protocol.Ptr(true)})
+	})
+	if resp.Ok || !strings.Contains(protocol.Deref(resp.Error), garden.Surface) {
+		t.Fatalf("seed ready on an outpost: %+v", resp)
+	}
+	if primer := d.gardenReadyForLaunch("ws-1"); primer != nil {
+		t.Fatalf("an outpost primed a launching agent with %d ready seeds", *primer)
+	}
+}

--- a/internal/daemon/plugin_launch_instructions.go
+++ b/internal/daemon/plugin_launch_instructions.go
@@ -33,13 +33,16 @@ func (d *Daemon) preparePluginLaunchInstructions(sessionID, workspaceID string, 
 		if err != nil {
 			return nil, rollback, fmt.Errorf("prepare chief notebook: %w", err)
 		}
-		content := hooks.ChiefGuidance(root, d.sessionHasSelfMonitor(sessionID))
-		if strings.TrimSpace(content) == "" {
+		if strings.TrimSpace(root) == "" {
 			return nil, rollback, fmt.Errorf("prepare chief guidance: notebook root is empty")
 		}
 		return &pluginLaunchInstructions{
-			Kind:         pluginInstructionKindChief,
-			Content:      content,
+			Kind: pluginInstructionKindChief,
+			Content: hooks.Launch{
+				NotebookRoot:   root,
+				HasSelfMonitor: d.sessionHasSelfMonitor(sessionID),
+				GardenReady:    d.gardenReadyForLaunch(workspaceID),
+			}.Instructions(),
 			WorkspaceID:  workspaceID,
 			NotebookRoot: root,
 		}, rollback, nil
@@ -61,10 +64,25 @@ func (d *Daemon) preparePluginLaunchInstructions(sessionID, workspaceID string, 
 		rollback = func() { _ = os.RemoveAll(workspaceContextCheckoutDir(d.dataRoot, sessionID)) }
 	}
 	return &pluginLaunchInstructions{
-		Kind:            pluginInstructionKindWorkspace,
-		Content:         hooks.AgentInstructions(result.Path, parseBooleanSetting(d.store.GetSetting(SettingWorkflowsEnabled))),
+		Kind: pluginInstructionKindWorkspace,
+		Content: hooks.Launch{
+			WorkspaceContextPath: result.Path,
+			InjectWorkflow:       parseBooleanSetting(d.store.GetSetting(SettingWorkflowsEnabled)),
+			GardenReady:          d.gardenReadyForLaunch(workspaceID),
+		}.Instructions(),
 		WorkspaceID:     workspaceID,
 		ContextPath:     result.Path,
 		ContextRevision: result.CanonicalRevision,
 	}, rollback, nil
+}
+
+// gardenReadyForLaunch is the ready count a launching agent is primed with, or
+// nil when this daemon has no garden to prime from — an outpost, where every
+// seed command refuses, must not hand its agents a loop they cannot run.
+func (d *Daemon) gardenReadyForLaunch(workspaceID string) *int {
+	count, err := d.gardenReadyCount(workspaceID)
+	if err != nil {
+		return nil
+	}
+	return &count
 }

--- a/internal/garden/edges.go
+++ b/internal/garden/edges.go
@@ -1,0 +1,414 @@
+package garden
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// Edges are the garden's structure and `ready` is the question they answer:
+// what can be tended right now. Both are pure functions over a set of seeds, so
+// the whole rule set is one readable table and one table-driven test; the daemon
+// reads the garden, calls in here, and writes back what it is handed.
+
+// Edge kinds. `blocks` and `part-of` are the two a caller may link; the others
+// are declared so a body written by a later slice stays readable, and so a kind
+// that arrives later is additive rather than a migration.
+const (
+	EdgeBlocks         = "blocks"
+	EdgePartOf         = "part-of"
+	EdgeSownFrom       = "sown-from"
+	EdgeDiscoveredFrom = "discovered-from"
+	EdgeRelatesTo      = "relates-to"
+)
+
+// LinkableKinds is what `attn seed link` accepts, in the order a refusal lists
+// them.
+var LinkableKinds = []string{EdgeBlocks, EdgePartOf}
+
+// ParseEdgeKind reads a kind off the command line, naming the whole set when it
+// is not one — including the kinds that exist in the schema but cannot be
+// linked yet, so a caller reading the type list is not told they do not exist.
+func ParseEdgeKind(raw string) (string, error) {
+	kind := strings.TrimSpace(strings.ToLower(raw))
+	if slices.Contains(LinkableKinds, kind) {
+		return kind, nil
+	}
+	if slices.Contains([]string{EdgeSownFrom, EdgeDiscoveredFrom, EdgeRelatesTo}, kind) {
+		return "", fmt.Errorf("%q is a real edge kind but nothing links one yet; the kinds you can link are %s",
+			kind, strings.Join(LinkableKinds, " and "))
+	}
+	return "", fmt.Errorf("%q is not how two seeds relate; the kinds are %s", raw, strings.Join(LinkableKinds, " and "))
+}
+
+// Link adds one edge to from and hands back the seed as it should be stored. The
+// second return is false when the edge was already there — nothing to write, and
+// the caller says so rather than publishing a fact about a garden that did not
+// move.
+//
+// seeds is the whole garden because a cycle is a property of the graph and not
+// of the two seeds named: `a blocks b` is legal until b already blocks a through
+// any chain.
+func Link(seeds []Seed, fromID, kind, toID string) (Seed, bool, error) {
+	from, to, err := linkEnds(seeds, fromID, kind, toID)
+	if err != nil {
+		return Seed{}, false, err
+	}
+	if slices.Contains(from.Edges, Edge{Kind: kind, To: to.ID}) {
+		return from, false, nil
+	}
+	if kind == EdgePartOf {
+		if parent, ok := parentOf(from); ok {
+			return Seed{}, false, fmt.Errorf(
+				"%s is already part of %s, and a seed sits in one plot: `attn seed unlink %s part-of %s` first, then link it to %s",
+				from.ID, parent, from.ID, parent, to.ID)
+		}
+	}
+	if path := reaches(seeds, to.ID, kind, from.ID); len(path) > 0 {
+		return Seed{}, false, cycleRefusal(from.ID, kind, to.ID, path)
+	}
+	next := from
+	next.Edges = append(slices.Clone(from.Edges), Edge{Kind: kind, To: to.ID})
+	return next, true, nil
+}
+
+// Unlink removes one edge, refusing when it is not there and naming what the
+// seed is actually linked to — an unlink that silently does nothing reads as a
+// removal that happened.
+func Unlink(seeds []Seed, fromID, kind, toID string) (Seed, error) {
+	from, to, err := linkEnds(seeds, fromID, kind, toID)
+	if err != nil {
+		return Seed{}, err
+	}
+	edge := Edge{Kind: kind, To: to.ID}
+	index := slices.Index(from.Edges, edge)
+	if index < 0 {
+		return Seed{}, fmt.Errorf("%s does not %s %s%s", from.ID, kind, to.ID, edgeInventory(from))
+	}
+	next := from
+	next.Edges = slices.Delete(slices.Clone(from.Edges), index, index+1)
+	return next, nil
+}
+
+// linkEnds resolves both ends of a link and refuses the two ways a pair of ids
+// cannot be one.
+func linkEnds(seeds []Seed, fromID, kind, toID string) (Seed, Seed, error) {
+	from, ok := find(seeds, fromID)
+	if !ok {
+		return Seed{}, Seed{}, fmt.Errorf("no seed %s is planted here; `attn seed ls --all` lists the garden", fromID)
+	}
+	to, ok := find(seeds, toID)
+	if !ok {
+		return Seed{}, Seed{}, fmt.Errorf("no seed %s is planted here; `attn seed ls --all` lists the garden", toID)
+	}
+	if from.ID == to.ID {
+		return Seed{}, Seed{}, fmt.Errorf("%s cannot %s itself", from.ID, kind)
+	}
+	return from, to, nil
+}
+
+// edgeInventory renders what a seed is linked to, for a refusal that would
+// otherwise leave the caller guessing which edge they meant.
+func edgeInventory(seed Seed) string {
+	if len(seed.Edges) == 0 {
+		return "; it has no edges at all"
+	}
+	rendered := make([]string, 0, len(seed.Edges))
+	for _, edge := range seed.Edges {
+		rendered = append(rendered, fmt.Sprintf("%s %s", edge.Kind, edge.To))
+	}
+	return fmt.Sprintf("; it is linked %s", strings.Join(rendered, ", "))
+}
+
+// cycleRefusal names both seeds, the chain that already runs between them, and
+// the edge to remove. A cycle in `blocks` is a deadlock — neither seed ever
+// becomes ready — and a cycle in `part-of` is a plot inside itself.
+func cycleRefusal(fromID, kind, toID string, path []string) error {
+	chain := strings.Join(append([]string{toID}, path...), " → ")
+	if kind == EdgePartOf {
+		return fmt.Errorf(
+			"%s is already inside %s (%s), so making %s part of %s would put the plot inside itself.\n"+
+				"Unlink an edge in that chain first: attn seed unlink %s part-of %s",
+			toID, fromID, chain, fromID, toID, toID, path[0])
+	}
+	return fmt.Errorf(
+		"%s already blocks %s (%s), so %s blocking %s would deadlock them — neither would ever be ready.\n"+
+			"Unlink an edge in that chain first: attn seed unlink %s blocks %s",
+		toID, fromID, chain, fromID, toID, toID, path[0])
+}
+
+// reaches walks edges of one kind from start and returns the rest of the path to
+// target, or nil when there is none. The visited set is what keeps a body that
+// already carries a cycle from looping here forever.
+func reaches(seeds []Seed, start, kind, target string) []string {
+	index := byID(seeds)
+	visited := map[string]bool{start: true}
+	var walk func(id string) []string
+	walk = func(id string) []string {
+		for _, edge := range index[id].Edges {
+			if edge.Kind != kind {
+				continue
+			}
+			if edge.To == target {
+				return []string{target}
+			}
+			if visited[edge.To] {
+				continue
+			}
+			visited[edge.To] = true
+			if rest := walk(edge.To); rest != nil {
+				return append([]string{edge.To}, rest...)
+			}
+		}
+		return nil
+	}
+	return walk(start)
+}
+
+// Ready reports which seeds can be tended right now, in the order they were
+// given. Truth at query time: nothing is stored, so harvesting a blocker makes
+// its dependent ready at the next call.
+//
+// A seed is ready when it is open (not closed, not parked), nothing is part of
+// it — a crown's work is its children, not the crown — no unclosed seed blocks
+// it, it is neither a packet nor under one, it is not a gate (a gate wants a
+// person and opens a turn, which is its own later slice), and no live tender
+// holds it.
+//
+// sessionLive answers whether a tender's session is still one the daemon knows.
+// A tender that names only a crew member is always held: attn has no signal that
+// a person in a terminal pane walked away, and handing their seed to somebody
+// else on a guess is worse than leaving it claimed.
+func Ready(seeds []Seed, sessionLive func(sessionID string) bool) []Seed {
+	index := byID(seeds)
+	blocked := blockedIDs(seeds)
+	parents := parentIDs(seeds)
+	ready := make([]Seed, 0, len(seeds))
+	for _, seed := range seeds {
+		switch {
+		case Closed(seed.Status), seed.Status == StatusDormant:
+			continue
+		case parents[seed.ID], blocked[seed.ID], seed.Gate:
+			continue
+		case underTemplate(index, seed):
+			continue
+		}
+		if held := seed.Tender(); held.Named() {
+			if held.Session == "" || sessionLive(held.Session) {
+				continue
+			}
+		}
+		ready = append(ready, seed)
+	}
+	return ready
+}
+
+// Blockers names the unclosed seeds that block one seed, in the order they were
+// given. It is what a surface renders beside a seed that is not ready.
+func Blockers(seeds []Seed, id string) []string {
+	out := []string{}
+	for _, seed := range seeds {
+		if Closed(seed.Status) {
+			continue
+		}
+		for _, edge := range seed.Edges {
+			if edge.Kind == EdgeBlocks && edge.To == id {
+				out = append(out, seed.ID)
+			}
+		}
+	}
+	return out
+}
+
+// InPlot is the seeds of one plot: its crown and everything part-of it,
+// transitively. The crown itself is included — it is a seed like any other, and
+// the readiness rules decide what a caller may tend.
+func InPlot(seeds []Seed, crownID string) []Seed {
+	inside := map[string]bool{crownID: true}
+	// Repeat until nothing new joins: a child may be listed before its parent,
+	// and one pass would then miss the grandchildren.
+	for grew := true; grew; {
+		grew = false
+		for _, seed := range seeds {
+			if inside[seed.ID] {
+				continue
+			}
+			if parent, ok := parentOf(seed); ok && inside[parent] {
+				inside[seed.ID] = true
+				grew = true
+			}
+		}
+	}
+	out := make([]Seed, 0, len(inside))
+	for _, seed := range seeds {
+		if inside[seed.ID] {
+			out = append(out, seed)
+		}
+	}
+	return out
+}
+
+// Relation is one edge as it reads from a seed's own point of view: outbound as
+// it is stored, inbound named the other way round, so `show` answers both "what
+// does this block" and "what blocks this".
+type Relation struct {
+	Label string
+	Seed  string
+}
+
+// Inbound labels. Only the two linkable kinds have a name from the other side;
+// anything else is reported as inbound rather than given a word this repo does
+// not use yet.
+var inboundLabels = map[string]string{
+	EdgeBlocks: "blocked-by",
+	EdgePartOf: "has-part",
+}
+
+func inboundLabel(kind string) string {
+	if label, ok := inboundLabels[kind]; ok {
+		return label
+	}
+	return "inbound " + kind
+}
+
+// Relations lists one seed's edges in both directions, outbound first.
+func Relations(seeds []Seed, id string) []Relation {
+	out := []Relation{}
+	if seed, ok := find(seeds, id); ok {
+		for _, edge := range seed.Edges {
+			out = append(out, Relation{Label: edge.Kind, Seed: edge.To})
+		}
+	}
+	for _, seed := range seeds {
+		if seed.ID == id {
+			continue
+		}
+		for _, edge := range seed.Edges {
+			if edge.To == id {
+				out = append(out, Relation{Label: inboundLabel(edge.Kind), Seed: seed.ID})
+			}
+		}
+	}
+	return out
+}
+
+// TreeRow is one line of `attn seed ls --tree`: a seed and how deep it sits
+// under its crown.
+type TreeRow struct {
+	Seed  Seed
+	Depth int
+}
+
+// Tree orders seeds by the `part-of` hierarchy, parents before their children,
+// keeping the given order within each level. A seed whose parent is not in the
+// list renders at the top: a scoped list must show everything it holds, even a
+// child whose crown lives in another workspace.
+func Tree(seeds []Seed) []TreeRow {
+	children := map[string][]Seed{}
+	roots := make([]Seed, 0, len(seeds))
+	present := byID(seeds)
+	for _, seed := range seeds {
+		parent, ok := parentOf(seed)
+		if _, inScope := present[parent]; ok && inScope {
+			children[parent] = append(children[parent], seed)
+			continue
+		}
+		roots = append(roots, seed)
+	}
+	rows := make([]TreeRow, 0, len(seeds))
+	placed := map[string]bool{}
+	var place func(seed Seed, depth int)
+	place = func(seed Seed, depth int) {
+		// A stored cycle would otherwise recurse forever; the seeds it holds are
+		// then unreachable from any root and land at the end of the list.
+		if placed[seed.ID] {
+			return
+		}
+		placed[seed.ID] = true
+		rows = append(rows, TreeRow{Seed: seed, Depth: depth})
+		for _, child := range children[seed.ID] {
+			place(child, depth+1)
+		}
+	}
+	for _, root := range roots {
+		place(root, 0)
+	}
+	for _, seed := range seeds {
+		place(seed, 0)
+	}
+	return rows
+}
+
+// parentOf is the seed's crown, if it sits in a plot. A seed has at most one:
+// Link refuses the second.
+func parentOf(seed Seed) (string, bool) {
+	for _, edge := range seed.Edges {
+		if edge.Kind == EdgePartOf {
+			return edge.To, true
+		}
+	}
+	return "", false
+}
+
+// underTemplate reports whether a seed is a packet or lives inside one — a
+// packet's subtree is a shape waiting to be sown, not work anybody tends.
+func underTemplate(index map[string]Seed, seed Seed) bool {
+	seen := map[string]bool{}
+	for {
+		if seed.Template {
+			return true
+		}
+		parent, ok := parentOf(seed)
+		if !ok || seen[parent] {
+			return false
+		}
+		seen[parent] = true
+		seed, ok = index[parent]
+		if !ok {
+			return false
+		}
+	}
+}
+
+func blockedIDs(seeds []Seed) map[string]bool {
+	blocked := map[string]bool{}
+	for _, seed := range seeds {
+		if Closed(seed.Status) {
+			continue
+		}
+		for _, edge := range seed.Edges {
+			if edge.Kind == EdgeBlocks {
+				blocked[edge.To] = true
+			}
+		}
+	}
+	return blocked
+}
+
+// parentIDs is every seed something is part of — the crowns.
+func parentIDs(seeds []Seed) map[string]bool {
+	parents := map[string]bool{}
+	for _, seed := range seeds {
+		if parent, ok := parentOf(seed); ok {
+			parents[parent] = true
+		}
+	}
+	return parents
+}
+
+func byID(seeds []Seed) map[string]Seed {
+	index := make(map[string]Seed, len(seeds))
+	for _, seed := range seeds {
+		index[seed.ID] = seed
+	}
+	return index
+}
+
+func find(seeds []Seed, id string) (Seed, bool) {
+	for _, seed := range seeds {
+		if seed.ID == id {
+			return seed, true
+		}
+	}
+	return Seed{}, false
+}

--- a/internal/garden/edges_test.go
+++ b/internal/garden/edges_test.go
@@ -1,0 +1,464 @@
+package garden
+
+import (
+	"strings"
+	"testing"
+)
+
+// seedWith is the shorthand every table below builds rows from: an open,
+// unheld, workspace-less seed that a case then bends.
+func seedWith(id string, edges ...Edge) Seed {
+	return Seed{ID: id, Title: id, Status: StatusPlanted, Edges: edges}
+}
+
+func blocks(to string) Edge { return Edge{Kind: EdgeBlocks, To: to} }
+func partOf(to string) Edge { return Edge{Kind: EdgePartOf, To: to} }
+func ids(seeds []Seed) []string {
+	out := make([]string, 0, len(seeds))
+	for _, seed := range seeds {
+		out = append(out, seed.ID)
+	}
+	return out
+}
+
+func equal(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// noSession is the liveness answer for a garden whose tenders name no session.
+func noSession(string) bool { return false }
+
+// Ready is the whole point of edges: what can be tended right now, answered at
+// query time so harvesting a blocker frees its dependent with nobody clearing
+// anything.
+func TestReady(t *testing.T) {
+	held := func(seed Seed, session, member string) Seed {
+		seed.Status = StatusGrowing
+		seed.TenderSession = session
+		seed.TenderMember = member
+		return seed
+	}
+
+	tests := []struct {
+		name  string
+		seeds []Seed
+		live  func(string) bool
+		want  []string
+	}{
+		{
+			name:  "a plain planted seed is ready",
+			seeds: []Seed{seedWith("s-a")},
+			want:  []string{"s-a"},
+		},
+		{
+			name:  "an unclosed blocker holds its dependent back",
+			seeds: []Seed{seedWith("s-a", blocks("s-b")), seedWith("s-b")},
+			want:  []string{"s-a"},
+		},
+		{
+			name: "harvesting the blocker surfaces the dependent",
+			seeds: []Seed{
+				func() Seed { s := seedWith("s-a", blocks("s-b")); s.Status = StatusHarvested; return s }(),
+				seedWith("s-b"),
+			},
+			want: []string{"s-b"},
+		},
+		{
+			name: "a withered blocker stops blocking too",
+			seeds: []Seed{
+				func() Seed { s := seedWith("s-a", blocks("s-b")); s.Status = StatusWithered; return s }(),
+				seedWith("s-b"),
+			},
+			want: []string{"s-b"},
+		},
+		{
+			name: "a parked blocker still blocks — parking is a pause, not an answer",
+			seeds: []Seed{
+				func() Seed { s := seedWith("s-a", blocks("s-b")); s.Status = StatusDormant; return s }(),
+				seedWith("s-b"),
+			},
+			want: []string{},
+		},
+		{
+			name:  "every blocker must go, not just one",
+			seeds: []Seed{seedWith("s-a", blocks("s-c")), seedWith("s-b", blocks("s-c")), seedWith("s-c")},
+			want:  []string{"s-a", "s-b"},
+		},
+		{
+			name:  "a crown is not ready — its work is its children",
+			seeds: []Seed{seedWith("s-child", partOf("s-crown")), seedWith("s-crown")},
+			want:  []string{"s-child"},
+		},
+		{
+			name: "a crown stays out of ready when its children close: it is finished by harvesting it, not by tending it",
+			seeds: []Seed{
+				func() Seed { s := seedWith("s-child", partOf("s-crown")); s.Status = StatusHarvested; return s }(),
+				seedWith("s-crown"),
+			},
+			want: []string{},
+		},
+		{
+			name:  "the chain the plan names: A blocks B, B part-of C leaves only A",
+			seeds: []Seed{seedWith("s-a", blocks("s-b")), seedWith("s-b", partOf("s-c")), seedWith("s-c")},
+			want:  []string{"s-a"},
+		},
+		{
+			name:  "a closed seed is never ready",
+			seeds: []Seed{func() Seed { s := seedWith("s-a"); s.Status = StatusHarvested; return s }()},
+			want:  []string{},
+		},
+		{
+			name:  "a parked seed is never ready",
+			seeds: []Seed{func() Seed { s := seedWith("s-a"); s.Status = StatusDormant; return s }()},
+			want:  []string{},
+		},
+		{
+			name:  "a gate wants a person, not an agent picking up work",
+			seeds: []Seed{func() Seed { s := seedWith("s-a"); s.Gate = true; return s }()},
+			want:  []string{},
+		},
+		{
+			name:  "a packet is a shape waiting to be sown",
+			seeds: []Seed{func() Seed { s := seedWith("s-a"); s.Template = true; return s }()},
+			want:  []string{},
+		},
+		{
+			name: "a seed under a packet is not work either",
+			seeds: []Seed{
+				func() Seed { s := seedWith("s-packet"); s.Template = true; return s }(),
+				seedWith("s-step", partOf("s-packet")),
+			},
+			want: []string{},
+		},
+		{
+			name:  "a live session holds its seed",
+			seeds: []Seed{held(seedWith("s-a"), "sess-1", "")},
+			live:  func(id string) bool { return id == "sess-1" },
+			want:  []string{},
+		},
+		{
+			name:  "a session the daemon no longer knows releases its seed",
+			seeds: []Seed{held(seedWith("s-a"), "sess-gone", "")},
+			live:  func(string) bool { return false },
+			want:  []string{"s-a"},
+		},
+		{
+			name:  "a member-only tender always holds: attn cannot tell that a person walked away",
+			seeds: []Seed{held(seedWith("s-a"), "", "victor")},
+			live:  func(string) bool { return false },
+			want:  []string{},
+		},
+		{
+			name:  "a stale tender name on an untended seed does not hold it",
+			seeds: []Seed{seedWith("s-a")},
+			want:  []string{"s-a"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			live := test.live
+			if live == nil {
+				live = noSession
+			}
+			got := ids(Ready(test.seeds, live))
+			if !equal(got, test.want) {
+				t.Fatalf("Ready = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+// A cycle is a property of the graph, not of the pair being linked, so the
+// refusal has to walk it — and say enough that the caller can undo it.
+func TestLinkRefusals(t *testing.T) {
+	tests := []struct {
+		name    string
+		seeds   []Seed
+		from    string
+		kind    string
+		to      string
+		wants   []string
+		changed bool
+		ok      bool
+	}{
+		{
+			name:  "a first edge is written",
+			seeds: []Seed{seedWith("s-a"), seedWith("s-b")},
+			from:  "s-a", kind: EdgeBlocks, to: "s-b",
+			changed: true, ok: true,
+		},
+		{
+			name:  "the same edge twice writes nothing",
+			seeds: []Seed{seedWith("s-a", blocks("s-b")), seedWith("s-b")},
+			from:  "s-a", kind: EdgeBlocks, to: "s-b",
+			changed: false, ok: true,
+		},
+		{
+			name:  "a seed cannot block itself",
+			seeds: []Seed{seedWith("s-a")},
+			from:  "s-a", kind: EdgeBlocks, to: "s-a",
+			wants: []string{"s-a", "cannot"},
+		},
+		{
+			name:  "an unknown seed is named, with the way to list the garden",
+			seeds: []Seed{seedWith("s-a")},
+			from:  "s-a", kind: EdgeBlocks, to: "s-nope",
+			wants: []string{"s-nope", "attn seed ls --all"},
+		},
+		{
+			name:  "a direct blocks cycle names both seeds and the way out",
+			seeds: []Seed{seedWith("s-a"), seedWith("s-b", blocks("s-a"))},
+			from:  "s-a", kind: EdgeBlocks, to: "s-b",
+			wants: []string{"s-a", "s-b", "deadlock", "attn seed unlink s-b blocks s-a"},
+		},
+		{
+			name: "an indirect blocks cycle names the chain it found",
+			seeds: []Seed{
+				seedWith("s-a"),
+				seedWith("s-b", blocks("s-c")),
+				seedWith("s-c", blocks("s-a")),
+			},
+			from: "s-a", kind: EdgeBlocks, to: "s-b",
+			wants: []string{"s-b → s-c → s-a", "attn seed unlink s-b blocks s-c"},
+		},
+		{
+			name:  "a part-of cycle is a plot inside itself",
+			seeds: []Seed{seedWith("s-crown", partOf("s-a")), seedWith("s-a")},
+			from:  "s-a", kind: EdgePartOf, to: "s-crown",
+			wants: []string{"plot inside itself", "attn seed unlink s-crown part-of s-a"},
+		},
+		{
+			name:  "a second plot is refused, naming the one it is in",
+			seeds: []Seed{seedWith("s-a", partOf("s-one")), seedWith("s-one"), seedWith("s-two")},
+			from:  "s-a", kind: EdgePartOf, to: "s-two",
+			wants: []string{"already part of s-one", "attn seed unlink s-a part-of s-one", "s-two"},
+		},
+		{
+			name:  "blocking in both directions is fine when it is not a cycle",
+			seeds: []Seed{seedWith("s-a", blocks("s-b")), seedWith("s-b"), seedWith("s-c")},
+			from:  "s-a", kind: EdgeBlocks, to: "s-c",
+			changed: true, ok: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			seed, changed, err := Link(test.seeds, test.from, test.kind, test.to)
+			if !test.ok {
+				if err == nil {
+					t.Fatalf("Link succeeded, want a refusal naming %v", test.wants)
+				}
+				for _, want := range test.wants {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("refusal %q does not name %q", err, want)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Link: %v", err)
+			}
+			if changed != test.changed {
+				t.Fatalf("changed = %v, want %v", changed, test.changed)
+			}
+			if test.changed && !hasEdge(seed, test.kind, test.to) {
+				t.Fatalf("edge %s %s missing from %v", test.kind, test.to, seed.Edges)
+			}
+		})
+	}
+}
+
+func hasEdge(seed Seed, kind, to string) bool {
+	for _, edge := range seed.Edges {
+		if edge.Kind == kind && edge.To == to {
+			return true
+		}
+	}
+	return false
+}
+
+// Link must not mutate the garden it was handed: the daemon writes back only the
+// seed it gets, and an in-place append would silently edit the read set.
+func TestLinkLeavesTheGardenAlone(t *testing.T) {
+	seeds := []Seed{seedWith("s-a", blocks("s-x")), seedWith("s-b")}
+	if _, _, err := Link(seeds, "s-a", EdgeBlocks, "s-b"); err != nil {
+		t.Fatalf("Link: %v", err)
+	}
+	if len(seeds[0].Edges) != 1 {
+		t.Fatalf("the source seed grew an edge: %v", seeds[0].Edges)
+	}
+}
+
+func TestUnlink(t *testing.T) {
+	seeds := []Seed{seedWith("s-a", blocks("s-b"), partOf("s-c")), seedWith("s-b"), seedWith("s-c")}
+
+	next, err := Unlink(seeds, "s-a", EdgeBlocks, "s-b")
+	if err != nil {
+		t.Fatalf("Unlink: %v", err)
+	}
+	if hasEdge(next, EdgeBlocks, "s-b") || !hasEdge(next, EdgePartOf, "s-c") {
+		t.Fatalf("Unlink removed the wrong edge: %v", next.Edges)
+	}
+	if len(seeds[0].Edges) != 2 {
+		t.Fatalf("Unlink edited the garden it read: %v", seeds[0].Edges)
+	}
+
+	// An unlink that silently does nothing reads as a removal that happened, so
+	// the refusal has to say what the seed is actually linked to.
+	_, err = Unlink(seeds, "s-b", EdgeBlocks, "s-c")
+	if err == nil {
+		t.Fatal("unlinking an edge that is not there succeeded")
+	}
+	for _, want := range []string{"s-b does not blocks s-c", "no edges at all"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal %q does not name %q", err, want)
+		}
+	}
+}
+
+func TestParseEdgeKind(t *testing.T) {
+	if kind, err := ParseEdgeKind(" BLOCKS "); err != nil || kind != EdgeBlocks {
+		t.Fatalf("ParseEdgeKind(BLOCKS) = %q, %v", kind, err)
+	}
+	// A kind the schema knows but nothing links yet must not read as a typo.
+	_, err := ParseEdgeKind(EdgeRelatesTo)
+	if err == nil || !strings.Contains(err.Error(), "real edge kind") {
+		t.Fatalf("relates-to refusal = %v", err)
+	}
+	_, err = ParseEdgeKind("blokcs")
+	if err == nil || !strings.Contains(err.Error(), "blocks and part-of") {
+		t.Fatalf("typo refusal = %v", err)
+	}
+}
+
+// Tree is what `attn seed ls --tree` renders: parents before children, and
+// nothing dropped — a scoped list holds children whose crown is out of scope,
+// and a garden that already stored a cycle still has to render.
+func TestTree(t *testing.T) {
+	tests := []struct {
+		name   string
+		seeds  []Seed
+		rows   []string
+		depths []int
+	}{
+		{
+			name:   "children follow their crown",
+			seeds:  []Seed{seedWith("s-crown"), seedWith("s-one", partOf("s-crown")), seedWith("s-two", partOf("s-crown"))},
+			rows:   []string{"s-crown", "s-one", "s-two"},
+			depths: []int{0, 1, 1},
+		},
+		{
+			name:   "a child listed before its crown still lands under it",
+			seeds:  []Seed{seedWith("s-child", partOf("s-crown")), seedWith("s-crown")},
+			rows:   []string{"s-crown", "s-child"},
+			depths: []int{0, 1},
+		},
+		{
+			name: "depth follows the chain",
+			seeds: []Seed{
+				seedWith("s-crown"),
+				seedWith("s-mid", partOf("s-crown")),
+				seedWith("s-leaf", partOf("s-mid")),
+			},
+			rows:   []string{"s-crown", "s-mid", "s-leaf"},
+			depths: []int{0, 1, 2},
+		},
+		{
+			name:   "a child whose crown is out of scope renders at the top rather than vanishing",
+			seeds:  []Seed{seedWith("s-child", partOf("s-elsewhere"))},
+			rows:   []string{"s-child"},
+			depths: []int{0},
+		},
+		{
+			name:   "a stored cycle renders instead of recursing forever",
+			seeds:  []Seed{seedWith("s-a", partOf("s-b")), seedWith("s-b", partOf("s-a"))},
+			rows:   []string{"s-a", "s-b"},
+			depths: []int{0, 1},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rows := Tree(test.seeds)
+			got := make([]string, 0, len(rows))
+			depths := make([]int, 0, len(rows))
+			for _, row := range rows {
+				got = append(got, row.Seed.ID)
+				depths = append(depths, row.Depth)
+			}
+			if !equal(got, test.rows) {
+				t.Fatalf("Tree = %v, want %v", got, test.rows)
+			}
+			for i := range depths {
+				if depths[i] != test.depths[i] {
+					t.Fatalf("depths = %v, want %v", depths, test.depths)
+				}
+			}
+		})
+	}
+}
+
+func TestInPlot(t *testing.T) {
+	seeds := []Seed{
+		seedWith("s-leaf", partOf("s-mid")),
+		seedWith("s-mid", partOf("s-crown")),
+		seedWith("s-crown"),
+		seedWith("s-outside"),
+	}
+	got := ids(InPlot(seeds, "s-crown"))
+	if !equal(got, []string{"s-leaf", "s-mid", "s-crown"}) {
+		t.Fatalf("InPlot = %v", got)
+	}
+	if got := ids(InPlot(seeds, "s-outside")); !equal(got, []string{"s-outside"}) {
+		t.Fatalf("InPlot(leaf crown) = %v", got)
+	}
+}
+
+// `show` answers both directions, because an edge is stored on one side only and
+// the seed being read is as often the other one.
+func TestRelations(t *testing.T) {
+	seeds := []Seed{
+		seedWith("s-a", blocks("s-b")),
+		seedWith("s-b", partOf("s-c")),
+		seedWith("s-c"),
+	}
+	got := Relations(seeds, "s-b")
+	want := []Relation{
+		{Label: EdgePartOf, Seed: "s-c"},
+		{Label: "blocked-by", Seed: "s-a"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("Relations = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("Relations = %v, want %v", got, want)
+		}
+	}
+	if got := Relations(seeds, "s-c"); len(got) != 1 || got[0] != (Relation{Label: "has-part", Seed: "s-b"}) {
+		t.Fatalf("Relations(crown) = %v", got)
+	}
+}
+
+func TestBlockers(t *testing.T) {
+	seeds := []Seed{
+		seedWith("s-a", blocks("s-c")),
+		func() Seed { s := seedWith("s-b", blocks("s-c")); s.Status = StatusHarvested; return s }(),
+		seedWith("s-c"),
+	}
+	if got := Blockers(seeds, "s-c"); !equal(got, []string{"s-a"}) {
+		t.Fatalf("Blockers = %v, want [s-a]", got)
+	}
+	if got := Blockers(seeds, "s-a"); len(got) != 0 {
+		t.Fatalf("Blockers(unblocked) = %v", got)
+	}
+}

--- a/internal/hooks/codex.go
+++ b/internal/hooks/codex.go
@@ -13,7 +13,7 @@ import (
 // attn-managed terminals without mutating user or project Codex config.
 // attn has always owned the resize-reflow value for its embedded renderer:
 // xterm needed it disabled, while Ghostty correctly renders the enabled redraw.
-func GenerateCodexConfigOverrides(sessionID, socketPath, wrapperPath, workspaceContextPath, notebookRoot string, injectWorkflow bool) []string {
+func GenerateCodexConfigOverrides(sessionID, socketPath, wrapperPath string, launch Launch) []string {
 	wrapper := strings.TrimSpace(wrapperPath)
 	if wrapper == "" {
 		wrapper = "attn"
@@ -78,15 +78,13 @@ func GenerateCodexConfigOverrides(sessionID, socketPath, wrapperPath, workspaceC
 			"shell_environment_policy.set.ATTN_SOCKET_PATH="+strconv.Quote(socket),
 		)
 	}
-	// A chief-of-staff launch (notebookRoot set) gets chief guidance instead
+	// A chief-of-staff launch (NotebookRoot set) gets chief guidance instead
 	// of the workspace-context checkout guidance. Every other workspace agent gets
 	// its workspace-context guidance (plus workflow-trigger guidance when enabled,
-	// folded in by AgentInstructions). Non-chief agents are NOT nudged to journal:
+	// folded in by Launch). Non-chief agents are NOT nudged to journal:
 	// the keeper narrates each workspace's own work into the journal, and the chief
 	// journals the cross-workspace layer.
-	if guidance := ChiefGuidance(notebookRoot, false); guidance != "" {
-		overrides = append(overrides, "developer_instructions="+strconv.Quote(guidance))
-	} else if instructions := AgentInstructions(workspaceContextPath, injectWorkflow); instructions != "" {
+	if instructions := launch.Instructions(); instructions != "" {
 		overrides = append(overrides, "developer_instructions="+strconv.Quote(instructions))
 	}
 	return overrides

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -110,6 +110,57 @@ func AgentInstructions(workspaceContextPath string, injectWorkflow bool) string 
 	return strings.Join(blocks, "\n\n")
 }
 
+// GardenPrimer is the standing garden block: the vocabulary, the loop, and how
+// many seeds this session's workspace had ready when it launched. ready is nil
+// when the daemon had no answer — no garden here, or none this session can
+// reach — and then nothing is injected, because an agent told to run a command
+// that refuses is worse off than one that was never told.
+//
+// The count is a starting position, not a live number: guidance is composed once
+// at launch, so the block says where the live answer is.
+func GardenPrimer(ready *int) string {
+	if ready == nil {
+		return ""
+	}
+	standing := "Nothing was ready in this workspace when you started"
+	if *ready == 1 {
+		standing = "One seed was ready in this workspace when you started"
+	} else if *ready > 1 {
+		standing = fmt.Sprintf("%d seeds were ready in this workspace when you started", *ready)
+	}
+	return fmt.Sprintf(`attn keeps work in **the garden**. A **seed** is one unit of work — a short id (`+"`s-7k3f9m`"+`), a title, a markdown body, and a state. Anything worth handing off, parking, or attributing is a seed; in-session scratch is not.
+
+The loop is ready → tend → harvest. `+"`attn seed ready`"+` says what you can pick up right now in this workspace: nothing open blocks it and nobody holds it. `+"`attn seed tend <id>`"+` claims one — one tender at a time, so the claim is how other agents know it is taken. `+"`attn seed note <id> -m \"…\"`"+` records what happened and what you learned, for whoever tends it next. `+"`attn seed harvest <id> -m \"what got done\"`"+` closes it as done; `+"`attn seed wither`"+` closes one nobody will pick up, and `+"`attn seed park`"+` puts it down without giving up on it. Plant with `+"`attn seed plant \"what this is\"`"+`, which prints the id. `+"`attn seed --help`"+` has the rest.
+
+%s. Run `+"`attn seed ready`"+` for the live answer — readiness is computed when you ask, so a blocker somebody harvests since then shows up on your next call.`, standing)
+}
+
+// Launch is everything attn injects into an agent's system prompt at launch. A
+// chief-of-staff session (NotebookRoot set) gets chief guidance in place of the
+// workspace-context guidance; the garden primer rides along with either, because
+// every attn-launched agent lives in the same garden.
+type Launch struct {
+	NotebookRoot         string
+	HasSelfMonitor       bool
+	WorkspaceContextPath string
+	InjectWorkflow       bool
+	GardenReady          *int
+}
+
+// Instructions composes the blocks, joined by a blank line.
+func (l Launch) Instructions() string {
+	blocks := make([]string, 0, 2)
+	if chief := ChiefGuidance(l.NotebookRoot, l.HasSelfMonitor); chief != "" {
+		blocks = append(blocks, chief)
+	} else {
+		blocks = append(blocks, AgentInstructions(l.WorkspaceContextPath, l.InjectWorkflow))
+	}
+	if primer := GardenPrimer(l.GardenReady); primer != "" {
+		blocks = append(blocks, primer)
+	}
+	return strings.Join(blocks, "\n\n")
+}
+
 // WorkspaceContextSessionStartOutput returns hook output used when an agent
 // could not receive workspace context guidance at launch. It carries the
 // workspace-context guidance the launch path injects for a non-chief agent, so

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -73,7 +73,7 @@ func TestGenerateHooks_CatchAllPostToolUseIsOneSpawn(t *testing.T) {
 }
 
 func TestGenerateCodexConfigOverrides_PostToolUseRecordsEdits(t *testing.T) {
-	overrides := strings.Join(GenerateCodexConfigOverrides("abc123", "/tmp/test.sock", "/tmp/attn", "", "", false), "\n")
+	overrides := strings.Join(GenerateCodexConfigOverrides("abc123", "/tmp/test.sock", "/tmp/attn", Launch{}), "\n")
 
 	if !strings.Contains(overrides, "hooks.PostToolUse=[{ matcher = \"*\", hooks = [{ type = \"command\", command = \"'/tmp/attn' '_hook-tool-use'\"") {
 		t.Fatalf("codex PostToolUse should run _hook-tool-use: %q", overrides)
@@ -203,7 +203,7 @@ func TestGenerateHooks_EnvBlock(t *testing.T) {
 }
 
 func TestGenerateCodexConfigOverrides_UsesStableEnvBasedCommands(t *testing.T) {
-	overrides := GenerateCodexConfigOverrides("session-1", "/tmp/attn.sock", "/tmp/attn", "/tmp/context.md", "", false)
+	overrides := GenerateCodexConfigOverrides("session-1", "/tmp/attn.sock", "/tmp/attn", Launch{WorkspaceContextPath: "/tmp/context.md"})
 	joined := strings.Join(overrides, "\n")
 	for _, expected := range []string{
 		`shell_environment_policy.set.ATTN_SESSION_ID="session-1"`,
@@ -251,7 +251,7 @@ func TestGenerateCodexConfigOverrides_UsesStableEnvBasedCommands(t *testing.T) {
 }
 
 func TestGenerateCodexConfigOverrides_OmitsEmptySocketButKeepsSessionIdentity(t *testing.T) {
-	overrides := strings.Join(GenerateCodexConfigOverrides("session-2", "", "", "", "", false), "\n")
+	overrides := strings.Join(GenerateCodexConfigOverrides("session-2", "", "", Launch{}), "\n")
 	if !strings.Contains(overrides, `shell_environment_policy.set.ATTN_SESSION_ID="session-2"`) ||
 		!strings.Contains(overrides, `shell_environment_policy.set.ATTN_WRAPPER_PATH="attn"`) {
 		t.Fatalf("codex overrides dropped required attn identity: %q", overrides)
@@ -295,12 +295,12 @@ func TestAgentInstructionsComposition(t *testing.T) {
 }
 
 func TestGenerateCodexConfigOverrides_InjectsWorkflowGuidanceWhenEnabled(t *testing.T) {
-	off := strings.Join(GenerateCodexConfigOverrides("s", "/sock", "/attn", "/tmp/context.md", "", false), "\n")
+	off := strings.Join(GenerateCodexConfigOverrides("s", "/sock", "/attn", Launch{WorkspaceContextPath: "/tmp/context.md"}), "\n")
 	if strings.Contains(off, "hypercode") {
 		t.Fatalf("workflow guidance injected while disabled: %q", off)
 	}
 
-	on := strings.Join(GenerateCodexConfigOverrides("s", "/sock", "/attn", "/tmp/context.md", "", true), "\n")
+	on := strings.Join(GenerateCodexConfigOverrides("s", "/sock", "/attn", Launch{WorkspaceContextPath: "/tmp/context.md", InjectWorkflow: true}), "\n")
 	if !strings.Contains(on, "developer_instructions=") {
 		t.Fatal("enabled overrides dropped developer_instructions")
 	}
@@ -313,7 +313,7 @@ func TestGenerateCodexConfigOverrides_InjectsWorkflowGuidanceWhenEnabled(t *test
 	}
 
 	// Workflow guidance is injected even without a workspace checkout.
-	noCtx := strings.Join(GenerateCodexConfigOverrides("s", "/sock", "/attn", "", "", true), "\n")
+	noCtx := strings.Join(GenerateCodexConfigOverrides("s", "/sock", "/attn", Launch{InjectWorkflow: true}), "\n")
 	if !strings.Contains(noCtx, "developer_instructions=") || !strings.Contains(noCtx, "hypercode") {
 		t.Fatalf("workflow guidance not injected without a checkout: %q", noCtx)
 	}
@@ -348,3 +348,60 @@ func TestChiefGuidanceEmptyWithoutRoot(t *testing.T) {
 // NOTE: AskUserQuestion PostToolUse hook was removed because it fires
 // AFTER the user responds, not when the question is displayed.
 // See: https://github.com/anthropics/claude-code/issues/10168
+
+// The primer is what makes an attn-launched agent a gardener: it arrives
+// knowing the vocabulary, the loop, and whether there is anything to pick up.
+func TestGardenPrimer(t *testing.T) {
+	// No garden reachable — an outpost, or a daemon that could not answer.
+	// Telling an agent to run a command that refuses is worse than silence.
+	if got := GardenPrimer(nil); got != "" {
+		t.Fatalf("GardenPrimer(nil) = %q, want nothing", got)
+	}
+
+	counts := map[int]string{
+		0: "Nothing was ready",
+		1: "One seed was ready",
+		4: "4 seeds were ready",
+	}
+	for count, want := range counts {
+		primer := GardenPrimer(&count)
+		if !strings.Contains(primer, want) {
+			t.Fatalf("primer for %d does not say %q:\n%s", count, want, primer)
+		}
+		// The loop, and where the live answer is: the count is a starting
+		// position, composed once at launch.
+		for _, phrase := range []string{"attn seed ready", "attn seed tend", "attn seed harvest", "live answer"} {
+			if !strings.Contains(primer, phrase) {
+				t.Fatalf("primer does not name %q:\n%s", phrase, primer)
+			}
+		}
+	}
+}
+
+// Every attn-launched agent lives in the same garden, so the primer rides with
+// chief guidance and workspace guidance alike — and never replaces either.
+func TestLaunchInstructionsCarryTheGardenPrimer(t *testing.T) {
+	count := 2
+
+	workspace := Launch{WorkspaceContextPath: "/tmp/context.md", GardenReady: &count}.Instructions()
+	if want := AgentInstructions("/tmp/context.md", false); !strings.HasPrefix(workspace, want) {
+		t.Fatalf("workspace launch dropped the agent instructions:\n%s", workspace)
+	}
+	if !strings.Contains(workspace, "2 seeds were ready") {
+		t.Fatalf("workspace launch dropped the primer:\n%s", workspace)
+	}
+
+	chief := Launch{NotebookRoot: "/tmp/notebook", GardenReady: &count}.Instructions()
+	if want := ChiefGuidance("/tmp/notebook", false); !strings.HasPrefix(chief, want) {
+		t.Fatalf("chief launch dropped the chief guidance:\n%s", chief)
+	}
+	if !strings.Contains(chief, "2 seeds were ready") {
+		t.Fatalf("chief launch dropped the primer:\n%s", chief)
+	}
+
+	// Nothing to prime with leaves the rest exactly as it was.
+	bare := Launch{WorkspaceContextPath: "/tmp/context.md"}.Instructions()
+	if bare != AgentInstructions("/tmp/context.md", false) {
+		t.Fatalf("a garden-less launch changed the instructions:\n%s", bare)
+	}
+}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "235"
+const ProtocolVersion = "236"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only
@@ -191,6 +191,8 @@ const (
 	CmdSeedTransition                        = "seed_transition"
 	CmdSeedNote                              = "seed_note"
 	CmdSeedNotes                             = "seed_notes"
+	CmdSeedLink                              = "seed_link"
+	CmdSeedReady                             = "seed_ready"
 	CmdStop                                  = "stop"
 	CmdTodos                                 = "todos"
 	CmdFilesEdited                           = "files_edited"
@@ -1215,6 +1217,20 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdSeedNotes:
 		var msg SeedNotesMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdSeedLink:
+		var msg SeedLinkMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdSeedReady:
+		var msg SeedReadyMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -5215,6 +5215,9 @@ type Response struct {
 	// Repos corresponds to the JSON schema field "repos".
 	Repos []RepoState `json:"repos,omitempty,omitzero"`
 
+	// SeedLinkResult corresponds to the JSON schema field "seed_link_result".
+	SeedLinkResult *SeedLinkResult `json:"seed_link_result,omitempty,omitzero"`
+
 	// SeedListResult corresponds to the JSON schema field "seed_list_result".
 	SeedListResult *SeedListResult `json:"seed_list_result,omitempty,omitzero"`
 
@@ -5226,6 +5229,9 @@ type Response struct {
 
 	// SeedPlantResult corresponds to the JSON schema field "seed_plant_result".
 	SeedPlantResult *SeedPlantResult `json:"seed_plant_result,omitempty,omitzero"`
+
+	// SeedReadyResult corresponds to the JSON schema field "seed_ready_result".
+	SeedReadyResult *SeedReadyResult `json:"seed_ready_result,omitempty,omitzero"`
 
 	// SeedShowResult corresponds to the JSON schema field "seed_show_result".
 	SeedShowResult *SeedShowResult `json:"seed_show_result,omitempty,omitzero"`
@@ -5361,6 +5367,9 @@ type Seed struct {
 	// PlanterSession corresponds to the JSON schema field "planter_session".
 	PlanterSession string `json:"planter_session"`
 
+	// Ready corresponds to the JSON schema field "ready".
+	Ready bool `json:"ready"`
+
 	// Reason corresponds to the JSON schema field "reason".
 	Reason *string `json:"reason,omitempty,omitzero"`
 
@@ -5401,6 +5410,31 @@ type SeedEdge struct {
 
 	// To corresponds to the JSON schema field "to".
 	To string `json:"to"`
+}
+
+type SeedLinkMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Kind corresponds to the JSON schema field "kind".
+	Kind string `json:"kind"`
+
+	// SeedID corresponds to the JSON schema field "seed_id".
+	SeedID string `json:"seed_id"`
+
+	// ToSeedID corresponds to the JSON schema field "to_seed_id".
+	ToSeedID string `json:"to_seed_id"`
+
+	// Unlink corresponds to the JSON schema field "unlink".
+	Unlink *bool `json:"unlink,omitempty,omitzero"`
+}
+
+type SeedLinkResult struct {
+	// Changed corresponds to the JSON schema field "changed".
+	Changed bool `json:"changed"`
+
+	// Seed corresponds to the JSON schema field "seed".
+	Seed Seed `json:"seed"`
 }
 
 type SeedListMessage struct {
@@ -5520,6 +5554,48 @@ type SeedPlantResult struct {
 	Seed Seed `json:"seed"`
 }
 
+type SeedReadyMessage struct {
+	// All corresponds to the JSON schema field "all".
+	All *bool `json:"all,omitempty,omitzero"`
+
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Plot corresponds to the JSON schema field "plot".
+	Plot *string `json:"plot,omitempty,omitzero"`
+
+	// SourceSessionID corresponds to the JSON schema field "source_session_id".
+	SourceSessionID *string `json:"source_session_id,omitempty,omitzero"`
+
+	// WorkspaceID corresponds to the JSON schema field "workspace_id".
+	WorkspaceID *string `json:"workspace_id,omitempty,omitzero"`
+}
+
+type SeedReadyResult struct {
+	// Scope corresponds to the JSON schema field "scope".
+	Scope string `json:"scope"`
+
+	// ScopeID corresponds to the JSON schema field "scope_id".
+	ScopeID string `json:"scope_id"`
+
+	// Seeds corresponds to the JSON schema field "seeds".
+	Seeds []Seed `json:"seeds"`
+}
+
+type SeedRelation struct {
+	// Label corresponds to the JSON schema field "label".
+	Label string `json:"label"`
+
+	// SeedID corresponds to the JSON schema field "seed_id".
+	SeedID string `json:"seed_id"`
+
+	// Status corresponds to the JSON schema field "status".
+	Status string `json:"status"`
+
+	// Title corresponds to the JSON schema field "title".
+	Title string `json:"title"`
+}
+
 type SeedShowMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -5534,6 +5610,9 @@ type SeedShowResult struct {
 
 	// NotesTotal corresponds to the JSON schema field "notes_total".
 	NotesTotal int `json:"notes_total"`
+
+	// Relations corresponds to the JSON schema field "relations".
+	Relations []SeedRelation `json:"relations"`
 
 	// Seed corresponds to the JSON schema field "seed".
 	Seed Seed `json:"seed"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -4235,6 +4235,12 @@ model Seed {
   "template": boolean;
   "gate": boolean;
   "vars": SeedVar[];
+  // Whether this seed can be tended right now: nothing open blocks it, it holds
+  // no live tender, nothing is part of it, and it is neither a packet nor a
+  // gate. Computed by the daemon on every read and every push — readiness is
+  // truth at query time, never a stored flag — so a client renders it rather
+  // than re-deriving a rule it would eventually disagree about.
+  "ready": boolean;
   // Why the seed was harvested or withered.
   "reason"?: string;
   // The document's own revision and stamps. `rev` is what a conditional write
@@ -4315,6 +4321,61 @@ model SeedShowResult {
   // `total` is what makes the shortfall visible rather than silent.
   "notes": SeedNote[];
   "notes_total": int32;
+  // Every edge that touches this seed, in both directions. The seed's own
+  // `edges` carry only what it points at, and "what blocks me" is the half a
+  // tender actually needs.
+  "relations": SeedRelation[];
+}
+
+// One edge as it reads from one seed's point of view: `blocks` and `part-of`
+// outbound, `blocked-by` and `has-part` for the same edges seen from the other
+// end.
+model SeedRelation {
+  "label": string;
+  "seed_id": string;
+  "title": string;
+  "status": string;
+}
+
+// Link or unlink two seeds. Structure lives in edges rather than in ids, so
+// re-parenting a seed never renames it. The daemon refuses what cannot be a
+// relation — an edge onto a seed that is not planted, a second crown, a cycle —
+// naming both seeds and the edge to remove.
+model SeedLinkMessage {
+  "cmd": "seed_link";
+  "seed_id": string;
+  // blocks | part-of.
+  "kind": string;
+  // The seed at the other end: `<seed_id> blocks <to_seed_id>`.
+  "to_seed_id": string;
+  // Remove the edge instead of adding it.
+  "unlink"?: boolean;
+}
+
+model SeedLinkResult {
+  "seed": Seed;
+  // False when the edge was already exactly as asked, so nothing was written.
+  "changed": boolean;
+}
+
+// What can be tended right now. Scope is inferred: the calling session's
+// workspace unless `plot`, `workspace_id` or `all` says otherwise — the daemon
+// knows who is asking, so the common form takes no flags at all.
+model SeedReadyMessage {
+  "cmd": "seed_ready";
+  "source_session_id"?: string;
+  // A crown: the answer is that plot's seeds, crown included.
+  "plot"?: string;
+  "workspace_id"?: string;
+  "all"?: boolean;
+}
+
+model SeedReadyResult {
+  "seeds": Seed[];
+  // What the answer was scoped to: plot | workspace | all, and the id of the
+  // plot or workspace when there is one.
+  "scope": string;
+  "scope_id": string;
 }
 
 // One lifecycle move. The five verbs share a command because they are one state
@@ -4753,6 +4814,8 @@ model Response {
   seed_transition_result?: SeedTransitionResult;
   seed_note_result?: SeedNoteResult;
   seed_notes_result?: SeedNotesResult;
+  seed_link_result?: SeedLinkResult;
+  seed_ready_result?: SeedReadyResult;
   doc_define_result?: DocDefineResult;
   doc_undefine_result?: DocUndefineResult;
   doc_collections_result?: DocCollectionsResult;


### PR DESCRIPTION
Slice 3 of the garden: seeds relate, and "what can I pick up right now" is one
flag-free command. Plan:
[docs/plans/2026-08-06-the-garden-vertical-slices.md](docs/plans/2026-08-06-the-garden-vertical-slices.md).

## What ships

- `attn seed link <a> blocks <b>` / `link <a> part-of <b>`, and `unlink`. The
  edge is stored on the seed it points from; `sown-from`, `discovered-from` and
  `relates-to` stay declared and inert, and say so when you try to link one.
- `attn seed ready`: the open seeds nothing blocks, nobody holds, and nothing is
  part-of, oldest first. Scope is the calling session's workspace unless
  `--plot <crown>`, `--workspace <id>` or `--all` says otherwise.
- `attn seed ls --tree` nests each seed under its crown; `attn seed show` lists
  a seed's edges in both directions (`blocks` / `blocked-by`, `part-of` /
  `has-part`) with each one's title and state.
- The garden panel marks ready seeds, says how many open blockers the others are
  waiting on, and lists both directions in the expanded detail. Readiness is
  computed by the daemon and rides on the seed, so the panel renders it rather
  than deriving a second answer.
- Every attn-launched agent is primed with the garden's vocabulary, the
  ready → tend → harvest loop, and its workspace's ready count — through the
  same launch-guidance path chief guidance rides, for Claude, Codex and plugin
  agents alike. A daemon with no garden to answer for (an outpost) primes
  nothing rather than teaching a loop that refuses.

Harvesting a blocker frees its dependent at the next query: readiness is worked
out per read and never stored, so nothing has to be cleared and nothing is
nudged.

## Rules decided here

Recorded in the plan (2026-08-12):

- A seed something is `part-of` is never itself ready — a crown's work is its
  children. Without this the plan's own acceptance ("`ready` shows only A")
  would hand out the crown too.
- A seed sits in at most one plot. The second `part-of` is refused naming the
  plot it is in and the `unlink` that moves it.
- A live tender holds its seed, where live means "a session this daemon still
  knows", `recoverable` included — which answers the plan's open question about
  dead vs. recoverable tenders. A session the daemon no longer knows releases
  the seed; a tender that names only a crew member always holds, because attn
  has no signal that a person in a terminal pane walked away.

## Shape

`internal/garden/edges.go` is the whole rule set as pure functions over a slice
of seeds — link, unlink, cycle detection, ready, plot walk, tree, relations — so
every rule is one table-driven test and the daemon just reads the garden, calls
in, and writes back what it is handed. The daemon reads the whole garden per
command (bounded by the same snapshot cap the push uses) rather than scoping in
SQL: a blocker or a crown can live in any workspace.

New facts `garden.linked` / `garden.unlinked` ride the existing `garden.*`
projection, with their fixtures in the fact-to-wire join test. Protocol 236 adds
`seed_link` / `seed_ready` and `Seed.ready`.

## Verification

Live on a throwaway profile (`seedlink3`), preflight clean, two real sessions in
two workspaces:

- The plan's chain — A blocks B, B part-of C — `ready` returns only A; `ls
  --tree` nests B under C; `show B` lists `part-of C` and `blocked-by A`.
- Harvesting A surfaces B on the next `ready`, in the CLI and in the panel,
  with nothing else touched (the recording below).
- Cycle creation refused both ways (`blocks` and `part-of`), naming both seeds,
  the chain, and the `unlink` that undoes it; so are a second plot, a self-link,
  and an inert edge kind.
- Two sessions in different workspaces get different flag-free `ready` answers,
  and a blocker in the other workspace still blocks.
- Priming: an agent launched into an empty workspace answers "0 — nothing was
  ready when you started"; one launched after the chain exists answers "one seed
  was ready", matching `attn seed ready`.

![garden-slice3](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/eb5bc08f325cc533ef3386595feb55a2015ee7ff/feat-garden-slice-3/garden-slice3.gif)

[Full-quality recording (mp4)](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/eb5bc08f325cc533ef3386595feb55a2015ee7ff/feat-garden-slice-3/garden-slice3.mp4)

The clip is the garden panel of one workspace while `attn seed harvest` runs in
a shell: the blocker goes to `harvested`, and the seed that was `blocked by 1`
becomes `ready`.

Surfaces walked: CLI (`link`/`unlink`/`ready`/`ls --tree`/`show`), daemon and
app (protocol, projection, panel), protocol lockstep (`main.tsp` →
`generated.go`/`generated.ts`, `ProtocolVersion` and `PROTOCOL_VERSION`), Linux
(`make build-linux-amd64` green), docs (glossary, plan, changelog fragment).
Plugin agents get the primer through `preparePluginLaunchInstructions`; the SDK
has no garden surface to touch.

## Named gap

`ready` reads the garden under the same cap every other read carries
(`docstore.MaxLimit`, 1000, newest first), and unlike `ls` it prints no
truncation marker. Past the cap it can therefore call a seed ready that a seed
it never read blocks. The fix is the shape `ls` already has — the scope's total
beside the answer and a line when the graph did not fit — which is a protocol
field, so it belongs to the next slice that touches this surface.

## Not in this slice

Seed-axis continuity (slice 4), plots and dispatch (slice 5), ready-nudges, new
edge kinds, and mint-collision observability.

https://claude.ai/code/session_01Pa9J3B4SFGTPsBwbfxAb2N
