### PR TITLE
docs: encode Victor's slice-5 rulings — navigation, stale, destructive scope

### DIFF
--- a/changelog.d/slice5-annotations.yaml
+++ b/changelog.d/slice5-annotations.yaml
@@ -1,0 +1,8 @@
+kind: internal
+area: docs
+change: >
+  Victor's slice-5 annotations land in the garden plan: dispatch-at-plot
+  is scope inference and never an assignment, the app navigates the
+  whole garden root to leaf, stale gets a definition, and the workspace
+  retirement is ruled destructive. The glossary gains the bed-and-crown
+  image and repoints ready's default to the whole garden.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -412,7 +412,10 @@ capture that costs ceremony does not happen.
 
 A **plot** is a seed with children plus the intent to execute them — the whole
 subtree, not just the parent. A plot has no id of its own: its root seed, the
-**crown**, is how it is addressed. A **packet** is a plot flagged as a template
+**crown**, is how it is addressed. Picture a garden bed with a labeled plant
+at its head: the bed is the plot, the head plant is the crown, and its label —
+the crown's body — says what the bed grows. You never point at the bed; you
+point at the labeled plant. A **packet** is a plot flagged as a template
 with declared variables, so a proven shape can be planted again with its blanks
 filled.
 
@@ -442,8 +445,10 @@ is created, naming both seeds and the edge to remove.
 blocks, nobody holds, and nothing is part of — a crown's work is its children,
 not the crown. It is computed when asked and never stored, so harvesting a
 blocker frees its dependent at the next call, with nobody clearing anything.
-`attn seed ready` scopes to the calling session's workspace unless told
-otherwise, and every attn-launched agent starts knowing its workspace's count.
+`attn seed ready` answers for the whole garden unless told otherwise — a
+delegation dispatched at a crown is the exception, scoped to its plot — and
+every attn-launched agent starts knowing the garden's count (ruled 2026-08-13;
+slice 5 repoints the shipped workspace scoping).
 
 "Nobody holds it" is one rule, shared by `ready` and by the claim `tend` makes,
 so a seed offered by one is accepted by the other. A tender whose session the

--- a/docs/plans/2026-08-06-the-garden-vertical-slices.md
+++ b/docs/plans/2026-08-06-the-garden-vertical-slices.md
@@ -469,22 +469,38 @@ Ships:
 - [ ] Planting under a crown: `attn seed plant --part-of <crown>` (or a
       `plot` convenience that plants crown + children in one JSON payload
       for agents).
-- [ ] Dispatch-at-plot: a delegation carries its crown; inside it,
-      flag-free `ready` scopes to the plot; children are parallel by
-      default, only `blocks` edges sequence.
+- [ ] Dispatch-at-plot: a delegation can be dispatched at a crown and
+      carries it as scope inference, nothing more — inside that
+      session, flag-free `ready` answers with the plot's ready seeds
+      and priming starts from the crown. It is not a fence and not an
+      assignment: the delegate may tend or plant anything, an agent
+      may tend several seeds across plots at once, and who-holds-what
+      stays the per-seed tender. Children are parallel by default;
+      only `blocks` edges sequence.
 - [ ] Priming, delegate side: a delegate dispatched at a crown launches
       already knowing its plot (crown body summary, ready seeds, freshest
       handoffs) — it never has to ask what it was sent to do.
-- [ ] App: the panel groups a plot's seeds under its crown and shows
-      progress (done / growing / ready / blocked counts).
-- [ ] `attn seed show <crown>` includes plot progress; a stale-plot query
-      (`attn seed ls --stale`) exists as a *query*, not an automatic reaper
-      — a person (or later a crew member) decides what withers.
-- [ ] The scope ruling lands: the `workspace_id` stamp and the
-      `--workspace` flag retire from plant/ls/ready; flag-free
-      interactive `ready`/`ls` answer for the whole garden; the panel
-      defaults to whole garden with its toggle scoping by plot; launch
-      priming speaks of the garden, not "your workspace's ready count".
+- [ ] App: the garden is navigable as a first-class experience — the
+      whole garden, root to leaf: drill from a crown into its
+      children, climb back up, cross into the next plot. A crown row
+      shows its plot's progress (done / growing / ready / blocked
+      counts). What the app shows about who works on what is the
+      per-seed tender, never a delegation-to-crown assignment.
+- [ ] `attn seed show <crown>` includes plot progress; a stale query
+      (`attn seed ls --stale`) exists as a *query*, not an automatic
+      reaper — a person (or later a crew member) decides what withers.
+      Stale means a seed claiming attention it is not getting: open,
+      with no trail movement (notes, moves, edges) for a window. The
+      window is a flag with a default that needs a receipt at build
+      time, and the output names the rule and window it applied.
+- [ ] The scope ruling lands, destructively (ruled 2026-08-13): drop
+      the `workspace_id` field and erase any stored values — no
+      compatibility reads, no fallback, no migration shim, because no
+      production install ever held seed data. The `--workspace` flag
+      retires from plant/ls/ready; flag-free interactive `ready`/`ls`
+      answer for the whole garden; the panel defaults to whole garden
+      with its toggle scoping by plot; launch priming speaks of the
+      garden, not "your workspace's ready count".
 
 Acceptance:
 


### PR DESCRIPTION
Victor annotated slice 5 of the garden plan; this PR encodes the four rulings and fixes a glossary drift the scope ruling exposed.

- **Dispatch-at-plot sharpened**: dispatching a delegation at a crown is scope inference, nothing more — flag-free `ready` answers with the plot and priming starts from the crown, but it is not a fence and not an assignment. Agents may tend several seeds across plots at once; who-holds-what stays the per-seed tender.
- **The app box is now first-class garden navigation**: traverse the whole garden root to leaf — drill from a crown into children, climb back up, cross plots — with progress counts on crown rows. The app never renders a delegation-to-crown assignment.
- **Stale defined**: a seed claiming attention it is not getting — open, with no trail movement (notes, moves, edges) for a window. The window is a flag with a default that needs a receipt at build time, and the query's output names the rule it applied.
- **Workspace retirement ruled destructive**: drop the `workspace_id` field and erase stored values, no compatibility reads, no fallback, no migration shim — no production install ever held seed data.
- **Glossary**: the `ready` paragraph still said workspace scoping, which the 2026-08-13 ruling (#881) falsified — repointed to whole-garden default with the dispatch-at-crown exception. The plot/crown definition gains a memory image: a garden bed with a labeled plant at its head — the bed is the plot, the head plant is the crown, its label says what the bed grows; you never point at the bed, you point at the labeled plant.

Docs only; no code changes.

https://claude.ai/code/session_012Bu5dMFLdBfrEo4WmQkF53