### PR TITLE
feat(app): walk an app's serving history one step at a time

### DIFF
--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -239,7 +239,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '238';
+export const PROTOCOL_VERSION = '239';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -968,13 +968,15 @@ export enum AppStatusMessageCmd {
 }
 
 export interface AppStatusResult {
-    app:              App;
-    invocations:      number;
-    recent?:          InvocationElement[];
-    recent_versions?: CurrentVersion[];
-    runtime?:         Runtime;
-    stall?:           Stall;
-    versions:         number;
+    app:                    App;
+    invocations:            number;
+    recent?:                InvocationElement[];
+    recent_versions?:       CurrentVersion[];
+    runtime?:               Runtime;
+    serving_history?:       CurrentVersion[];
+    serving_history_steps?: number;
+    stall?:                 Stall;
+    versions:               number;
     [property: string]: any;
 }
 
@@ -5265,13 +5267,15 @@ export interface AppSetEnabledResultObject {
 }
 
 export interface AppStatusResultObject {
-    app:              App;
-    invocations:      number;
-    recent?:          InvocationElement[];
-    recent_versions?: CurrentVersion[];
-    runtime?:         Runtime;
-    stall?:           Stall;
-    versions:         number;
+    app:                    App;
+    invocations:            number;
+    recent?:                InvocationElement[];
+    recent_versions?:       CurrentVersion[];
+    runtime?:               Runtime;
+    serving_history?:       CurrentVersion[];
+    serving_history_steps?: number;
+    stall?:                 Stall;
+    versions:               number;
     [property: string]: any;
 }
 
@@ -12442,6 +12446,8 @@ const typeMap: any = {
         { json: "recent", js: "recent", typ: u(undefined, a(r("InvocationElement"))) },
         { json: "recent_versions", js: "recent_versions", typ: u(undefined, a(r("CurrentVersion"))) },
         { json: "runtime", js: "runtime", typ: u(undefined, r("Runtime")) },
+        { json: "serving_history", js: "serving_history", typ: u(undefined, a(r("CurrentVersion"))) },
+        { json: "serving_history_steps", js: "serving_history_steps", typ: u(undefined, 0) },
         { json: "stall", js: "stall", typ: u(undefined, r("Stall")) },
         { json: "versions", js: "versions", typ: 0 },
     ], "any"),
@@ -15065,6 +15071,8 @@ const typeMap: any = {
         { json: "recent", js: "recent", typ: u(undefined, a(r("InvocationElement"))) },
         { json: "recent_versions", js: "recent_versions", typ: u(undefined, a(r("CurrentVersion"))) },
         { json: "runtime", js: "runtime", typ: u(undefined, r("Runtime")) },
+        { json: "serving_history", js: "serving_history", typ: u(undefined, a(r("CurrentVersion"))) },
+        { json: "serving_history_steps", js: "serving_history_steps", typ: u(undefined, 0) },
         { json: "stall", js: "stall", typ: u(undefined, r("Stall")) },
         { json: "versions", js: "versions", typ: 0 },
     ], "any"),

--- a/changelog.d/app-rollback-walks-serving-history.yaml
+++ b/changelog.d/app-rollback-walks-serving-history.yaml
@@ -1,0 +1,10 @@
+kind: changed
+area: app
+change: >
+  `attn app rollback <name>` now walks an app's serving history one step at a
+  time: each bare rollback goes one version further back, instead of returning
+  to where the previous one started. Rolling back past the oldest version on the
+  history refuses and lists the versions. Applying a version, or naming one to
+  roll onto, starts the history again from there, so the way back from a fix is
+  whatever was running when you applied it. Apps mid-rollback when they upgrade
+  keep the version they could already go back to.

--- a/changelog.d/app-rollback-walks-serving-history.yaml
+++ b/changelog.d/app-rollback-walks-serving-history.yaml
@@ -6,5 +6,6 @@ change: >
   to where the previous one started. Rolling back past the oldest version on the
   history refuses and lists the versions. Applying a version, or naming one to
   roll onto, starts the history again from there, so the way back from a fix is
-  whatever was running when you applied it. Apps mid-rollback when they upgrade
-  keep the version they could already go back to.
+  whatever was running when you applied it. `attn app status` shows where a bare
+  rollback can still go, so you can see the walk without running it. Apps
+  mid-rollback when they upgrade keep the version they could already go back to.

--- a/cmd/attn/app.go
+++ b/cmd/attn/app.go
@@ -117,9 +117,9 @@ commands:
 
   status <name> [--json]
         one app in full — its current version, its bus consumer, the ids of its
-        recent versions (what rollback takes), and its most recent runs. Reports
-        only what exists: an app with no consumer says so rather than showing a
-        default.
+        recent versions (what rollback takes), where a bare rollback can still
+        go, and its most recent runs. Reports only what exists: an app with no
+        consumer says so rather than showing a default.
 
   enable <name>
         resume delivery to the app, from wherever its consumer's cursor stands.
@@ -303,6 +303,7 @@ func runAppStatus(args []string) {
 				len(result.RecentVersions), result.Versions)
 		}
 	}
