### PR TITLE
perf(app): stop paying for GPU surfaces nobody can see

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,6 +372,14 @@ forgets that position and `--since <RFC3339>` replays from an instant.
 - No continuously repainting animations. attn renders GPU terminals, often on
   high-refresh displays, beside agents that run all day — a permanent repaint
   loop is a battery and thermal bug no test will catch.
+- Nothing invisible holds a GPU surface. A compositing layer, a canvas drawing
+  buffer, or an attachment the graphics API hands you by default all cost the
+  element's area in device pixels — whether it is ever drawn, and whether
+  anyone can see it. An always-mounted component must not hold one while it is
+  closed, and a pane behind another session must not hold one at all. `ps` RSS
+  cannot see any of this, so a change here is measured by physical footprint
+  and by which surfaces exist, never by RSS:
+  [docs/plans/2026-08-14-app-memory-floor.md](docs/plans/2026-08-14-app-memory-floor.md).
 - Comments state what the code cannot show — a constraint, an invariant, a
   measured receipt — in one or two lines, and move when the code moves. A
   comment claims only what this commit does: describing the design you

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -195,3 +195,34 @@ pnpm run e2e:headed -- e2e/component-harness.spec.ts  # Debug visually
 4. **Git status subscription**: Only 1 subscription per client. New subscription replaces old one.
 
 5. **Circuit breaker auto-reset**: Opens after failed reconnects, auto-resets after 30s even without user action.
+
+6. **GPU surfaces outnumber what you can see.** Three traps, each of which
+   cost the app over 100MB at rest until 2026-08-14. Receipts and the
+   measurement recipe:
+   [docs/plans/2026-08-14-app-memory-floor.md](../docs/plans/2026-08-14-app-memory-floor.md).
+
+   - **`will-change` on an always-mounted component.** The right dock mounts
+     all five panels and only toggles a class, so a permanent hint gave every
+     closed one a full-height backing store it never drew. Promote under the
+     open state, not on the base rule — and check whether the component is
+     conditionally rendered before reaching for the hint at all. The same
+     applies to `translateZ`, `backdrop-filter`, `isolation`, and `contain`.
+   - **WebGL context attributes default to on.** `depth` is `true` unless you
+     say otherwise, and each attachment is another drawing-buffer-sized
+     allocation per canvas. Ask for what you read; the terminal renderer reads
+     neither depth nor stencil.
+   - **A hidden canvas still owns its drawing buffer.** `display:none` hides
+     an element; the buffer is sized by the canvas's width/height attributes.
+     An inactive session's panes hand theirs back via
+     `setSurfaceReleased(true)` on the terminal handle, driven from
+     `SessionTerminalWorkspace`. If you add a surface that survives being
+     off-screen, give it the same treatment — and restore in a layout effect
+     so the repaint precedes the frame that reveals it.
+
+   Never resolve one of these by tearing down and rebuilding a WebGL context.
+   WKWebView's live-context pool is small enough that rebuilding every mounted
+   pane loses contexts and permanently breaks panes — the reason the font-size
+   effect in `GhosttyTerminal.tsx` re-metrics in place.
+
+   Measure with `scenario-perf-baseline`'s `APP FOOTPRINT` and its
+   `paneSizedSurfaces` histogram. `ps` RSS cannot see graphics memory at all.

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -207,10 +207,12 @@ pnpm run e2e:headed -- e2e/component-harness.spec.ts  # Debug visually
      open state, not on the base rule — and check whether the component is
      conditionally rendered before reaching for the hint at all. The same
      applies to `translateZ`, `backdrop-filter`, `isolation`, and `contain`.
-   - **WebGL context attributes default to on.** `depth` is `true` unless you
-     say otherwise, and each attachment is another drawing-buffer-sized
-     allocation per canvas. Ask for what you read; the terminal renderer reads
-     neither depth nor stencil.
+   - **A WebGL context hands you attachments you did not ask for.** `depth`
+     is `true` unless you say otherwise, and every attachment is another
+     drawing-buffer-sized allocation per canvas. Ask for what you read; the
+     terminal renderer reads neither depth nor stencil, so it asks for
+     neither — `stencil` already defaults to `false`, which makes that half
+     insurance rather than a saving.
    - **A hidden canvas still owns its drawing buffer.** `display:none` hides
      an element; the buffer is sized by the canvas's width/height attributes.
      An inactive session's panes hand theirs back via

--- a/app/scripts/real-app-harness/perfMeasure.mjs
+++ b/app/scripts/real-app-harness/perfMeasure.mjs
@@ -126,6 +126,195 @@ export function classRssMb(snap, label) {
   return snap?.byClass?.[label]?.rssMb ?? 0;
 }
 
