### PR TITLE
docs(plans): record the crew-skill seed-handoff step as landed

### DIFF
--- a/changelog.d/tick-crew-handoff-step.yaml
+++ b/changelog.d/tick-crew-handoff-step.yaml
@@ -1,0 +1,6 @@
+kind: internal
+area: docs
+change: >
+  The garden plan's last slice-4 box is ticked: the crew /handoff skill
+  gained its leave-a-seed-handoff step in the maintainer's user config,
+  outside the repo, so the plan records it as landed with the date.

--- a/docs/plans/2026-08-06-the-garden-vertical-slices.md
+++ b/docs/plans/2026-08-06-the-garden-vertical-slices.md
@@ -427,11 +427,11 @@ Ships:
       equivalent flag) marking "written to my successor on this seed".
 - [x] `attn seed show` surfaces the freshest handoff note prominently;
       `tend` prints it on claim so pickup primes automatically.
-- [ ] The `/handoff` skill (crew side) gains one step: for each seed you
+- [x] The `/handoff` skill (crew side) gains one step: for each seed you
       tended and are not harvesting, leave a seed handoff note. Member
-      homes stay untouched otherwise — the axes are additive. *Lands
-      outside this repo: the skill is in the maintainer's user config, so
-      it does not ride a repo PR.*
+      homes stay untouched otherwise — the axes are additive. *Landed
+      outside this repo 2026-08-13: the skill lives in the maintainer's
+      user config, so the step shipped there, not in a repo PR.*
 
 One rule fixed while building this (2026-08-12): `ready` and `tend` decided
 "is somebody holding this" separately, so a seed whose tender's session had


### PR DESCRIPTION
The garden plan's third slice-4 checkbox covered the `/handoff` crew skill gaining one step: for each seed tended and not harvested, leave a seed handoff note (`attn seed note <id> -m ... --handoff`, shipped in #879). That skill lives in the maintainer's user config, outside this repo, and the step landed there on 2026-08-13 — worded to keep the two handoff axes distinct (the seed's thread vs the member's day-line). This PR ticks the box and records where and when it landed, so the plan's ledger stays honest.

No code changes; docs and changelog fragment only.

https://claude.ai/code/session_012Bu5dMFLdBfrEo4WmQkF53