+	fmt.Printf("  rollback:   %s\n", rollbackPath(result))
 	if len(result.Recent) == 0 {
 		fmt.Println("  recent:     no invocations recorded")
 		return
@@ -348,6 +349,28 @@ func indentBlock(prefix, text string) string {
 
 // versionIDList is the line `attn app rollback` sends people looking for: the
 // ids, marked so the one serving is obvious.
+// rollbackPath says where bare `attn app rollback` goes from here, and how far
+// it can keep going — the one question the walk otherwise only answers by being
+// run. The first entry of the serving history is the version serving now, so
+// the path is what follows it.
+func rollbackPath(result *protocol.AppStatusResult) string {
+	if len(result.ServingHistory) < 2 {
+		return "nothing further back — name a version to move onto one the walk went past"
+	}
+	path := result.ServingHistory[1:]
+	parts := make([]string, 0, len(path))
+	for _, v := range path {
+		parts = append(parts, fmt.Sprintf("%d (%s)", v.ID, appbuild.ShortHash(v.ContentHash)))
+	}
+	line := "walks back to " + strings.Join(parts, ", then ")
+	// The history is capped on the wire; saying so is what keeps a walk longer
+	// than the cap from reading as a walk that ends here.
+	if steps := protocol.Deref(result.ServingHistorySteps); steps > len(result.ServingHistory) {
+		line += fmt.Sprintf(", then %d older step(s)", steps-len(result.ServingHistory))
+	}
+	return line
+}
+
 func versionIDList(versions []protocol.AppVersionInfo, current *protocol.AppVersionInfo) string {
 	parts := make([]string, 0, len(versions))
 	for _, v := range versions {

--- a/cmd/attn/app.go
+++ b/cmd/attn/app.go
@@ -92,12 +92,17 @@ commands:
 
   rollback <name> [version]
         point the app at a version it already has — the one you name, or with no
-        version, the one that was serving immediately before the current one.
-        That is a recorded pointer, not the next id down. If a broken version
-        was rolled off before the current one was applied, the next id down is
-        that broken version; what was serving is the one you kept running.
-        Rolling back again returns to where you started, because every move
-        records what it replaced.
+        version, one step back through the app's serving history: the version
+        that was serving immediately before the current one. That is recorded
+        history, not the next id down. If a broken version was rolled off before
+        the current one was applied, the next id down is that broken version;
+        what was serving is the one you kept running.
+
+        Bare rollback again goes one step further back, and again, walking the
+        history down until the oldest version on it; past that it refuses and
+        lists the versions. Applying a version — or naming one here — starts the
+        history again from where it lands, so the way back from a fix is
+        whatever you were running when you applied it.
 
         Builds nothing: the artifact is still on disk.
 

--- a/cmd/attn/app_build.go
+++ b/cmd/attn/app_build.go
@@ -169,11 +169,11 @@ func runAppRollback(args []string) {
 	}
 	target := fmt.Sprintf("version %d (%s)", result.VersionID, appbuild.ShortHash(result.ContentHash))
 	switch {
-	// Bare rollback follows a recorded pointer rather than the version list, and
-	// the id it lands on can be higher than the one it left — rolling back off a
-	// rollback is exactly that. Saying which version was serving is what makes
-	// the choice checkable, and it is always backwards in time, whatever the ids
-	// did.
+	// Bare rollback walks recorded history rather than the version list, and the
+	// id it lands on can be higher than the one it left — a fix applied on top of
+	// an old version leaves exactly that behind it. Saying which version it was
+	// serving before is what makes the choice checkable, and the walk is always
+	// backwards in time, whatever the ids did.
 	case versionID == 0 && result.PreviousVersionID != nil:
 		fmt.Printf("rolled app %s back to %s, which was serving before version %d\n",
 			result.Name, target, *result.PreviousVersionID)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -286,6 +286,14 @@ is the same pointer move to an older row. Re-applying byte-identical content
 reuses the version that is already there, which is what keeps "which version
 actually ran" answerable in the invocation log after a long editing session.
 
+An app's **serving history** is the chain of versions it has served, and it is
+what `attn app rollback <name>` walks. Each bare rollback goes one step further
+back, until the oldest version on the chain, where it refuses rather than
+wrapping. Applying a version — or naming one to roll onto — starts the history
+again from there, so the way back from a fix is whatever was running when it was
+applied. The history is not the version list: a version the walk went past is
+still a version, still reachable by name.
+
 **Applying** is how a directory becomes a version: parse the manifest, generate
 the types the handlers are checked against, typecheck, bundle, hash, write the
 artifact, insert the row, move the pointer. Apply never evaluates the app's

--- a/docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md
+++ b/docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md
@@ -536,17 +536,30 @@ recovery drain, bare-rollback trap):
   because
   profile-isolated daemons share one `~/.local/bin` and one shared file name
   would have the newest sync replace another profile's runtime.
-- **Bare rollback: previously-serving.** `attn app rollback <name>` without
-  a version returns to the version that was serving before the current one
-  — the registry records the pointer at every flip — and says which version
-  it chose and why. No recorded previous fails loud with the version list.
-  *Shipped* (#858) with undo semantics: the pointer swaps on every move, so
-  a second bare rollback returns to where you started (`cd -`), stated in
-  `--help` and tested. **Open, deliberately until the platform work's end:**
-  Victor leans toward a stack instead — each bare rollback walking one step
-  further back through serving history. Undo was shipped first because its
-  meaning never depends on how many times it has run; revisit once real
-  rollback usage exists to judge against.
+- **Bare rollback: one step back through serving history.** `attn app
+  rollback <name>` without a version returns to the version that was serving
+  before the current one, and says which version it chose and why. Walking
+  past the oldest version fails loud with the version list.
+
+  First shipped (#858) with undo semantics — one recorded pointer, swapped
+  at every move, so a second bare rollback returned to where you started
+  (`cd -`). Victor **ruled for a stack on 2026-08-13**, judging it worth
+  deciding then rather than waiting for the platform work's end: each bare
+  rollback walks one step further back, which is what an operator hunting
+  for the last version that worked actually does. Undo could only ever
+  answer that question once.
+
+  Serving history is now data rather than one pointer: `app_serving_steps`
+  is an append-only chain where a step names the version that started
+  serving and the step it was pushed onto, and `apps.serving_step_id` is
+  where the app stands on it. Applying, or naming a version to roll onto,
+  pushes a step and so restarts the walk from there — which makes the way
+  back from a fix the version that was actually running when it was
+  applied, not the ones the walk had already gone past. A bare rollback
+  moves the cursor down one step and pushes nothing. Migration 105 carries
+  every recorded predecessor into a two-step chain, so a profile upgrading
+  mid-rollback lands exactly where the old rule would have put it and can
+  then keep walking.
 - **Restart must not forget a park.** The park persists and is restored at
   daemon startup before anything can lazy-start the broken host; `attn app
   runtime restart` stays the only unpark and clears the persisted state.

--- a/docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md
+++ b/docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md
@@ -556,7 +556,9 @@ recovery drain, bare-rollback trap):
   pushes a step and so restarts the walk from there — which makes the way
   back from a fix the version that was actually running when it was
   applied, not the ones the walk had already gone past. A bare rollback
-  moves the cursor down one step and pushes nothing. Migration 105 carries
+  moves the cursor down one step and pushes nothing. `attn app status` shows
+  the history, so "is there another step and where does it land" is answerable
+  without running the rollback. Migration 105 carries
   every recorded predecessor into a two-step chain, so a profile upgrading
   mid-rollback lands exactly where the old rule would have put it and can
   then keep walking.

--- a/internal/client/apps.go
+++ b/internal/client/apps.go
@@ -72,7 +72,7 @@ func (c *Client) AppApply(name, contentHash, declaration, sourcePath string) (*p
 }
 
 // AppRollback moves an app onto a version it already has. A zero versionID means
-// the version applied before the current one.
+// one step back along the app's serving history.
 func (c *Client) AppRollback(name string, versionID int) (*protocol.AppRollbackResult, error) {
 	msg := protocol.AppRollbackMessage{Cmd: protocol.CmdAppRollback, Name: name}
 	if versionID > 0 {

--- a/internal/daemon/app_apply.go
+++ b/internal/daemon/app_apply.go
@@ -158,7 +158,16 @@ func (d *Daemon) handleAppRollback(conn net.Conn, msg *protocol.AppRollbackMessa
 		d.sendError(conn, err.Error())
 		return
 	}
-	if err := d.store.SetAppCurrentVersion(name, target.ID, time.Now()); err != nil {
+	// The two rollbacks move the pointer differently on purpose. A named version
+	// starts serving history again from where it lands; a bare rollback walks the
+	// existing history down one step, which is what lets the next one walk
+	// further rather than come back here.
+	if msg.VersionID == nil {
+		err = d.store.StepAppVersionBack(name, target.ID, time.Now())
+	} else {
+		err = d.store.SetAppCurrentVersion(name, target.ID, time.Now())
+	}
+	if err != nil {
 		d.sendError(conn, fmt.Sprintf("app rollback %s: %v", name, err))
 		return
 	}
@@ -201,30 +210,31 @@ func pickRollbackTarget(name string, app store.App, versions []store.AppVersion,
 		}
 		return store.AppVersion{}, fmt.Errorf("app rollback %s: version %d is not a version of this app; %s", name, id, versionsSentence(versions, app.CurrentVersionID))
 	}
-	// No version named: whatever was serving immediately before the current one,
-	// which the registry records at every pointer move. The numerically previous
-	// id is a different question and answers it wrong exactly when rollback
-	// matters — an app that went good, broken, fixed has the broken one below its
-	// pointer, and that is the version an operator is running from.
+	// No version named: one step back along the app's serving history, which the
+	// registry extends at every pointer move. The numerically previous id is a
+	// different question and answers it wrong exactly when rollback matters — an
+	// app that went good, broken, fixed has the broken one below its pointer, and
+	// that is the version an operator is running from.
 	//
-	// Because the predecessor is rewritten on every move, rolling back twice
-	// returns to where the first rollback started. That flip-flop is the point:
-	// "back" always means the version that was serving a moment ago.
+	// Because walking moves along the chain rather than rewriting one pointer,
+	// each further bare rollback goes one step further back, and the step below
+	// the one the app stands on is always a version that really did serve before
+	// it.
 	if app.CurrentVersionID == 0 {
 		return store.AppVersion{}, fmt.Errorf("app rollback %s: it is not on any version, so there is no back to go to; name one of them. %s",
 			name, versionsSentence(versions, 0))
 	}
-	if app.PreviousVersionID == 0 {
-		return store.AppVersion{}, fmt.Errorf("app rollback %s: nothing is recorded as serving before version %d, so bare rollback has no target; name the version to roll onto. %s",
+	if app.PreviousServingVersionID == 0 {
+		return store.AppVersion{}, fmt.Errorf("app rollback %s: version %d is the oldest version in its serving history, so there is no further back to go; name the version to roll onto. %s",
 			name, app.CurrentVersionID, versionsSentence(versions, app.CurrentVersionID))
 	}
 	for _, v := range versions {
-		if v.ID == app.PreviousVersionID {
+		if v.ID == app.PreviousServingVersionID {
 			return v, nil
 		}
 	}
 	return store.AppVersion{}, fmt.Errorf("app rollback %s: version %d is recorded as serving before version %d but is not among this app's versions; name the version to roll onto. %s",
-		name, app.PreviousVersionID, app.CurrentVersionID, versionsSentence(versions, app.CurrentVersionID))
+		name, app.PreviousServingVersionID, app.CurrentVersionID, versionsSentence(versions, app.CurrentVersionID))
 }
 
 // versionsSentence lists what an app actually has, marking the current one. It

--- a/internal/daemon/app_apply_test.go
+++ b/internal/daemon/app_apply_test.go
@@ -334,15 +334,16 @@ func TestAppRollbackSkipsAVersionThatWasRolledOff(t *testing.T) {
 	}
 }
 
-// Rolling back twice flips between the two most recent serving versions, because
-// every move rewrites the predecessor. It is the consequence of "back means what
-// was serving a moment ago", and it is what makes rollback undoable.
-func TestAppRollbackTwiceFlipsBetweenTwoVersions(t *testing.T) {
+// Each bare rollback walks one step further back, and the oldest version on the
+// history is the bottom: rolling back again refuses and lists the versions
+// rather than wrapping around onto something the operator already rejected.
+func TestAppRollbackWalksOneStepFurtherBackEachTime(t *testing.T) {
 	d := appApplyDaemon(t)
 	first := applyOK(t, d, "approval-gate", declarationFor("approval-gate", "first"), "export default {}\n")
 	second := applyOK(t, d, "approval-gate", declarationFor("approval-gate", "second"), "export default { two: true }\n")
+	applyOK(t, d, "approval-gate", declarationFor("approval-gate", "third"), "export default { three: true }\n")
 
-	for i, want := range []int{first.VersionID, second.VersionID, first.VersionID} {
+	for i, want := range []int{second.VersionID, first.VersionID} {
 		resp := appRollback(t, d, "approval-gate", 0)
 		if !resp.Ok {
 			t.Fatalf("rollback %d: %v", i+1, protocol.Deref(resp.Error))
@@ -351,21 +352,71 @@ func TestAppRollbackTwiceFlipsBetweenTwoVersions(t *testing.T) {
 			t.Fatalf("rollback %d landed on %d, want %d", i+1, got, want)
 		}
 	}
+	resp := appRollback(t, d, "approval-gate", 0)
+	if resp.Ok {
+		t.Fatalf("a third rollback moved to %d, want the bottom of the history to refuse",
+			resp.AppRollbackResult.VersionID)
+	}
+	msg := protocol.Deref(resp.Error)
+	if !strings.Contains(msg, "oldest version in its serving history") {
+		t.Errorf("error does not name the situation: %s", msg)
+	}
+	if !strings.Contains(msg, fmt.Sprint(second.VersionID)) || !strings.Contains(msg, "current") {
+		t.Errorf("error does not list the versions: %s", msg)
+	}
 }
 
-// An app on its first version has no predecessor to follow, and the numerically
-// previous id is not one — there is nothing below it. The refusal has to name the
+// Applying starts the history again from where the walk stopped, so the way back
+// from a fix is what was actually running when it was applied — not the versions
+// the walk already went past.
+func TestAppApplyRestartsTheRollbackWalk(t *testing.T) {
+	d := appApplyDaemon(t)
+	first := applyOK(t, d, "approval-gate", declarationFor("approval-gate", "first"), "export default {}\n")
+	applyOK(t, d, "approval-gate", declarationFor("approval-gate", "second"), "export default { two: true }\n")
+	third := applyOK(t, d, "approval-gate", declarationFor("approval-gate", "third"), "export default { three: true }\n")
+
+	for i := 0; i < 2; i++ {
+		if resp := appRollback(t, d, "approval-gate", 0); !resp.Ok {
+			t.Fatalf("rollback %d: %v", i+1, protocol.Deref(resp.Error))
+		}
+	}
+	fixed := applyOK(t, d, "approval-gate", declarationFor("approval-gate", "fixed"), "export default { fixed: true }\n")
+
+	resp := appRollback(t, d, "approval-gate", 0)
+	if !resp.Ok {
+		t.Fatalf("rollback off the fix: %v", protocol.Deref(resp.Error))
+	}
+	switch got := resp.AppRollbackResult.VersionID; got {
+	case first.VersionID:
+	case third.VersionID:
+		t.Fatalf("rolling back off the fix landed on %d, a version the walk had already gone past", third.VersionID)
+	default:
+		t.Fatalf("rolling back off the fix landed on %d, want the version it was applied over, %d", got, first.VersionID)
+	}
+	if p := resp.AppRollbackResult.PreviousVersionID; p == nil || *p != fixed.VersionID {
+		t.Fatalf("previous = %v, want %d", p, fixed.VersionID)
+	}
+	// One step is all the restarted history has: the versions below belong to the
+	// walk that was left behind.
+	if resp := appRollback(t, d, "approval-gate", 0); resp.Ok {
+		t.Fatalf("a second rollback off the fix moved to %d, want the bottom to refuse",
+			resp.AppRollbackResult.VersionID)
+	}
+}
+
+// An app on its first version has nothing below it on its serving history, and
+// the numerically previous id is not a substitute. The refusal has to name the
 // situation and list the versions, because that is all the caller gets.
-func TestAppRollbackWithoutARecordedPreviousRefusesLoudly(t *testing.T) {
+func TestAppRollbackAtTheBottomOfTheHistoryRefusesLoudly(t *testing.T) {
 	d := appApplyDaemon(t)
 	only := applyOK(t, d, "approval-gate", declarationFor("approval-gate", "first"), "export default {}\n")
 
 	resp := appRollback(t, d, "approval-gate", 0)
 	if resp.Ok {
-		t.Fatal("rollback with no recorded predecessor reported success")
+		t.Fatal("rollback at the bottom of the serving history reported success")
 	}
 	msg := protocol.Deref(resp.Error)
-	if !strings.Contains(msg, "nothing is recorded as serving before") {
+	if !strings.Contains(msg, "oldest version in its serving history") {
 		t.Errorf("error does not name the situation: %s", msg)
 	}
 	if !strings.Contains(msg, fmt.Sprint(only.VersionID)) || !strings.Contains(msg, "current") {

--- a/internal/daemon/apps.go
+++ b/internal/daemon/apps.go
@@ -39,6 +39,15 @@ const recentInvocationLimit = 10
 // invocations.
 const recentVersionLimit = 10
 
+// servingHistoryLimit is how many steps of an app's serving history
+// `attn app status` carries back, on the same wire budget and for the same
+// reason as recentVersionLimit above. Ten is far past any real walk: a step is
+// pushed only when the serving version actually changes, and an operator
+// hunting for the version that worked gives up long before ten bare rollbacks.
+// The list says when it was cut, so a longer chain is visible rather than
+// silently ending.
+const servingHistoryLimit = 10
+
 // appEnabledChanged is FactAppEnabledChanged's payload.
 type appEnabledChanged struct {
 	Name     string `json:"name"`
@@ -128,11 +137,17 @@ func (d *Daemon) handleAppStatus(conn net.Conn, msg *protocol.AppStatusMessage) 
 		d.sendError(conn, fmt.Sprintf("reading invocations of app %q: %v", name, err))
 		return
 	}
-	recentVersions, err := d.store.ListAppVersions(name)
+	allVersions, err := d.store.ListAppVersions(name)
 	if err != nil {
 		d.sendError(conn, fmt.Sprintf("reading versions of app %q: %v", name, err))
 		return
 	}
+	history, steps, err := d.store.ListAppServingHistory(name, servingHistoryLimit)
+	if err != nil {
+		d.sendError(conn, fmt.Sprintf("reading the serving history of app %q: %v", name, err))
+		return
+	}
+	recentVersions := allVersions
 	if len(recentVersions) > recentVersionLimit {
 		recentVersions = recentVersions[:recentVersionLimit]
 	}
@@ -145,6 +160,27 @@ func (d *Daemon) handleAppStatus(conn net.Conn, msg *protocol.AppStatusMessage) 
 			ArtifactPath: version.ArtifactPath,
 			CreatedAt:    stampForWire(version.CreatedAt),
 		})
+	}
+	// The history walks past the newest versions once an app has been rolled
+	// back, so its rows come from the whole list rather than the capped one.
+	byID := make(map[int64]store.AppVersion, len(allVersions))
+	for _, version := range allVersions {
+		byID[version.ID] = version
+	}
+	for _, id := range history {
+		version, ok := byID[id]
+		if !ok {
+			continue
+		}
+		result.ServingHistory = append(result.ServingHistory, protocol.AppVersionInfo{
+			ID:           int(version.ID),
+			ContentHash:  version.ContentHash,
+			ArtifactPath: version.ArtifactPath,
+			CreatedAt:    stampForWire(version.CreatedAt),
+		})
+	}
+	if steps > 0 {
+		result.ServingHistorySteps = protocol.Ptr(steps)
 	}
 	for _, inv := range recent {
 		result.Recent = append(result.Recent, appInvocationForWire(inv.ID, inv))

--- a/internal/daemon/apps_test.go
+++ b/internal/daemon/apps_test.go
@@ -408,6 +408,66 @@ func TestAppStatusListsTheVersionIdsRollbackTakes(t *testing.T) {
 	}
 }
 
+// Status is where the serving history is readable, because bare rollback walks
+// it and nothing else says whether another step exists. The list starts at the
+// version serving now, so what follows it is where the next rollbacks go, and
+// the total keeps a capped list honest.
+func TestAppStatusShowsWhereRollbackCanStillGo(t *testing.T) {
+	d := newDaemonForTest(t)
+	seedApp(t, d, "approval-gate", false)
+
+	now := time.Now().UTC()
+	var ids []int64
+	for i := 0; i < recentVersionLimit+3; i++ {
+		version, _, err := d.store.CommitAppVersion(store.AppVersion{
+			AppName:      "approval-gate",
+			ContentHash:  fmt.Sprintf("sha256:build-%02d", i),
+			Declaration:  `{"name":"approval-gate","subscribe":[{"events":["ticket.*"]}]}`,
+			ArtifactPath: fmt.Sprintf("apps/approval-gate/%02d.js", i),
+		}, now)
+		if err != nil {
+			t.Fatalf("commit version %d: %v", i, err)
+		}
+		ids = append(ids, version.ID)
+	}
+
+	result := appStatus(t, d, "approval-gate").AppStatusResult
+	if len(result.ServingHistory) != servingHistoryLimit {
+		t.Fatalf("serving_history = %d, want the %d cap", len(result.ServingHistory), servingHistoryLimit)
+	}
+	if result.ServingHistory[0].ID != int(ids[len(ids)-1]) {
+		t.Fatalf("serving_history[0] = %d, want the version serving now, %d",
+			result.ServingHistory[0].ID, ids[len(ids)-1])
+	}
+	if result.ServingHistory[1].ID != int(ids[len(ids)-2]) {
+		t.Fatalf("serving_history[1] = %d, want the next rollback's target %d",
+			result.ServingHistory[1].ID, ids[len(ids)-2])
+	}
+	// One step per version applied, plus the one seedApp left.
+	if steps := protocol.Deref(result.ServingHistorySteps); steps != len(ids)+1 {
+		t.Fatalf("serving_history_steps = %d, want %d", steps, len(ids)+1)
+	}
+
+	// A walk that goes past the newest versions still reports a history: the
+	// versions on it come from the whole list, not the capped recent one.
+	for i := 0; i < recentVersionLimit+1; i++ {
+		if resp := appRollback(t, d, "approval-gate", 0); !resp.Ok {
+			t.Fatalf("rollback %d: %v", i+1, protocol.Deref(resp.Error))
+		}
+	}
+	result = appStatus(t, d, "approval-gate").AppStatusResult
+	if len(result.ServingHistory) == 0 {
+		t.Fatal("a walked-back app reports no serving history")
+	}
+	if result.ServingHistory[0].ID != int(ids[len(ids)-1-(recentVersionLimit+1)]) {
+		t.Fatalf("serving_history[0] = %d, want the walked-to version %d",
+			result.ServingHistory[0].ID, ids[len(ids)-1-(recentVersionLimit+1)])
+	}
+	if result.ServingHistory[0].ContentHash == "" {
+		t.Fatalf("serving_history[0] = %+v, want the hash that tells builds apart", result.ServingHistory[0])
+	}
+}
+
 func TestAppCommandsRefuseAnInvalidName(t *testing.T) {
 	d := newDaemonForTest(t)
 	for _, resp := range []protocol.Response{

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "238"
+const ProtocolVersion = "239"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -546,6 +546,13 @@ type AppStatusResult struct {
 	// Runtime corresponds to the JSON schema field "runtime".
 	Runtime *AppRuntimeInfo `json:"runtime,omitempty,omitzero"`
 
+	// ServingHistory corresponds to the JSON schema field "serving_history".
+	ServingHistory []AppVersionInfo `json:"serving_history,omitempty,omitzero"`
+
+	// ServingHistorySteps corresponds to the JSON schema field
+	// "serving_history_steps".
+	ServingHistorySteps *int `json:"serving_history_steps,omitempty,omitzero"`
+
 	// Stall corresponds to the JSON schema field "stall".
 	Stall *AppStallInfo `json:"stall,omitempty,omitzero"`
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -4554,6 +4554,16 @@ model AppStatusResult {
   // read them, so a status that carried only a count sent the reader looking for
   // a list that does not exist.
   "recent_versions"?: AppVersionInfo[];
+  // The app's serving history: the version it serves now, then each version one
+  // bare rollback further back, capped. It is the only way to see whether a
+  // rollback has anywhere left to go without running it. A version missing from
+  // here is not gone — the walk went past it and it is still in
+  // "recent_versions", reachable by name.
+  "serving_history"?: AppVersionInfo[];
+  // How many steps that history has in total — "serving_history" carries the
+  // newest of them, so a walk longer than the cap is visible rather than
+  // silently ending.
+  "serving_history_steps"?: safeint;
   // The most recent invocations, newest first, when any have been recorded.
   "recent"?: AppInvocationInfo[];
   // The shared runtime every app's handlers execute in. Absent until it has been

--- a/internal/store/apps.go
+++ b/internal/store/apps.go
@@ -6,61 +6,94 @@ import (
 	"time"
 )
 
-// The app registry's persistence (migration 102). An app is a manifest-declared,
-// bus-consuming automation running in the shared runtime; this file is the three
-// tables it lives in and nothing else — the lifecycle that stops a delivery loop
-// and the pipeline that builds an artifact are the daemon's.
+// The app registry's persistence (migrations 102 and 105). An app is a
+// manifest-declared, bus-consuming automation running in the shared runtime;
+// this file is the four tables it lives in and nothing else — the lifecycle that
+// stops a delivery loop and the pipeline that builds an artifact are the
+// daemon's.
 //
 // Two absences carry meaning and are load-bearing here:
 //
 //   - There is no enabled bit. An app's enabled state is its bus consumer's
 //     (`app:<name>`), because that one bit both stops delivery and releases the
 //     retention floor. Nothing in this file reads or writes it.
-//   - Removing an app removes its registry row and nothing else. Versions and
-//     invocations are history, and the documents under `app/<name>` are the
-//     user's data; deleting either is a separate, explicit act that does not
-//     exist yet, deliberately.
+//   - Removing an app removes its registry row and nothing else. Versions,
+//     invocations and serving steps are history, and the documents under
+//     `app/<name>` are the user's data; deleting either is a separate, explicit
+//     act that does not exist yet, deliberately.
 //
 // See docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md.
 
 // App is one registered app. CurrentVersionID is 0 until a version has been
 // applied — a registry row can exist ahead of its first successful build.
 //
-// PreviousVersionID is what was serving immediately before CurrentVersionID, and
-// it is 0 until the pointer has moved at least once off a real version. It is
-// the fact bare `attn app rollback` follows, so it is maintained by every path
-// that moves the pointer and by nothing else.
+// PreviousServingVersionID is the version one step back along the app's serving
+// chain: what bare `attn app rollback` lands on. It is derived from
+// app_serving_steps at read time rather than stored, so it always agrees with
+// the chain, and it is 0 when the app sits at the bottom of its chain.
 type App struct {
-	Name              string
-	CurrentVersionID  int64
-	PreviousVersionID int64
-	CreatedAt         time.Time
-	UpdatedAt         time.Time
+	Name                     string
+	CurrentVersionID         int64
+	PreviousServingVersionID int64
+	CreatedAt                time.Time
+	UpdatedAt                time.Time
 }
 
-// movePointerSQL sets an app's current version and carries the version it
-// replaced into previous_version_id. Both pointer-moving statements share it, so
-// there is one place the predecessor can be recorded and no way to move the
-// pointer without recording it.
+// appColumnsSQL reads a registry row and derives the version one step back along
+// its serving chain — the current step's parent. Both readers share it so a bare
+// rollback's target is computed one way.
+const appColumnsSQL = `
+	SELECT a.name, a.current_version_id,
+	       (SELECT p.version_id FROM app_serving_steps c
+	          JOIN app_serving_steps p ON p.id = c.parent_id
+	         WHERE c.id = a.serving_step_id),
+	       a.created_at, a.updated_at
+	FROM apps a`
+
+// pushServingStep points an app at a version and records the step it took to get
+// there, inside the caller's transaction. Every path that moves the pointer
+// forward — an apply, a rollback onto a named version — goes through it, so
+// there is no way to move the pointer without extending the chain.
 //
-// The CASE keeps the predecessor unchanged when the move is a no-op — re-applying
-// byte-identical content lands on the version already current, and overwriting
-// the predecessor with itself would make a rollback that changed nothing lose the
-// version it could have gone back to. SQLite evaluates every assignment against
-// the pre-update row, so current_version_id on the right-hand side is the
-// outgoing one.
+// The new step's parent is the step the app was on, which is what makes the
+// chain walkable: bare rollback follows parents down, and applying while already
+// walked back parents the new step where the walk stopped, so the way back from
+// it is the version that was actually serving. Nothing above is deleted; a step
+// nothing points at is simply unreachable.
 //
-// Parameters, in order: the incoming version id (twice), the stamp, the name.
-const movePointerSQL = `
-	UPDATE apps SET
-		previous_version_id = CASE
-			WHEN current_version_id IS NOT NULL AND current_version_id <> ?
-			THEN current_version_id
-			ELSE previous_version_id
-		END,
-		current_version_id = ?,
-		updated_at = ?
-	WHERE name = ?`
+// Landing on the version already current is not a move — re-applying
+// byte-identical content does exactly that — so it pushes nothing and leaves the
+// chain, and the way back, alone.
+func pushServingStep(tx *sql.Tx, name string, versionID int64, stamp string) error {
+	var current, cursor sql.NullInt64
+	err := tx.QueryRow(`SELECT current_version_id, serving_step_id FROM apps WHERE name = ?`, name).
+		Scan(&current, &cursor)
+	if err == sql.ErrNoRows {
+		return fmt.Errorf("store: no app named %q", name)
+	}
+	if err != nil {
+		return err
+	}
+	if current.Valid && current.Int64 == versionID {
+		_, err = tx.Exec(`UPDATE apps SET updated_at = ? WHERE name = ?`, stamp, name)
+		return err
+	}
+	res, err := tx.Exec(`
+		INSERT INTO app_serving_steps (app_name, version_id, parent_id, created_at)
+		VALUES (?, ?, ?, ?)
+	`, name, versionID, cursor, stamp)
+	if err != nil {
+		return err
+	}
+	step, err := res.LastInsertId()
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(`
+		UPDATE apps SET current_version_id = ?, serving_step_id = ?, updated_at = ? WHERE name = ?
+	`, versionID, step, stamp, name)
+	return err
+}
 
 // AppVersion is an immutable record of one built artifact. ContentHash is the
 // version's identity: applying byte-identical content again reuses this row
@@ -127,9 +160,7 @@ func (s *Store) GetApp(name string) (App, bool, error) {
 	if s.db == nil {
 		return App{}, false, nil
 	}
-	app, err := scanApp(s.db.QueryRow(`
-		SELECT name, current_version_id, previous_version_id, created_at, updated_at FROM apps WHERE name = ?
-	`, name))
+	app, err := scanApp(s.db.QueryRow(appColumnsSQL+` WHERE a.name = ?`, name))
 	switch err {
 	case nil:
 		return app, true, nil
@@ -148,9 +179,7 @@ func (s *Store) ListApps() ([]App, error) {
 	if s.db == nil {
 		return nil, nil
 	}
-	rows, err := s.db.Query(`
-		SELECT name, current_version_id, previous_version_id, created_at, updated_at FROM apps ORDER BY name ASC
-	`)
+	rows, err := s.db.Query(appColumnsSQL + ` ORDER BY a.name ASC`)
 	if err != nil {
 		return nil, err
 	}
@@ -167,9 +196,10 @@ func (s *Store) ListApps() ([]App, error) {
 	return out, rows.Err()
 }
 
-// DeleteApp removes a registry row and reports whether one was there. Versions
-// and invocations are untouched: they are the record of what ran, and an
-// uninstall does not rewrite history.
+// DeleteApp removes a registry row and reports whether one was there. Versions,
+// invocations and serving steps are untouched: they are the record of what ran,
+// and an uninstall does not rewrite history. Registering the name again starts a
+// fresh chain — the cursor went with the row, so the old steps are unreachable.
 func (s *Store) DeleteApp(name string) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -250,7 +280,7 @@ func (s *Store) CommitAppVersion(v AppVersion, now time.Time) (AppVersion, bool,
 		return AppVersion{}, false, err
 	}
 
-	if _, err := tx.Exec(movePointerSQL, v.ID, v.ID, stamp, v.AppName); err != nil {
+	if err := pushServingStep(tx, v.AppName, v.ID, stamp); err != nil {
 		return AppVersion{}, false, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -259,9 +289,11 @@ func (s *Store) CommitAppVersion(v AppVersion, now time.Time) (AppVersion, bool,
 	return v, created, nil
 }
 
-// SetAppCurrentVersion moves an app onto a version it already has — the pointer
-// move a rollback is. It refuses a version belonging to another app rather than
-// leaving one app pointing into another's history.
+// SetAppCurrentVersion moves an app onto a version it already has, naming that
+// version — what `attn app rollback <name> <version>` does. It extends the
+// serving chain like an apply does, so the walk starts again from where it lands.
+// It refuses a version belonging to another app rather than leaving one app
+// pointing into another's history.
 func (s *Store) SetAppCurrentVersion(name string, versionID int64, now time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -279,17 +311,52 @@ func (s *Store) SetAppCurrentVersion(name string, versionID int64, now time.Time
 	case owner != name:
 		return fmt.Errorf("store: app version %d belongs to app %q, not %q", versionID, owner, name)
 	}
-	stamp := now.UTC().Format(sortableTimeFormat)
-	res, err := s.db.Exec(movePointerSQL, versionID, versionID, stamp, name)
+	tx, err := s.db.Begin()
 	if err != nil {
 		return err
 	}
-	if n, err := res.RowsAffected(); err != nil {
+	defer func() { _ = tx.Rollback() }()
+	if err := pushServingStep(tx, name, versionID, now.UTC().Format(sortableTimeFormat)); err != nil {
 		return err
-	} else if n == 0 {
-		return fmt.Errorf("store: no app named %q", name)
 	}
-	return nil
+	return tx.Commit()
+}
+
+// StepAppVersionBack walks one step down an app's serving chain — what bare
+// `attn app rollback <name>` does — and is the one writer that does not extend
+// it. Walking is a cursor move, so a second bare rollback steps back again
+// rather than returning to where the first started.
+//
+// target is the version the caller resolved from App.PreviousServingVersionID
+// and reported to the user; the move refuses unless the step below still carries
+// it, so a chain that moved between the two calls cannot land the app somewhere
+// nobody was told about.
+func (s *Store) StepAppVersionBack(name string, target int64, now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil
+	}
+	var stepID, versionID int64
+	err := s.db.QueryRow(`
+		SELECT p.id, p.version_id FROM apps a
+			JOIN app_serving_steps c ON c.id = a.serving_step_id
+			JOIN app_serving_steps p ON p.id = c.parent_id
+		WHERE a.name = ?
+	`, name).Scan(&stepID, &versionID)
+	switch {
+	case err == sql.ErrNoRows:
+		return fmt.Errorf("store: app %q has nothing below it in its serving history", name)
+	case err != nil:
+		return err
+	case versionID != target:
+		return fmt.Errorf("store: app %q now has version %d one step back, not the %d this rollback resolved; nothing moved", name, versionID, target)
+	}
+	_, err = s.db.Exec(`
+		UPDATE apps SET current_version_id = ?, serving_step_id = ?, updated_at = ? WHERE name = ?
+	`, versionID, stepID, now.UTC().Format(sortableTimeFormat), name)
+	return err
 }
 
 // GetAppVersion loads one version row.
@@ -497,7 +564,7 @@ func scanApp(row rowScanner) (App, error) {
 		return App{}, err
 	}
 	app.CurrentVersionID = versionID.Int64
-	app.PreviousVersionID = previousID.Int64
+	app.PreviousServingVersionID = previousID.Int64
 	app.CreatedAt = parseStoreTime(createdAt)
 	app.UpdatedAt = parseStoreTime(updatedAt)
 	return app, nil

--- a/internal/store/apps.go
+++ b/internal/store/apps.go
@@ -134,8 +134,9 @@ type AppInvocation struct {
 }
 
 // SaveApp creates a registry row, or touches an existing one. It never moves
-// current_version_id: the pointer moves only through CommitAppVersion and
-// SetAppCurrentVersion, so no caller can flip an app onto a version by accident.
+// current_version_id: the pointer moves only through CommitAppVersion,
+// SetAppCurrentVersion and StepAppVersionBack, so no caller can flip an app onto
+// a version by accident.
 func (s *Store) SaveApp(name string, now time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -357,6 +358,62 @@ func (s *Store) StepAppVersionBack(name string, target int64, now time.Time) err
 		UPDATE apps SET current_version_id = ?, serving_step_id = ?, updated_at = ? WHERE name = ?
 	`, versionID, stepID, now.UTC().Format(sortableTimeFormat), name)
 	return err
+}
+
+// ListAppServingHistory returns the versions on an app's serving history,
+// currently-serving first and each next one a bare rollback away, up to limit
+// steps. It is how `attn app status` answers the question the walk otherwise
+// only answers by being run: is there another step, and where does it land.
+//
+// The versions below the first are not "the older versions" — a version the
+// walk went past is off the history but still in the version list, and still
+// reachable by name.
+//
+// The second return is how many steps the whole history has, so a caller that
+// shows a capped list can say it was cut. The walk itself is followed a step at
+// a time and never reads this, so the whole chain is scanned only when someone
+// asks to look at it.
+func (s *Store) ListAppServingHistory(name string, limit int) ([]int64, int, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return nil, 0, nil
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+	rows, err := s.db.Query(`
+		WITH RECURSIVE walk(id, version_id, parent_id) AS (
+			SELECT s.id, s.version_id, s.parent_id FROM app_serving_steps s
+				JOIN apps a ON a.serving_step_id = s.id
+			WHERE a.name = ?
+			UNION ALL
+			SELECT s.id, s.version_id, s.parent_id FROM app_serving_steps s
+				JOIN walk w ON s.id = w.parent_id
+		)
+		SELECT version_id FROM walk
+	`, name)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var (
+		out   []int64
+		steps int
+	)
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, 0, err
+		}
+		steps++
+		if len(out) < limit {
+			out = append(out, id)
+		}
+	}
+	return out, steps, rows.Err()
 }
 
 // GetAppVersion loads one version row.

--- a/internal/store/apps_test.go
+++ b/internal/store/apps_test.go
@@ -277,6 +277,60 @@ func TestApps_BareRollbackWalksTheChainDown(t *testing.T) {
 	}
 }
 
+// The history read is what `attn app status` shows: the version serving now
+// first, then each version one bare rollback further back, and a total so a
+// capped answer can say it was cut.
+func TestApps_ServingHistoryReadsTheWalkFromTheTop(t *testing.T) {
+	s := New()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	older, newer := seedApps(t, s, now)
+
+	history, steps, err := s.ListAppServingHistory("approval-gate", 10)
+	if err != nil {
+		t.Fatalf("read history: %v", err)
+	}
+	if len(history) != 2 || history[0] != newer.ID || history[1] != older.ID {
+		t.Fatalf("history = %v, want [%d %d]", history, newer.ID, older.ID)
+	}
+	if steps != 2 {
+		t.Fatalf("steps = %d, want 2", steps)
+	}
+
+	// Walking does not shorten the history; it moves where the app stands on it,
+	// so what is left below is what the next rollback can still reach.
+	if err := s.StepAppVersionBack("approval-gate", older.ID, now.Add(time.Hour)); err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	history, steps, err = s.ListAppServingHistory("approval-gate", 10)
+	if err != nil {
+		t.Fatalf("read history after the walk: %v", err)
+	}
+	if len(history) != 1 || history[0] != older.ID || steps != 1 {
+		t.Fatalf("history after the walk = %v (%d steps), want just %d", history, steps, older.ID)
+	}
+
+	// The cap trims what is returned and never the total, so a longer walk is
+	// visible rather than silently ending.
+	if err := s.SetAppCurrentVersion("approval-gate", newer.ID, now.Add(2*time.Hour)); err != nil {
+		t.Fatalf("named rollback: %v", err)
+	}
+	history, steps, err = s.ListAppServingHistory("approval-gate", 1)
+	if err != nil {
+		t.Fatalf("read capped history: %v", err)
+	}
+	if len(history) != 1 || history[0] != newer.ID || steps != 2 {
+		t.Fatalf("capped history = %v (%d steps), want one entry of two", history, steps)
+	}
+
+	// An app that has never served has no history at all.
+	if err := s.SaveApp("half-installed", now); err != nil {
+		t.Fatalf("save app: %v", err)
+	}
+	if history, steps, err := s.ListAppServingHistory("half-installed", 10); err != nil || len(history) != 0 || steps != 0 {
+		t.Fatalf("unserved app history = %v (%d steps, %v)", history, steps, err)
+	}
+}
+
 // A walk refuses when the step below is not the version the caller resolved and
 // reported, rather than landing somewhere nobody was told about.
 func TestApps_WalkRefusesAStaleTarget(t *testing.T) {

--- a/internal/store/apps_test.go
+++ b/internal/store/apps_test.go
@@ -147,10 +147,10 @@ func TestApps_RollbackMovesThePointerOnly(t *testing.T) {
 	}
 }
 
-// Every path that moves the pointer records the version it replaced, and a
-// no-op move leaves that record alone. This is what bare `attn app rollback`
-// reads, so the two writers have to agree.
-func TestApps_PointerMovesRecordWhatTheyReplaced(t *testing.T) {
+// Every path that moves the pointer extends the serving chain, and a no-op move
+// leaves it alone. This is what bare `attn app rollback` walks, so the writers
+// have to agree.
+func TestApps_PointerMovesExtendTheServingChain(t *testing.T) {
 	s := New()
 	now := time.Now().UTC().Truncate(time.Millisecond)
 	older, newer := seedApps(t, s, now)
@@ -161,15 +161,15 @@ func TestApps_PointerMovesRecordWhatTheyReplaced(t *testing.T) {
 		if err != nil || !ok {
 			t.Fatalf("%s: get app: %v ok=%t", step, err, ok)
 		}
-		return app.PreviousVersionID
+		return app.PreviousServingVersionID
 	}
 
-	// The first version had nothing before it; the second replaced it.
+	// The first version had nothing before it; the second was pushed onto it.
 	if got := previousOf("after two applies"); got != older.ID {
-		t.Fatalf("previous after the second apply = %d, want %d", got, older.ID)
+		t.Fatalf("one step back after the second apply = %d, want %d", got, older.ID)
 	}
 
-	// Re-applying the version already current moves nothing, so the predecessor
+	// Re-applying the version already current moves nothing, so the step below
 	// must survive — otherwise an idle dev loop erases the way back.
 	if _, _, err := s.CommitAppVersion(AppVersion{
 		AppName:      "approval-gate",
@@ -180,26 +180,122 @@ func TestApps_PointerMovesRecordWhatTheyReplaced(t *testing.T) {
 		t.Fatalf("re-apply: %v", err)
 	}
 	if got := previousOf("after a no-op re-apply"); got != older.ID {
-		t.Fatalf("a no-op re-apply rewrote the predecessor to %d, want %d", got, older.ID)
+		t.Fatalf("a no-op re-apply changed the step below to %d, want %d", got, older.ID)
 	}
 
-	// A rollback is a pointer move like any other and records the same way, which
-	// is what lets a second rollback undo the first.
+	// Naming a version is a pointer move like an apply: it lands on the older
+	// version with the newer one now behind it, so the history reads forward.
 	if err := s.SetAppCurrentVersion("approval-gate", older.ID, now.Add(2*time.Hour)); err != nil {
 		t.Fatalf("rollback: %v", err)
 	}
-	if got := previousOf("after a rollback"); got != newer.ID {
-		t.Fatalf("previous after the rollback = %d, want %d", got, newer.ID)
+	if got := previousOf("after a named rollback"); got != newer.ID {
+		t.Fatalf("one step back after the named rollback = %d, want %d", got, newer.ID)
 	}
 
-	// An app whose pointer has never moved off a real version has no predecessor,
-	// and reports 0 rather than guessing at one.
+	// An app whose pointer has never moved off its first version has nothing
+	// below it, and reports 0 rather than guessing at one.
 	other, _, err := s.GetApp("standup-digest")
 	if err != nil {
 		t.Fatalf("get the single-version app: %v", err)
 	}
-	if other.PreviousVersionID != 0 {
-		t.Fatalf("a first apply invented a predecessor: %d", other.PreviousVersionID)
+	if other.PreviousServingVersionID != 0 {
+		t.Fatalf("a first apply invented a step below: %d", other.PreviousServingVersionID)
+	}
+}
+
+// The stack: each bare rollback walks one step further back, applying starts the
+// history again from where it lands, and the bottom refuses rather than wrapping.
+func TestApps_BareRollbackWalksTheChainDown(t *testing.T) {
+	s := New()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	v := func(n int, at time.Duration) AppVersion {
+		t.Helper()
+		version, _, err := s.CommitAppVersion(AppVersion{
+			AppName:      "approval-gate",
+			ContentHash:  "sha256:" + string(rune('a'+n)),
+			Declaration:  "{}",
+			ArtifactPath: "bundle.js",
+		}, now.Add(at))
+		if err != nil {
+			t.Fatalf("apply v%d: %v", n, err)
+		}
+		return version
+	}
+	standing := func(step string) (current, below int64) {
+		t.Helper()
+		app, ok, err := s.GetApp("approval-gate")
+		if err != nil || !ok {
+			t.Fatalf("%s: get app: %v ok=%t", step, err, ok)
+		}
+		return app.CurrentVersionID, app.PreviousServingVersionID
+	}
+	walk := func(step string, target int64) {
+		t.Helper()
+		if err := s.StepAppVersionBack("approval-gate", target, now.Add(time.Hour)); err != nil {
+			t.Fatalf("%s: %v", step, err)
+		}
+	}
+
+	v1, v2, v3 := v(1, 0), v(2, time.Minute), v(3, 2*time.Minute)
+
+	walk("first bare rollback", v2.ID)
+	if current, below := standing("after one step"); current != v2.ID || below != v1.ID {
+		t.Fatalf("after one step: on %d with %d below, want %d and %d", current, below, v2.ID, v1.ID)
+	}
+	walk("second bare rollback", v1.ID)
+	if current, below := standing("after two steps"); current != v1.ID || below != 0 {
+		t.Fatalf("after two steps: on %d with %d below, want %d and the bottom", current, below, v1.ID)
+	}
+	if err := s.StepAppVersionBack("approval-gate", v1.ID, now.Add(2*time.Hour)); err == nil {
+		t.Fatal("walking past the oldest version was accepted")
+	}
+	if current, _ := standing("after the refused step"); current != v1.ID {
+		t.Fatalf("a refused walk moved the pointer to %d", current)
+	}
+
+	// Applying while walked back starts the history from where the walk stopped:
+	// the way back from the fix is what was actually running when it was applied,
+	// not the versions the walk already rejected.
+	v4 := v(4, 3*time.Minute)
+	if current, below := standing("after applying on top of the walk"); current != v4.ID || below != v1.ID {
+		t.Fatalf("after applying v4: on %d with %d below, want %d and %d", current, below, v4.ID, v1.ID)
+	}
+	walk("rollback off the fix", v1.ID)
+	if current, below := standing("back off the fix"); current != v1.ID || below != 0 {
+		t.Fatalf("off the fix: on %d with %d below, want %d and the bottom", current, below, v1.ID)
+	}
+	// v3 is still a version, still reachable by name — only the walk moved past it.
+	versions, err := s.ListAppVersions("approval-gate")
+	if err != nil || len(versions) != 4 {
+		t.Fatalf("the walk changed the version list: %d (%v)", len(versions), err)
+	}
+	if err := s.SetAppCurrentVersion("approval-gate", v3.ID, now.Add(4*time.Minute)); err != nil {
+		t.Fatalf("naming the version the walk passed: %v", err)
+	}
+	if current, below := standing("after naming v3"); current != v3.ID || below != v1.ID {
+		t.Fatalf("after naming v3: on %d with %d below, want %d and %d", current, below, v3.ID, v1.ID)
+	}
+}
+
+// A walk refuses when the step below is not the version the caller resolved and
+// reported, rather than landing somewhere nobody was told about.
+func TestApps_WalkRefusesAStaleTarget(t *testing.T) {
+	s := New()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	older, newer := seedApps(t, s, now)
+
+	if err := s.StepAppVersionBack("approval-gate", newer.ID, now.Add(time.Hour)); err == nil {
+		t.Fatal("a walk onto a version that is not the step below was accepted")
+	}
+	app, _, err := s.GetApp("approval-gate")
+	if err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if app.CurrentVersionID != newer.ID {
+		t.Fatalf("a refused walk moved the pointer to %d", app.CurrentVersionID)
+	}
+	if err := s.StepAppVersionBack("approval-gate", older.ID, now.Add(time.Hour)); err != nil {
+		t.Fatalf("walk onto the step below: %v", err)
 	}
 }
 
@@ -342,35 +438,43 @@ func TestApps_CommitVersionRefusesAnIncompleteRow(t *testing.T) {
 	}
 }
 
-// A database written before this column existed carries its app rows across the
-// migration with no predecessor rather than inventing one: what was serving
-// before is history the registry never recorded, and deriving it from ids is the
-// bug bare rollback exists to avoid.
-func TestApps_MigrationCarriesRowsWithNoPredecessor(t *testing.T) {
+// A profile that ran the shipped single-pointer rollback carries its recorded
+// predecessor into the chain: the first bare rollback after the upgrade lands
+// where it would have landed before, and the next one continues down instead of
+// bouncing back. An app that never recorded one is carried with nothing below
+// it rather than having a predecessor invented from version ids — the bug bare
+// rollback exists to avoid.
+func TestApps_MigrationCarriesTheRecordedPredecessorIntoTheChain(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "attn.db")
 	s, err := NewWithDB(path)
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
 	now := time.Now().UTC().Truncate(time.Millisecond)
-	seedApps(t, s, now)
+	older, newer := seedApps(t, s, now)
 	s.Close()
 
-	// Rewind to the schema as it stood before 103, with the app rows still there.
-	// The recorded version is the maximum, so every later migration goes too —
-	// dropping 103's row alone would leave the version ahead of it and skip the
-	// migration under test. The later ones re-run, which they tolerate.
+	// Rewind to the schema as it stood after 103 and before 105, with the app
+	// rows carrying exactly what the shipped writer would have left: the newer
+	// version serving, the older one recorded behind it, and the single-version
+	// app with no predecessor at all.
 	db, err := OpenDB(path)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
 	for _, stmt := range []string{
-		"ALTER TABLE apps DROP COLUMN previous_version_id",
-		"DELETE FROM schema_migrations WHERE version >= 103",
+		"ALTER TABLE apps ADD COLUMN previous_version_id INTEGER",
+		"ALTER TABLE apps DROP COLUMN serving_step_id",
+		"DROP TABLE app_serving_steps",
+		"DELETE FROM schema_migrations WHERE version >= 105",
 	} {
 		if _, err := db.Exec(stmt); err != nil {
 			t.Fatalf("rewinding with %q: %v", stmt, err)
 		}
+	}
+	if _, err := db.Exec(
+		"UPDATE apps SET previous_version_id = ? WHERE name = 'approval-gate'", older.ID); err != nil {
+		t.Fatalf("seeding the recorded predecessor: %v", err)
 	}
 	db.Close()
 
@@ -383,10 +487,33 @@ func TestApps_MigrationCarriesRowsWithNoPredecessor(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("get app after migration: %v ok=%t", err, ok)
 	}
-	if app.CurrentVersionID == 0 {
+	if app.CurrentVersionID != newer.ID {
+		t.Fatalf("the migration moved the current version to %d, want %d", app.CurrentVersionID, newer.ID)
+	}
+	if app.PreviousServingVersionID != older.ID {
+		t.Fatalf("one step back after the migration = %d, want the recorded %d", app.PreviousServingVersionID, older.ID)
+	}
+	// The carried chain is two steps, so the walk works once and then reports the
+	// bottom — it does not bounce back onto the version it just left.
+	if err := s.StepAppVersionBack("approval-gate", older.ID, now.Add(time.Hour)); err != nil {
+		t.Fatalf("walking the carried chain: %v", err)
+	}
+	if app, _, err := s.GetApp("approval-gate"); err != nil || app.PreviousServingVersionID != 0 {
+		t.Fatalf("the carried chain has more below the oldest version: %+v (%v)", app, err)
+	}
+	if err := s.StepAppVersionBack("approval-gate", older.ID, now.Add(2*time.Hour)); err == nil {
+		t.Fatal("walking past the bottom of a carried chain was accepted")
+	}
+
+	// An app with no recorded predecessor keeps none.
+	other, _, err := s.GetApp("standup-digest")
+	if err != nil {
+		t.Fatalf("get the single-version app: %v", err)
+	}
+	if other.CurrentVersionID == 0 {
 		t.Fatal("the migration lost the current version pointer")
 	}
-	if app.PreviousVersionID != 0 {
-		t.Fatalf("the migration invented a predecessor: %d", app.PreviousVersionID)
+	if other.PreviousServingVersionID != 0 {
+		t.Fatalf("the migration invented a predecessor: %d", other.PreviousServingVersionID)
 	}
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -2672,16 +2672,17 @@ func applyMigration103(tx *sql.Tx) error {
 // old column and its data untouched rather than half-carried.
 func applyMigration105(tx *sql.Tx) error {
 	if _, err := tx.Exec(`
+-- No index beyond the primary key: every reader arrives holding a step id —
+-- the registry's cursor, or the parent of the step it is standing on — so the
+-- chain is walked by rowid. app_name is carried to keep a step readable on its
+-- own and for the one-time carry below.
 CREATE TABLE IF NOT EXISTS app_serving_steps (
     id         INTEGER PRIMARY KEY AUTOINCREMENT,
     app_name   TEXT NOT NULL,
     version_id INTEGER NOT NULL,
     parent_id  INTEGER,
     created_at TEXT NOT NULL
-);
--- One app's chain, and the walk down it: both start from a step and follow
--- parent_id, and the registry reads the newest steps of one app.
-CREATE INDEX IF NOT EXISTS idx_app_serving_steps_app ON app_serving_steps(app_name, id DESC);`); err != nil {
+);`); err != nil {
 		return err
 	}
 	has, err := columnExists(tx, "apps", "serving_step_id")

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -1085,7 +1085,8 @@ CREATE INDEX IF NOT EXISTS idx_app_invocations_started ON app_invocations(starte
 	// recorded, and inventing it from ids would reproduce the bug this fixes. An
 	// app carried across this migration has no recorded previous until its next
 	// pointer move, and bare rollback says so rather than guessing.
-	// Applied by applyMigration103, whose ALTER is column-guarded.
+	// Applied by applyMigration103, whose ALTER is column-guarded. Migration 105
+	// replaces the column it adds with a walkable chain.
 	{103, "record the previously-serving version of each app", ``},
 	{104, "remember a parked supervised child across daemon restarts", `CREATE TABLE IF NOT EXISTS supervised_parks (
     child           TEXT PRIMARY KEY,
@@ -1096,6 +1097,18 @@ CREATE INDEX IF NOT EXISTS idx_app_invocations_started ON app_invocations(starte
     exit_signal     TEXT NOT NULL DEFAULT '',
     exit_error      TEXT NOT NULL DEFAULT ''
 );`},
+	// An app's serving history, as a chain a bare rollback walks down one step at
+	// a time. A step names the version that started serving and the step it was
+	// pushed onto; apps.serving_step_id is where the app stands on it. One
+	// pointer could only ever express one step back, so a second bare rollback
+	// returned to where the first started; a chain answers "one step further
+	// back" however many times it is asked.
+	//
+	// Applied by applyMigration105, which also carries every recorded
+	// previously-serving version into the chain before dropping the column that
+	// held it — an app on version B with A behind it becomes the two-step chain
+	// A → B, which walks exactly as it did before.
+	{105, "walk an app's serving history as a chain", ``},
 }
 
 // migration99SQL is everything migration 99 does after its guarded ALTER.
@@ -1477,6 +1490,11 @@ func migrateDB(db *sql.DB, dbPath string) error {
 			}
 		} else if m.version == 103 {
 			if err := applyMigration103(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
+		} else if m.version == 105 {
+			if err := applyMigration105(tx); err != nil {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
@@ -2637,6 +2655,78 @@ func applyMigration103(tx *sql.Tx) error {
 		return err
 	}
 	_, err = tx.Exec("ALTER TABLE apps ADD COLUMN previous_version_id INTEGER")
+	return err
+}
+
+// applyMigration105 turns each app's single previously-serving pointer into a
+// chain bare rollback can walk down repeatedly.
+//
+// The carry is the whole reason this is Go and not SQL in the table: an app on
+// version B with A recorded behind it becomes the chain A → B standing on B, so
+// the first bare rollback after the upgrade lands exactly where it would have
+// landed before, and the next one continues down instead of bouncing back. An
+// app with no recorded predecessor becomes a one-step chain and says there is
+// nothing below it, as it did. Nothing is invented from version ids.
+//
+// It all runs in the migration's transaction, so a failure anywhere leaves the
+// old column and its data untouched rather than half-carried.
+func applyMigration105(tx *sql.Tx) error {
+	if _, err := tx.Exec(`
+CREATE TABLE IF NOT EXISTS app_serving_steps (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    app_name   TEXT NOT NULL,
+    version_id INTEGER NOT NULL,
+    parent_id  INTEGER,
+    created_at TEXT NOT NULL
+);
+-- One app's chain, and the walk down it: both start from a step and follow
+-- parent_id, and the registry reads the newest steps of one app.
+CREATE INDEX IF NOT EXISTS idx_app_serving_steps_app ON app_serving_steps(app_name, id DESC);`); err != nil {
+		return err
+	}
+	has, err := columnExists(tx, "apps", "serving_step_id")
+	if err != nil || has {
+		return err
+	}
+	if _, err := tx.Exec("ALTER TABLE apps ADD COLUMN serving_step_id INTEGER"); err != nil {
+		return err
+	}
+
+	carried, err := columnExists(tx, "apps", "previous_version_id")
+	if err != nil {
+		return err
+	}
+	if carried {
+		// The bottom step of a carried chain: what was serving before the version
+		// the app is on. The table is empty here, so the next statement can find
+		// this row by app name alone.
+		if _, err := tx.Exec(`
+			INSERT INTO app_serving_steps (app_name, version_id, parent_id, created_at)
+			SELECT name, previous_version_id, NULL, updated_at FROM apps
+			WHERE current_version_id IS NOT NULL
+				AND previous_version_id IS NOT NULL
+				AND previous_version_id <> current_version_id`); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.Exec(`
+		INSERT INTO app_serving_steps (app_name, version_id, parent_id, created_at)
+		SELECT a.name, a.current_version_id,
+		       (SELECT MIN(p.id) FROM app_serving_steps p WHERE p.app_name = a.name),
+		       a.updated_at
+		FROM apps a WHERE a.current_version_id IS NOT NULL`); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`
+		UPDATE apps SET serving_step_id = (
+			SELECT MAX(s.id) FROM app_serving_steps s WHERE s.app_name = apps.name
+		) WHERE current_version_id IS NOT NULL`); err != nil {
+		return err
+	}
+	if !carried {
+		return nil
+	}
+	_, err = tx.Exec("ALTER TABLE apps DROP COLUMN previous_version_id")
 	return err
 }
 


### PR DESCRIPTION
Bare `attn app rollback <name>` was undo. One column, `apps.previous_version_id`,
held what was serving before the current version and was rewritten at every
pointer move, so a second bare rollback returned to where the first started —
`cd -`. An operator hunting for the last version that worked can only ask that
question once.

Victor ruled for stack semantics on 2026-08-13: each bare rollback walks one
step further back. That needs serving history as data, because one pointer can
only ever express one step.

## The shape

`app_serving_steps` is an append-only chain. A step names the version that
started serving and the step it was pushed onto; `apps.serving_step_id` is
where the app stands on it.

- **Applying**, or **naming a version** to roll onto, pushes a step parented at
  the current cursor and moves the cursor there. Landing on the version already
  current is not a move, so a byte-identical re-apply pushes nothing and the way
  back survives an idle `attn app dev` loop.
- **A bare rollback** moves the cursor to the current step's parent and pushes
  nothing. That is what makes the next one go further rather than come back.
- Walking past the oldest version on the chain refuses and lists the versions,
  as it did.

Parenting at the cursor rather than at the chain's head is what makes the walk
useful after a fix: apply v1..v3, roll back twice to v1, apply the fix v4, and
one bare rollback goes to v1 — what was actually running when the fix landed —
not to v3, which the walk already rejected. Nothing is deleted; a step nothing
points at is simply unreachable, and a version the walk went past is still a
version, still reachable by name.

## Migration 105 carries the old pointer

`attn app rollback` shipped in a released CLI, so profiles hold real
`previous_version_id` values. The migration creates the table, adds the cursor,
carries every recorded predecessor into a two-step chain `A → B` standing on B,
and only then drops the old column — all inside the migration's transaction, so
a failure anywhere leaves the old column and its data untouched rather than
half-carried. An app that recorded no predecessor gets a one-step chain; nothing
is invented from version ids. A profile upgrading mid-rollback lands exactly
where the old rule would have put it and can then keep walking.

## Seeing the walk

Turning one pointer into a chain added state no output described: whether
another step exists, and where it lands, could only be discovered by running the
rollback. `attn app status` now shows it:

```
  versions:   13 (571053196f9c), 12 (3f8fa38da24d), 11 (da2b29a840f0), 10 (18a09bd2f615) ← serving
  rollback:   walks back to 12 (3f8fa38da24d), then 11 (da2b29a840f0)
```

and at the bottom of the chain:

```
  rollback:   nothing further back — name a version to move onto one the walk went past
```

That is the one wire change: `serving_history` and `serving_history_steps` on
`AppStatusResult`, protocol 239 (schema → `make generate-types` → constants.go →
`useDaemonSocket.ts`). The existing `previous_version_id` on the apply/rollback
results is unchanged — it means "the version you were on before this call" and
is computed from the current pointer, not from the dropped column.

## Verification

Unit tests: the multi-step walk, applying restarting the walk, the bottom
refusing, a no-op re-apply leaving the chain alone, a stale walk target refusing
before it moves, the capped history read, and a migration test that rewinds a
database to the shipped single-pointer schema, seeds a recorded predecessor, and
checks the carried chain walks once and then reports the bottom.

Live-verified on a throwaway profile (`rbstack`, since cleaned) against a daemon
built from this branch: apply v1→v2→v3, bare rollback twice (v3→v2→v1), a third
refuses with the version list, apply v4 and the walk restarts — one rollback to
v1, the next refuses. `attn app status` and `--json` checked at the top of a
walk, mid-walk and at the bottom.

Surfaces walked: CLI (`--help` for rollback and status, both output paths,
tests), store and migration, daemon status and rollback handlers, protocol
(bumped in all three lockstep spots), plan doc, glossary, changelog fragment.
No app/UI work — A5 owns app-facing UI, and the registry has no UI surface yet.
Linux is unaffected: no new build constraints, no platform-specific code.

## Pre-PR adversarial review

Three parallel finders over the diff (correctness, migration/data-carry, CLI
semantics), then a refute pass per finding. Five raised, two refuted, three
confirmed (two of them the same point from different lenses):

- **Confirmed, fixed** — the steps table carried an `(app_name, id DESC)` index
  no runtime query reads (every reader arrives with a step id and walks by
  rowid) under a comment claiming access paths that do not exist. Index and
  comment dropped; the table now says why it needs no secondary index.
- **Confirmed, fixed** — no surface showed the serving history. That is the
  "way to see it" section above.
- **Refuted** — that `--help`, glossary and changelog promise apply *truncates*
  the chain. The same paragraph states the multi-step walk two sentences
  earlier, and the clause's own consequence ("the way back from a fix is
  whatever you were running") is what it asserts.
- **Refuted as a defect** — that `SaveApp`'s comment enumerating pointer writers
  is now incomplete. Its actual claim (SaveApp never moves the pointer, so
  nothing flips an app onto a version by accident) still holds. The enumeration
  was one name short, so it now names the third writer.

The migration/data-carry finder returned no findings.