+// Region types worth naming in a memory receipt, and why each one is here.
+// `ps` RSS sums these into one number, so a change that moves memory between
+// them — releasing a GPU surface, bounding allocator churn — is invisible
+// without the split.
+const REGION_SLICES = {
+  // Per-pane GPU surfaces: the WebGL drawing buffer and glyph atlas of every
+  // MOUNTED terminal, visible or not. Owned by this process, mapped in the GPU
+  // process, so it lands here rather than in any malloc zone.
+  graphics: ['owned unmapped (graphics)', 'VM_ALLOCATE (graphics)'],
+  // bmalloc: WebKit's C++ allocator. Ingestion-path churn high-water lives here,
+  // NOT in the JS heap, and the scavenger returns it lazily.
+  webkitMalloc: ['WebKit Malloc', 'WebKit Malloc metadata'],
+  // The JS object heap proper. Measured small on attn (~7 MB) — kept so a claim
+  // of "JS leak" can be checked rather than assumed.
+  jsHeap: ['JS VM Gigacage', 'JS JIT generated code'],
+  // The wasm linear memory of every Ghostty model plus other large buffers.
+  malloc: ['MALLOC_LARGE', 'MALLOC_SMALL', 'MALLOC_TINY'],
+};
+
+function parseVmmapSize(token) {
+  const match = /^([\d.]+)([KMGT])?$/.exec(token);
+  if (!match) return null;
+  const value = Number(match[1]);
+  if (!Number.isFinite(value)) return null;
+  const scale = { K: 1 / 1024, M: 1, G: 1024, T: 1024 * 1024 };
+  return match[2] ? value * scale[match[2]] : value / (1024 * 1024);
+}
+
+// Locates the measurement window in a summary row: 7 size columns
+// (VIRTUAL/RESIDENT/DIRTY/SWAPPED/VOLATILE/NONVOL/EMPTY) followed by an integer
+// REGION COUNT. Neither end of the row can be trusted as an anchor — the name
+// may end in a bare number ("Memory Tag 241") and the row may carry trailing
+// prose ("see MALLOC ZONE table below"), so the window is found rather than
+// counted from an edge. Returns the index the sizes start at, or -1.
+function findSizeWindow(columns) {
+  for (let start = 1; start + 7 < columns.length + 1; start += 1) {
+    if (!/^\d+$/.test(columns[start + 7] ?? '')) continue;
+    const sizes = columns.slice(start, start + 7).map(parseVmmapSize);
+    if (sizes.length === 7 && sizes.every((size) => size !== null)) return start;
+  }
+  return -1;
+}
+
+// Pure: parses `vmmap --summary` into per-region-type resident/dirty megabytes.
+// Parsing stops at the MALLOC ZONE table below, whose rows have a different
+// arity and would otherwise mis-parse.
+export function parseVmmapSummary(text) {
+  const byRegion = {};
+  // Unrounded, so a slice sums raw values and rounds once. Rounding each region
+  // first and then adding lets the per-region error accumulate into the slice.
+  const exactDirtyMb = {};
+  let totalDirtyMb = 0;
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trimEnd();
+    if (/^\s*MALLOC ZONE/.test(line)) break;
+    if (!line || /^[=\s]+$/.test(line) || /^REGION TYPE/.test(line)) continue;
+    const columns = line.trim().split(/\s+/);
+    if (columns.length < 9) continue;
+    const start = findSizeWindow(columns);
+    if (start < 0) continue;
+    const sizes = columns.slice(start, start + 7).map(parseVmmapSize);
+    const name = columns.slice(0, start).join(' ');
+    // Both summary rows: `TOTAL` and `TOTAL, minus reserved VM space`.
+    if (!name || name.startsWith('TOTAL')) continue;
+    const [residentMb, dirtyMb] = [sizes[1], sizes[2]];
+    byRegion[name] = {
+      residentMb: Number(residentMb.toFixed(1)),
+      dirtyMb: Number(dirtyMb.toFixed(1)),
+    };
+    exactDirtyMb[name] = dirtyMb;
+    totalDirtyMb += dirtyMb;
+  }
+
+  const slices = {};
+  for (const [slice, names] of Object.entries(REGION_SLICES)) {
+    slices[slice] = Number(
+      names.reduce((sum, name) => sum + (exactDirtyMb[name] ?? 0), 0).toFixed(1),
+    );
+  }
+  return {
+    byRegion,
+    slices,
+    totalDirtyMb: Number(totalDirtyMb.toFixed(1)),
+    footprintMb: parseFootprint(text),
+  };
+}
+
+// The number Activity Monitor prints in its Memory column, and the only one that
+// counts `owned unmapped (graphics)` — those pages are charged to this process
+// but mapped in another, so `ps` RSS cannot see them at all. An app measured by
+// RSS alone is missing its GPU surfaces entirely.
+export function parseFootprint(text) {
+  const match = /^Physical footprint:\s+(\S+)/m.exec(text);
+  if (!match) return null;
+  const mb = parseVmmapSize(match[1]);
+  return mb === null ? null : Number(mb.toFixed(1));
+}
+
+// The app is the Tauri process plus the WebKit processes it drives. The daemon,
+// its pty-workers, the session shells, and anything an agent spawns are separate
+// programs that happen to share a process tree — counting them as "the app"
+// attributes a 450MB headless classifier to the UI.
+export const APP_PROCESS_CLASSES = ['app', 'webkit_webcontent', 'webkit_gpu', 'webkit_networking'];
+
+export function appPids(snap) {
+  return APP_PROCESS_CLASSES.flatMap((label) => (snap?.byClass?.[label]?.pids ?? []).map((entry) => entry.pid));
+}
+
+// Physical footprint of the app alone, per process and summed. Returns null
+// entries for any process vmmap could not read rather than dropping it silently,
+// so a partial total is visible as partial.
+export async function readAppFootprint(snap) {
+  const byPid = {};
+  let totalMb = 0;
+  let missing = 0;
+  for (const label of APP_PROCESS_CLASSES) {
+    for (const entry of snap?.byClass?.[label]?.pids ?? []) {
+      const regions = await readRegionFootprint(entry.pid);
+      const mb = regions?.footprintMb ?? null;
+      byPid[entry.pid] = { label, footprintMb: mb };
+      if (mb === null) missing += 1;
+      else totalMb += mb;
+    }
+  }
+  return { totalMb: Number(totalMb.toFixed(1)), missing, byPid };
+}
+
+// A GPU surface below this is chrome (compositing tiles, small layers), not a
+// pane-sized buffer. At a 1710x1073 window a full-width surface is ~22-30 MB,
+// and WebKit's 512x512@2x compositing tiles are ~4 MB, so 10 MB separates them
+// cleanly. Reported alongside the count so a shifted window size is visible
+// rather than silently re-bucketing.
+const LARGE_GRAPHICS_SURFACE_MB = 10;
+
+// Pure: the individual `owned unmapped (graphics)` regions from a full `vmmap`
+// (NOT --summary, which pre-aggregates them). The summary says how much GPU
+// surface a process holds; this says how many surfaces and what size, which is
+// what distinguishes "one buffer per pane" from "a fixed cost per window".
+export function parseGraphicsRegions(text) {
+  const surfaces = [];
+  for (const line of text.split('\n')) {
+    if (!line.includes('owned unmapped (graphics)')) continue;
+    const match = /\[\s*(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s*\]/.exec(line);
+    if (!match) continue;
+    const virtualMb = parseVmmapSize(match[1]);
+    const dirtyMb = parseVmmapSize(match[3]);
+    if (virtualMb === null || dirtyMb === null) continue;
+    surfaces.push({ virtualMb, dirtyMb });
+  }
+  const large = surfaces.filter((surface) => surface.virtualMb >= LARGE_GRAPHICS_SURFACE_MB);
+  const histogram = {};
+  for (const surface of large) {
+    const key = surface.virtualMb.toFixed(1);
+    histogram[key] = (histogram[key] ?? 0) + 1;
+  }
+  return {
+    regionCount: surfaces.length,
+    largeCount: large.length,
+    largeDirtyMb: Number(large.reduce((sum, s) => sum + s.dirtyMb, 0).toFixed(1)),
+    largeVirtualMb: Number(large.reduce((sum, s) => sum + s.virtualMb, 0).toFixed(1)),
+    histogram,
+  };
+}
+
+export async function readGraphicsRegions(pid) {
+  if (!pid) return null;
+  try {
+    const { stdout } = await execFileAsync('vmmap', [String(pid)], { maxBuffer: 128 * 1024 * 1024 });
+    return parseGraphicsRegions(stdout);
+  } catch {
+    return null;
+  }
+}
+
+// Dirty-page breakdown of one process. Returns null (never throws) when vmmap
+// is unavailable or the process is gone: a region receipt is an enrichment of
+// the RSS numbers, and losing it must not fail a run that measured fine.
+export async function readRegionFootprint(pid) {
+  if (!pid) return null;
+  try {
+    const { stdout } = await execFileAsync('vmmap', ['--summary', String(pid)], {
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    return parseVmmapSummary(stdout);
+  } catch {
+    return null;
+  }
+}
+
 // Sample RSS repeatedly over a window and return the peak (by total RSS) and the
 // last sample. Used to catch the transient/retained spike from heavy output.
 export async function sampleWindow(appPid, daemonPid, webkitBaseline, windowMs, intervalMs = 1000) {

--- a/app/scripts/real-app-harness/perfMeasure.test.mjs
+++ b/app/scripts/real-app-harness/perfMeasure.test.mjs
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest';
+import { appPids, parseFootprint, parseGraphicsRegions, parseVmmapSummary } from './perfMeasure.mjs';
+
+// Verbatim `vmmap` (non-summary) rows: two pane-sized surfaces, one volatile
+// (0K dirty), one compositing tile, and one small layer.
+const REGIONS = `owned unmapped (graphics)    unmapped-unmapped     [ 22.6M  22.6M  22.6M     0K] rw-/rw- SM=PRV PURGE=N  owned physical footprint (unmapped) (graphics)
+owned unmapped (graphics)    unmapped-unmapped     [ 27.9M  27.9M  27.9M     0K] rw-/rw- SM=PRV PURGE=N  owned physical footprint (unmapped) (graphics)
+owned unmapped (graphics)    unmapped-unmapped     [ 22.6M  22.6M     0K     0K] rw-/rw- SM=PRV PURGE=V  owned physical footprint (unmapped) (graphics)
+owned unmapped (graphics)    unmapped-unmapped     [ 4144K  4144K  4144K     0K] rw-/rw- SM=PRV PURGE=N  owned physical footprint (unmapped) (graphics)
+owned unmapped (graphics)    unmapped-unmapped     [   64K    64K    64K     0K] rw-/rw- SM=PRV PURGE=N  owned physical footprint (unmapped) (graphics)
+MALLOC_SMALL                 0x117000000-0x117800000 [ 8192K  1024K  1024K    0K] rw-/rwx SM=PRV
+`;
+
+describe('parseGraphicsRegions', () => {
+  it('counts every graphics region and ignores other region types', () => {
+    expect(parseGraphicsRegions(REGIONS).regionCount).toBe(5);
+  });
+
+  it('separates pane-sized surfaces from compositing tiles and small layers', () => {
+    const { largeCount, histogram } = parseGraphicsRegions(REGIONS);
+    expect(largeCount).toBe(3);
+    expect(histogram).toEqual({ '22.6': 2, '27.9': 1 });
+  });
+
+  it('sums dirty separately from virtual, so a volatile surface is visible', () => {
+    const { largeDirtyMb, largeVirtualMb } = parseGraphicsRegions(REGIONS);
+    // The third surface is resident but purgeable: it counts toward virtual and
+    // not toward dirty, which is how reclaimable GPU memory shows up.
+    expect(largeDirtyMb).toBeCloseTo(50.5, 1);
+    expect(largeVirtualMb).toBeCloseTo(73.1, 1);
+  });
+
+  it('returns empty results rather than throwing on unparseable input', () => {
+    expect(parseGraphicsRegions('').regionCount).toBe(0);
+    expect(parseGraphicsRegions('nonsense').largeCount).toBe(0);
+  });
+});
+
+// Verbatim rows from `vmmap --summary` on a packaged attn WebContent process,
+// including the trailing MALLOC ZONE table that must not be parsed as regions.
+const SUMMARY = `Process:         com.apple.WebKit.WebContent [44033]
+Physical footprint:         1.2G
+Physical footprint (peak):  3.5G
+----
+
+                                VIRTUAL RESIDENT    DIRTY  SWAPPED VOLATILE   NONVOL    EMPTY   REGION
+REGION TYPE                        SIZE     SIZE     SIZE     SIZE     SIZE     SIZE     SIZE    COUNT (non-coalesced)
+===========                     ======= ========    =====  ======= ========   ======    =====  =======
+JS JIT generated code            512.0M    14.9M    9600K    2384K       0K       0K       0K        3
+JS VM Gigacage                     1.0G    20.4M    6720K     384K       0K       0K       0K        5
+JS VM Gigacage (reserved)         14.9G       0K       0K       0K       0K       0K       0K        3         reserved VM address space (unallocated)
+MALLOC_LARGE                      2464K      48K      48K    2416K       0K       0K       0K        1         see MALLOC ZONE table below
+MALLOC_SMALL                      66.2M    13.9M    10.4M    3008K       0K       0K       0K     2275         see MALLOC ZONE table below
+MALLOC_TINY                       4096K     240K     240K      48K       0K       0K       0K        1         see MALLOC ZONE table below
+Memory Tag 241                     320K       0K       0K      80K       0K       0K       0K        4
+dyld private memory                160K       56       56       0K       0K       0K       0K        4
+VM_ALLOCATE (graphics)             128K     128K     128K       0K       0K     128K       0K        5
+WebKit Malloc                     23.2G   709.7M   385.1M    25.9M       0K       0K       0K      402
+WebKit Malloc metadata           128.1M    4272K    4144K     368K       0K       0K       0K        2
+__CTF                               824      824       0K       0K       0K       0K       0K        1
+owned unmapped (graphics)          1.0G     1.0G   665.5M    43.6M       0K       0K       0K      141
+===========                     ======= ========    =====  ======= ========   ======    =====  =======
+TOTAL                             75.7G     2.4G     1.1G    79.2M       0K    10.0M    2608K     9307
+TOTAL, minus reserved VM space    29.1G     2.4G     1.1G    79.2M       0K    10.0M    2608K     9307
+
+                                          VIRTUAL   RESIDENT      DIRTY    SWAPPED ALLOCATION      BYTES DIRTY+SWAP          REGION
+MALLOC ZONE                                  SIZE       SIZE       SIZE       SIZE      COUNT  ALLOCATED  FRAG SIZE  % FRAG   COUNT
+===========                               =======  =========  =========  =========  =========  =========  =========  ======  ======
+WebKit Malloc_0x10610e678                    3.8G     741.8M     405.5M      27.6M     632159      20.4G         0K      0%     203
+`;
+
+describe('parseVmmapSummary', () => {
+  it('reads dirty and resident megabytes for a region', () => {
+    const { byRegion } = parseVmmapSummary(SUMMARY);
+    expect(byRegion['WebKit Malloc']).toEqual({ residentMb: 709.7, dirtyMb: 385.1 });
+  });
+
+  it('keeps a multi-word region name intact', () => {
+    const { byRegion } = parseVmmapSummary(SUMMARY);
+    expect(byRegion['owned unmapped (graphics)']).toEqual({ residentMb: 1024, dirtyMb: 665.5 });
+  });
+
+  it('converts each size suffix to megabytes', () => {
+    const { byRegion } = parseVmmapSummary(SUMMARY);
+    // K, M and G all appear in the DIRTY column above.
+    expect(byRegion['JS JIT generated code'].dirtyMb).toBeCloseTo(9.4, 1);
+    expect(byRegion['MALLOC_SMALL'].dirtyMb).toBe(10.4);
+    expect(byRegion['owned unmapped (graphics)'].residentMb).toBe(1024);
+  });
+
+  it('sums the slices a memory receipt reports', () => {
+    const { slices } = parseVmmapSummary(SUMMARY);
+    expect(slices.graphics).toBe(665.6); // owned unmapped + VM_ALLOCATE
+    expect(slices.webkitMalloc).toBe(389.1); // WebKit Malloc + its metadata
+    expect(slices.jsHeap).toBeCloseTo(15.9, 1);
+  });
+
+  it('excludes both summary rows from the region map and the dirty total', () => {
+    const { byRegion, totalDirtyMb } = parseVmmapSummary(SUMMARY);
+    expect(Object.keys(byRegion).filter((name) => name.startsWith('TOTAL'))).toEqual([]);
+    // Sum of the region rows above. Counting either summary row (1.1G each)
+    // would roughly triple it.
+    expect(totalDirtyMb).toBeCloseTo(1081.4, 1);
+  });
+
+  it('stops before the MALLOC ZONE table, whose rows have a different arity', () => {
+    const { byRegion } = parseVmmapSummary(SUMMARY);
+    expect(Object.keys(byRegion).some((name) => name.includes('0x10610e678'))).toBe(false);
+  });
+
+  it('keeps a row that carries trailing prose after the region count', () => {
+    // These rows were silently dropped while the parser anchored on the last
+    // column, which read a 0 MB malloc slice as if it were measured.
+    const { byRegion, slices } = parseVmmapSummary(SUMMARY);
+    expect(byRegion.MALLOC_SMALL).toEqual({ residentMb: 13.9, dirtyMb: 10.4 });
+    expect(slices.malloc).toBeCloseTo(10.7, 1);
+  });
+
+  it('keeps a region name that ends in a bare number', () => {
+    const { byRegion } = parseVmmapSummary(SUMMARY);
+    expect(byRegion['Memory Tag 241']).toEqual({ residentMb: 0, dirtyMb: 0 });
+  });
+
+  it('keeps a multi-word name followed by unsuffixed byte counts', () => {
+    const { byRegion } = parseVmmapSummary(SUMMARY);
+    expect(byRegion['dyld private memory']).toEqual({ residentMb: 0, dirtyMb: 0 });
+  });
+
+  it('excludes a reserved-address-space row from its slice', () => {
+    // `JS VM Gigacage (reserved)` is unallocated VM, not memory in use.
+    const { slices } = parseVmmapSummary(SUMMARY);
+    expect(slices.jsHeap).toBeCloseTo(15.9, 1);
+  });
+
+  it('parses a raw byte count with no size suffix, rounding sub-MB to 0.0', () => {
+    const { byRegion } = parseVmmapSummary(SUMMARY);
+    // 824 bytes. The row is kept (not dropped as unparseable) but reports 0.0:
+    // a memory receipt is read in megabytes, so sub-MB regions are noise.
+    expect(byRegion.__CTF).toEqual({ residentMb: 0, dirtyMb: 0 });
+  });
+
+  it('returns empty results rather than throwing on unparseable input', () => {
+    expect(parseVmmapSummary('').byRegion).toEqual({});
+    expect(parseVmmapSummary('garbage\nmore garbage').totalDirtyMb).toBe(0);
+  });
+});
+
+describe('parseFootprint', () => {
+  it('reads the physical footprint, not the peak line below it', () => {
+    // 1.2G vs the 3.5G peak. Taking the peak would report a number the process
+    // has not held since some earlier burst.
+    expect(parseFootprint(SUMMARY)).toBeCloseTo(1228.8, 1);
+  });
+
+  it('is null when the header is absent, so a missing value is never a zero', () => {
+    expect(parseFootprint('no header here')).toBeNull();
+  });
+
+  it('travels with the region breakdown', () => {
+    expect(parseVmmapSummary(SUMMARY).footprintMb).toBeCloseTo(1228.8, 1);
+  });
+});
+
+describe('appPids', () => {
+  // A headless `claude -p` the daemon spawns for classification is a child of
+  // the daemon, so a process-tree walk sweeps it into the snapshot. It is a
+  // separate program; counting its ~450MB as the app's makes every app number
+  // wrong in the same direction.
+  const SNAP = {
+    byClass: {
+      app: { pids: [{ pid: 10 }] },
+      webkit_webcontent: { pids: [{ pid: 11 }] },
+      webkit_gpu: { pids: [{ pid: 12 }] },
+      webkit_networking: { pids: [{ pid: 13 }] },
+      daemon: { pids: [{ pid: 20 }] },
+      pty_worker: { pids: [{ pid: 21 }, { pid: 22 }] },
+      shell: { pids: [{ pid: 23 }] },
+      '/Users/victor/.l': { pids: [{ pid: 24 }] },
+    },
+  };
+
+  it('selects the Tauri process and its WebKit processes', () => {
+    expect(appPids(SNAP).sort((a, b) => a - b)).toEqual([10, 11, 12, 13]);
+  });
+
+  it('excludes the daemon, its workers, session shells, and spawned agents', () => {
+    const pids = appPids(SNAP);
+    for (const notApp of [20, 21, 22, 23, 24]) expect(pids).not.toContain(notApp);
+  });
+
+  it('returns nothing rather than throwing when a snapshot is missing classes', () => {
+    expect(appPids({})).toEqual([]);
+    expect(appPids(undefined)).toEqual([]);
+  });
+});

--- a/app/scripts/real-app-harness/scenario-perf-baseline.mjs
+++ b/app/scripts/real-app-harness/scenario-perf-baseline.mjs
@@ -32,14 +32,27 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import http from 'node:http';
-import { spawn } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
+import { promisify } from 'node:util';
 import { DaemonObserver } from './daemonObserver.mjs';
 import { createRunContext, createSessionAndWaitForInitialPane, emitVerdict, parseCommonArgs, printCommonHelp } from './common.mjs';
 import { UiAutomationClient } from './uiAutomationClient.mjs';
 import { profileForAppPath, socketPathForProfile } from './harnessProfile.mjs';
 import { getMachineFingerprint, loadBaseline, recordOrCompareBaseline } from './machineRegistry.mjs';
 import { buildBaselineVerdict, evaluateRssBaseline } from './rssBaselineVerdict.mjs';
-import { delay, captureWebKitPids, snapshot, classRssMb, sampleWindow, readLiveDaemonPid, stopDaemon, paneIdForSession, closeSessions, fillAllPanes } from './perfMeasure.mjs';
+import { captureFrontWindowScreenshot, getFrontWindowBounds, setFrontWindowBounds } from './nativeWindowCapture.mjs';
+import { delay, captureWebKitPids, snapshot, classRssMb, sampleWindow, readLiveDaemonPid, stopDaemon, paneIdForSession, closeSessions, fillAllPanes, readRegionFootprint, readGraphicsRegions, readAppFootprint } from './perfMeasure.mjs';
+
+const execFileAsync = promisify(execFile);
+
+// The app's own WebContent: the largest of the attributed WebContent pids. A
+// second one appears for an auxiliary web view (the in-app browser), and it is
+// never the one holding the terminal panes.
+function webContentPid(snap) {
+  const pids = snap?.byClass?.webkit_webcontent?.pids ?? [];
+  if (pids.length === 0) return null;
+  return pids.reduce((best, entry) => (entry.rssKb > best.rssKb ? entry : best)).pid;
+}
 
 function parseArgs(argv) {
   const filtered = argv.filter((arg) => arg !== '--');
@@ -54,11 +67,17 @@ function parseArgs(argv) {
     cpuSeconds: 20,
     realCmd: null,
     realWindowMs: 25000,
+    window: null,
     warm: null,
     fillCmd: null,
     fillSettleMs: 3000,
     reclaimHoldMs: 0,
     reclaimHoldIntervalMs: 15000,
+    pressure: false,
+    closeProbe: false,
+    churnRounds: 0,
+    dockProbe: null,
+    switchProbe: false,
     rssTolerancePct: 15,
     recordBaseline: false,
   };
@@ -74,16 +93,37 @@ function parseArgs(argv) {
     else if (arg === '--real-window-ms') extras.realWindowMs = Number(filtered[++index]);
     else if (arg === '--no-restart-daemon') extras.restartDaemon = false;
     else if (arg === '--warm') extras.warm = filtered[++index];
+    else if (arg === '--window') extras.window = filtered[++index];
     else if (arg === '--fill-cmd') extras.fillCmd = filtered[++index];
     else if (arg === '--fill-settle-ms') extras.fillSettleMs = Number(filtered[++index]);
     else if (arg === '--reclaim-hold-ms') extras.reclaimHoldMs = Number(filtered[++index]);
     else if (arg === '--reclaim-hold-interval-ms') extras.reclaimHoldIntervalMs = Number(filtered[++index]);
     else if (arg === '--rss-tolerance-pct') extras.rssTolerancePct = Number(filtered[++index]);
+    else if (arg === '--pressure') extras.pressure = true;
+    else if (arg === '--close-probe') extras.closeProbe = true;
+    else if (arg === '--churn') extras.churnRounds = Number(filtered[++index]);
+    else if (arg === '--dock-probe') extras.dockProbe = filtered[++index];
+    else if (arg === '--switch-probe') extras.switchProbe = true;
     else if (arg === '--record-baseline') extras.recordBaseline = true;
     else passthrough.push(arg);
   }
   const options = parseCommonArgs(passthrough);
   return Object.assign(options, extras);
+}
+
+// The harness parks the window nearly off-screen, and `screencapture -R` grabs a
+// screen region -- so a shot taken as-is catches the parked sliver, or whatever
+// window happens to sit in front. Put the window fully on screen and raise the
+// app before capturing anything.
+async function bringWindowForward(client) {
+  const parked = await getFrontWindowBounds(client.bundleId, { client }).catch(() => null);
+  if (parked) {
+    await setFrontWindowBounds({ x: 0, y: 25, width: parked.width, height: parked.height }, { client })
+      .catch((error) => console.warn(`[perf] unpark failed: ${error.message}`));
+    await delay(1500);
+  }
+  await execFileAsync('open', ['-b', client.bundleId]).catch(() => {});
+  await delay(1200);
 }
 
 function pprofPort() {
@@ -216,6 +256,9 @@ async function main() {
     console.log('                      synthetic benchmark/CPU profile and samples peak + post RSS.');
     console.log('  --real-window-ms <n>  Sampling window for --real-cmd (default: 25000)');
     console.log('  --no-restart-daemon Do not restart the dev daemon for ATTN_PPROF');
+    console.log('  --window <WxH>      Resize the app window before measuring (e.g. 1728x1080). A');
+    console.log('                      pane\'s GPU surface is sized in device pixels, so the default');
+    console.log('                      1200x800 launch window understates per-pane graphics memory.');
     console.log('  --warm <list>       Warm-workspace A/B (terminal virtualization). Drives every');
     console.log('                      session to idle (the real `attn _hook-state idle` path), then');
     console.log('                      sweeps each comma-separated limit, snapshotting retained RSS at');
@@ -230,6 +273,19 @@ async function main() {
     console.log('                      curve -- distinguishes soft-but-delayed from hard. Pair with');
     console.log('                      --fill-cmd + --warm <low>.');
     console.log('  --reclaim-hold-interval-ms <n>  Sample interval during the hold (default: 15000)');
+    console.log('  --pressure          After the warm sweep, fire WebKit\'s low-memory notification and');
+    console.log('                      re-measure. Separates surfaces a live layer owns (survive) from');
+    console.log('                      surfaces WebKit is caching for reuse (dropped).');
+    console.log('  --churn <rounds>    Open --sessions sessions, close them all, repeat <rounds> times,');
+    console.log('                      measuring at rest each round. A rising at-rest line is memory');
+    console.log('                      no session owns any more.');
+    console.log('  --switch-probe      Walk every session with select_session and screenshot each one');
+    console.log('                      after it is revealed. A pane that hands its GPU drawing buffer');
+    console.log('                      back while hidden has to paint again on reveal; a blank or');
+    console.log('                      stale window in a shot is that repaint missing. Pair with');
+    console.log('                      --fill-cmd so each pane holds distinguishable content.');
+    console.log('  --close-probe       Close every session after the sweep and re-measure, to see');
+    console.log('                      whether full teardown releases what unmounting did not.');
     console.log('  --rss-tolerance-pct <n>  Allowed growth over the per-machine baseline before the');
     console.log('                      verdict fails (default: 15)');
     console.log('  --record-baseline   Overwrite the per-machine baseline with this run\'s RSS instead');
@@ -289,6 +345,23 @@ async function main() {
     await client.waitForFrontendResponsive(20_000);
     await observer.connect();
 
+    // A pane's GPU surface is sized in device pixels, so every graphics number
+    // is only readable next to the window it was measured at. The harness
+    // launches at Tauri's 1200x800 default, which is far smaller than a real
+    // window and understates the per-pane surface accordingly.
+    if (options.window) {
+      const match = /^(\d+)x(\d+)$/.exec(options.window);
+      if (!match) throw new Error(`--window expects WxH (e.g. 1728x1080), got: ${options.window}`);
+      const current = await getFrontWindowBounds(client.bundleId, { client });
+      await setFrontWindowBounds(
+        { x: current?.x ?? 0, y: current?.y ?? 0, width: Number(match[1]), height: Number(match[2]) },
+        { client },
+      );
+      await delay(1500);
+    }
+    summary.window = await getFrontWindowBounds(client.bundleId, { client }).catch(() => null);
+    console.log(`[perf] window bounds: ${summary.window ? `${summary.window.width}x${summary.window.height}` : 'unknown'}`);
+
     // Clear detritus from prior runs. Sessions persist in the daemon's SQLite
     // store and are restored across daemon restarts, so a fresh daemon can still
     // surface stale perf-baseline sessions (with dead workers).
@@ -341,7 +414,27 @@ async function main() {
     summary.daemonPidSource = daemonPid ? (summary.diagUp ? 'debug-vars' : 'pid-file') : 'none';
 
     summary.snapshots.empty = await snapshot(appPid, daemonPid, webkitBaseline);
-    console.log(`[perf] empty snapshot: ${summary.snapshots.empty.totalRssMb} MB (${summary.snapshots.empty.procCount} procs)`);
+    // The app's own floor, in the accounting the user sees. Everything else in
+    // the tree -- daemon, pty-workers, session shells, agents the daemon spawns
+    // -- is a different program, and summing them hides what the UI costs.
+    summary.appFootprint = { empty: await readAppFootprint(summary.snapshots.empty) };
+    const emptyWc = webContentPid(summary.snapshots.empty);
+    summary.emptyWebContent = {
+      regions: await readRegionFootprint(emptyWc),
+      surfaces: await readGraphicsRegions(emptyWc),
+    };
+    console.log(
+      `[perf] empty snapshot: ${summary.snapshots.empty.totalRssMb} MB rss `
+      + `(${summary.snapshots.empty.procCount} procs) | APP FOOTPRINT `
+      + `${summary.appFootprint.empty.totalMb} MB`,
+    );
+    console.log(
+      `[perf] empty app webContent: ${JSON.stringify(summary.emptyWebContent.regions?.slices ?? {})} `
+      + `footprint=${summary.emptyWebContent.regions?.footprintMb ?? 'n/a'}MB | surfaces=`
+      + `${summary.emptyWebContent.surfaces?.largeCount ?? 'n/a'} `
+      + JSON.stringify(summary.emptyWebContent.surfaces?.histogram ?? {}),
+    );
+    console.log(`[perf] empty app by pid: ${JSON.stringify(summary.appFootprint.empty.byPid)}`);
 
     // Pace creation: wait for each session's initial pane to mount before
     // creating the next, so the frontend main thread is free to reply to the
@@ -419,6 +512,16 @@ async function main() {
         }
         await delay(options.settleMs);
         const snap = await snapshot(appPid, daemonPid, webkitBaseline);
+        // Per-pane GPU surfaces do not appear as their own class in `ps` RSS, so
+        // the sweep reads the WebContent region split too: a warm level that
+        // mounts fewer panes should show `graphics` fall with `livePanes`.
+        const pid = webContentPid(snap);
+        const regions = await readRegionFootprint(pid);
+        // How many pane-sized GPU surfaces exist at this warm level. If the
+        // count tracks mounted panes, virtualization releases surfaces; if it
+        // tracks sessions, something holds them past unmount.
+        const surfaces = await readGraphicsRegions(pid);
+        const appFootprint = await readAppFootprint(snap);
         const expectedVirtualized = limit < 0 ? 0 : Math.max(0, options.sessions - (limit + 1));
         const entry = {
           warm: limit,
@@ -429,12 +532,25 @@ async function main() {
           webContentRssMb: classRssMb(snap, 'webkit_webcontent'),
           gpuRssMb: classRssMb(snap, 'webkit_gpu'),
           appRssMb: classRssMb(snap, 'app'),
+          webContentDirtyMb: regions?.slices ?? null,
+          graphicsSurfaces: surfaces ?? null,
+          appFootprintMb: appFootprint.totalMb,
+          appFootprintByPid: appFootprint.byPid,
         };
         summary.warmSweep.push(entry);
         console.log(
           `[perf] warm=${limit}: live=${entry.livePanes}/${options.sessions} `
           + `virtualized=${entry.virtualizedPanes} (expected ${expectedVirtualized}) | `
-          + `total=${entry.totalRssMb}MB webContent=${entry.webContentRssMb}MB gpu=${entry.gpuRssMb}MB`,
+          + `APP FOOTPRINT ${entry.appFootprintMb}MB | `
+          + `total=${entry.totalRssMb}MB webContent=${entry.webContentRssMb}MB gpu=${entry.gpuRssMb}MB`
+          + (regions
+            ? ` | dirty: graphics=${regions.slices.graphics}MB `
+              + `webkitMalloc=${regions.slices.webkitMalloc}MB jsHeap=${regions.slices.jsHeap}MB`
+            : ' | dirty: unavailable')
+          + (surfaces
+            ? ` | paneSizedSurfaces=${surfaces.largeCount} (${surfaces.largeDirtyMb}MB dirty) `
+              + JSON.stringify(surfaces.histogram)
+            : ''),
         );
         // The per-pane RSS slope is only meaningful if the warm-set actually
         // reached the intended live/virtual split. A mismatch means
@@ -451,6 +567,173 @@ async function main() {
       }
     }
 
+    // Does WebKit hand the pane-sized GPU surfaces back when asked? A surface a
+    // live compositing layer still owns survives the low-memory notification; a
+    // surface WebKit is merely caching for reuse is dropped by it. The two have
+    // different fixes — mount fewer panes vs. cap or defeat the cache — so the
+    // sweep alone cannot pick one.
+    if (options.pressure) {
+      const before = await snapshot(appPid, daemonPid, webkitBaseline);
+      const pid = webContentPid(before);
+      const beforeRegions = await readRegionFootprint(pid);
+      const beforeSurfaces = await readGraphicsRegions(pid);
+      await execFileAsync('notifyutil', ['-p', 'org.WebKit.lowMemory']);
+      await delay(options.settleMs);
+      const after = await snapshot(appPid, daemonPid, webkitBaseline);
+      const afterRegions = await readRegionFootprint(pid);
+      const afterSurfaces = await readGraphicsRegions(pid);
+      summary.pressure = {
+        before: {
+          totalRssMb: before.totalRssMb,
+          byClass: before.byClass,
+          webContentDirtyMb: beforeRegions?.slices ?? null,
+          graphicsSurfaces: beforeSurfaces ?? null,
+        },
+        after: {
+          totalRssMb: after.totalRssMb,
+          byClass: after.byClass,
+          webContentDirtyMb: afterRegions?.slices ?? null,
+          graphicsSurfaces: afterSurfaces ?? null,
+        },
+      };
+      console.log(
+        `[perf] pressure: total ${before.totalRssMb} -> ${after.totalRssMb}MB | `
+        + `graphics ${beforeRegions?.slices.graphics ?? 'n/a'} -> ${afterRegions?.slices.graphics ?? 'n/a'}MB | `
+        + `paneSizedSurfaces ${beforeSurfaces?.largeCount ?? 'n/a'} -> ${afterSurfaces?.largeCount ?? 'n/a'} `
+        + `(${beforeSurfaces?.largeDirtyMb ?? 'n/a'} -> ${afterSurfaces?.largeDirtyMb ?? 'n/a'}MB dirty)`,
+      );
+    }
+
+    // A dock panel costs a compositing layer only while it is open. Measures
+    // both directions -- the layer must be absent when closed and present when
+    // open -- and captures the open panel so a memory win that stopped the
+    // drawer from rendering cannot pass as a win.
+    if (options.dockProbe) {
+      const closedPid = webContentPid(await snapshot(appPid, daemonPid, webkitBaseline));
+      const closed = await readGraphicsRegions(closedPid);
+      await client.request('open_dock_panel', { panelId: options.dockProbe }, { timeoutMs: 15_000 });
+      await delay(options.settleMs);
+      const openPid = webContentPid(await snapshot(appPid, daemonPid, webkitBaseline));
+      const opened = await readGraphicsRegions(openPid);
+      await bringWindowForward(client);
+      const shot = path.join(runDir, `dock-${options.dockProbe}-open.png`);
+      await captureFrontWindowScreenshot(shot).catch((error) => console.warn(`[perf] dock screenshot failed: ${error.message}`));
+      summary.dockProbe = { panelId: options.dockProbe, closed, opened, screenshot: shot };
+      console.log(
+        `[perf] dock ${options.dockProbe}: closed surfaces=${closed?.largeCount ?? 'n/a'} `
+        + JSON.stringify(closed?.histogram ?? {})
+        + ` -> open surfaces=${opened?.largeCount ?? 'n/a'} `
+        + JSON.stringify(opened?.histogram ?? {}) + ` | shot=${shot}`,
+      );
+    }
+
+    // An off-screen pane hands its GPU drawing buffer back, so being revealed is
+    // the moment it owes a repaint. Walk every session and photograph the window
+    // right after each switch: the memory win is only a win if the pane the user
+    // switched to still shows its own content.
+    if (options.switchProbe && sessionIds.length > 0) {
+      await bringWindowForward(client);
+      summary.switchProbe = [];
+      for (let index = 0; index < sessionIds.length; index += 1) {
+        const sessionId = sessionIds[index];
+        await client.request('select_session', { sessionId }, { timeoutMs: 15_000 });
+        await delay(options.settleMs);
+        const shot = path.join(runDir, `switch-${index + 1}.png`);
+        await captureFrontWindowScreenshot(shot)
+          .catch((error) => console.warn(`[perf] switch screenshot failed: ${error.message}`));
+        const surfaces = await readGraphicsRegions(webContentPid(await snapshot(appPid, daemonPid, webkitBaseline)));
+        summary.switchProbe.push({ sessionId, screenshot: shot, graphicsSurfaces: surfaces ?? null });
+        console.log(
+          `[perf] switch ${index + 1}/${sessionIds.length}: ${sessionId} | `
+          + `paneSizedSurfaces=${surfaces?.largeCount ?? 'n/a'} `
+          + JSON.stringify(surfaces?.histogram ?? {}) + ` | shot=${shot}`,
+        );
+      }
+    }
+
+    // What a day of real use does that a single snapshot cannot see: open a set
+    // of sessions, close them, and do it again. A round that ends heavier than
+    // it started is memory no session owns any more, so nothing will ever
+    // release it — the shape that turns a working app into a 1GB one by evening.
+    if (options.churnRounds > 0) {
+      summary.churn = [];
+      for (let round = 0; round < options.churnRounds; round += 1) {
+        const roundIds = [];
+        for (let i = 0; i < options.sessions; i += 1) {
+          roundIds.push(await createSessionAndWaitForInitialPane({
+            client,
+            observer,
+            cwd: sessionDir,
+            label: `perf-churn-${runId}-${round}-${i}`,
+            agent: 'shell',
+            sessionWaitMs: 30_000,
+            waitForInitialPaneVisible: true,
+            initialPaneWaitMs: 25_000,
+          }));
+        }
+        if (options.fillCmd) await fillAllPanes(client, roundIds, options.fillCmd, options.fillSettleMs);
+        await delay(options.settleMs);
+        const peak = await snapshot(appPid, daemonPid, webkitBaseline);
+        const peakRegions = await readRegionFootprint(webContentPid(peak));
+        await closeSessions(client, roundIds);
+        await delay(options.settleMs);
+        const rest = await snapshot(appPid, daemonPid, webkitBaseline);
+        const pid = webContentPid(rest);
+        const restRegions = await readRegionFootprint(pid);
+        const restSurfaces = await readGraphicsRegions(pid);
+        summary.churn.push({
+          round,
+          peak: { totalRssMb: peak.totalRssMb, webContentDirtyMb: peakRegions?.slices ?? null },
+          rest: {
+            totalRssMb: rest.totalRssMb,
+            webContentDirtyMb: restRegions?.slices ?? null,
+            graphicsSurfaces: restSurfaces ?? null,
+          },
+        });
+        console.log(
+          `[perf] churn round ${round + 1}/${options.churnRounds}: `
+          + `at rest (0 sessions) graphics=${restRegions?.slices.graphics ?? 'n/a'}MB `
+          + `webkitMalloc=${restRegions?.slices.webkitMalloc ?? 'n/a'}MB `
+          + `jsHeap=${restRegions?.slices.jsHeap ?? 'n/a'}MB `
+          + `total=${rest.totalRssMb}MB | peak webkitMalloc=${peakRegions?.slices.webkitMalloc ?? 'n/a'}MB`,
+        );
+      }
+    }
+
+    // Full teardown, not just unmount: close every session and re-measure. If
+    // closing releases the pane-sized surfaces that virtualization did not, the
+    // retention is attn's to fix; if it does not, WebKit is caching them past
+    // any lifetime attn controls and only memory pressure returns them.
+    if (options.closeProbe) {
+      const before = await snapshot(appPid, daemonPid, webkitBaseline);
+      const pid = webContentPid(before);
+      const beforeRegions = await readRegionFootprint(pid);
+      const beforeSurfaces = await readGraphicsRegions(pid);
+      await closeSessions(client, sessionIds);
+      sessionIds.length = 0;
+      await delay(options.settleMs);
+      const after = await snapshot(appPid, daemonPid, webkitBaseline);
+      const afterRegions = await readRegionFootprint(pid);
+      const afterSurfaces = await readGraphicsRegions(pid);
+      summary.closeProbe = {
+        before: {
+          webContentDirtyMb: beforeRegions?.slices ?? null,
+          graphicsSurfaces: beforeSurfaces ?? null,
+        },
+        after: {
+          webContentDirtyMb: afterRegions?.slices ?? null,
+          graphicsSurfaces: afterSurfaces ?? null,
+        },
+      };
+      console.log(
+        `[perf] close-all: graphics ${beforeRegions?.slices.graphics ?? 'n/a'} -> `
+        + `${afterRegions?.slices.graphics ?? 'n/a'}MB | webkitMalloc `
+        + `${beforeRegions?.slices.webkitMalloc ?? 'n/a'} -> ${afterRegions?.slices.webkitMalloc ?? 'n/a'}MB | `
+        + `jsHeap ${beforeRegions?.slices.jsHeap ?? 'n/a'} -> ${afterRegions?.slices.jsHeap ?? 'n/a'}MB | `
+        + `paneSizedSurfaces ${beforeSurfaces?.largeCount ?? 'n/a'} -> ${afterSurfaces?.largeCount ?? 'n/a'}`,
+      );
+    }
+
     // Reclaim decay sampler (no pressure, no GC nudge). Hold the torn-down
     // (most-virtualized) state and sample retained RSS over time. WebKit's
     // scavenger / periodic memory monitor reclaims freed WASM + heap on a delay
@@ -465,16 +748,19 @@ async function main() {
       let elapsed = 0;
       for (;;) {
         const snap = await snapshot(appPid, daemonPid, webkitBaseline);
+        const regions = await readRegionFootprint(webContentPid(snap));
         const entry = {
           tMs: elapsed,
           totalRssMb: snap.totalRssMb,
           webContentRssMb: classRssMb(snap, 'webkit_webcontent'),
           gpuRssMb: classRssMb(snap, 'webkit_gpu'),
+          webContentDirtyMb: regions?.slices ?? null,
         };
         summary.reclaimHold.push(entry);
         console.log(
           `[perf] HOLD t=${Math.round(elapsed / 1000)}s: webContent=${entry.webContentRssMb}MB `
-          + `gpu=${entry.gpuRssMb}MB total=${entry.totalRssMb}MB`,
+          + `gpu=${entry.gpuRssMb}MB total=${entry.totalRssMb}MB`
+          + (regions ? ` gfxDirty=${regions.slices.graphics}MB mallocDirty=${regions.slices.webkitMalloc}MB` : ''),
         );
         if (elapsed >= options.reclaimHoldMs) break;
         await delay(Math.min(options.reclaimHoldIntervalMs, options.reclaimHoldMs - elapsed));
@@ -592,9 +878,14 @@ async function main() {
           totalRssMb: entry.totalRssMb,
           webContentRssMb: entry.webContentRssMb,
           gpuRssMb: entry.gpuRssMb,
+          webContentDirtyMb: entry.webContentDirtyMb,
         })),
         perLivePaneTotalMb: paneSpan > 0 ? Number(((most.totalRssMb - least.totalRssMb) / paneSpan).toFixed(1)) : null,
         perLivePaneWebContentMb: paneSpan > 0 ? Number(((most.webContentRssMb - least.webContentRssMb) / paneSpan).toFixed(1)) : null,
+        // The per-pane GPU surface: what release-on-hide could actually reclaim.
+        perLivePaneGraphicsMb: paneSpan > 0 && most.webContentDirtyMb && least.webContentDirtyMb
+          ? Number(((most.webContentDirtyMb.graphics - least.webContentDirtyMb.graphics) / paneSpan).toFixed(1))
+          : null,
       };
     }
 
@@ -632,7 +923,7 @@ async function main() {
   if (summary.headline?.warmSweep) {
     const { levels, perLivePaneTotalMb, perLivePaneWebContentMb } = summary.headline.warmSweep;
     console.log(`\n[perf] WARM-SET A/B (${options.sessions} idle sessions)`);
-    console.log('  warm  live  virt  total(MB)  webContent(MB)  gpu(MB)');
+    console.log('  warm  live  virt  total(MB)  webContent(MB)  gpu(MB)  gfxDirty(MB)  mallocDirty(MB)');
     for (const lvl of levels) {
       const warmCol = String(lvl.warm).padStart(4);
       const liveCol = String(lvl.livePanes).padStart(4);
@@ -640,9 +931,27 @@ async function main() {
       const totalCol = String(lvl.totalRssMb).padStart(9);
       const wcCol = String(lvl.webContentRssMb).padStart(14);
       const gpuCol = String(lvl.gpuRssMb).padStart(7);
-      console.log(`  ${warmCol}  ${liveCol}  ${virtCol}  ${totalCol}  ${wcCol}  ${gpuCol}`);
+      const gfxCol = String(lvl.webContentDirtyMb?.graphics ?? 'n/a').padStart(12);
+      const mallocCol = String(lvl.webContentDirtyMb?.webkitMalloc ?? 'n/a').padStart(15);
+      console.log(`  ${warmCol}  ${liveCol}  ${virtCol}  ${totalCol}  ${wcCol}  ${gpuCol}  ${gfxCol}  ${mallocCol}`);
     }
     console.log(`  per-live-pane: total ${perLivePaneTotalMb ?? 'n/a'} MB, webContent ${perLivePaneWebContentMb ?? 'n/a'} MB`);
+    // The A/B this table exists for: graphics dirty is the per-pane GPU surface.
+    // If it does not fall with livePanes, invisible panes are not holding it and
+    // the release-on-hide hypothesis is wrong.
+    const withGfx = levels.filter((lvl) => lvl.webContentDirtyMb?.graphics != null);
+    if (withGfx.length >= 2) {
+      const first = withGfx[0];
+      const last = withGfx[withGfx.length - 1];
+      const paneDelta = first.livePanes - last.livePanes;
+      const gfxDelta = first.webContentDirtyMb.graphics - last.webContentDirtyMb.graphics;
+      console.log(
+        `  graphics dirty: ${first.webContentDirtyMb.graphics} MB @ ${first.livePanes} live `
+        + `-> ${last.webContentDirtyMb.graphics} MB @ ${last.livePanes} live `
+        + `(${gfxDelta >= 0 ? '-' : '+'}${Math.abs(gfxDelta).toFixed(1)} MB`
+        + (paneDelta > 0 ? `, ${(gfxDelta / paneDelta).toFixed(1)} MB per pane` : '') + ')',
+      );
+    }
   }
 
   console.log(JSON.stringify({ headline: summary.headline, reclaimHold: summary.reclaimHold, idleByClass: summary.snapshots.idle?.byClass, profiles: summary.profiles, runDir }, null, 2));

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -247,6 +247,12 @@ export interface GhosttyTerminalHandle {
   // is meaningful: it clears what the pane drew before the reattach.
   seedPlacements: (sessionId: string, placements: PlacementElement[]) => Promise<void>;
   reset: () => void;
+  // Hand back (or take back) the GPU drawing buffer while the pane is off-screen.
+  // The model, its scrollback, and the GL context all survive; only the surface
+  // the compositor would show goes. Releasing must be paired with a restore
+  // before the pane is painted again, and the restore repaints synchronously so
+  // a revealed pane never shows a blank frame.
+  setSurfaceReleased: (released: boolean) => void;
   scrollToTop: () => boolean;
   getText: () => string;
   getSize: () => { cols: number; rows: number } | null;
@@ -525,6 +531,8 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const terminalRef = useRef<GhosttyModel | null>(null);
     const rendererRef = useRef<WebGlTerminalRenderer | null>(null);
+    // Belongs to the pane, not to a renderer instance: it outlives the rebuilds.
+    const surfaceReleasedRef = useRef(false);
     const inputRef = useRef<InputHandler | null>(null);
     const modelSizeRef = useRef({ cols: 80, rows: 24 });
     // False until fit() measures the container: the construction-default size
@@ -1054,6 +1062,25 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         return false;
       }
     }, [getViewportCells, recoverFromModelFault, resolvedTheme]);
+
+    // Off-screen panes hand their GPU drawing buffer back; the owner that knows
+    // whether this pane is on screen drives both directions. The restore repaints
+    // from the model, which never left, so the caller only has to run it before
+    // the browser paints the reveal.
+    const setSurfaceReleased = useCallback((released: boolean) => {
+      // The owner re-asserts this on every layout pass; only a real transition
+      // may repaint, or a visible pane would take a forced full paint per render.
+      if (surfaceReleasedRef.current === released) return;
+      surfaceReleasedRef.current = released;
+      const renderer = rendererRef.current;
+      if (!renderer) return;
+      if (released) {
+        renderer.releaseDrawingBuffer();
+        return;
+      }
+      renderer.restoreDrawingBuffer();
+      renderSurface(true);
+    }, [renderSurface]);
 
     // The annotation store is a mutable object, so adding, editing, or removing
     // an annotation changes nothing React can see. The owner bumps the version
@@ -2273,6 +2300,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       applyPlacements,
       seedPlacements,
       reset: () => { recordDiag({ kind: 'reset', pane: diagKeyRef.current, session: runtimeMetaRef.current?.sessionId ?? undefined, model: modelInstanceRef.current }); modelOpRingRef.current.noteReset(); blockStoreRef.current.clear(); placementStoreRef.current.clear(); annotationsRef.current?.reset(); selectedBlockIdRef.current = null; void write('\x1bc'); },
+      setSurfaceReleased,
       scrollToTop: () => {
         const terminal = terminalRef.current;
         if (!terminal) return false;
@@ -2298,7 +2326,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       getBlockState,
       getPlacementState,
       drain: () => writeChainRef.current,
-    }), [applyPlacements, fit, getBlockState, getPlacementState, getText, getVisibleContent, getVisibleStyleSummary, openFind, renderSurface, resizeLocal, seedBlocks, seedPlacements, write]);
+    }), [applyPlacements, fit, getBlockState, getPlacementState, getText, getVisibleContent, getVisibleStyleSummary, openFind, renderSurface, resizeLocal, seedBlocks, seedPlacements, setSurfaceReleased, write]);
 
     useEffect(() => {
       let active = true;
@@ -2393,6 +2421,11 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         });
         terminalRef.current = terminal;
         rendererRef.current = renderer;
+        // A fresh renderer always owns a drawing buffer. A theme change or a
+        // model-fault recovery rebuilds one for every mounted pane, including the
+        // hidden ones, so the released state has to survive the rebuild or those
+        // panes silently re-take the surfaces they gave back.
+        if (surfaceReleasedRef.current) renderer.releaseDrawingBuffer();
         const recoveryAttempt = recoveryAttemptRef.current;
         const recoveredModelFault = modelRecoveryPendingRef.current;
         recoveryAttemptRef.current = 0;
@@ -2490,6 +2523,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           applyPlacements,
           seedPlacements,
           reset: () => { recordDiag({ kind: 'reset', pane: diagKeyRef.current, session: runtimeMetaRef.current?.sessionId ?? undefined, model: modelInstanceRef.current }); modelOpRingRef.current.noteReset(); blockStoreRef.current.clear(); placementStoreRef.current.clear(); annotationsRef.current?.reset(); selectedBlockIdRef.current = null; void write('\x1bc'); },
+          setSurfaceReleased,
           scrollToTop: () => { viewportOffsetRef.current = terminal.getScrollbackLength(); wheelRemainderRowsRef.current = 0; hoverGenerationRef.current += 1; renderSurface(true); return true; },
           getText,
           getSize: () => ({ cols: terminal.cols, rows: terminal.rows }),
@@ -2657,7 +2691,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     // fontSize is intentionally NOT a dependency: see the font-size effect
     // below for why a size change must re-metric the existing renderer in
     // place instead of rebuilding the model/renderer for every mounted pane.
-    }, [cancelScheduledOutputRender, clearSynchronizedOutputRenderTimer, fit, getText, getVisibleContent, getVisibleStyleSummary, openFind, renderSurface, rendererEpoch, resizeLocal, resolvedTheme, write]);
+    }, [cancelScheduledOutputRender, clearSynchronizedOutputRenderTimer, fit, getText, getVisibleContent, getVisibleStyleSummary, openFind, renderSurface, rendererEpoch, resizeLocal, resolvedTheme, setSurfaceReleased, write]);
 
     // React to a font-size change without tearing down the WASM model or the
     // WebGL renderer. Rebuilding on every font-size change (the previous

