### PR TITLE
fix(build): pin attn's npm registry, and put the clippy gate in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,10 @@ jobs:
           go-version: '1.22'
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: '1.95.0'
+          components: clippy, rustfmt
 
       - name: Build attn binary
         run: |
@@ -327,6 +330,11 @@ jobs:
 
       - name: Cargo fmt
         run: cargo fmt -- --check
+
+      # The pre-commit hook has always run clippy; CI never did, so a lint that
+      # only the hook rejects reached main and blocked every local commit.
+      - name: Cargo clippy
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: Cargo test
         run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,28 +284,19 @@ jobs:
           echo "shards result: $result"
           [ "$result" = "success" ] || [ "$result" = "skipped" ]
 
+  # macOS, because the app is macOS-only: on Linux the platform half of it is
+  # cfg'd out, so `cargo test` checked a build nobody ships and clippy read the
+  # macOS-only code as dead. The runner is free on a public repo.
   rust:
     name: Tauri
     needs: changes
     if: needs.changes.outputs.tauri == 'true'
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     defaults:
       run:
         working-directory: app/src-tauri
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install system deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            pkg-config \
-            libgtk-3-dev \
-            libwebkit2gtk-4.1-dev \
-            libsoup-3.0-dev \
-            libjavascriptcoregtk-4.1-dev \
-            libssl-dev \
-            libclang-dev
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -332,7 +323,8 @@ jobs:
         run: cargo fmt -- --check
 
       # The pre-commit hook has always run clippy; CI never did, so a lint that
-      # only the hook rejects reached main and blocked every local commit.
+      # only the hook rejects reached main and blocked every local commit. Same
+      # pinned toolchain on both sides, so they cannot disagree.
       - name: Cargo clippy
         run: cargo clippy --all-targets -- -D warnings
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: '1.95.0'
           targets: aarch64-apple-darwin
 
       - name: Build bundled daemon binary

--- a/app/src-tauri/src/browser_host.rs
+++ b/app/src-tauri/src/browser_host.rs
@@ -252,25 +252,36 @@ fn native_position(window: &tauri::Window, x: f64, y: f64) -> LogicalPosition<f6
     LogicalPosition::new((x + inset.0).max(0.0), (y + inset.1).max(0.0))
 }
 
