### PR TITLE
feat(garden): a seed carries a handoff to whoever tends it next

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -64,6 +64,7 @@
     "real-app:scenario-editor-workspace-root": "node scripts/real-app-harness/scenario-editor-workspace-root.mjs",
     "real-app:scenario-autoclose-on-exit": "node scripts/real-app-harness/scenario-autoclose-on-exit.mjs",
     "real-app:scenario-present-flow": "node scripts/real-app-harness/scenario-present-flow.mjs",
+    "real-app:scenario-garden-seed-handoff": "node scripts/real-app-harness/scenario-garden-seed-handoff.mjs",
     "real-app:scenario-ticket-lifecycle": "node scripts/real-app-harness/scenario-ticket-delegation-lifecycle.mjs",
     "real-app:scenario-ordinary-delegation-ticket": "node scripts/real-app-harness/scenario-ordinary-delegation-ticket.mjs",
     "real-app:scenario-ticket-resume": "node scripts/real-app-harness/scenario-ticket-resume.mjs",

--- a/app/scripts/real-app-harness/scenario-garden-seed-handoff.mjs
+++ b/app/scripts/real-app-harness/scenario-garden-seed-handoff.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+//
+// Garden slice 4's acceptance, against the packaged app and its own daemon.
+//
+// Session A tends a seed, leaves a handoff and ends; session B — a fresh
+// errand — runs `attn seed tend` and the note is in its face before it does
+// any work. Both are real app sessions, because the rule under test is "a
+// tender whose session the daemon no longer knows has let go", and only a real
+// session can stop being known.
+//
+// The commands run inside the panes, which is where an agent runs them: the
+// app puts its own `attn` first on a session's PATH, so what a pane answers is
+// this build talking to this profile's daemon. What the CLI prints — order,
+// indentation, the handoff appearing once — is pinned in cmd/attn's unit
+// tests; what this scenario is for is the crossing between two live sessions.
+import path from 'node:path';
+import {
+  createSessionAndWaitForInitialPane,
+  launchFreshAppAndConnect,
+  parseCommonArgs,
+  printCommonHelp,
+} from './common.mjs';
+import { waitForFirstWorkspacePane } from './scenarioAssertions.mjs';
+import { delay } from './macosDriver.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { createScenarioRunner } from './scenarioRunner.mjs';
+import { recordingEnabled } from './windowRecording.mjs';
+import fs from 'node:fs';
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') args.shift();
+  return { options: parseCommonArgs(args), help: args.includes('--help') || args.includes('-h') };
+}
+
+// The handoff body. Short enough to survive any pane width without wrapping,
+// so finding it is finding the note rather than guessing at a line break.
+const HANDOFF = 'PICKUP7 start at freshestHandoff';
+
+function occurrences(haystack, needle) {
+  let count = 0;
+  let at = haystack.indexOf(needle);
+  while (at !== -1) {
+    count += 1;
+    at = haystack.indexOf(needle, at + needle.length);
+  }
+  return count;
+}
+
+// The whole flow runs in about five seconds, which is unreadable in a clip. A
+// recorded run holds each answer on screen long enough to read; an ordinary run
+// pauses for nothing.
+const PACE_MS = recordingEnabled() ? 1_400 : 0;
+
+async function pace() {
+  if (PACE_MS > 0) await delay(PACE_MS);
+}
+
+async function paneText(client, pane) {
+  const payload = await client.request('read_pane_text', pane);
+  return payload.text || '';
+}
+
+// runInPane types a command and waits for a *new* occurrence of what the
+// command answers. New, not present: the pane still shows what the earlier
+// commands printed, so "contains it" would pass before this command ran.
+async function runInPane(client, pane, command, expected, timeoutMs = 30_000) {
+  const before = occurrences(await paneText(client, pane), expected);
+  await client.request('write_pane', { ...pane, text: command });
+  const deadline = Date.now() + timeoutMs;
+  let text = '';
+  while (Date.now() < deadline) {
+    await delay(250);
+    text = await paneText(client, pane);
+    if (occurrences(text, expected) > before) {
+      await pace();
+      return text;
+    }
+  }
+  throw new Error(`pane never answered ${JSON.stringify(command)} with ${JSON.stringify(expected)}:\n${text}`);
+}
+
+async function openPane(client, observer, runner, label) {
+  const cwd = path.join(runner.sessionDir, label);
+  fs.mkdirSync(cwd, { recursive: true });
+  const sessionId = await createSessionAndWaitForInitialPane({
+    client, observer, cwd, label, agent: 'shell',
+  });
+  const pane = await waitForFirstWorkspacePane(client, sessionId, `pane for ${label}`, 20_000);
+  return { sessionId, paneId: pane.paneId };
+}
+
+async function main() {
+  const { options, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scenario-garden-seed-handoff');
+    return;
+  }
+
+  const client = new UiAutomationClient(options);
+  const observer = new DaemonObserver(options);
+  const runner = createScenarioRunner(options, {
+    scenarioId: 'GardenSeedHandoff',
+    tier: 'local',
+    prefix: 'garden-seed-handoff',
+  });
+
+  let paneA = null;
+  let paneB = null;
+  let seedID = null;
+  let authorID = null;
+  try {
+    await launchFreshAppAndConnect(client, observer);
+
+    paneA = await runner.step('open_session_a', () => openPane(client, observer, runner, 'gardenA'));
+
+    seedID = await runner.step('a_plants_and_tends', async () => {
+      // A shell pane carries no session identity of its own — attn withholds it
+      // so an ordinary command cannot report against a session — so the tender
+      // is named. An agent pane has ATTN_SESSION_ID and passes nothing.
+      const planted = await runInPane(client, paneA,
+        `attn seed plant "carry a seed across two sessions" --session ${paneA.sessionId}`, 's-');
+      // plant answers with the id and nothing else, so the id is a line of its own.
+      const ids = [...planted.matchAll(/^\s*(s-[a-z0-9]{5,})\s*$/gm)].map((match) => match[1]);
+      const id = ids[ids.length - 1];
+      runner.assert(Boolean(id), 'plant answered with a seed id', { planted });
+      const claimed = await runInPane(client, paneA, `attn seed tend ${id} --session ${paneA.sessionId}`, 'is growing');
+      runner.assert(claimed.includes('is growing'), 'A claimed the seed', { claimed });
+      return id;
+    });
+
+    await runner.step('the_panel_shows_the_seed', async () => {
+      await client.request('open_dock_panel', { panelId: 'garden' });
+      await delay(500);
+      const shot = await client.request('capture_screenshot_data', { selector: '.garden-panel' });
+      runner.assert(Boolean(shot?.pngBase64), 'the garden panel is on screen', {});
+      fs.writeFileSync(path.join(runner.runDir, 'garden-panel.png'), Buffer.from(shot.pngBase64, 'base64'));
+      await pace();
+      // The panel is scoped to the active workspace and sits over the pane, so
+      // it is closed again before the crossing: what the successor is told is
+      // told in the terminal.
+      await client.request('dom_click', { selector: '.garden-panel__close' });
+    });
+
+    await runner.step('a_leaves_a_handoff_and_ends', async () => {
+      const left = await runInPane(client, paneA,
+        `attn seed note ${seedID} -m "${HANDOFF}" --handoff --session ${paneA.sessionId}`, 'handoff left on');
+      runner.assert(left.includes('handoff left on'), 'the note was recorded as a handoff', { left });
+      const ended = paneA.sessionId;
+      authorID = ended;
+      await client.request('close_session', { sessionId: ended });
+      await observer.waitFor(
+        () => !observer.sessionsById.has(ended),
+        'session A is a session the daemon no longer knows',
+        30_000,
+      );
+      paneA = null;
+      await pace();
+    });
+
+    paneB = await runner.step('open_session_b', () => openPane(client, observer, runner, 'gardenB'));
+
+    await runner.step('b_tends_and_is_primed', async () => {
+      const claimed = await runInPane(client, paneB, `attn seed tend ${seedID} --session ${paneB.sessionId}`, HANDOFF);
+      runner.assert(claimed.includes('is growing'), 'B claimed the seed A let go of', { claimed });
+      runner.assert(
+        claimed.lastIndexOf('is growing') < claimed.lastIndexOf(HANDOFF),
+        'the claim is confirmed before the handoff', { claimed });
+      // Who wrote it, on the header. The id wraps in a narrow pane, so the
+      // assertion takes the part that cannot straddle a line break.
+      runner.assert(claimed.includes(`handoff — ${authorID.slice(0, 8)}`),
+        'the handoff names the session that left it', { claimed, authorID });
+      runner.writeText('tend.txt', claimed + '\n');
+    });
+
+    await runner.step('show_puts_the_handoff_first', async () => {
+      const shown = await runInPane(client, paneB, `attn seed show ${seedID}`, 'handoff — ');
+      const handoffAt = shown.lastIndexOf('handoff — ');
+      runner.assert(handoffAt < shown.lastIndexOf('status'), 'the handoff is above the seed', { shown });
+      runner.writeText('show.txt', shown + '\n');
+    });
+
+    await runner.step('b_harvests', async () => {
+      const done = await runInPane(client, paneB,
+        `attn seed harvest ${seedID} -m "the handoff reached its successor" --session ${paneB.sessionId}`,
+        'is harvested');
+      runner.assert(done.includes('is harvested'), 'harvest closed the seed', { done });
+    });
+
+    const summary = runner.finishSuccess({ seedID, sessionB: paneB.sessionId });
+    console.log('[RealAppHarness] Garden seed handoff passed.');
+    console.log(JSON.stringify(summary, null, 2));
+  } catch (error) {
+    const summary = runner.finishFailure(error, { seedID });
+    console.error(summary.error);
+    process.exitCode = 1;
+  } finally {
+    for (const pane of [paneA, paneB]) {
+      if (pane) await client.request('close_session', { sessionId: pane.sessionId }).catch(() => {});
+    }
+    await client.quitApp().catch(() => {});
+    await observer.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/app/scripts/real-app-harness/scenarioCatalog.mjs
+++ b/app/scripts/real-app-harness/scenarioCatalog.mjs
@@ -71,6 +71,11 @@ export const scenarioCatalog = [
     timeoutMs: 240_000,
   },
   {
+    id: 'garden-seed-handoff',
+    label: 'Garden seed handoff: one session leaves a handoff and ends, the next is primed on tend',
+    command: ['pnpm', 'run', 'real-app:scenario-garden-seed-handoff'],
+  },
+  {
     id: 'ticket-lifecycle',
     label: 'Ticket lifecycle: chief delegates, worker reports, chief reviews in the panel',
     command: ['pnpm', 'run', 'real-app:scenario-ticket-lifecycle'],

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -239,7 +239,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '237';
+export const PROTOCOL_VERSION = '238';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -5433,6 +5433,7 @@ export interface SeedReadyResultObject {
 }
 
 export interface SeedShowResultObject {
+    handoff?:    Note;
     notes:       Note[];
     notes_total: number;
     relations:   RelationElement[];
@@ -5449,7 +5450,8 @@ export interface RelationElement {
 }
 
 export interface SeedTransitionResultObject {
-    seed: SeedElement;
+    handoff?: Note;
+    seed:     SeedElement;
     [property: string]: any;
 }
 
@@ -5799,6 +5801,7 @@ export interface SeedNote {
 export interface SeedNoteMessage {
     body:               string;
     cmd:                SeedNoteMessageCmd;
+    kind?:              string;
     member?:            string;
     seed_id:            string;
     source_session_id?: string;
@@ -5889,6 +5892,7 @@ export enum SeedShowMessageCmd {
 }
 
 export interface SeedShowResult {
+    handoff?:    Note;
     notes:       Note[];
     notes_total: number;
     relations:   RelationElement[];
@@ -5911,7 +5915,8 @@ export enum SeedTransitionMessageCmd {
 }
 
 export interface SeedTransitionResult {
-    seed: SeedElement;
+    handoff?: Note;
+    seed:     SeedElement;
     [property: string]: any;
 }
 
@@ -15175,6 +15180,7 @@ const typeMap: any = {
         { json: "seeds", js: "seeds", typ: a(r("SeedElement")) },
     ], "any"),
     "SeedShowResultObject": o([
+        { json: "handoff", js: "handoff", typ: u(undefined, r("Note")) },
         { json: "notes", js: "notes", typ: a(r("Note")) },
         { json: "notes_total", js: "notes_total", typ: 0 },
         { json: "relations", js: "relations", typ: a(r("RelationElement")) },
@@ -15187,6 +15193,7 @@ const typeMap: any = {
         { json: "title", js: "title", typ: "" },
     ], "any"),
     "SeedTransitionResultObject": o([
+        { json: "handoff", js: "handoff", typ: u(undefined, r("Note")) },
         { json: "seed", js: "seed", typ: r("SeedElement") },
     ], "any"),
     "SessionInstructionsResultObject": o([
@@ -15437,6 +15444,7 @@ const typeMap: any = {
     "SeedNoteMessage": o([
         { json: "body", js: "body", typ: "" },
         { json: "cmd", js: "cmd", typ: r("SeedNoteMessageCmd") },
+        { json: "kind", js: "kind", typ: u(undefined, "") },
         { json: "member", js: "member", typ: u(undefined, "") },
         { json: "seed_id", js: "seed_id", typ: "" },
         { json: "source_session_id", js: "source_session_id", typ: u(undefined, "") },
@@ -15487,6 +15495,7 @@ const typeMap: any = {
         { json: "seed_id", js: "seed_id", typ: "" },
     ], "any"),
     "SeedShowResult": o([
+        { json: "handoff", js: "handoff", typ: u(undefined, r("Note")) },
         { json: "notes", js: "notes", typ: a(r("Note")) },
         { json: "notes_total", js: "notes_total", typ: 0 },
         { json: "relations", js: "relations", typ: a(r("RelationElement")) },
@@ -15501,6 +15510,7 @@ const typeMap: any = {
         { json: "verb", js: "verb", typ: "" },
     ], "any"),
     "SeedTransitionResult": o([
+        { json: "handoff", js: "handoff", typ: u(undefined, r("Note")) },
         { json: "seed", js: "seed", typ: r("SeedElement") },
     ], "any"),
     "SeedVar": o([

--- a/changelog.d/garden-seed-handoffs.yaml
+++ b/changelog.d/garden-seed-handoffs.yaml
@@ -1,0 +1,17 @@
+kind: added
+area: cli
+change: >
+  A seed can now be handed over. `attn seed note <id> -m "…" --handoff` writes
+  a note to whoever tends that seed next, and it is put in front of them
+  instead of being left in the trail to be found: `attn seed show` renders the
+  freshest handoff above the seed, and `attn seed tend` prints it the moment
+  the claim lands. So a session that leaves a handoff and ends primes the next
+  one before it does any work — a handoff written months and a hundred notes
+  ago still surfaces, because it is looked up rather than scanned for. A seed
+  whose tender's session has ended can now be tended by somebody else: it was
+  already listed by `attn seed ready`, and the claim used to refuse it, naming
+  a session that no longer exists. A tender who gave only `--member` still
+  holds their seed — attn has no way to know a person walked away from a
+  terminal. `attn seed tend|park|harvest|wither|replant --json` now answer with
+  the whole result rather than the seed alone, which is what carries the
+  handoff.

--- a/cmd/attn/seed.go
+++ b/cmd/attn/seed.go
@@ -91,12 +91,14 @@ commands:
         remove the edge. Every link has one.
 
   show <id> [--json]
-        one seed: its state, who tends it, every edge that touches it in both
-        directions, its body, and the newest notes on its trail.
+        one seed: the freshest handoff left on it, its state, who tends it,
+        every edge that touches it in both directions, its body, and the newest
+        notes on its trail.
 
   tend <id> [--member <name>]
         claim the seed and start growing it. One tender at a time: tending a
-        seed somebody else holds is refused, naming them.
+        seed somebody else holds is refused, naming them. The freshest handoff
+        prints on the claim, so picking a seed up primes you.
 
   park <id>
         pause the seed deliberately — it goes dormant and lets go of its
@@ -112,9 +114,11 @@ commands:
         reopen a harvested or withered seed. A closed seed reopens before it
         moves again.
 
-  note <id> -m "<what happened>"
+  note <id> -m "<what happened>" [--handoff]
         append to the seed's trail — what happened and what you learned, for
-        whoever tends it next. - reads stdin.
+        whoever tends it next. - reads stdin. --handoff addresses it to your
+        successor on this seed: show renders the freshest one first and tend
+        prints it on the claim, so it is read before any work.
 
   notes <id> [--limit <n>] [--json]
         the whole trail, newest first. show renders the newest few and says
@@ -130,6 +134,7 @@ flags:
   --plot <crown>     scope a ready answer to one plot
   --tree             nest a listing under its crowns
   --workspace <id>   the workspace to stamp (plant) or to list (ls, ready)
+  --handoff          write a note to whoever tends the seed next (note)
   --member <name>    the crew member asking, recorded as planter, tender or
                      note author
   --session <id>     the session asking (defaults to ATTN_SESSION_ID)
@@ -162,6 +167,7 @@ type seedFlags struct {
 	message   *string
 	out       *string
 	limit     *int
+	handoff   *bool
 }
 
 func newSeedFlags(verb string) *seedFlags {
@@ -179,7 +185,17 @@ func newSeedFlags(verb string) *seedFlags {
 		message:   fs.String("m", "", "the seed's body, as markdown (- reads stdin)"),
 		out:       fs.String("out", "", "file to write (- for stdout)"),
 		limit:     fs.Int("limit", 0, "how many trail entries to read"),
+		handoff:   fs.Bool("handoff", false, "write this note to whoever tends the seed next"),
 	}
+}
+
+// noteKind reads --handoff. The plain trail entry is the default, so a note
+// written the way it always was stays one.
+func (f *seedFlags) noteKind() string {
+	if *f.handoff {
+		return garden.NoteKindHandoff
+	}
+	return ""
 }
 
 // text reads -m, taking stdin when it is "-", so a long body or note can be
@@ -339,22 +355,64 @@ func runSeedShow(args []string) {
 		writeJSON(result)
 		return
 	}
-	printSeed(result.Seed)
+	fprintSeedShow(os.Stdout, result)
+}
+
+// fprintSeedShow renders one seed for a reader. The handoff comes before the
+// seed, not after it: it was written to whoever is reading this, and a
+// continuity note under the body is a note nobody reads.
+func fprintSeedShow(w io.Writer, result *protocol.SeedShowResult) {
+	fprintHandoff(w, result.Handoff)
+	fprintSeed(w, result.Seed)
 	if len(result.Relations) > 0 {
-		fmt.Println()
-		printRelations(result.Relations)
+		fmt.Fprintln(w)
+		fprintRelations(w, result.Relations)
 	}
-	if len(result.Notes) > 0 {
-		fmt.Println()
-		printNotes(result.Notes, result.NotesTotal)
+	// The handoff is already above; repeating it in the trail would print the
+	// same paragraph twice on one screen. What was withheld is counted against
+	// the window the daemon read, not against what is printed here, so dropping
+	// it does not turn one shown note into one hidden note.
+	trail := withoutNote(result.Notes, result.Handoff)
+	if len(trail) > 0 {
+		fmt.Fprintln(w)
+		fprintNotes(w, trail, result.Seed.ID, result.NotesTotal-len(result.Notes))
 	}
 }
 
-// printRelations renders both directions of a seed's edges. The other seed's
+// fprintHandoff renders the freshest handoff as its own block. Nothing prints
+// when there is none — a seed nobody handed over says nothing about handoffs.
+func fprintHandoff(w io.Writer, handoff *protocol.SeedNote) {
+	if handoff == nil {
+		return
+	}
+	fmt.Fprintf(w, "handoff — %s, %s\n",
+		orDash(firstNonEmpty(handoff.AuthorMember, handoff.AuthorSession)), shortStamp(handoff.CreatedAt))
+	for _, line := range strings.Split(strings.TrimRight(handoff.Body, "\n"), "\n") {
+		fmt.Fprintf(w, "  %s\n", line)
+	}
+	fmt.Fprintln(w)
+}
+
+// withoutNote drops one note from a trail by id, so a note rendered elsewhere on
+// the same screen is not printed twice.
+func withoutNote(notes []protocol.SeedNote, drop *protocol.SeedNote) []protocol.SeedNote {
+	if drop == nil {
+		return notes
+	}
+	out := make([]protocol.SeedNote, 0, len(notes))
+	for _, note := range notes {
+		if note.ID != drop.ID {
+			out = append(out, note)
+		}
+	}
+	return out
+}
+
+// fprintRelations renders both directions of a seed's edges. The other seed's
 // state is on the line because "blocked-by s-7k3f9m" is only actionable when the
 // reader can see whether that blocker is still open.
-func printRelations(relations []protocol.SeedRelation) {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+func fprintRelations(out io.Writer, relations []protocol.SeedRelation) {
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 	for _, relation := range relations {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", relation.Label, relation.SeedID, relation.Status, relation.Title)
 	}
@@ -438,8 +496,8 @@ func readyScopeName(result *protocol.SeedReadyResult) string {
 	}
 }
 
-func printSeed(seed protocol.Seed) {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+func fprintSeed(out io.Writer, seed protocol.Seed) {
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 	fmt.Fprintf(w, "%s\t%s\n", seed.ID, seed.Title)
 	fmt.Fprintf(w, "status\t%s\n", seed.Status)
 	fmt.Fprintf(w, "step\t%s\n", seed.StepSlug)
@@ -495,10 +553,23 @@ func runSeedTransition(verb string, args []string) {
 		seedFail(verb, err)
 	}
 	if *f.json {
-		writeJSON(result.Seed)
+		// The whole result, not just the seed: a tend carries the handoff, and a
+		// --json caller that only ever saw the seed would never be primed.
+		writeJSON(result)
 		return
 	}
-	fmt.Println(transitionLine(result.Seed))
+	fprintTransition(os.Stdout, result)
+}
+
+// fprintTransition renders what a move did, and then the handoff when the move
+// was the pickup. The claim is confirmed first — the tender needs to know it
+// landed — and the note it primes with follows on the same screen.
+func fprintTransition(w io.Writer, result *protocol.SeedTransitionResult) {
+	fmt.Fprintln(w, transitionLine(result.Seed))
+	if result.Handoff != nil {
+		fmt.Fprintln(w)
+		fprintHandoff(w, result.Handoff)
+	}
 }
 
 // transitionLine is the one line a move prints: what the seed is now, and who
@@ -520,12 +591,17 @@ func runSeedNote(args []string) {
 	if len(positionals) != 1 {
 		seedFail("note", fmt.Errorf(`needs exactly one seed id, got %d: attn seed note s-7k3f9m -m "what happened"`, len(positionals)))
 	}
-	result, err := seedClient().SeedNote(f.sessionID(), positionals[0], f.text("note"), strings.TrimSpace(*f.member))
+	result, err := seedClient().SeedNote(
+		f.sessionID(), positionals[0], f.text("note"), strings.TrimSpace(*f.member), f.noteKind())
 	if err != nil {
 		seedFail("note", err)
 	}
 	if *f.json {
 		writeJSON(result.Note)
+		return
+	}
+	if result.Note.Kind == garden.NoteKindHandoff {
+		fmt.Printf("handoff left on %s — whoever tends it next reads this first\n", result.Note.SeedID)
 		return
 	}
 	fmt.Printf("noted on %s\n", result.Note.SeedID)
@@ -549,22 +625,32 @@ func runSeedNotes(args []string) {
 		fmt.Printf("nothing on this seed's trail yet — `attn seed note %s -m \"what happened\"` starts it\n", positionals[0])
 		return
 	}
-	printNotes(result.Notes, result.Total)
+	fprintNotes(os.Stdout, result.Notes, positionals[0], result.Total-len(result.Notes))
 }
 
-// printNotes renders a trail newest first, and says what it did not print. A
+// fprintNotes renders a trail newest first, and says what it did not print. A
 // silently short trail reads as a complete one.
-func printNotes(notes []protocol.SeedNote, total int) {
+func fprintNotes(w io.Writer, notes []protocol.SeedNote, seedID string, withheld int) {
 	for i, note := range notes {
 		if i > 0 {
-			fmt.Println()
+			fmt.Fprintln(w)
 		}
-		fmt.Printf("%s  %s\n", shortStamp(note.CreatedAt), orDash(firstNonEmpty(note.AuthorMember, note.AuthorSession)))
-		fmt.Printf("%s\n", strings.TrimRight(note.Body, "\n"))
+		fmt.Fprintf(w, "%s  %s%s\n", shortStamp(note.CreatedAt),
+			orDash(firstNonEmpty(note.AuthorMember, note.AuthorSession)), noteKindSuffix(note.Kind))
+		fmt.Fprintf(w, "%s\n", strings.TrimRight(note.Body, "\n"))
 	}
-	if withheld := total - len(notes); withheld > 0 && len(notes) > 0 {
-		fmt.Printf("\n%d more — `attn seed notes %s`\n", withheld, notes[0].SeedID)
+	if withheld > 0 {
+		fmt.Fprintf(w, "\n%d more — `attn seed notes %s`\n", withheld, seedID)
 	}
+}
+
+// noteKindSuffix labels a trail entry that is not a plain note, so a handoff
+// read in the trail is recognisable as one written to a successor.
+func noteKindSuffix(kind string) string {
+	if kind == "" || kind == garden.NoteKindNote {
+		return ""
+	}
+	return "  " + kind
 }
 
 // runSeedExport is the review bridge: it renders a seed to a markdown file so

--- a/cmd/attn/seed_handoff_print_test.go
+++ b/cmd/attn/seed_handoff_print_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/garden"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+func seedNote(id, kind, body string) protocol.SeedNote {
+	return protocol.SeedNote{
+		ID: id, SeedID: "s-7k3f9m", Kind: kind, Body: body,
+		AuthorMember: "keel", CreatedAt: "2026-08-13T10:22:00Z",
+	}
+}
+
+// The slice's acceptance, at the surface a successor actually reads: the
+// handoff is above the seed, not under its body and not buried in the trail.
+func TestFprintSeedShowPutsTheHandoffFirst(t *testing.T) {
+	left := seedNote("n-aaaaaa", garden.NoteKindHandoff, "the join test is the gate")
+	var buf bytes.Buffer
+	fprintSeedShow(&buf, &protocol.SeedShowResult{
+		Seed:       protocol.Seed{ID: "s-7k3f9m", Title: "carry this", Status: "growing", Body: "the plan"},
+		Notes:      []protocol.SeedNote{left, seedNote("n-bbbbbb", garden.NoteKindNote, "ordinary progress")},
+		NotesTotal: 2,
+		Handoff:    &left,
+	})
+	out := buf.String()
+
+	if !strings.HasPrefix(out, "handoff — keel,") {
+		t.Fatalf("the handoff is not the first thing on the screen:\n%s", out)
+	}
+	if strings.Index(out, "the join test is the gate") > strings.Index(out, "s-7k3f9m") {
+		t.Fatalf("the handoff renders after the seed:\n%s", out)
+	}
+	// Rendered once. The same paragraph twice on one screen reads as a bug.
+	if n := strings.Count(out, "the join test is the gate"); n != 1 {
+		t.Fatalf("the handoff body appears %d times, want once:\n%s", n, out)
+	}
+	if !strings.Contains(out, "ordinary progress") {
+		t.Fatalf("dropping the handoff from the trail dropped the rest of it:\n%s", out)
+	}
+}
+
+// A seed nobody handed over says nothing about handoffs, and its trail is
+// whole.
+func TestFprintSeedShowWithoutAHandoff(t *testing.T) {
+	var buf bytes.Buffer
+	fprintSeedShow(&buf, &protocol.SeedShowResult{
+		Seed:       protocol.Seed{ID: "s-7k3f9m", Title: "quiet", Status: "planted"},
+		Notes:      []protocol.SeedNote{seedNote("n-bbbbbb", garden.NoteKindNote, "what happened")},
+		NotesTotal: 1,
+	})
+	out := buf.String()
+
+	if strings.Contains(out, "handoff") {
+		t.Fatalf("a seed with no handoff mentions one:\n%s", out)
+	}
+	if !strings.Contains(out, "what happened") {
+		t.Fatalf("the trail is missing:\n%s", out)
+	}
+}
+
+// Dropping the handoff from the trail must not turn a shown note into a hidden
+// one: what is withheld is counted against the window the daemon read.
+func TestFprintSeedShowCountsWhatItWithheld(t *testing.T) {
+	left := seedNote("n-aaaaaa", garden.NoteKindHandoff, "over to you")
+	notes := []protocol.SeedNote{left}
+	for _, id := range []string{"n-bbbbbb", "n-cccccc", "n-dddddd", "n-eeeeee"} {
+		notes = append(notes, seedNote(id, garden.NoteKindNote, "progress "+id))
+	}
+	var buf bytes.Buffer
+	fprintSeedShow(&buf, &protocol.SeedShowResult{
+		Seed:       protocol.Seed{ID: "s-7k3f9m", Title: "busy", Status: "growing"},
+		Notes:      notes,
+		NotesTotal: 9,
+		Handoff:    &left,
+	})
+
+	if out := buf.String(); !strings.Contains(out, "4 more — `attn seed notes s-7k3f9m`") {
+		t.Fatalf("the withheld count is wrong or missing:\n%s", out)
+	}
+}
+
+// A handoff read in the trail — an older one, or one on `attn seed notes` — is
+// labelled, so it is recognisable as written to a successor rather than to
+// nobody.
+func TestFprintNotesLabelsAHandoff(t *testing.T) {
+	var buf bytes.Buffer
+	fprintNotes(&buf, []protocol.SeedNote{
+		seedNote("n-aaaaaa", garden.NoteKindHandoff, "over to you"),
+		seedNote("n-bbbbbb", garden.NoteKindNote, "progress"),
+	}, "s-7k3f9m", 0)
+	out := buf.String()
+
+	handoffLine, plainLine := "", ""
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "2026-08-13") {
+			if handoffLine == "" {
+				handoffLine = line
+			} else if plainLine == "" {
+				plainLine = line
+			}
+		}
+	}
+	if !strings.Contains(handoffLine, garden.NoteKindHandoff) {
+		t.Fatalf("a handoff on the trail is not labelled: %q", handoffLine)
+	}
+	if strings.Contains(plainLine, garden.NoteKindNote) {
+		t.Fatalf("a plain note carries a kind nobody needs: %q", plainLine)
+	}
+}
+
+// Tending confirms the claim first — the tender needs to know it landed — and
+// primes with the handoff on the same screen.
+func TestFprintTransitionPrimesOnTend(t *testing.T) {
+	left := seedNote("n-aaaaaa", garden.NoteKindHandoff, "start at the docstore compiler")
+	var buf bytes.Buffer
+	fprintTransition(&buf, &protocol.SeedTransitionResult{
+		Seed:    protocol.Seed{ID: "s-7k3f9m", Status: "growing", TenderMember: "alder"},
+		Handoff: &left,
+	})
+	out := buf.String()
+
+	if !strings.HasPrefix(out, "s-7k3f9m is growing, tended by alder\n") {
+		t.Fatalf("the claim is not confirmed first:\n%s", out)
+	}
+	if !strings.Contains(out, "start at the docstore compiler") {
+		t.Fatalf("tend did not print the handoff:\n%s", out)
+	}
+
+	// A move that carries none says nothing about handoffs.
+	buf.Reset()
+	fprintTransition(&buf, &protocol.SeedTransitionResult{
+		Seed: protocol.Seed{ID: "s-7k3f9m", Status: "dormant"},
+	})
+	if out := buf.String(); strings.Contains(out, "handoff") {
+		t.Fatalf("a move with no handoff mentions one:\n%s", out)
+	}
+}
+
+// A multi-line handoff stays readable: every line is indented under its header,
+// so the note is one block instead of prose that runs into the seed below it.
+func TestFprintHandoffIndentsEveryLine(t *testing.T) {
+	left := seedNote("n-aaaaaa", garden.NoteKindHandoff, "first line\nsecond line\n")
+	var buf bytes.Buffer
+	fprintHandoff(&buf, &left)
+
+	for _, want := range []string{"  first line\n", "  second line\n"} {
+		if !strings.Contains(buf.String(), want) {
+			t.Fatalf("line %q is not indented under the header:\n%s", strings.TrimSpace(want), buf.String())
+		}
+	}
+}

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -445,10 +445,25 @@ blocker frees its dependent at the next call, with nobody clearing anything.
 `attn seed ready` scopes to the calling session's workspace unless told
 otherwise, and every attn-launched agent starts knowing its workspace's count.
 
+"Nobody holds it" is one rule, shared by `ready` and by the claim `tend` makes,
+so a seed offered by one is accepted by the other. A tender whose session the
+daemon no longer knows has let go — which is how a successor picks up a seed
+somebody tended and then ended on. A tender that names only a crew member
+always holds: attn has no signal that a person in a terminal pane walked away.
+
 A **note** is one entry on a seed's trail: what happened and what was learned,
 written for whoever tends that seed next. Notes are anchored to the work and
 routed to nobody — a message with an addressee is a message, not a note — and
 they are read where the tender already looks, in the seed's own `show`.
+
+A **handoff** is a note kind: one written to your successor on this seed
+(`attn seed note <id> -m "…" --handoff`). It is still a note on the trail and
+still routed to nobody, but the freshest one is put in front of whoever picks
+the seed up — `attn seed show` renders it above the seed, and `attn seed tend`
+prints it on the claim — so pickup primes without anybody being told to go
+looking. This is continuity along the *seed*: a crew member's handoff, filed in
+their home when they wrap, is continuity along the *member*, and the two are
+independent.
 
 Plan:
 [docs/plans/2026-08-06-the-garden-vertical-slices.md](plans/2026-08-06-the-garden-vertical-slices.md).

--- a/docs/plans/2026-08-06-the-garden-vertical-slices.md
+++ b/docs/plans/2026-08-06-the-garden-vertical-slices.md
@@ -383,17 +383,30 @@ two-axis rule, seed side.
 
 Ships:
 
-- [ ] A note kind `handoff`: `attn seed note <id> -m --handoff` (or
+- [x] A note kind `handoff`: `attn seed note <id> -m --handoff` (or
       equivalent flag) marking "written to my successor on this seed".
-- [ ] `attn seed show` surfaces the freshest handoff note prominently;
+- [x] `attn seed show` surfaces the freshest handoff note prominently;
       `tend` prints it on claim so pickup primes automatically.
 - [ ] The `/handoff` skill (crew side) gains one step: for each seed you
       tended and are not harvesting, leave a seed handoff note. Member
-      homes stay untouched otherwise — the axes are additive.
+      homes stay untouched otherwise — the axes are additive. *Lands
+      outside this repo: the skill is in the maintainer's user config, so
+      it does not ride a repo PR.*
+
+One rule fixed while building this (2026-08-12): `ready` and `tend` decided
+"is somebody holding this" separately, so a seed whose tender's session had
+ended was offered by `ready` and then refused by `tend` — naming a session that
+no longer exists, which is an answer nobody can act on. It is also exactly the
+wall this slice hits, since leaving a handoff and ending is what a successor
+picks up from. Both now read `Tender.Holds`.
+
+The handoff is not on the wire Seed and so not in the panel: the plan gives
+slice 4 no app line, and the panel renders no notes of any kind today. Whichever
+slice teaches it the trail teaches it handoffs in the same move.
 
 Acceptance:
 
-- [ ] Session A tends a seed, files a handoff note, ends. Session B (a
+- [x] Session A tends a seed, files a handoff note, ends. Session B (a
       fresh errand) runs `tend` and the note is in its face before any
       work.
 

--- a/internal/client/garden.go
+++ b/internal/client/garden.go
@@ -91,14 +91,18 @@ func (c *Client) SeedTransition(sessionID, seedID, verb, reason, member string) 
 	return resp.SeedTransitionResult, nil
 }
 
-// SeedNote appends one entry to a seed's trail.
-func (c *Client) SeedNote(sessionID, seedID, body, member string) (*protocol.SeedNoteResult, error) {
+// SeedNote appends one entry to a seed's trail. An empty kind is the plain
+// entry; `handoff` writes it to whoever tends the seed next.
+func (c *Client) SeedNote(sessionID, seedID, body, member, kind string) (*protocol.SeedNoteResult, error) {
 	msg := protocol.SeedNoteMessage{Cmd: protocol.CmdSeedNote, SeedID: seedID, Body: body}
 	if sessionID != "" {
 		msg.SourceSessionID = protocol.Ptr(sessionID)
 	}
 	if member != "" {
 		msg.Member = protocol.Ptr(member)
+	}
+	if kind != "" {
+		msg.Kind = protocol.Ptr(kind)
 	}
 	resp, err := c.send(msg)
 	if err != nil {

--- a/internal/daemon/garden.go
+++ b/internal/daemon/garden.go
@@ -564,6 +564,7 @@ func (d *Daemon) handleSeedShow(conn net.Conn, msg *protocol.SeedShowMessage) {
 			Notes:      notes,
 			NotesTotal: total,
 			Relations:  gardenRelations(read, seed.ID),
+			Handoff:    d.gardenHandoff(seed.ID),
 		},
 	})
 }
@@ -799,10 +800,13 @@ func (d *Daemon) handleSeedTransition(conn net.Conn, msg *protocol.SeedTransitio
 		d.sendGardenError(conn, string(verb), err)
 		return
 	}
-	d.sendGardenResponse(conn, protocol.Response{
-		Ok:                   true,
-		SeedTransitionResult: &protocol.SeedTransitionResult{Seed: seedToProtocol(seed, doc, d.gardenReady()[seed.ID])},
-	})
+	result := &protocol.SeedTransitionResult{Seed: seedToProtocol(seed, doc, d.gardenReady()[seed.ID])}
+	// Tending is the pickup, so it is the move that primes: whoever just claimed
+	// the seed reads what the last tender wrote to them before doing any work.
+	if verb == garden.VerbTend {
+		result.Handoff = d.gardenHandoff(seed.ID)
+	}
+	d.sendGardenResponse(conn, protocol.Response{Ok: true, SeedTransitionResult: result})
 }
 
 // applySeedTransition is the atomic claim, and the same read-decide-write for
@@ -830,7 +834,7 @@ func (d *Daemon) applySeedTransition(id string, verb garden.Verb, actor garden.T
 		if err != nil {
 			return garden.Seed{}, docstore.Document{}, err
 		}
-		next, err := garden.Transition(seed, verb, actor, reason)
+		next, err := garden.Transition(seed, verb, actor, reason, d.sessionExists)
 		if err != nil {
 			return garden.Seed{}, docstore.Document{}, err
 		}
@@ -867,6 +871,11 @@ func (d *Daemon) handleSeedNote(conn net.Conn, msg *protocol.SeedNoteMessage) {
 		d.sendGardenError(conn, "note", err)
 		return
 	}
+	kind, err := garden.ParseNoteKind(protocol.Deref(msg.Kind))
+	if err != nil {
+		d.sendGardenError(conn, "note", err)
+		return
+	}
 	// A note on a seed that is not planted is refused by name rather than
 	// written into a trail nobody will ever read.
 	seed, _, err := d.readSeed(msg.SeedID)
@@ -881,7 +890,7 @@ func (d *Daemon) handleSeedNote(conn net.Conn, msg *protocol.SeedNoteMessage) {
 	}
 	note := garden.Note{
 		Seed:          seed.ID,
-		Kind:          garden.NoteKindNote,
+		Kind:          kind,
 		Body:          msg.Body,
 		AuthorSession: strings.TrimSpace(protocol.Deref(msg.SourceSessionID)),
 		AuthorMember:  strings.TrimSpace(protocol.Deref(msg.Member)),
@@ -1007,6 +1016,55 @@ func (d *Daemon) readNotes(seedID string, limit int) ([]protocol.SeedNote, int, 
 		total = counted.Count
 	}
 	return notes, total, nil
+}
+
+// freshestHandoff reads the one handoff a tender must see: the newest note of
+// kind `handoff` on this seed. It is its own query rather than a scan of the
+// notes `show` already read, because a handoff older than the newest few trail
+// entries is exactly the one that would fall out of that window — and a
+// continuity surface that goes quiet once the trail gets busy is worse than
+// none.
+//
+// A read failure is not a refusal. The caller is claiming or reading a seed;
+// losing the handoff is worth a log line, never a failed tend.
+func (d *Daemon) freshestHandoff(seedID string) (*protocol.SeedNote, error) {
+	if d.store == nil {
+		return nil, errors.New("no database")
+	}
+	read, _, err := d.runDocQuery(docstore.Query{
+		Namespace:  garden.Namespace,
+		Collection: garden.CollectionNotes,
+		Filters: []docstore.Filter{
+			{Field: "seed", Op: docstore.OpEq, Value: seedID},
+			{Field: "kind", Op: docstore.OpEq, Value: garden.NoteKindHandoff},
+		},
+		Sort:  &docstore.Sort{Field: docstore.FieldCreatedAt, Desc: true},
+		Limit: 1,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(read.Documents) == 0 {
+		return nil, nil
+	}
+	doc := read.Documents[0]
+	note, err := garden.DecodeNote(doc.Body)
+	if err != nil {
+		return nil, fmt.Errorf("note %s has an unreadable body: %w", doc.ID, err)
+	}
+	wire := noteToProtocol(note, doc)
+	return &wire, nil
+}
+
+// gardenHandoff is freshestHandoff for the two surfaces that render it, with the
+// logging their contract wants: they answer with the seed either way.
+func (d *Daemon) gardenHandoff(seedID string) *protocol.SeedNote {
+	handoff, err := d.freshestHandoff(seedID)
+	if err != nil {
+		d.logf("garden: reading the freshest handoff on %s: %v", seedID, err)
+		return nil
+	}
+	return handoff
 }
 
 func noteToProtocol(note garden.Note, doc docstore.Document) protocol.SeedNote {

--- a/internal/daemon/garden_handoff_test.go
+++ b/internal/daemon/garden_handoff_test.go
@@ -1,0 +1,191 @@
+package daemon
+
+import (
+	"net"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/bus"
+	"github.com/victorarias/attn/internal/garden"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// handoff writes a note addressed to whoever tends the seed next.
+func handoff(t *testing.T, d *Daemon, session, seedID, body, member string) protocol.SeedNote {
+	t.Helper()
+	msg := protocol.SeedNoteMessage{
+		Cmd: protocol.CmdSeedNote, SeedID: seedID, Body: body, Kind: protocol.Ptr(garden.NoteKindHandoff),
+	}
+	if session != "" {
+		msg.SourceSessionID = protocol.Ptr(session)
+	}
+	if member != "" {
+		msg.Member = protocol.Ptr(member)
+	}
+	resp := gardenCall(t, func(c net.Conn) { d.handleSeedNote(c, &msg) })
+	if !resp.Ok {
+		t.Fatalf("handoff on %s: %v", seedID, protocol.Deref(resp.Error))
+	}
+	return resp.SeedNoteResult.Note
+}
+
+// The slice's acceptance, with two real sessions: session A tends a seed, files
+// a handoff and ends; session B picks the seed up and the handoff is in the
+// answer to its claim, before it has done anything.
+func TestGarden_AHandoffReachesTheNextTender(t *testing.T) {
+	d := newGardenDaemon(t)
+	addGardenSession(t, d, "sess-b")
+	seed := plant(t, d, protocol.SeedPlantMessage{
+		SourceSessionID: protocol.Ptr("sess-a"), Title: "carry this across sessions",
+	})
+
+	move(t, d, "sess-a", seed.ID, garden.VerbTend, "", "trellis")
+	note(t, d, "sess-a", seed.ID, "read the docstore compiler first", "trellis")
+	left := handoff(t, d, "sess-a", seed.ID,
+		"the join test is the gate; run it before touching wireProjections", "trellis")
+	if left.Kind != garden.NoteKindHandoff {
+		t.Fatalf("the note was stored as %q, want a handoff", left.Kind)
+	}
+
+	// Session A ends. The seed keeps A's name on it, and nothing settles it.
+	d.store.Remove("sess-a")
+
+	resp := transition(t, d, "sess-b", seed.ID, garden.VerbTend, "", "alder")
+	if !resp.Ok {
+		t.Fatalf("the successor could not tend the seed: %v", protocol.Deref(resp.Error))
+	}
+	got := resp.SeedTransitionResult.Handoff
+	if got == nil {
+		t.Fatal("tend handed back no handoff; the successor starts blind")
+	}
+	if got.ID != left.ID || got.Body != left.Body {
+		t.Fatalf("tend carried %+v, want the handoff A left", got)
+	}
+	if got.AuthorMember != "trellis" {
+		t.Fatalf("the handoff does not name who wrote it: %+v", got)
+	}
+
+	// And the same note is what `show` puts in front of a reader.
+	shown := show(t, d, seed.ID)
+	if shown.Handoff == nil || shown.Handoff.ID != left.ID {
+		t.Fatalf("show surfaced %+v, want the handoff", shown.Handoff)
+	}
+}
+
+// A handoff outlives the trail window. It is the case a scan of `show`'s newest
+// few notes would miss, and the one that matters most: a busy seed is exactly
+// where a successor needs the note that was written to them.
+func TestGarden_TheFreshestHandoffSurvivesABusyTrail(t *testing.T) {
+	d := newGardenDaemon(t)
+	seed := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "busy"})
+
+	handoff(t, d, "sess-a", seed.ID, "the first word", "keel")
+	newest := handoff(t, d, "sess-a", seed.ID, "the last word", "keel")
+	for range garden.ShowNotes + 2 {
+		note(t, d, "sess-a", seed.ID, "ordinary progress", "keel")
+	}
+
+	shown := show(t, d, seed.ID)
+	if shown.Handoff == nil {
+		t.Fatal("the handoff fell out of the trail window and was lost")
+	}
+	if shown.Handoff.ID != newest.ID {
+		t.Fatalf("show surfaced %q, want the freshest handoff %q", shown.Handoff.ID, newest.ID)
+	}
+	// The window itself is unchanged: `show` still renders the newest few notes
+	// and still counts the whole trail.
+	if len(shown.Notes) != garden.ShowNotes {
+		t.Fatalf("show rendered %d notes, want the usual %d", len(shown.Notes), garden.ShowNotes)
+	}
+	if want := garden.ShowNotes + 4; shown.NotesTotal != want {
+		t.Fatalf("the trail counts %d, want %d — handoffs are notes and are counted as such", shown.NotesTotal, want)
+	}
+}
+
+// Tending is the pickup, so it is the only move whose answer primes. The other
+// four settle a seed; nobody is picking it up and a handoff there is noise.
+func TestGarden_OnlyTendCarriesTheHandoff(t *testing.T) {
+	d := newGardenDaemon(t)
+	seed := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "settled"})
+	handoff(t, d, "sess-a", seed.ID, "what I learned", "keel")
+
+	tended := transition(t, d, "sess-a", seed.ID, garden.VerbTend, "", "keel")
+	if tended.SeedTransitionResult.Handoff == nil {
+		t.Fatal("tend carried no handoff")
+	}
+	for _, tc := range []struct {
+		verb   garden.Verb
+		reason string
+	}{{garden.VerbPark, ""}, {garden.VerbHarvest, "done"}, {garden.VerbReplant, ""}} {
+		resp := transition(t, d, "sess-a", seed.ID, tc.verb, tc.reason, "keel")
+		if !resp.Ok {
+			t.Fatalf("%s: %v", tc.verb, protocol.Deref(resp.Error))
+		}
+		if resp.SeedTransitionResult.Handoff != nil {
+			t.Fatalf("%s carried a handoff; only the pickup primes", tc.verb)
+		}
+	}
+}
+
+// A seed nobody handed over says nothing about handoffs, and a note written the
+// way `attn seed note` always wrote one is still a plain trail entry.
+func TestGarden_NoHandoffIsNoHandoff(t *testing.T) {
+	d := newGardenDaemon(t)
+	seed := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "quiet"})
+	plain := note(t, d, "sess-a", seed.ID, "what happened", "keel")
+	if plain.Kind != garden.NoteKindNote {
+		t.Fatalf("an unkinded note was stored as %q", plain.Kind)
+	}
+
+	if shown := show(t, d, seed.ID); shown.Handoff != nil {
+		t.Fatalf("show invented a handoff: %+v", shown.Handoff)
+	}
+	tended := transition(t, d, "sess-a", seed.ID, garden.VerbTend, "", "keel")
+	if tended.SeedTransitionResult.Handoff != nil {
+		t.Fatal("tend invented a handoff")
+	}
+}
+
+func TestGarden_AnUnknownNoteKindIsRefusedByName(t *testing.T) {
+	d := newGardenDaemon(t)
+	seed := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "kinds"})
+
+	resp := gardenCall(t, func(c net.Conn) {
+		d.handleSeedNote(c, &protocol.SeedNoteMessage{
+			Cmd: protocol.CmdSeedNote, SeedID: seed.ID, Body: "words", Kind: protocol.Ptr("farewell"),
+		})
+	})
+	if resp.Ok {
+		t.Fatal("a note kind nothing knows about was written")
+	}
+	message := protocol.Deref(resp.Error)
+	for _, want := range garden.NoteKinds {
+		if !strings.Contains(message, want) {
+			t.Fatalf("the refusal does not offer %q:\n%s", want, message)
+		}
+	}
+}
+
+// A handoff is a note: it rides `garden.noted` like every other trail entry, so
+// the panel re-push a note already produced covers it and no new fact exists to
+// leave unprojected.
+func TestGarden_AHandoffPublishesTheNoteFact(t *testing.T) {
+	d := newGardenDaemon(t)
+	seed := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "facts"})
+
+	var seen []string
+	unsubscribe := d.eventBus.Subscribe(bus.Filter{"garden.*"}, func(ev bus.Event) {
+		if ev.Subject != seed.ID {
+			t.Errorf("fact %s names subject %q, want the seed", ev.Name, ev.Subject)
+		}
+		seen = append(seen, ev.Name)
+	})
+	defer unsubscribe()
+
+	handoff(t, d, "sess-a", seed.ID, "over to you", "keel")
+
+	if !slices.Equal(seen, []string{FactGardenNoted}) {
+		t.Fatalf("a handoff published %v, want just %s", seen, FactGardenNoted)
+	}
+}

--- a/internal/garden/edges.go
+++ b/internal/garden/edges.go
@@ -175,10 +175,9 @@ func reaches(seeds []Seed, start, kind, target string) []string {
 // person and opens a turn, which is its own later slice), and no live tender
 // holds it.
 //
-// sessionLive answers whether a tender's session is still one the daemon knows.
-// A tender that names only a crew member is always held: attn has no signal that
-// a person in a terminal pane walked away, and handing their seed to somebody
-// else on a guess is worse than leaving it claimed.
+// sessionLive answers whether a tender's session is still one the daemon knows;
+// Tender.Holds is the rule it feeds, shared with the claim `tend` makes, so a
+// seed offered here is one `tend` accepts.
 func Ready(seeds []Seed, sessionLive func(sessionID string) bool) []Seed {
 	index := byID(seeds)
 	blocked := blockedIDs(seeds)
@@ -193,10 +192,8 @@ func Ready(seeds []Seed, sessionLive func(sessionID string) bool) []Seed {
 		case underTemplate(index, seed):
 			continue
 		}
-		if held := seed.Tender(); held.Named() {
-			if held.Session == "" || sessionLive(held.Session) {
-				continue
-			}
+		if seed.Tender().Holds(sessionLive) {
+			continue
 		}
 		ready = append(ready, seed)
 	}

--- a/internal/garden/lifecycle.go
+++ b/internal/garden/lifecycle.go
@@ -69,6 +69,29 @@ func (t Tender) Is(other Tender) bool {
 	return mine == theirs && strings.TrimSpace(t.Member) == strings.TrimSpace(other.Member)
 }
 
+// Holds reports whether this tender still holds its seed, given a way to ask
+// whether a session is one the daemon still knows.
+//
+// It is the one rule `ready` and `tend` both read. They used to decide
+// separately, and a seed whose tender's session had ended was offered by
+// `ready` and then refused by `tend` naming a session that no longer exists —
+// an answer nobody can act on.
+//
+// A tender that names only a crew member always holds: attn has no signal that
+// a person in a terminal pane walked away, and handing their seed to somebody
+// else on a guess is worse than leaving it claimed. A tender with a session
+// holds while the daemon still knows it, `recoverable` included — revive brings
+// that session back to the seed it was tending.
+func (t Tender) Holds(sessionLive func(sessionID string) bool) bool {
+	if !t.Named() {
+		return false
+	}
+	if session := strings.TrimSpace(t.Session); session != "" {
+		return sessionLive(session)
+	}
+	return true
+}
+
 // move is one verb's rule: which states it accepts, where it lands, and what it
 // does to the tender.
 type move struct {
@@ -150,7 +173,11 @@ func ParseVerb(raw string) (Verb, error) {
 // abandoning — and a seed whose tender walked away must stay reachable by
 // somebody; guarding those too would make an ended session a one-way door with
 // no key, which is worse than a rude harvest that the trail records anyway.
-func Transition(seed Seed, verb Verb, actor Tender, reason string) (Seed, error) {
+//
+// sessionLive is how the claim asks whether the tender is still around, and it
+// is the same predicate `ready` reads: a seed `ready` offers must be one `tend`
+// accepts.
+func Transition(seed Seed, verb Verb, actor Tender, reason string, sessionLive func(sessionID string) bool) (Seed, error) {
 	rule, ok := moves[verb]
 	if !ok {
 		return Seed{}, fmt.Errorf("%q is not something a seed does", verb)
@@ -165,7 +192,7 @@ func Transition(seed Seed, verb Verb, actor Tender, reason string) (Seed, error)
 			return Seed{}, fmt.Errorf(
 				"tending %s records who holds it and this call named nobody; run it from an attn session, or pass --member <name>", seed.ID)
 		}
-		if held := seed.Tender(); held.Named() && !held.Is(actor) {
+		if held := seed.Tender(); held.Holds(sessionLive) && !held.Is(actor) {
 			return Seed{}, fmt.Errorf(
 				"%s is being tended by %s, and a seed has one tender at a time.\n"+
 					"Wait for %s to harvest or park it, or say what you need on the trail: attn seed note %s -m \"…\"",
@@ -243,17 +270,40 @@ func refuseState(seed Seed, verb Verb, rule move) error {
 type Note struct {
 	ID   string `json:"id"`
 	Seed string `json:"seed"`
-	// Kind is `note` today; slice 4 adds `handoff`, addressed to the next tender.
+	// Kind is `note` or `handoff`; the notes collection indexes it, which is what
+	// makes "the freshest handoff on this seed" one query.
 	Kind          string `json:"kind"`
 	Body          string `json:"body"`
 	AuthorSession string `json:"author_session"`
 	AuthorMember  string `json:"author_member"`
 }
 
-// NoteKindNote is the plain trail entry. Declared as a constant rather than
-// written as a literal because the notes collection indexes `kind`, and slice
-// 4's handoff is a filter over it.
-const NoteKindNote = "note"
+// The kinds a note may carry. A plain note is the seed's memory of itself; a
+// handoff is written to whoever tends the seed next, which is why `show` and
+// `tend` put the freshest one in front of them instead of leaving it in the
+// trail to be scrolled past.
+const (
+	NoteKindNote    = "note"
+	NoteKindHandoff = "handoff"
+)
+
+// NoteKinds is every kind, in the order they are offered to a caller that named
+// one that is not a kind.
+var NoteKinds = []string{NoteKindNote, NoteKindHandoff}
+
+// ParseNoteKind reads a wire kind, naming the whole set when it is not one. An
+// empty kind is the plain trail entry: a caller that never heard of kinds writes
+// a note, which is what `attn seed note` has always done.
+func ParseNoteKind(raw string) (string, error) {
+	kind := strings.TrimSpace(strings.ToLower(raw))
+	if kind == "" {
+		return NoteKindNote, nil
+	}
+	if slices.Contains(NoteKinds, kind) {
+		return kind, nil
+	}
+	return "", fmt.Errorf("%q is not a kind of note; the kinds are %s", raw, strings.Join(NoteKinds, ", "))
+}
 
 // Note limits.
 //

--- a/internal/garden/lifecycle_test.go
+++ b/internal/garden/lifecycle_test.go
@@ -12,6 +12,14 @@ const (
 	other = "sess-you"
 )
 
+// alive is a daemon that still knows every session. Most of these cases are
+// about the state machine, not about who walked away; the cases that are name
+// their own predicate.
+func alive(string) bool { return true }
+
+// gone is a daemon that knows no session at all.
+func gone(string) bool { return false }
+
 func seedIn(status string, tender Tender) Seed {
 	return Seed{
 		ID: "s-7k3f9m", Title: "a seed", Status: status,
@@ -84,7 +92,7 @@ func TestTransitionMatrix(t *testing.T) {
 			if tc.verb == VerbHarvest || tc.verb == VerbWither {
 				reason = "because"
 			}
-			next, err := Transition(tc.seed, tc.verb, mine, reason)
+			next, err := Transition(tc.seed, tc.verb, mine, reason, alive)
 			// A move never edits the seed it was handed: the daemon writes the
 			// result against the revision it read, and a mutated input would make
 			// a refused move leave a changed seed behind.
@@ -126,7 +134,7 @@ func TestTransitionMatrix(t *testing.T) {
 func TestTransitionMovesTheTender(t *testing.T) {
 	actor := Tender{Session: me, Member: "trellis"}
 
-	claimed, err := Transition(seedIn(StatusPlanted, Tender{}), VerbTend, actor, "")
+	claimed, err := Transition(seedIn(StatusPlanted, Tender{}), VerbTend, actor, "", alive)
 	if err != nil {
 		t.Fatalf("tend: %v", err)
 	}
@@ -138,7 +146,7 @@ func TestTransitionMovesTheTender(t *testing.T) {
 		verb   Verb
 		reason string
 	}{{VerbPark, ""}, {VerbHarvest, "done"}, {VerbWither, "done"}} {
-		released, err := Transition(claimed, tc.verb, actor, tc.reason)
+		released, err := Transition(claimed, tc.verb, actor, tc.reason, alive)
 		if err != nil {
 			t.Fatalf("%s: %v", tc.verb, err)
 		}
@@ -158,7 +166,7 @@ func TestTransitionRefusesAReasonTheMoveWouldDrop(t *testing.T) {
 		if verb == VerbReplant {
 			from = StatusHarvested
 		}
-		_, err := Transition(seedIn(from, Tender{}), verb, actor, "some words")
+		_, err := Transition(seedIn(from, Tender{}), verb, actor, "some words", alive)
 		if err == nil {
 			t.Fatalf("%s swallowed a reason instead of refusing it", verb)
 		}
@@ -175,14 +183,14 @@ func TestTransitionRefusesAReasonTheMoveWouldDrop(t *testing.T) {
 // seed is open.
 func TestReplantClearsTheClosingReason(t *testing.T) {
 	actor := Tender{Session: me}
-	harvested, err := Transition(seedIn(StatusPlanted, Tender{}), VerbHarvest, actor, "shipped it")
+	harvested, err := Transition(seedIn(StatusPlanted, Tender{}), VerbHarvest, actor, "shipped it", alive)
 	if err != nil {
 		t.Fatalf("harvest: %v", err)
 	}
 	if harvested.Reason != "shipped it" {
 		t.Fatalf("harvest did not record the reason: %+v", harvested)
 	}
-	replanted, err := Transition(harvested, VerbReplant, actor, "")
+	replanted, err := Transition(harvested, VerbReplant, actor, "", alive)
 	if err != nil {
 		t.Fatalf("replant: %v", err)
 	}
@@ -195,7 +203,7 @@ func TestReplantClearsTheClosingReason(t *testing.T) {
 // which seed, who holds it, and what to do instead.
 func TestTendRefusalNamesTheTenderAndTheWayForward(t *testing.T) {
 	held := seedIn(StatusGrowing, Tender{Session: other, Member: "alder"})
-	_, err := Transition(held, VerbTend, Tender{Session: me, Member: "trellis"}, "")
+	_, err := Transition(held, VerbTend, Tender{Session: me, Member: "trellis"}, "", alive)
 	if err == nil {
 		t.Fatal("a second session was allowed to take a live claim")
 	}
@@ -217,14 +225,14 @@ func TestTendRefusalNamesTheTenderAndTheWayForward(t *testing.T) {
 func TestTendRefusesAnotherMemberWhenNeitherCarriesASession(t *testing.T) {
 	held := Seed{ID: "s-abc123", Status: StatusGrowing, TenderMember: "trellis"}
 
-	if _, err := Transition(held, VerbTend, Tender{Member: "alder"}, ""); err == nil {
+	if _, err := Transition(held, VerbTend, Tender{Member: "alder"}, "", alive); err == nil {
 		t.Fatal("a different member took a live claim; the seed has one tender at a time")
 	} else if !strings.Contains(err.Error(), "trellis") {
 		t.Fatalf("refusal does not name who holds it: %v", err)
 	}
 
 	// The same name is the same person picking their own work back up.
-	if _, err := Transition(held, VerbTend, Tender{Member: "trellis"}, ""); err != nil {
+	if _, err := Transition(held, VerbTend, Tender{Member: "trellis"}, "", alive); err != nil {
 		t.Fatalf("trellis was refused their own claim: %v", err)
 	}
 }
@@ -234,40 +242,72 @@ func TestTendRefusesAnotherMemberWhenNeitherCarriesASession(t *testing.T) {
 func TestTendIdentifiesASessionByItsIDNotItsLabel(t *testing.T) {
 	held := Seed{ID: "s-abc123", Status: StatusGrowing, TenderSession: "sess-a", TenderMember: "trellis"}
 
-	if _, err := Transition(held, VerbTend, Tender{Session: "sess-a", Member: "keel"}, ""); err != nil {
+	if _, err := Transition(held, VerbTend, Tender{Session: "sess-a", Member: "keel"}, "", alive); err != nil {
 		t.Fatalf("the holding session was refused its own claim: %v", err)
 	}
 	// And a session arriving at a claim nobody attached a session to is somebody
 	// else, whatever it calls itself.
 	memberOnly := Seed{ID: "s-abc123", Status: StatusGrowing, TenderMember: "trellis"}
-	if _, err := Transition(memberOnly, VerbTend, Tender{Session: "sess-a", Member: "trellis"}, ""); err == nil {
+	if _, err := Transition(memberOnly, VerbTend, Tender{Session: "sess-a", Member: "trellis"}, "", alive); err == nil {
 		t.Fatal("a session took a claim held with no session id")
+	}
+}
+
+// `ready` and `tend` read one rule, so a seed offered by one is accepted by the
+// other. They used to decide separately: a tender whose session had ended
+// released the seed into `ready` and then refused the claim, naming a session
+// that no longer exists — an answer nobody can act on, and the wall the
+// handoff flow hits, since leaving a handoff and ending is exactly what a
+// successor picks up from.
+func TestTendReleasesASeedWhoseTenderSessionIsGone(t *testing.T) {
+	held := seedIn(StatusGrowing, Tender{Session: other, Member: "alder"})
+
+	if got := held.Tender().Holds(gone); got {
+		t.Fatal("a tender whose session the daemon no longer knows still holds its seed")
+	}
+	claimed, err := Transition(held, VerbTend, Tender{Session: me, Member: "trellis"}, "", gone)
+	if err != nil {
+		t.Fatalf("a successor was refused a seed whose tender's session ended: %v", err)
+	}
+	if claimed.TenderSession != me || claimed.TenderMember != "trellis" {
+		t.Fatalf("the claim did not move to the successor: %+v", claimed)
+	}
+
+	// A tender that names only a member always holds: attn has no signal that a
+	// person in a terminal pane walked away, so an ended-session rule must not
+	// reach them.
+	pane := Seed{ID: "s-abc123", Status: StatusGrowing, TenderMember: "trellis"}
+	if !pane.Tender().Holds(gone) {
+		t.Fatal("a member-only tender was released by a session rule that cannot see them")
+	}
+	if _, err := Transition(pane, VerbTend, Tender{Member: "alder"}, "", gone); err == nil {
+		t.Fatal("a member-only claim was taken because no session was alive")
 	}
 }
 
 func TestTendRefusalFallsBackToTheSessionID(t *testing.T) {
 	held := seedIn(StatusGrowing, Tender{Session: other})
-	_, err := Transition(held, VerbTend, Tender{Session: me}, "")
+	_, err := Transition(held, VerbTend, Tender{Session: me}, "", alive)
 	if err == nil || !strings.Contains(err.Error(), other) {
 		t.Fatalf("a member-less tender did not hold the claim by name: %v", err)
 	}
 }
 
 func TestTendNeedsSomebodyToRecord(t *testing.T) {
-	_, err := Transition(seedIn(StatusPlanted, Tender{}), VerbTend, Tender{}, "")
+	_, err := Transition(seedIn(StatusPlanted, Tender{}), VerbTend, Tender{}, "", alive)
 	if err == nil || !strings.Contains(err.Error(), "--member") {
 		t.Fatalf("a tend that names nobody was accepted or refused unhelpfully: %v", err)
 	}
 }
 
 func TestHarvestNeedsAReason(t *testing.T) {
-	_, err := Transition(seedIn(StatusPlanted, Tender{}), VerbHarvest, Tender{Session: me}, "  ")
+	_, err := Transition(seedIn(StatusPlanted, Tender{}), VerbHarvest, Tender{Session: me}, "  ", alive)
 	if err == nil || !strings.Contains(err.Error(), "-m") {
 		t.Fatalf("a wordless harvest was accepted or refused unhelpfully: %v", err)
 	}
 	// Withering may be wordless: often there is nothing to say beyond "nobody
 	// will pick this up".
-	withered, err := Transition(seedIn(StatusPlanted, Tender{}), VerbWither, Tender{Session: me}, "")
+	withered, err := Transition(seedIn(StatusPlanted, Tender{}), VerbWither, Tender{Session: me}, "", alive)
 	if err != nil {
 		t.Fatalf("a wordless wither was refused: %v", err)
 	}
@@ -277,7 +317,7 @@ func TestHarvestNeedsAReason(t *testing.T) {
 }
 
 func TestReasonLimitNamesItselfAndPointsAtTheTrail(t *testing.T) {
-	_, err := Transition(seedIn(StatusPlanted, Tender{}), VerbHarvest, Tender{Session: me}, strings.Repeat("x", MaxReasonChars+1))
+	_, err := Transition(seedIn(StatusPlanted, Tender{}), VerbHarvest, Tender{Session: me}, strings.Repeat("x", MaxReasonChars+1), alive)
 	if err == nil {
 		t.Fatal("an oversized reason was accepted")
 	}
@@ -326,6 +366,31 @@ func TestValidateNote(t *testing.T) {
 	}
 	if err := ValidateNote("what happened"); err != nil {
 		t.Fatalf("a real note was refused: %v", err)
+	}
+}
+
+func TestParseNoteKindNamesTheWholeSet(t *testing.T) {
+	// An unnamed kind is the plain trail entry: `attn seed note` wrote one
+	// before kinds existed and must keep writing one.
+	if got, err := ParseNoteKind(""); err != nil || got != NoteKindNote {
+		t.Fatalf("ParseNoteKind(\"\") = %q, %v; want the plain note", got, err)
+	}
+	for _, kind := range NoteKinds {
+		if got, err := ParseNoteKind(kind); err != nil || got != kind {
+			t.Fatalf("ParseNoteKind(%q) = %q, %v", kind, got, err)
+		}
+	}
+	if got, err := ParseNoteKind(" HANDOFF "); err != nil || got != NoteKindHandoff {
+		t.Fatalf("a kind is read case- and space-insensitively: %q, %v", got, err)
+	}
+	_, err := ParseNoteKind("farewell")
+	if err == nil {
+		t.Fatal("an unknown note kind was accepted")
+	}
+	for _, kind := range NoteKinds {
+		if !strings.Contains(err.Error(), kind) {
+			t.Fatalf("the refusal does not offer %q: %s", kind, err)
+		}
 	}
 }
 

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "237"
+const ProtocolVersion = "238"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -5495,6 +5495,9 @@ type SeedNoteMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
 
+	// Kind corresponds to the JSON schema field "kind".
+	Kind *string `json:"kind,omitempty,omitzero"`
+
 	// Member corresponds to the JSON schema field "member".
 	Member *string `json:"member,omitempty,omitzero"`
 
@@ -5605,6 +5608,9 @@ type SeedShowMessage struct {
 }
 
 type SeedShowResult struct {
+	// Handoff corresponds to the JSON schema field "handoff".
+	Handoff *SeedNote `json:"handoff,omitempty,omitzero"`
+
 	// Notes corresponds to the JSON schema field "notes".
 	Notes []SeedNote `json:"notes"`
 
@@ -5639,6 +5645,9 @@ type SeedTransitionMessage struct {
 }
 
 type SeedTransitionResult struct {
+	// Handoff corresponds to the JSON schema field "handoff".
+	Handoff *SeedNote `json:"handoff,omitempty,omitzero"`
+
 	// Seed corresponds to the JSON schema field "seed".
 	Seed Seed `json:"seed"`
 }

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -4342,6 +4342,11 @@ model SeedShowResult {
   // `edges` carry only what it points at, and "what blocks me" is the half a
   // tender actually needs.
   "relations": SeedRelation[];
+  // The freshest handoff on this seed, absent when nobody left one. It rides
+  // beside `notes` rather than being found in them: a handoff is written to
+  // whoever tends the seed next, so it is rendered before the seed itself and
+  // not left to be recognised in a trail.
+  "handoff"?: SeedNote;
 }
 
 // One edge as it reads from one seed's point of view: `blocks` and `part-of`
@@ -4412,6 +4417,10 @@ model SeedTransitionMessage {
 
 model SeedTransitionResult {
   "seed": Seed;
+  // The freshest handoff, carried on `tend` alone: tending is the pickup, so it
+  // is the one move whose answer has to prime the tender. The other four are
+  // fate calls and nobody is picking the seed up.
+  "handoff"?: SeedNote;
 }
 
 // One entry on a seed's trail: what happened and what was learned, written for
@@ -4420,7 +4429,8 @@ model SeedTransitionResult {
 model SeedNote {
   "id": string;
   "seed_id": string;
-  // note today; slice 4 adds handoff.
+  // note or handoff. A handoff is written to whoever tends the seed next, and
+  // the freshest one is put in front of them by show and tend.
   "kind": string;
   "body": string;
   "author_session": string;
@@ -4434,6 +4444,9 @@ model SeedNoteMessage {
   "seed_id": string;
   "body": string;
   "member"?: string;
+  // Omitted is a plain trail entry, so a caller that never heard of kinds
+  // writes a note. An unknown kind is refused, naming the whole set.
+  "kind"?: string;
 }
 
 model SeedNoteResult {


### PR DESCRIPTION
Garden slice 4 — the seed axis of continuity. A seed can now carry a note
written to whoever tends it next, so work picked up by a fresh session starts
where the last one stopped instead of from the trail.

## What ships

- **A note kind.** `attn seed note <id> -m "…" --handoff` files the note as a
  handoff. The kinds are `note` and `handoff`; an unknown one is refused by
  name, listing the set.
- **It is put in front of the successor, not left to be found.**
  `attn seed show` renders the freshest handoff above the seed, and
  `attn seed tend` prints it the moment the claim lands — the only move that
  carries it, because tend is the moment somebody picks the seed up.
- **The freshest handoff is looked up, not scanned for.** `show` reads the
  newest few notes; a handoff written a hundred notes ago would fall out of
  that window, which is exactly the seed where it matters. It is its own
  indexed query over the notes collection (`seed`, `kind`, newest first,
  limit 1).

A handoff is a note, so it publishes the existing `garden.noted` fact and rides
the `garden.*` projection already there — no new fact, per what slice 2
established. `TestGarden_AHandoffPublishesTheNoteFact` pins that.

## A rule that was decided twice

`ready` and `tend` each decided "is somebody holding this seed", separately. A
seed whose tender's session had ended was offered by `ready` and then refused by
`tend`, naming a session that no longer exists — an answer nobody can act on,
and it would have hit the acceptance flow head-on: session A tends, ends, and B
can never claim what A left. Both now read one rule, `Tender.Holds`. A tender
who gave only `--member` still holds their seed: attn has no way to know a
person walked away from a terminal.

## Wire and CLI shape

- Protocol 237 → 238: `seed_note` takes an optional `kind`; `seed_show_result`
  and `seed_transition_result` carry an optional `handoff`.
- `attn seed tend|park|harvest|wither|replant --json` now answer with the whole
  result rather than the seed alone — that is what carries the handoff. The
  seed moved from the top level to `.seed`.

## Not in this PR

- **The panel.** The plan gives slice 4 no app line (slices 1–3 each named
  one), and the panel renders no notes of any kind today. Putting the handoff
  on the wire `Seed` would mean a bulk notes query on every seed push plus a
  permanent protocol field for a surface that has nowhere to draw it. Whichever
  slice teaches the panel the trail teaches it handoffs in the same move; noted
  in the plan doc.
- **The `/handoff` crew skill's leave-a-seed-handoff step** — the plan's third
  slice-4 box. That skill lives in the maintainer's user config, not this repo,
  so it does not ride a repo PR. The box is left open with that note.

## Verification

Live, on a throwaway `gardenho` profile installed from this branch (preflight
PASS, protocol 238 on both `cli_app` and `app_daemon`).

The acceptance flow is a new packaged-app scenario,
`real-app:scenario-garden-seed-handoff`, and it runs the commands **inside the
panes** — the app puts its own `attn` first on a session's PATH, so what a pane
answers is this build talking to this profile's daemon. Session A plants, tends,
leaves a handoff, and is closed; the scenario waits until the daemon no longer
knows that session; session B then tends and is told what A left, before it does
anything else. What the CLI prints — order, indentation, the handoff appearing
once, the withheld count — is pinned in `cmd/attn`'s unit tests; the scenario is
for the crossing between two live sessions.

![recording-01](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/f45d54fe161a840759df091721ce2255564b51ba/feat-garden-slice-4/recording-01.gif)

[Full-quality recording (mp4)](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/f45d54fe161a840759df091721ce2255564b51ba/feat-garden-slice-4/recording-01.mp4)

The garden panel is checked in the same run (it opens, lists the tended seed
with its tender, and closes) so the wire change is shown not to disturb it.

Also green: `go build ./...`, `go test` for `internal/garden`,
`internal/daemon`, `cmd/attn`, `internal/client`, `internal/protocol`; the
frontend suite (250 files, 2775 tests); `tsc --noEmit`; and
`make build-linux-amd64`.
