### PR TITLE
docs(plans): rule the garden's scope — plots only, workspace stamp retires

### DIFF
--- a/changelog.d/garden-scope-ruling.yaml
+++ b/changelog.d/garden-scope-ruling.yaml
@@ -1,0 +1,8 @@
+kind: internal
+area: docs
+change: >
+  The garden drops location scoping: Victor ruled plots are the only
+  grouping, after the receipt that every production workspace is a
+  worktree of the same project. The scope-rethink doc records the
+  options and ruling, a desktops note captures the wider workspace
+  untangle, and the garden plan repoints its decisions and slice 5.

--- a/docs/plans/2026-08-06-the-garden-vertical-slices.md
+++ b/docs/plans/2026-08-06-the-garden-vertical-slices.md
@@ -172,15 +172,22 @@ crown s-a1b2c3           body = the plan
 
 ### Scope and lifecycle
 
-- **Every seed belongs somewhere.** A seed is stamped with the workspace of
-  the session that planted it (overridable with `--workspace`); a seed
-  planted outside any workspace context carries none and surfaces only under
-  `--all`. Workspace is the default human scope; the plot is the default
-  delegate scope.
+- **Plots are the only grouping (ruled 2026-08-13, superseding "every
+  seed belongs somewhere").** The workspace stamp recorded which
+  checkout the planter stood in, and every production workspace turned
+  out to be a worktree of the same project — the stamp scattered one
+  project's ideas across checkouts. Receipt and priced options:
+  [the scope rethink](2026-08-13-garden-scope-rethink.md). The garden
+  is one space; standing plots ("attn", "home") play the area role as
+  ordinary crowns. The seed schema's `workspace_id` field retires in
+  slice 5, before any production install holds seed data. Directory
+  claims on plots (buying the zero-flag inference back) stay shelved
+  until flag-typing actually stings.
 - **`ready` infers its scope from the caller.** The daemon knows the
-  session: a delegation dispatched at a crown sees its plot's ready seeds; an
-  interactive session sees its workspace's. `--plot`, `--workspace`, `--all`
-  override. Ready = no open `blocks` edges, not dormant, no live tender,
+  session: a delegation dispatched at a crown sees its plot's ready
+  seeds; an interactive session sees the whole garden (per the
+  2026-08-13 scope ruling). `--plot` narrows; `--workspace` retires
+  with the stamp. Ready = no open `blocks` edges, not dormant, no live tender,
   not a template, and — once gates exist — not a gate. Truth at query time;
   nudging a tender when its blocker falls is named-later work.
 
@@ -258,8 +265,10 @@ stateDiagram-v2
   launcher — the chief-guidance injection path is the donor). Two layers:
   a brief garden primer (vocabulary + the ready→tend→harvest loop) injected
   into any attn-launched agent's guidance once the garden is live, and
-  context priming at launch — an interactive session learns its workspace's
-  ready count; a delegate dispatched at a crown starts knowing its plot,
+  context priming at launch — an interactive session learns the garden's
+  ready count (repointed from the workspace's by the 2026-08-13 scope
+  ruling; slice 5 does the repointing); a delegate dispatched at a
+  crown starts knowing its plot,
   its ready seeds, and the freshest handoffs. No agent should have to
   discover the garden exists.
 - **Audit trail = revisions + notes + facts.** Docstore revisions record
@@ -471,6 +480,11 @@ Ships:
 - [ ] `attn seed show <crown>` includes plot progress; a stale-plot query
       (`attn seed ls --stale`) exists as a *query*, not an automatic reaper
       — a person (or later a crew member) decides what withers.
+- [ ] The scope ruling lands: the `workspace_id` stamp and the
+      `--workspace` flag retire from plant/ls/ready; flag-free
+      interactive `ready`/`ls` answer for the whole garden; the panel
+      defaults to whole garden with its toggle scoping by plot; launch
+      priming speaks of the garden, not "your workspace's ready count".
 
 Acceptance:
 