-fn set_geometry(
-    webview: &tauri::Webview,
-    x: f64,
-    y: f64,
-    width: f64,
-    height: f64,
-    visible: bool,
-) -> Result<(), String> {
-    if !visible {
+// Where a browser webview sits and whether it shows. One value because the five
+// numbers only ever travel together, and a caller that could pass four of them
+// is a caller that can pass them in the wrong order.
+#[derive(Debug, Clone, Copy, Deserialize)]
+pub struct Geometry {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+    pub visible: bool,
+}
+
+impl Geometry {
+    fn size(&self) -> LogicalSize<f64> {
+        LogicalSize::new(self.width.max(1.0), self.height.max(1.0))
+    }
+}
+
+fn set_geometry(webview: &tauri::Webview, geometry: Geometry) -> Result<(), String> {
+    if !geometry.visible {
         clear_browser_focus_for(webview.label());
     }
     let window = webview.window();
     webview
-        .set_position(native_position(&window, x, y))
+        .set_position(native_position(&window, geometry.x, geometry.y))
         .map_err(|error| format!("position browser webview: {error}"))?;
     webview
-        .set_size(LogicalSize::new(width.max(1.0), height.max(1.0)))
+        .set_size(geometry.size())
         .map_err(|error| format!("resize browser webview: {error}"))?;
-    if visible {
+    if geometry.visible {
         webview.show()
     } else {
         webview.hide()
@@ -284,11 +295,7 @@ pub async fn browser_host_mount(
     app: AppHandle,
     label: String,
     url: String,
-    x: f64,
-    y: f64,
-    width: f64,
-    height: f64,
-    visible: bool,
+    geometry: Geometry,
 ) -> Result<(), String> {
     validate_label(&label)?;
     let url = parse_url(&url)?;
@@ -296,7 +303,7 @@ pub async fn browser_host_mount(
         webview
             .navigate(url)
             .map_err(|error| format!("navigate browser webview: {error}"))?;
-        return set_geometry(&webview, x, y, width, height, visible);
+        return set_geometry(&webview, geometry);
     }
 
     let window = app
@@ -333,8 +340,8 @@ pub async fn browser_host_mount(
     let webview = window
         .add_child(
             builder,
-            native_position(&window, x, y),
-            LogicalSize::new(width.max(1.0), height.max(1.0)),
+            native_position(&window, geometry.x, geometry.y),
+            geometry.size(),
         )
         .map_err(|error| format!("create browser webview: {error}"))?;
     register_focus_handler(&webview)?;
@@ -344,7 +351,7 @@ pub async fn browser_host_mount(
     webview
         .navigate(url)
         .map_err(|error| format!("navigate browser webview: {error}"))?;
-    set_geometry(&webview, x, y, width, height, visible)
+    set_geometry(&webview, geometry)
 }
 
 #[tauri::command]
@@ -352,17 +359,13 @@ pub fn browser_host_update(
     _caller: TrustedMainWebview,
     app: AppHandle,
     label: String,
-    x: f64,
-    y: f64,
-    width: f64,
-    height: f64,
-    visible: bool,
+    geometry: Geometry,
 ) -> Result<(), String> {
     validate_label(&label)?;
     let webview = app
         .get_webview(&label)
         .ok_or_else(|| "browser webview is not mounted".to_string())?;
-    set_geometry(&webview, x, y, width, height, visible)
+    set_geometry(&webview, geometry)
 }
 
 #[tauri::command]

--- a/app/src/browser/host.test.ts
+++ b/app/src/browser/host.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from 'vitest';
-import { isBrowserHostOwnedTarget, serializeBrowserControlResultMessage } from './host';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  isBrowserHostOwnedTarget,
+  mountBrowserHost,
+  serializeBrowserControlResultMessage,
+  updateBrowserHost,
+} from './host';
+
+const invoke = vi.hoisted(() => vi.fn(async () => undefined));
+vi.mock('@tauri-apps/api/core', () => ({ invoke, isTauri: () => true }));
 
 describe('serializeBrowserControlResultMessage', () => {
   it('accepts results within the transport budget', () => {
@@ -23,6 +31,34 @@ describe('serializeBrowserControlResultMessage', () => {
     expect(() => serializeBrowserControlResultMessage(plain, JSON.stringify(plain).length - 1)).toThrow(
       /serialized browser control result is .* bytes/,
     );
+  });
+});
+
+// The Rust commands take one `geometry` argument and reject anything else at
+// deserialization, which no typechecker on this side can see. These pin the
+// payload shape both commands are called with.
+describe('browser host geometry payload', () => {
+  const rect = { x: 10, y: 20, width: 300, height: 400 };
+
+  it('mounts with the rect and visibility inside one geometry argument', async () => {
+    invoke.mockClear();
+    await mountBrowserHost('browser-a-b', 'https://example.com/', rect, true);
+
+    expect(invoke).toHaveBeenCalledWith('browser_host_mount', {
+      label: 'browser-a-b',
+      url: 'https://example.com/',
+      geometry: { ...rect, visible: true },
+    });
+  });
+
+  it('updates with the same shape', async () => {
+    invoke.mockClear();
+    await updateBrowserHost('browser-a-b', rect, false);
+
+    expect(invoke).toHaveBeenCalledWith('browser_host_update', {
+      label: 'browser-a-b',
+      geometry: { ...rect, visible: false },
+    });
   });
 });
 

--- a/app/src/browser/host.ts
+++ b/app/src/browser/host.ts
@@ -64,7 +64,7 @@ export async function mountBrowserHost(
   recordUiDiag({ kind: 'browser_host_request', action: 'mount', label, rect, visible });
   tracedBrowserHostState.set(label, { visible, suspicious: false });
   try {
-    await invoke('browser_host_mount', { label, url, ...rect, visible });
+    await invoke('browser_host_mount', { label, url, geometry: { ...rect, visible } });
     recordUiDiag({ kind: 'browser_host_result', action: 'mount', label, rect, visible });
   } catch (error) {
     recordUiDiag({ kind: 'browser_host_error', action: 'mount', label, rect, visible, error: String(error) });
@@ -77,7 +77,7 @@ export async function updateBrowserHost(label: string, rect: BrowserHostRect, vi
   const trace = shouldTraceBrowserUpdate(label, rect, visible);
   if (trace) recordUiDiag({ kind: 'browser_host_request', action: 'update', label, rect, visible });
   try {
-    await invoke('browser_host_update', { label, ...rect, visible });
+    await invoke('browser_host_update', { label, geometry: { ...rect, visible } });
     if (trace) recordUiDiag({ kind: 'browser_host_result', action: 'update', label, rect, visible });
   } catch (error) {
     recordUiDiag({ kind: 'browser_host_error', action: 'update', label, rect, visible, error: String(error) });

--- a/changelog.d/build-registry-and-clippy-gate.yaml
+++ b/changelog.d/build-registry-and-clippy-gate.yaml
@@ -1,0 +1,9 @@
+kind: internal
+area: build
+change: >
+  attn's own package installs pin the public npm registry instead of
+  inheriting a machine's NPM_CONFIG_REGISTRY, so a corporate mirror no
+  longer 401s an app apply or a bundled-plugin build; ATTN_NPM_REGISTRY
+  overrides it. The Rust toolchain is pinned and CI now runs the clippy
+  gate the pre-commit hook has always enforced, which is what let a lint
+  only the hook rejects reach main.

--- a/internal/appbuild/toolchain.go
+++ b/internal/appbuild/toolchain.go
@@ -39,6 +39,31 @@ const (
 	toolchainStamp = ".attn-typescript-version"
 )
 
+// DefaultNPMRegistry is where attn fetches its own pinned packages from.
+//
+// Set explicitly rather than inherited: a work machine commonly exports
+// NPM_CONFIG_REGISTRY for a corporate mirror, and attn's build then depends on
+// that mirror's credentials, availability, and VPN. Measured here as a 401 on
+// every install. ATTN_NPM_REGISTRY overrides it for anyone who does need one.
+const DefaultNPMRegistry = "https://registry.npmjs.org/"
+
+// npmRegistryEnv is the environment an attn-owned package install runs in: the
+// caller's, with the registry decided here.
+func npmRegistryEnv(environ []string) []string {
+	registry := strings.TrimSpace(os.Getenv("ATTN_NPM_REGISTRY"))
+	if registry == "" {
+		registry = DefaultNPMRegistry
+	}
+	out := make([]string, 0, len(environ)+1)
+	for _, entry := range environ {
+		if strings.HasPrefix(entry, "NPM_CONFIG_REGISTRY=") || strings.HasPrefix(entry, "npm_config_registry=") {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return append(out, "NPM_CONFIG_REGISTRY="+registry)
+}
+
 // Toolchain is the resolved location of every external tool an apply runs.
 type Toolchain struct {
 	Bun string
@@ -95,6 +120,7 @@ func ensureTypeScript(bun, dir string, log func(string)) (string, error) {
 	}
 	cmd := exec.Command(bun, "install", "--no-save")
 	cmd.Dir = dir
+	cmd.Env = npmRegistryEnv(os.Environ())
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("installing TypeScript %s into %s failed (%v); apply needs a typechecker and this is the one it uses. Output:\n%s",
 			TypeScriptVersion, dir, err, strings.TrimSpace(string(out)))

--- a/internal/appbuild/toolchain_test.go
+++ b/internal/appbuild/toolchain_test.go
@@ -1,0 +1,52 @@
+package appbuild
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestNPMRegistryEnvReplacesAnInheritedRegistry(t *testing.T) {
+	env := npmRegistryEnv([]string{"PATH=/usr/bin", "NPM_CONFIG_REGISTRY=https://mirror.invalid/npm/", "HOME=/tmp"})
+
+	if slices.Contains(env, "NPM_CONFIG_REGISTRY=https://mirror.invalid/npm/") {
+		t.Fatalf("the inherited registry survived: %v", env)
+	}
+	if !slices.Contains(env, "NPM_CONFIG_REGISTRY="+DefaultNPMRegistry) {
+		t.Fatalf("the default registry is not set: %v", env)
+	}
+	for _, keep := range []string{"PATH=/usr/bin", "HOME=/tmp"} {
+		if !slices.Contains(env, keep) {
+			t.Fatalf("%s was dropped: %v", keep, env)
+		}
+	}
+}
+
+func TestNPMRegistryEnvHonoursTheOverride(t *testing.T) {
+	t.Setenv("ATTN_NPM_REGISTRY", "https://registry.example/npm/")
+
+	env := npmRegistryEnv([]string{"npm_config_registry=https://mirror.invalid/npm/"})
+
+	if !slices.Contains(env, "NPM_CONFIG_REGISTRY=https://registry.example/npm/") {
+		t.Fatalf("the override is not set: %v", env)
+	}
+	if slices.Contains(env, "npm_config_registry=https://mirror.invalid/npm/") {
+		t.Fatalf("the lowercase inherited registry survived: %v", env)
+	}
+}
+
+// The seam that matters: a machine exporting a registry attn has no credentials
+// for must not break an apply. This is the shape of the real failure — a
+// corporate mirror answering 401 for every public package.
+func TestToolchainInstallIgnoresAnUnreachableInheritedRegistry(t *testing.T) {
+	t.Setenv("NPM_CONFIG_REGISTRY", "https://npm-registry.invalid/")
+
+	dir := t.TempDir()
+	if _, err := ResolveToolchain(dir, func(line string) { t.Log(line) }); err != nil {
+		t.Fatalf("installing the toolchain under a hostile inherited registry: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, toolchainDirName, "node_modules", ".bin", "tsc")); err != nil {
+		t.Fatalf("no compiler was installed: %v", err)
+	}
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,7 @@
+# Pinned so `cargo clippy -D warnings` means the same thing in CI, in the
+# pre-commit hook, and on a contributor's machine. Without a pin the hook
+# enforces whichever lint set rustup last installed, and a stricter release
+# turns a green main red locally with no CI signal.
+[toolchain]
+channel = "1.95.0"
+components = ["clippy", "rustfmt"]

--- a/scripts/build-bundled-plugins.sh
+++ b/scripts/build-bundled-plugins.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 stage_root="${1:-${repo_root}/app/src-tauri/bundled-plugins}"
 
+# Set, not inherited: a work machine commonly exports NPM_CONFIG_REGISTRY for a
+# corporate mirror, and every public package a bundled plugin pins then comes
+# back 401. ATTN_NPM_REGISTRY overrides it, matching internal/appbuild.
+export NPM_CONFIG_REGISTRY="${ATTN_NPM_REGISTRY:-https://registry.npmjs.org/}"
+unset npm_config_registry
+
 # `bun build --compile` on macOS arm64 leaves stale bytes past the end of its
 # ad-hoc code signature (upstream bug: oven-sh/bun#32159, fix pending in
 # oven-sh/bun#32162 as of bun 1.3.14). Those trailing bytes make every later


### PR DESCRIPTION
Two build gates that made a clean checkout of main uncommittable on a work
machine. Found while shipping #876, where both had to be worked around by hand.

## attn's installs inherited a registry it has no credentials for

`internal/appbuild/toolchain.go` and `scripts/build-bundled-plugins.sh` shell
out to `bun install` and inherited `NPM_CONFIG_REGISTRY`. A machine that points
npm at a corporate mirror — Spotify's, here, exported by its devex tooling —
gets a 401 for every public package attn pins, which fails `attn app apply`,
`make install`, and five `internal/appbuild` tests. It also failed two
`internal/daemon` app-apply tests, which had been dismissed as environmental.

Both installs now set the registry rather than inheriting it, honouring
`ATTN_NPM_REGISTRY` for anyone who genuinely needs a mirror. The reasoning is
in one comment on each side: attn's build must not depend on a mirror's
credentials, uptime, or VPN.

`TestToolchainInstallIgnoresAnUnreachableInheritedRegistry` is the guard. It
exports a registry that resolves nowhere and asserts the compiler still
installs — verified to fail without the fix (`FailedToOpenSocket downloading
package manifest typescript`) rather than passing off bun's cache.

## The clippy gate existed only on your machine

`scripts/pre-commit.sh` has always run `cargo clippy --all-targets -- -D
warnings`. CI never did — the Tauri job runs `cargo fmt` and `cargo test` — and
nothing pinned the Rust toolchain. So clippy 1.95 tightened
`too_many_arguments`, and `browser_host_mount` (9 args) and
`browser_host_update` (8) started failing the hook on a main that CI called
green. Every local commit in the repo was blocked.

- The two commands take one `Geometry` — the five loose values only ever travel
  together, and a caller that can pass four of them can pass them in the wrong
  order. Both call sites already had the rect as an object.
- `rust-toolchain.toml` pins 1.95.0; CI and the release workflow read the pin
  instead of `stable`, so the hook and CI enforce the same lint set.
- CI runs the clippy gate, because a gate only the hook enforces is how this
  reached main.

Not `#[allow(clippy::too_many_arguments)]`: the smell is real, and the next
clippy release finds the next one.

## The gate had to move to macOS

Adding clippy to CI failed on the first run, and the failure was worth having:
the Tauri job runs on `ubuntu-latest`, where the platform half of a macOS-only
app is `cfg`'d out. Clippy read every macOS-only import, constant, and helper as
dead code — twelve errors under `-D warnings` — and `cargo test` had been
checking a build nobody ships.

So that job now runs on `macos-14`, which drops the Linux GTK/WebKit apt step
and makes fmt, clippy, and test all mean what the hook means. The runner is free
on a public repo.

## Verification

- `go test ./...` fully green for the first time on this machine — including the
  two `internal/daemon` app-apply tests and all of `internal/appbuild`, with the
  corporate registry still exported in the shell.
- `scripts/build-bundled-plugins.sh` and `make install PROFILE=…` both succeed
  in that same shell, with no registry override in front of them.
- Frontend: 250 files, 2775 passed. `tsc --noEmit` clean. `cargo fmt --check`,
  `cargo clippy --all-targets -- -D warnings`, and `cargo test` (25) green on
  the pinned toolchain.
- The pre-commit hook passed this PR's own commit with no `--no-verify`.
- Live, in a signed packaged profile install — the IPC payload changed, so tests
  cannot cover it: opened a real page in a browser tile, read its content back
  over the control channel, split the pane, and switched sessions. The app's own
  diagnostics show `browser_host_mount` and `browser_host_update` both
  succeeding with the new argument, the update carrying a real rect and
  `visible=true`. The two `browser_host_error` entries in that log are the
  pre-existing update-before-mount race reporting `browser webview is not
  mounted` — a message from inside the command, which is itself evidence the
  arguments deserialized.

New `Geometry` shape on the wire, both sides in this PR:

```ts
invoke('browser_host_update', { label, geometry: { x, y, width, height, visible } })
```

`app/src/browser/host.test.ts` pins that payload, since no typechecker spans
the IPC boundary.