--- a/app/src/components/GhosttyWebGlRenderer.test.ts
+++ b/app/src/components/GhosttyWebGlRenderer.test.ts
@@ -293,9 +293,9 @@ function makeRenderer(fontSize = 14, fontFamily = 'monospace', recorder?: GlReco
   }) as any);
 
   let renderer: WebGlTerminalRenderer;
+  const mainCanvas = makeFakeCanvas(recorder);
   try {
-    const mainCanvas = makeFakeCanvas(recorder) as unknown as HTMLCanvasElement;
-    renderer = new WebGlTerminalRenderer(mainCanvas, fontSize, fontFamily, {
+    renderer = new WebGlTerminalRenderer(mainCanvas as unknown as HTMLCanvasElement, fontSize, fontFamily, {
       background: '#000000',
       foreground: '#ffffff',
       cursor: '#ffffff',
@@ -306,7 +306,7 @@ function makeRenderer(fontSize = 14, fontFamily = 'monospace', recorder?: GlReco
 
   const atlasContext = created[1].recordingContext as RecordingContext;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return { renderer: renderer as any, atlasContext };
+  return { renderer: renderer as any, atlasContext, canvas: mainCanvas };
 }
 
 function makeFakeTerminal(
@@ -507,6 +507,69 @@ function makeControllableTerminal(cols: number, rows: number) {
   } as unknown as GhosttyTerminal;
   return { terminal, cells, state, markClean };
 }
+
+// A pane hidden behind another session holds two window-sized GPU surfaces for
+// a frame nobody can see. Release hands them back without touching the context,
+// the glyph atlas, or the model — so the only thing a reveal owes is a repaint.
+describe('WebGlTerminalRenderer off-screen drawing buffer', () => {
+  it('hands the drawing buffer back and takes it again at the same geometry', () => {
+    const { renderer, canvas } = makeRenderer();
+    renderer.resize(50, 40);
+    const { width, height } = canvas;
+    expect(width).toBeGreaterThan(1);
+
+    renderer.releaseDrawingBuffer();
+    expect({ width: canvas.width, height: canvas.height }).toEqual({ width: 1, height: 1 });
+
+    renderer.restoreDrawingBuffer();
+    expect({ width: canvas.width, height: canvas.height }).toEqual({ width, height });
+  });
+
+  it('records a resize that lands while released and allocates at that geometry on restore', () => {
+    const { renderer, canvas } = makeRenderer();
+    renderer.resize(50, 40);
+    renderer.releaseDrawingBuffer();
+
+    renderer.resize(20, 10);
+    expect({ width: canvas.width, height: canvas.height }).toEqual({ width: 1, height: 1 });
+
+    renderer.restoreDrawingBuffer();
+    expect(canvas.width).toBe(20 * renderer.cellWidth * renderer.dpr);
+    expect(canvas.height).toBe(10 * renderer.cellHeight * renderer.dpr);
+  });
+
+  it('repaints the whole grid on the first frame after a restore', () => {
+    const { renderer } = makeRenderer();
+    const { terminal, state } = makeControllableTerminal(50, 50);
+    renderer.resize(50, 50);
+    renderer.render(terminal);
+
+    state.dirty = 1;
+    state.rows = new Set([25]);
+    expect(renderer.render(terminal)).toMatchObject({ fullPaint: false });
+
+    renderer.releaseDrawingBuffer();
+    renderer.restoreDrawingBuffer();
+
+    state.dirty = 1;
+    state.rows = new Set([25]);
+    expect(renderer.render(terminal)).toMatchObject({ fullPaint: true, paintedRows: 50 });
+  });
+
+  it('ignores a repeated release and a restore that was never released', () => {
+    const { renderer, canvas } = makeRenderer();
+    renderer.resize(50, 40);
+    const { width, height } = canvas;
+
+    renderer.restoreDrawingBuffer();
+    expect({ width: canvas.width, height: canvas.height }).toEqual({ width, height });
+
+    renderer.releaseDrawingBuffer();
+    renderer.releaseDrawingBuffer();
+    renderer.restoreDrawingBuffer();
+    expect({ width: canvas.width, height: canvas.height }).toEqual({ width, height });
+  });
+});
 
 describe('WebGlTerminalRenderer dirty rows', () => {
   it('rebuilds small grids directly instead of paying to copy a row cache', () => {

--- a/app/src/components/GhosttyWebGlRenderer.ts
+++ b/app/src/components/GhosttyWebGlRenderer.ts
@@ -376,7 +376,16 @@ export class WebGlTerminalRenderer {
     this.cursorBgPacked = parsePackedColor(theme.cursor);
     this.dpr = Math.max(window.devicePixelRatio || 1, 1);
 
-    const gl = canvas.getContext('webgl2', { alpha: false, antialias: false });
+    // depth/stencil default to on for a WebGL2 context, and each is a
+    // drawing-buffer-sized allocation per pane. This renderer draws 2D text in
+    // draw order -- it never enables a depth or stencil test -- so both are
+    // allocated and never read.
+    const gl = canvas.getContext('webgl2', {
+      alpha: false,
+      antialias: false,
+      depth: false,
+      stencil: false,
+    });
     if (!gl) {
       throw new Error('WebGL2 is unavailable; the Ghostty terminal cannot render');
     }

--- a/app/src/components/GhosttyWebGlRenderer.ts
+++ b/app/src/components/GhosttyWebGlRenderer.ts
@@ -365,6 +365,9 @@ export class WebGlTerminalRenderer {
   // Set by setFontSize() so the next resize() re-sizes the canvas even when cols/rows
   // are unchanged — otherwise a hidden pane keeps the old font's canvas until fit().
   private metricsDirty = false;
+  // True between releaseDrawingBuffer() and restoreDrawingBuffer(): the canvas is
+  // 1×1 and resize() records geometry without re-allocating it.
+  private bufferReleased = false;
 
   constructor(canvas: HTMLCanvasElement, fontSize: number, fontFamily: string, theme: RendererTheme) {
     this.canvas = canvas;
@@ -450,12 +453,44 @@ export class WebGlTerminalRenderer {
     this.metricsDirty = false;
     this.cols = cols;
     this.rows = rows;
-    this.canvas.width = Math.ceil(cols * this.cellWidth * this.dpr);
-    this.canvas.height = Math.ceil(rows * this.cellHeight * this.dpr);
-    this.canvas.style.width = `${cols * this.cellWidth}px`;
-    this.canvas.style.height = `${rows * this.cellHeight}px`;
+    if (this.bufferReleased) {
+      // The pane is off-screen and holds no drawing buffer; restoreDrawingBuffer()
+      // allocates at this geometry when it is revealed.
+      this.resetRowCache(rows);
+      return;
+    }
+    this.applyCanvasGeometry();
+  }
+
+  // A pane hidden behind another session keeps its drawing buffer — two
+  // window-sized surfaces, ~45MB per pane at 2x DPR — for a frame nobody can
+  // see. Shrinking the canvas to 1×1 frees them while the GL context, its
+  // program, and the glyph atlas stay alive, so waking costs one full repaint
+  // instead of the context rebuild that WKWebView's small context pool
+  // punishes. The caller must restore before the pane is painted again.
+  releaseDrawingBuffer(): void {
+    if (this.bufferReleased) return;
+    this.bufferReleased = true;
+    this.canvas.width = 1;
+    this.canvas.height = 1;
+    // CSS size is left alone: it is layout, and the pane's container measures
+    // itself, not the canvas.
+    this.resetRowCache(this.rows);
+  }
+
+  restoreDrawingBuffer(): void {
+    if (!this.bufferReleased) return;
+    this.bufferReleased = false;
+    this.applyCanvasGeometry();
+  }
+
+  private applyCanvasGeometry(): void {
+    this.canvas.width = Math.ceil(this.cols * this.cellWidth * this.dpr);
+    this.canvas.height = Math.ceil(this.rows * this.cellHeight * this.dpr);
+    this.canvas.style.width = `${this.cols * this.cellWidth}px`;
+    this.canvas.style.height = `${this.rows * this.cellHeight}px`;
     this.gl.viewport(0, 0, this.canvas.width, this.canvas.height);
-    this.resetRowCache(rows);
+    this.resetRowCache(this.rows);
   }
 
   render(

--- a/app/src/components/GhosttyWebGlRenderer.ts
+++ b/app/src/components/GhosttyWebGlRenderer.ts
@@ -379,10 +379,10 @@ export class WebGlTerminalRenderer {
     this.cursorBgPacked = parsePackedColor(theme.cursor);
     this.dpr = Math.max(window.devicePixelRatio || 1, 1);
 
-    // depth/stencil default to on for a WebGL2 context, and each is a
-    // drawing-buffer-sized allocation per pane. This renderer draws 2D text in
-    // draw order -- it never enables a depth or stencil test -- so both are
-    // allocated and never read.
+    // `depth` defaults to on for a WebGL2 context and is a drawing-buffer-sized
+    // allocation per pane. This renderer draws 2D text in draw order -- it never
+    // enables a depth or a stencil test -- so it was allocated and never read.
+    // `stencil` already defaults to off; asking is insurance.
     const gl = canvas.getContext('webgl2', {
       alpha: false,
       antialias: false,

--- a/app/src/components/SessionTerminalWorkspace.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace.test.tsx
@@ -109,6 +109,10 @@ const { mockTerminalFit } = vi.hoisted(() => ({
   mockTerminalFit: vi.fn(),
 }));
 
+const { mockTerminalSetSurfaceReleased } = vi.hoisted(() => ({
+  mockTerminalSetSurfaceReleased: vi.fn(),
+}));
+
 const { mockTerminalOverflowsContainer } = vi.hoisted(() => ({
   mockTerminalOverflowsContainer: vi.fn(() => false),
 }));
@@ -146,6 +150,7 @@ vi.mock('./GhosttyTerminal', () => ({
       write: vi.fn(() => Promise.resolve()),
       resizeLocal: vi.fn(),
       reset: vi.fn(),
+      setSurfaceReleased: mockTerminalSetSurfaceReleased,
       scrollToTop: vi.fn(() => true),
       getText: vi.fn(() => ''),
       getSize: vi.fn(() => ({ cols: 80, rows: 24 })),
@@ -214,6 +219,7 @@ describe('SessionTerminalWorkspace', () => {
     terminalLifecycleCounts.clear();
     vi.mocked(mockEventRouter.registerBinding).mockClear();
     mockTerminalFit.mockReset();
+    mockTerminalSetSurfaceReleased.mockReset();
     mockTerminalOverflowsContainer.mockReset().mockReturnValue(false);
     mockPtyAttach.mockReset();
     mockPtyDetach.mockReset();
@@ -279,6 +285,62 @@ describe('SessionTerminalWorkspace', () => {
     );
     expect(screen.queryByTestId('mock-terminal')).toBeNull();
     expect(screen.getByTestId(`pane-virtualized-${SESSION_PANE_ID}`)).toBeTruthy();
+  });
+
+  // An inactive session's wrapper is display:none, so its panes' GPU drawing
+  // buffers show nothing and can go back. A pane behind a modal is still on
+  // screen, which is why `enabled` must not drive this.
+  it('releases pane drawing buffers while the session is inactive and takes them back on reveal', () => {
+    const releasedCalls = () => mockTerminalSetSurfaceReleased.mock.calls.map(([released]) => released);
+    const { rerender } = render(
+      <SessionTerminalWorkspace
+        {...virtualizationProps}
+        workspace={createSingleAgentWorkspace()}
+        isActiveSession
+      />,
+    );
+    expect(releasedCalls()).toEqual([false]);
+
+    mockTerminalSetSurfaceReleased.mockClear();
+    rerender(
+      <SessionTerminalWorkspace
+        {...virtualizationProps}
+        workspace={createSingleAgentWorkspace()}
+        isActiveSession={false}
+      />,
+    );
+    expect(releasedCalls()).toEqual([true]);
+
+    mockTerminalSetSurfaceReleased.mockClear();
+    rerender(
+      <SessionTerminalWorkspace
+        {...virtualizationProps}
+        workspace={createSingleAgentWorkspace()}
+        isActiveSession
+      />,
+    );
+    expect(releasedCalls()).toEqual([false]);
+  });
+
+  it('keeps the drawing buffer when a modal disables the session', () => {
+    const { rerender } = render(
+      <SessionTerminalWorkspace
+        {...virtualizationProps}
+        workspace={createSingleAgentWorkspace()}
+        isActiveSession
+      />,
+    );
+
+    mockTerminalSetSurfaceReleased.mockClear();
+    rerender(
+      <SessionTerminalWorkspace
+        {...virtualizationProps}
+        workspace={createSingleAgentWorkspace()}
+        isActiveSession
+        enabled={false}
+      />,
+    );
+    expect(mockTerminalSetSurfaceReleased.mock.calls.map(([released]) => released)).not.toContain(true);
   });
 
   it('virtualizes every pane of a split workspace, not just the active one', () => {

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.closeFocusedLeaf.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.closeFocusedLeaf.test.tsx
@@ -52,6 +52,7 @@ vi.mock('../GhosttyTerminal', async () => {
         },
         getSize: () => null,
         fit: () => {},
+        setSurfaceReleased: () => {},
       }), [paneId]);
       React.useImperativeHandle(ref, () => handle, [handle]);
       // Once per mount, like the real terminal: onReady's identity changes every

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.ticketOverlay.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.ticketOverlay.test.tsx
@@ -31,6 +31,7 @@ vi.mock('../GhosttyTerminal', async () => {
         write: async () => {},
         resizeLocal: async () => {},
         reset: () => {},
+        setSurfaceReleased: () => {},
         scrollToTop: () => false,
         getText: () => '',
         hasMeasuredSize: () => true,

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -462,6 +462,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       });
     }, [fitPane, runtimePanes]);
     const getPaneSize = runtime.getPaneSize;
+    const setPaneSurfaceReleased = runtime.setPaneSurfaceReleased;
     const paneOverflowsContainer = runtime.paneOverflowsContainer;
     const splitLayoutActive = workspace.layoutTree?.type === 'split';
     // Show the pane header (which doubles as the drag-to-move handle) whenever the
@@ -711,6 +712,19 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
         window.clearTimeout(secondLateRefitTimeout);
       };
     }, [fitPane, getPaneSize, paneOverflowsContainer]);
+
+    // An inactive session's wrapper is display:none, so its panes hold two
+    // window-sized GPU surfaces each for frames nobody can see. Hand those back
+    // while hidden; the model and its scrollback stay warm, so switching back
+    // still costs one repaint rather than a replay. The trigger is
+    // `isActiveSession` and not `sessionVisible`, which also goes false behind a
+    // modal that leaves the panes on screen. Declared before the refit effect so
+    // a revealed pane has its buffer back before anything measures or paints it.
+    useLayoutEffect(() => {
+      for (const paneId of renderedPaneIds) {
+        setPaneSurfaceReleased(paneId, !isActiveSession);
+      }
+    }, [isActiveSession, renderedPaneIds, renderedPaneIdsKey, setPaneSurfaceReleased]);
 
     useLayoutEffect(() => {
       if (!sessionVisible) {

--- a/app/src/components/SessionTerminalWorkspace/useGhosttyPaneRuntime.test.ts
+++ b/app/src/components/SessionTerminalWorkspace/useGhosttyPaneRuntime.test.ts
@@ -29,6 +29,7 @@ function createTerminal(): GhosttyTerminalHandle {
     write: vi.fn(() => Promise.resolve()),
     resizeLocal: vi.fn(() => Promise.resolve()),
     reset: vi.fn(),
+    setSurfaceReleased: vi.fn(),
     scrollToTop: vi.fn(() => true),
     getText: vi.fn(() => ''),
     getSize: vi.fn(() => ({ cols: 120, rows: 40 })),

--- a/app/src/components/SessionTerminalWorkspace/useGhosttyPaneRuntime.ts
+++ b/app/src/components/SessionTerminalWorkspace/useGhosttyPaneRuntime.ts
@@ -49,6 +49,7 @@ export interface GhosttyPaneRuntime {
   focusPane: (paneId: string, retries?: number) => void;
   fitPane: (paneId: string) => void;
   fitActivePane: () => void;
+  setPaneSurfaceReleased: (paneId: string, released: boolean) => void;
   openFindInActivePane: () => void;
   typeTextViaPaneInput: (paneId: string, text: string) => boolean;
   isPaneInputFocused: (paneId: string) => boolean;
@@ -403,6 +404,7 @@ export function useGhosttyPaneRuntime(
     },
     fitPane: (paneId: string) => get(paneId)?.fit(),
     fitActivePane: () => get(activePaneId)?.fit(),
+    setPaneSurfaceReleased: (paneId: string, released: boolean) => get(paneId)?.setSurfaceReleased(released),
     openFindInActivePane: () => get(activePaneId)?.openFind(),
     typeTextViaPaneInput: (paneId: string, text: string) => get(paneId)?.typeTextViaInput(text) ?? false,
     isPaneInputFocused: (paneId: string) => get(paneId)?.isInputFocused() ?? false,

--- a/app/src/components/SidePanel.css
+++ b/app/src/components/SidePanel.css
@@ -32,13 +32,18 @@
   transform: translateX(calc(100% + 18px));
   transition: transform 240ms cubic-bezier(0.22, 1, 0.36, 1), opacity 180ms ease;
   width: var(--side-panel-width, min(420px, 42vw));
-  will-change: transform, opacity;
 }
 
+/* will-change only while the panel is open. The dock mounts all five panels
+   unconditionally, so a permanent hint gave every closed one a compositing
+   layer with a full-height backing store it never draws: measured 74MB of the
+   empty app's 212MB of GPU surface. Promotion still happens for the open/close
+   transition, which is the only time these move. */
 .side-panel-shell.is-open .side-panel {
   opacity: 1;
   pointer-events: auto;
   transform: translateX(0);
+  will-change: transform, opacity;
 }
 
 .side-panel--running {

--- a/changelog.d/hidden-pane-drawing-buffer.yaml
+++ b/changelog.d/hidden-pane-drawing-buffer.yaml
@@ -1,0 +1,9 @@
+kind: fixed
+area: app
+change: >
+  A session you are not looking at no longer holds the GPU memory to draw
+  itself. Every warm pane kept a full window's worth of drawing surface ready
+  while it sat behind another session, so eight open sessions paid for eight
+  windows and showed one. Hidden panes now hand that surface back and take it
+  again as they are revealed; the terminal, its scrollback, and instant
+  switching are unchanged.

--- a/changelog.d/perf-baseline-app-footprint.yaml
+++ b/changelog.d/perf-baseline-app-footprint.yaml
@@ -1,0 +1,13 @@
+kind: internal
+area: testing
+change: >
+  The perf-baseline scenario now measures the app's physical footprint --
+  the number Activity Monitor shows -- for the Tauri process and its WebKit
+  processes only. It previously summed `ps` RSS across the whole process
+  tree, which cannot see GPU surfaces at all (they are charged to the
+  process but mapped in another) and counted a daemon-spawned headless
+  classifier as part of the app, inflating every reading by around 400MB.
+  New probes report the individual GPU surfaces a process holds, whether
+  memory returns under memory pressure, on session close, and across
+  repeated open/close rounds, and photograph the window after each session
+  switch so a memory win that stopped a pane from painting cannot pass.

--- a/changelog.d/side-panel-closed-layer.yaml
+++ b/changelog.d/side-panel-closed-layer.yaml
@@ -1,0 +1,8 @@
+kind: fixed
+area: app
+change: >
+  The app holds about 110MB less memory at rest. All five dock panels are
+  mounted from the moment the window opens, and each one asked the renderer
+  to keep a full-height GPU layer ready even while it was closed and
+  invisible, so an app with nothing open carried five surfaces it never
+  drew. Panels now claim that layer only while they are open.

--- a/changelog.d/terminal-depth-buffer.yaml
+++ b/changelog.d/terminal-depth-buffer.yaml
@@ -1,7 +1,7 @@
 kind: fixed
 area: app
 change: >
-  Terminal panes no longer reserve depth and stencil buffers they never read.
-  Every pane asked the GPU for them because they are on by default, and each
-  one is as large as the pane itself -- around 30MB per pane at 8 sessions,
-  never touched, since terminal text is drawn flat and in order.
+  Terminal panes no longer reserve a depth buffer they never read. Every pane
+  asked the GPU for one because it is on by default, and it is as large as the
+  pane itself -- around 30MB per pane at 8 sessions, never touched, since
+  terminal text is drawn flat and in order.

--- a/changelog.d/terminal-depth-buffer.yaml
+++ b/changelog.d/terminal-depth-buffer.yaml
@@ -1,0 +1,7 @@
+kind: fixed
+area: app
+change: >
+  Terminal panes no longer reserve depth and stencil buffers they never read.
+  Every pane asked the GPU for them because they are on by default, and each
+  one is as large as the pane itself -- around 30MB per pane at 8 sessions,
+  never touched, since terminal text is drawn flat and in order.

--- a/docs/plans/2026-08-14-app-memory-floor.md
+++ b/docs/plans/2026-08-14-app-memory-floor.md
@@ -1,0 +1,145 @@
+# The app's memory floor: where a gigabyte actually went
+
+Written 2026-08-14, after Victor asked to bring the app from "1GB with
+very few agents" toward a 500MB baseline, and then pushed back on the
+first round of work: *"so far i can see you're trying to optimize gpu
+rendering? but what if the problem is not there?"*
+
+The pushback was right about the attention and wrong about the address.
+The cost really was GPU surfaces — but not in the renderer's drawing
+code, where the attention had been going. It was in **who holds a
+surface, and for how long**. Three fixes, all of them about ownership,
+none of them about how a frame is drawn.
+
+## The measurement was broken first
+
+Two defects had to be fixed before any number meant anything.
+
+**`ps` RSS cannot see GPU memory at all.** Those pages are `owned
+unmapped (graphics)`: charged to the process that owns them, mapped in
+another. A run that dropped 482MB of graphics moved total RSS by −34MB.
+The number that counts is the **physical footprint** — what Activity
+Monitor prints — read per pid from `vmmap`.
+
+**A process tree is not "the app".** The walk swept in a
+daemon-spawned headless classifier (`claude --print`, 451MB) and
+counted it as UI, inflating every reading by ~400MB. The app is the
+Tauri process plus its WebKit children (`APP_PROCESS_CLASSES`), and
+nothing else.
+
+Both are fixed in `app/scripts/real-app-harness/perfMeasure.mjs`, with
+unit tests over verbatim `vmmap` fixtures.
+
+## The receipt
+
+Same window (1710×1073), all sessions mounted, physical footprint in MB:
+
+| | empty | 4 sessions | 8 sessions |
+|---|---|---|---|
+| before | 358.7 | 783.2 | 1055.6 |
+| + closed dock panels drop their layer | 248.4 | 744.3 | 1017.6 |
+| + WebGL depth/stencil off | ~248 | 610.6 | 840.4 |
+| + hidden panes release the drawing buffer | 249.6 | **472.0** | **696.9** |
+
+Marginal cost per session: **87MB → 56MB**. At 8 sessions, −34%.
+
+The empty app's graphics is window-area-proportional. Solving across
+1710×1073 and 855×536 gave **7.07 window-sized layers + 14.3MB fixed** —
+which is what said the floor was layers, not pixels drawn.
+
+## The three fixes
+
+**1. A closed dock panel held a compositing layer.** `RightDock` mounts
+all five panels unconditionally and only toggles a class, while
+`.side-panel` carried a permanent `will-change: transform, opacity`. So
+an app with nothing open carried five full-height backing stores it
+never drew: 74MB of the empty app's 212MB of GPU surface. The hint now
+applies only under `.is-open`, which is the only time these move.
+Empty-app histogram went `{15.2:2, 13.8:1, 16.0:1, 14.5:1}` → `{27.0:4}`.
+
+**2. Every pane reserved a depth and a stencil buffer it never read.**
+`depth` defaults to `true` on a WebGL2 context and the renderer draws 2D
+text in draw order — it never enables a depth or stencil test. Each is a
+drawing-buffer-sized allocation per pane. Turning both off removed one
+whole 23.2MB bucket per session from the histogram, which is how we know
+that is what it was.
+
+**3. A hidden session's panes held a full window of drawing buffer.**
+An inactive session's wrapper is `display:none`, but a canvas's drawing
+buffer is sized by its width/height attributes, not by whether anything
+can see it. Eight open sessions paid for eight windows and showed one.
+`releaseDrawingBuffer()` shrinks the canvas to 1×1 while the GL context,
+its program, and the glyph atlas stay alive; the reveal restores it and
+repaints from the model, which never left.
+
+Two details that are load-bearing:
+
+- The trigger is `isActiveSession`, **not** the workspace's
+  `sessionVisible`. The latter also goes false behind a modal, and most
+  of attn's modals leave the terminal on screen — keying on it blanks a
+  visible pane.
+- The released state lives on a ref that outlives the renderer. A theme
+  change or a model-fault recovery rebuilds every mounted pane's
+  renderer, and a fresh renderer always owns a buffer, so without that
+  the hidden panes silently re-take what they gave back.
+
+The restore runs in a layout effect, so the repaint lands before the
+browser paints the frame that reveals the pane. It does **not** rebuild
+the GL context: WKWebView's live-context pool punishes that hard enough
+to permanently break panes (see the font-size effect's comment in
+`GhosttyTerminal.tsx`).
+
+## What is WebKit's and not ours
+
+The pane-sized surface count fell 16 → 10 at 8 panes, not 16 → 2. The
+IOSurface pool is a **high-water mark that never shrinks on its own**:
+released surfaces stay allocated but dead. Receipts —
+
+- virtualizing panes releases nothing: 37 → 37 surfaces;
+- closing every session releases nothing: 37 → 37, with zero sessions;
+- only `notifyutil -p org.WebKit.lowMemory` collects them: 36 → 14,
+  699.6 → 217.3MB, and it is a no-op when every pane is live (control).
+
+So the win is that the surfaces are now *dead* rather than live, which
+is what the footprint drop measures. The corpses are WebKit's to keep.
+
+## Ruled out along the way
+
+- **Session churn does not leak WebKit Malloc.** At-rest across rounds:
+  107.8 → 105.7 → 104.3 → 104.3MB. Flat.
+- **Deep scrollback is not a malloc driver.** 60,000 lines × 4 panes
+  added ~22MB.
+- **Modals are not part of the floor.** `SettingsModal` and
+  `WorktreeCleanupPrompt` are placed unconditionally but both `return
+  null` when closed.
+- **The wrapper-layer hypothesis was wrong.** Surfaces were identical at
+  8 live panes and 1; `.terminal-wrapper` is plain `display:none`, a
+  virtualized pane renders an empty div, and `loseContext()` is called
+  deterministically on unmount.
+
+## What is left
+
+- **The glyph atlas is per-pane** — a 1024²-growing-to-2048² canvas plus
+  its own GPU texture for every mounted pane — while font, size, and
+  theme are app-wide. A shared atlas is the obvious next cut, and it is
+  a larger share of a hidden pane's cost now than it was before fix 3.
+- **Constant chrome is `27.0 × 4` plus `24.0 × 3–4`** in the histogram,
+  most likely WebKit's own root layers. Unattributed.
+- **Production truth, for scale:** 1617.6MB across 32 processes, of
+  which WebContent alone is 1126.4MB (~465MB graphics, much already
+  compressed to swap; ~425MB WebKit Malloc). The app is one part of
+  what a real day costs.
+
+## How to measure this again
+
+```bash
+node scripts/real-app-harness/scenario-perf-baseline.mjs \
+  --sessions 8 --stream 0 --window 1710x1073 --warm -1,3,0
+```
+
+`APP FOOTPRINT` is the number that counts. `paneSizedSurfaces` plus its
+histogram names *which* surfaces exist, which is what turns a total into
+a diagnosis. `--pressure` separates live surfaces from cached ones,
+`--switch-probe` photographs the window after every session switch, and
+`--dock-probe` measures a panel closed vs open and captures it open — so
+a memory win that stopped something from rendering cannot pass as a win.

--- a/docs/plans/2026-08-14-app-memory-floor.md
+++ b/docs/plans/2026-08-14-app-memory-floor.md
@@ -38,7 +38,7 @@ Same window (1710×1073), all sessions mounted, physical footprint in MB:
 |---|---|---|---|
 | before | 358.7 | 783.2 | 1055.6 |
 | + closed dock panels drop their layer | 248.4 | 744.3 | 1017.6 |
-| + WebGL depth/stencil off | ~248 | 610.6 | 840.4 |
+| + WebGL depth buffer off | ~248 | 610.6 | 840.4 |
 | + hidden panes release the drawing buffer | 249.6 | **472.0** | **696.9** |
 
 Marginal cost per session: **87MB → 56MB**. At 8 sessions, −34%.
@@ -57,12 +57,13 @@ never drew: 74MB of the empty app's 212MB of GPU surface. The hint now
 applies only under `.is-open`, which is the only time these move.
 Empty-app histogram went `{15.2:2, 13.8:1, 16.0:1, 14.5:1}` → `{27.0:4}`.
 
-**2. Every pane reserved a depth and a stencil buffer it never read.**
-`depth` defaults to `true` on a WebGL2 context and the renderer draws 2D
-text in draw order — it never enables a depth or stencil test. Each is a
-drawing-buffer-sized allocation per pane. Turning both off removed one
-whole 23.2MB bucket per session from the histogram, which is how we know
-that is what it was.
+**2. Every pane reserved a depth buffer it never read.** `depth` defaults
+to `true` on a WebGL2 context, and it is a drawing-buffer-sized
+allocation per pane. The renderer draws 2D text in draw order — it never
+enables a depth or a stencil test. Turning it off removed one whole
+23.2MB bucket per session from the histogram, which is how we know that
+is what it was. `stencil` already defaults to `false`, so asking for
+neither is one word of insurance, not the other half of the win.
 
 **3. A hidden session's panes held a full window of drawing buffer.**
 An inactive session's wrapper is `display:none`, but a canvas's drawing
@@ -119,6 +120,16 @@ is what the footprint drop measures. The corpses are WebKit's to keep.
 
 ## What is left
 
+- **A whole view still hides panes that keep their buffers.** The
+  release keys on `isActiveSession`, so parking on Home or the grid
+  leaves the active session's panes off-screen — the container is
+  `display:none` without unmounting — and paying. It is the same shape as
+  the modal case, on a different wall: invisible-by-view rather than
+  invisible-by-session. The conservative trigger was chosen because
+  `sessionVisible` also folds in the modal case, which must not release;
+  the fix is a trigger that reads view visibility without it, and the
+  reveal path (Home → session) needs the same no-blank-frame
+  verification the switch path got.
 - **The glyph atlas is per-pane** — a 1024²-growing-to-2048² canvas plus
   its own GPU texture for every mounted pane — while font, size, and
   theme are app-wide. A shared atlas is the obvious next cut, and it is

--- a/scripts/pr-evidence.sh
+++ b/scripts/pr-evidence.sh
@@ -26,10 +26,13 @@ die() {
   exit 1
 }
 
-# Prints "<window-id> <width>" for the largest on-screen layer-0 window owned
-# by $1; with WINID_LIST=1, prints every attn* owner instead (for the error
-# path). CGWindowID is not reachable from AppleScript, so this goes through a
-# throwaway swift script.
+# Prints "<window-id> <width>" for the largest on-screen window owned by $1;
+# with WINID_LIST=1, prints every attn* owner instead (for the error path).
+# CGWindowID is not reachable from AppleScript, so this goes through a
+# throwaway swift script. Window level is deliberately not filtered: the
+# harness floats the app it drives above everything else, so a layer-0 rule
+# finds no window on exactly the runs worth recording. Largest-area already
+# rejects the status items and panels that rule was aimed at.
 window_id_for_app() {
   local owner="$1"
   local swift_src
@@ -43,7 +46,6 @@ let target = CommandLine.arguments.count > 1 ? CommandLine.arguments[1] : ""
 var best: (id: Int, area: Int, width: Int) = (0, 0, 0)
 var owners = Set<String>()
 for w in list {
-    guard (w[kCGWindowLayer as String] as? Int ?? -1) == 0 else { continue }
     let owner = w[kCGWindowOwnerName as String] as? String ?? ""
     if owner.hasPrefix("attn") { owners.insert(owner) }
     guard owner == target, let num = w[kCGWindowNumber as String] as? Int,


### PR DESCRIPTION
The app could reach ~1GB with very few agents. This brings 8 sessions from
1055.6MB to 696.9MB and 4 sessions from 783.2MB to 472.0MB, by taking three
GPU surfaces away from things nobody can see.

Full write-up, with every receipt and the recipe to reproduce it:
[docs/plans/2026-08-14-app-memory-floor.md](docs/plans/2026-08-14-app-memory-floor.md).

## The measurement was broken first

Two defects had to be fixed before any number meant anything.

**`ps` RSS cannot see GPU memory at all.** Those pages are `owned unmapped
(graphics)`: charged to the process that owns them, mapped in another. A run
that dropped 482MB of graphics moved total RSS by −34MB. The number that counts
is the **physical footprint** — what Activity Monitor prints — read per pid from
`vmmap`.

**A process tree is not "the app".** The walk swept in a daemon-spawned headless
classifier (`claude --print`, 451MB) and counted it as UI, inflating every
reading by ~400MB.

Both are fixed in `perfMeasure.mjs`, with unit tests over verbatim `vmmap`
fixtures. New probes report which individual GPU surfaces a process holds,
whether memory returns under memory pressure, and photograph the window after
every session switch — so a memory win that stopped something from painting
cannot pass as a win.

## The receipt

Same window (1710×1073), all sessions mounted, physical footprint in MB:

| | empty | 4 sessions | 8 sessions |
|---|---|---|---|
| before | 358.7 | 783.2 | 1055.6 |
| + closed dock panels drop their layer | 248.4 | 744.3 | 1017.6 |
| + WebGL depth/stencil off | ~248 | 610.6 | 840.4 |
| + hidden panes release the drawing buffer | 249.6 | **472.0** | **696.9** |

Marginal cost per session: **87MB → 56MB**. At 8 sessions, −34%.

## The three fixes

**1. A closed dock panel held a compositing layer.** `RightDock` mounts all five
panels unconditionally and only toggles a class, while `.side-panel` carried a
permanent `will-change: transform, opacity`. An app with nothing open carried
five full-height backing stores it never drew: 74MB of the empty app's 212MB of
GPU surface. The hint now applies only under `.is-open`, which is the only time
these move. Empty-app surface histogram went `{15.2:2, 13.8:1, 16.0:1, 14.5:1}`
→ `{27.0:4}`.

**2. Every pane reserved a depth buffer nothing read.** `depth` defaults to
`true` on a WebGL2 context, and it is a drawing-buffer-sized allocation per
canvas. The terminal renderer draws 2D text in draw order — it never enables a
depth or a stencil test. Turning it off removed one whole 23.2MB bucket per
session from the histogram, which is how we know that is what it was. `stencil`
already defaults to `false`, so asking for neither is one word of insurance, not
the other half of the win.

**3. A hidden session's panes held a full window of drawing buffer.** An
inactive session's wrapper is `display:none`, but a canvas's drawing buffer is
sized by its width/height attributes, not by whether anything can see it. Eight
open sessions paid for eight windows and showed one. `releaseDrawingBuffer()`
shrinks the canvas to 1×1 while the GL context, its program, and the glyph atlas
stay alive; the reveal restores it and repaints from the model, which never
left.

Three details in fix 3 are load-bearing:

- The trigger is `isActiveSession`, **not** the workspace's `sessionVisible`.
  The latter also goes false behind a modal, and most of attn's modals leave the
  terminal on screen — keying on it would blank a visible pane. There is a test
  for that case.
- The released state lives on a ref that outlives the renderer. A theme change
  or a model-fault recovery rebuilds every mounted pane's renderer, and a fresh
  renderer always owns a buffer, so without that the hidden panes silently
  re-take what they gave back.
- The restore runs in a layout effect declared before the refit effect, so the
  full repaint lands before the browser paints the frame that reveals the pane.
  It does **not** rebuild the GL context: WKWebView's live-context pool punishes
  that hard enough to permanently break panes (the reason the font-size effect
  re-metrics in place).

## Live verification

`scenario-perf-baseline --switch-probe`, perf profile, 4 sessions, 5s per
switch. Every revealed pane paints its own content immediately; there is no
blank or stale frame at any switch.

![session-switch](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/2777e1dba5a5712790734ea983f5be7e75bb180b/dizzy-meerkat/session-switch.gif)

[Full-quality recording (mp4)](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/2777e1dba5a5712790734ea983f5be7e75bb180b/dizzy-meerkat/session-switch.mp4)

Also re-ran the terminal scenarios that could plausibly break on this:
`reveal-overflow`, `webgl-recovery`, `workspace-switching` — all pass.
`pnpm test` (251 files / 2803 tests) and `tsc --noEmit` are clean.

## Keeping it fixed

The class of bug is one mistake in three costumes: something invisible holding a
window-sized GPU surface, where `ps` cannot see it. So the rule is written down
where an agent will hit it — a bullet in `AGENTS.md` under change discipline,
and gotcha 6 in `app/CLAUDE.md` with the three specific traps, the
never-rebuild-a-WebGL-context warning, and the measurement recipe. Both link to
the plan doc for the receipts.

## What this does not fix

- **WebKit's IOSurface pool is a high-water mark.** Pane-sized surfaces fell
  16 → 10 at 8 panes, not 16 → 2. Released surfaces stay allocated but dead;
  only `notifyutil -p org.WebKit.lowMemory` collects them (36 → 14 surfaces,
  699.6 → 217.3MB, and a no-op when every pane is live). The win measured here
  is that the surfaces are dead rather than live.
- **A whole view still hides panes that keep their buffers.** The release keys
  on `isActiveSession`, so parking on Home or the grid leaves the active
  session's panes off-screen — the container is `display:none` without
  unmounting — and paying. Same shape as the modal case, different wall:
  invisible-by-view rather than invisible-by-session. The conservative trigger
  was chosen because `sessionVisible` also folds in the modal case, which must
  not release; the fix is a trigger that reads view visibility without it, and
  the Home → session reveal needs the same no-blank-frame verification the
  switch path got.
- **The glyph atlas is still per-pane** — a 1024²-growing-to-2048² canvas plus
  its own GPU texture for every mounted pane, while font, size, and theme are
  app-wide. That is the obvious next cut, and a larger share of a hidden pane's
  cost now than before fix 3.
- **The scenario's baseline comparison still uses tree RSS**, so a run can print
  "RSS regression" while the app's footprint fell — it swept in whatever else
  the daemon had spawned. It is a trend signal that never sets the exit code, and
  moving it onto footprint means re-recording every machine baseline; out of
  scope here, named so the next reader is not misled by the line.

https://claude.ai/code/session_0184DSz47QNd7Fvfruo6Z1UU