--- a/docs/plans/2026-08-13-desktops-note.md
+++ b/docs/plans/2026-08-13-desktops-note.md
@@ -1,0 +1,68 @@
+# Desktops: untangling the workspace
+
+Conversation capture, 2026-08-13 — direction with early rulings, not
+yet a plan. Written so the eventual plan starts from what Victor ruled,
+not from archaeology.
+
+## The doubt
+
+The workspace is one word doing five jobs:
+
+```
+workspace ─┬─ launch default    (directory sessions open in)
+           ├─ sidebar grouping  (sessions listed under it)
+           ├─ the screen        (layout panes; switching workspace
+           │                     swaps the whole visible tile set)
+           ├─ shared context    (the per-workspace context.md overlay)
+           └─ scope stamp       (was: garden seeds; annotation keys)
+```
+
+Victor is not in love with two of them: workspace-as-screen (being in
+the same workspace should not force sessions to share the screen, and
+sessions from different workspaces should be able to) and the workspace
+context. Grouping itself makes sense. The wish: freely organize what
+shows together, independent of where sessions belong.
+
+## The desktop
+
+A **desktop** is a composition surface: created and removed freely,
+holding whatever panes were dragged into it — agents with their
+terminals, from any group. A session's group says where it *lives*; its
+desktop says where it *shows*. macOS Spaces for agents.
+
+Migration is incremental, not big-bang: day one, every workspace
+projects a default desktop and behavior is identical to today; free
+desktops grow beside them and the projected ones stop being special.
+The drag mechanics have a donor (the drag-to-workspace drop zones and
+rank keys).
+
+If the workspace stops being the unit agents cohabit, the workspace
+context loses its host. Its content would split along lines that
+already exist — direction and decisions to garden crowns (plans live in
+the garden), durable knowledge to the Notebook. Not ruled; consistent
+with the doubt.
+
+## Ruled (2026-08-13)
+
+1. **One pane, one desktop.** A pane is never on two desktops; drag
+   moves it. (Also sidesteps PTY geometry — one active client owns the
+   grid, so one placement means one size that wins.)
+2. **Sidebar, queue on.** The cross-desktop queue keeps top priority.
+   Below the queue, below pinned agents, desktop names render as
+   clickable rows. Vertical space is precious: leverage the sidebar we
+   have, no new chrome.
+3. **Attention navigation keeps its feel.** Following the next session
+   switches to that session in its desktop. That does not change.
+
+## Open
+
+- **Sidebar with queue off.** Undecided; Victor accepts proposals.
+  Standing proposal: desktops replace workspaces as the sidebar's
+  sections — sessions listed under the desktop holding them, groups
+  demoted to labels — so the structure and the vertical budget mirror
+  today's sidebar exactly. Whatever wins must protect keyboard flow.
+- **Where crew members sit** relative to pinned agents and desktop rows
+  (the crew plan keeps members always visible in the sidebar).
+- **Workspace context's fate**, per above.
+- **What remains of the workspace** once screen and scope are gone:
+  launch default + grouping label + status rollup, or less.

--- a/docs/plans/2026-08-13-garden-scope-rethink.md
+++ b/docs/plans/2026-08-13-garden-scope-rethink.md
@@ -1,0 +1,144 @@
+# Garden scope rethink: what is a seed's "somewhere"?
+
+Written for discussion 2026-08-13, after Victor flagged "we need to
+reconsider the per-workspace seeds/garden" before slices 5–6 build on
+the current answer. This doc grounds what shipped, shows the receipt
+that made the doubt concrete, and prices the options.
+
+## Ruling (2026-08-13)
+
+Victor ruled **C**: location scoping goes; plots are the garden's only
+grouping. D's directory claims stay on the shelf until flag-typing
+actually stings. Slice 5 absorbs the change (it was already the plots
+slice) and the panel's default flips to whole garden, scoped by plot on
+request. The wider doubt behind the ruling — the workspace concept
+bundles too many jobs — is captured in
+[the desktops note](2026-08-13-desktops-note.md).
+
+## What shipped (slices 1–4)
+
+One garden at the home daemon; each seed carries a `workspace_id`
+stamped at plant. Everything downstream scopes by that stamp:
+
+```
+plant  ── stamps ──►  workspace of the planting session
+                      (--workspace overrides; none → empty stamp)
+
+ready  ── infers ──►  interactive session: its workspace's seeds
+                      delegate at a crown:  its plot's seeds
+                      (--plot / --workspace / --all override)
+
+panel  ── filters ──► the workspace being viewed, with a sticky
+                      "Whole garden" toggle; dashboard = whole garden
+
+empty stamp ───────►  surfaces only under --all
+```
+
+The design words behind it: "workspace is the default human scope; the
+plot is the default delegate scope."
+
+## The receipt
+
+What a workspace actually is on the machine that matters — every
+workspace row in production today:
+
+| workspace          | directory                        |
+|--------------------|----------------------------------|
+| attn--reasearch    | ~/projects/victor/attn--reasearch |
+| attn--sunny-meerkat| ~/projects/victor/attn--sunny-meerkat |
+| attn--brisk-marmot | ~/projects/victor/attn--brisk-marmot |
+| attn--fluffy-otter | ~/projects/victor/attn--fluffy-otter |
+| attn--fluffy-otter (duplicate row) | same directory   |
+| attn--crispy-capybara | ~/projects/victor/attn--crispy-capybara |
+| attn--jolly-llama  | ~/projects/victor/attn--jolly-llama |
+
+Seven workspaces; every one a worktree of the same project, one of them
+twice. "This workspace's seeds" therefore answers *"which checkout was
+I standing in when the idea arrived?"* — a question nobody asks. The
+same idea planted from sunny-meerkat and from fluffy-otter lands in two
+different scopes; a duplicate workspace row splits even one checkout's
+seeds in two.
+
+Two more sessions of the same rub, from the crew rewrite:
+
+- Direction seeds — the crew plan, the garden itself — are about the
+  whole system, not any checkout. Whatever plants them mis-stamps them.
+- Crew members get their own cwd, not a workspace. A member planting
+  from its home lands in the empty-stamp ghetto, visible only under
+  `--all`.
+
+## Options
+
+What `ready` answers under each model, same three seeds — an attn idea
+(planted from sunny-meerkat), an attn idea (from fluffy-otter), a
+life admin seed:
+
+```
+A. workspace (today)   B. project           C. plots only
+──────────────────     ──────────────       ──────────────
+in fluffy-otter:       in any attn tree:    anywhere:
+  attn idea #2 only      both attn ideas      all 3 (filter by
+life admin: --all      life admin: its        plot when asked)
+                         own project/none
+```
+
+### A. Keep the workspace stamp
+
+Price of keeping it: the fragmentation above, forever, and it worsens
+with every worktree. Fixing the duplicate row helps nobody — the grain
+itself is wrong. Listed for completeness, not advocated.
+
+### B. Stamp the project, not the checkout
+
+Derive the scope from the repo identity (origin URL or main-checkout
+path), so every attn worktree is one scope. Keeps the "seeds where I'm
+standing" inference. Price: a new project-identity notion the daemon
+does not have today; non-repo sessions still need a fallback; and the
+grain is still *location*, when some seeds are about no location.
+
+### C. Drop location scoping; plots are the only grouping
+
+The garden becomes one space. Standing plots play the area role the
+workspace was playing — "attn", "home", "writing" are crown seeds, and
+`part-of` puts a seed in its area. `ready` and the panel default to the
+whole garden; `--plot` narrows. The plan already ruled "plots are seeds
+with children — one primitive," so this *deletes* a concept instead of
+adding one, and the crew/cwd and direction-seed cases stop being
+special. Price: whole-garden defaults get noisy as seeds grow into the
+hundreds, and "what's relevant where I'm standing" stops being free —
+you name the plot.
+
+### D. C plus a directory claim on plots
+
+C, with the inference restored: a standing plot may claim directories
+("attn" claims `~/projects/victor/attn*`), and a session's cwd resolves
+through the claims to a default plot for plant and ready. One small
+mapping instead of a stamp; wrong claims are visible and editable on
+the crown. Price: the mapping is one more thing to keep true, and
+claims need a loud answer for "two plots claim this directory."
+
+## My read
+
+C is the honest core: the workspace stamp encodes where you stood, and
+where you stood is not what a seed is about. D is C with the one thing
+the stamp genuinely bought — zero-flag inference — bought back at the
+cost of a small, visible mapping instead of an invisible wrong one.
+I'd rule C now and treat D's directory claims as a later slice if the
+flag-typing actually stings. B only wins if "project" is a concept attn
+wants anyway for other reasons; nothing else on the roadmap asks for
+it.
+
+Migration is cheap whichever way: no production install has the garden
+yet, so there is no user state to convert — the schema's `workspace_id`
+field can retire or be repurposed before it ever holds real data.
+
+## If we rule
+
+- Slice 5 (plots and dispatch) absorbs the change: it was already the
+  plot-building slice; it now also removes/repoints the workspace scope
+  in `ready`, `ls`, the panel, and the launch priming ("your
+  workspace's ready count" becomes "your plot's" or "the garden's").
+- The panel's default view flips to whole garden; the toggle scopes to
+  a plot instead of a workspace.
+- The garden plan's "Every seed belongs somewhere" decision gets
+  rewritten with a dated ruling pointing here.


### PR DESCRIPTION
Victor ruled option C of the garden scope rethink on 2026-08-13: location scoping goes, plots are the garden's only grouping.

- **New: `docs/plans/2026-08-13-garden-scope-rethink.md`** — the grounding and ruling record. The receipt: every workspace row in production is a worktree of the same project (one of them twice), so a per-workspace stamp answers "which checkout was I standing in when the idea arrived" — a question nobody asks. Four options priced; C ruled; D's directory claims shelved until flag-typing stings.
- **New: `docs/plans/2026-08-13-desktops-note.md`** — conversation capture of the wider doubt behind the ruling: the workspace bundles five jobs (launch default, grouping, screen, shared context, scope stamp) and a **desktop** composition surface may take the screen job. Carries Victor's early rulings (one pane one desktop; queue-on sidebar order; attention navigation unchanged) and the open forks, so the eventual plan starts from rulings.
- **Garden plan updated** — the "every seed belongs somewhere" decision is superseded with a dated ruling pointing at the rethink doc; `ready`'s interactive default becomes the whole garden; the priming decision repoints; slice 5 gains the absorption checkbox (stamp and `--workspace` retire, panel defaults flip). No production install holds seed data yet, so the schema field retires before it ever carries real state.

Docs only; no code changes.

https://claude.ai/code/session_012Bu5dMFLdBfrEo4WmQkF53