### PR TITLE
feat(apps): declare views in the manifest and build them for the browser

### DIFF
--- a/changelog.d/a5-slice1-views-declared-and-built.yaml
+++ b/changelog.d/a5-slice1-views-declared-and-built.yaml
@@ -1,0 +1,13 @@
+kind: internal
+area: apps
+change: >
+  An app can declare [[views]] in attn-app.toml — a named component with a kind
+  (only "tile" is accepted), a title, an entrypoint and an optional one-line
+  param declaration. `attn app apply` and `attn app dev` bundle each view for
+  the browser into the version's content-addressed directory beside the handler
+  bundle, and the version hash now covers every artifact, so editing only a view
+  mints a new version. An app that declares a view and no subscriptions is
+  accepted: a view is something that runs.
+notes: >
+  A5 slice 1. Nothing renders a view yet — the tile host, the bundle route and
+  the SDK are later slices — so there is no user-visible behavior to report.

--- a/cmd/attn/app.go
+++ b/cmd/attn/app.go
@@ -271,8 +271,14 @@ func runAppStatus(args []string) {
 			state = "enabled"
 		}
 		filter := app.Consumer.Filter
-		if filter == "" {
+		switch filter {
+		case "":
 			filter = "everything"
+		case apps.NoSubscriptionsPattern:
+			// An app can declare a view and no subscriptions, and its filter is
+			// then a fact name nothing publishes. Printing that name sends the
+			// reader looking for an event that does not exist.
+			filter = "nothing — it declares no subscriptions"
 		}
 		fmt.Printf("  consumer:   %s — %s, cursor %d, %d event(s) behind\n",
 			app.Consumer.Name, state, app.Consumer.Cursor, app.Consumer.Lag)

--- a/cmd/attn/app_build.go
+++ b/cmd/attn/app_build.go
@@ -116,7 +116,7 @@ func printApplied(result *protocol.AppApplyResult, res appbuild.Result) {
 	var state string
 	switch {
 	case result.VersionCreated:
-		state = fmt.Sprintf("new, %d bytes", res.BundleBytes)
+		state = fmt.Sprintf("new, %d bytes", totalArtifactBytes(res))
 	case moved:
 		state = "this content already had a version; nothing new was recorded"
 	default:
@@ -128,6 +128,25 @@ func printApplied(result *protocol.AppApplyResult, res appbuild.Result) {
 		fmt.Printf("  was on version %d\n", *result.PreviousVersionID)
 	}
 	fmt.Printf("  artifact %s\n", result.ArtifactPath)
+	// A version made of several artifacts gets each one's size named. There is no
+	// bundle size cap — nothing measured yet would justify a number — so making
+	// the numbers visible is what apply owes an author instead.
+	if len(res.ViewBytes) > 0 {
+		fmt.Printf("    %s  %d bytes\n", appbuild.ArtifactName, res.BundleBytes)
+		for _, v := range res.ViewBytes {
+			fmt.Printf("    views/%s.js  %d bytes\n", v.Name, v.Bytes)
+		}
+	}
+}
+
+// totalArtifactBytes is everything a version holds: the handler bundle and one
+// module per view.
+func totalArtifactBytes(res appbuild.Result) int64 {
+	total := res.BundleBytes
+	for _, v := range res.ViewBytes {
+		total += v.Bytes
+	}
+	return total
 }
 
 func runAppRollback(args []string) {

--- a/internal/appbuild/build.go
+++ b/internal/appbuild/build.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -42,7 +43,7 @@ type Options struct {
 type Result struct {
 	Manifest    Manifest
 	Declaration string
-	// ContentHash identifies the version: the declaration and the bundle
+	// ContentHash identifies the version: the declaration and every artifact
 	// together. See versionHash.
 	ContentHash  string
 	ArtifactPath string
@@ -51,10 +52,25 @@ type Result struct {
 	// the version row.
 	ArtifactWritten bool
 	BundleBytes     int64
+	// ViewBytes is the size of each built view's artifact, in declaration order.
+	// A5 sets no bundle size cap — nothing measured yet would justify a number —
+	// so what apply owes the author instead is the number itself, per artifact.
+	ViewBytes []ViewSize
 }
 
-// ArtifactName is the file every built app is bundled into.
+// ViewSize is one built view's artifact and how big it came out.
+type ViewSize struct {
+	Name  string
+	Path  string
+	Bytes int64
+}
+
+// ArtifactName is the file every built app's handlers are bundled into.
 const ArtifactName = "bundle.js"
+
+// viewsDirName is where a version's view bundles live, beside its handler
+// bundle: one file per declared view, named by the view.
+const viewsDirName = "views"
 
 // ShortHash renders a version hash for a human-facing line. The full hash is
 // always available in a command's --json output; a sentence carrying 64
@@ -73,9 +89,17 @@ func ArtifactDir(storeDir, name, hash string) string {
 	return filepath.Join(storeDir, name, hash)
 }
 
-// ArtifactPath is the built bundle for one version.
+// ArtifactPath is the built handler bundle for one version.
 func ArtifactPath(storeDir, name, hash string) string {
 	return filepath.Join(ArtifactDir(storeDir, name, hash), ArtifactName)
+}
+
+// ViewArtifactPath is the built module for one of a version's views. Derived
+// from the app, the version and the view name for the same reason ArtifactPath
+// is: the builder, the daemon and whatever serves it later cannot disagree about
+// where a view's bytes are.
+func ViewArtifactPath(storeDir, name, hash, view string) string {
+	return filepath.Join(ArtifactDir(storeDir, name, hash), viewsDirName, view+".js")
 }
 
 // Build runs the pipeline.
@@ -129,10 +153,35 @@ func Build(ctx context.Context, opts Options) (Result, error) {
 		return Result{}, fmt.Errorf("reading the built bundle: %w", err)
 	}
 
-	hash := versionHash(declaration, built)
+	views := make([]ViewArtifact, 0, len(manifest.Views))
+	for _, v := range manifest.Views {
+		logf(opts.Log, "bundling view %s from %s", v.Name, v.Entrypoint)
+		out := filepath.Join(staging, viewsDirName, v.Name+".js")
+		if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+			return Result{}, fmt.Errorf("creating the view build directory %s: %w", filepath.Dir(out), err)
+		}
+		if err := bundleView(ctx, tools, dir, manifest, v, out); err != nil {
+			return Result{}, err
+		}
+		content, err := os.ReadFile(out)
+		if err != nil {
+			return Result{}, fmt.Errorf("reading the built view %q: %w", v.Name, err)
+		}
+		views = append(views, ViewArtifact{Name: v.Name, Content: content})
+	}
+
+	hash := versionHash(declaration, built, views)
 	path, written, err := placeArtifact(opts.StoreDir, manifest.Name, hash, staging)
 	if err != nil {
 		return Result{}, err
+	}
+	sizes := make([]ViewSize, 0, len(views))
+	for _, v := range views {
+		sizes = append(sizes, ViewSize{
+			Name:  v.Name,
+			Path:  ViewArtifactPath(opts.StoreDir, manifest.Name, hash, v.Name),
+			Bytes: int64(len(v.Content)),
+		})
 	}
 	return Result{
 		Manifest:        manifest,
@@ -141,6 +190,7 @@ func Build(ctx context.Context, opts Options) (Result, error) {
 		ArtifactPath:    path,
 		ArtifactWritten: written,
 		BundleBytes:     int64(len(built)),
+		ViewBytes:       sizes,
 	}, nil
 }
 
@@ -229,28 +279,101 @@ func bundleApp(ctx context.Context, tools Toolchain, dir string, m Manifest, out
 	return nil
 }
 
-// versionHash is the version's identity: the frozen declaration and the built
-// bundle, hashed together.
+// ViewArtifact is one built view: the name it was declared under and the module
+// bytes that name resolves to.
+type ViewArtifact struct {
+	Name    string
+	Content []byte
+}
+
+// bundleView builds one view for the browser.
 //
-// Hashing the bundle alone would be wrong in a way that is easy to miss. The
-// generated types are erased at build time, so a manifest edit that changes what
-// the app declares — a new collection, a changed description — can leave the
-// bundle byte-identical. The version row would then be reused and its frozen
-// declaration would describe the *previous* manifest, which is exactly the drift
-// freezing a declaration exists to prevent.
-func versionHash(declaration string, bundle []byte) string {
+// Two differences from the handler bundle, and nothing else. The target is the
+// browser, because this artifact is imported by attn's frontend rather than run
+// in the sidecar. And the SDK specifiers are external: they are supplied by the
+// host at mount time from the frontend's own modules, which is what makes an
+// app's component and attn's UI share one React — bundling a copy in here would
+// give the view a second React and a hook dispatcher that is not the one
+// rendering it. Everything else an app imports is bundled in, unchanged from the
+// handler build: a version has to be the whole of what runs.
+func bundleView(ctx context.Context, tools Toolchain, dir string, m Manifest, v View, outfile string) error {
+	cmd := exec.CommandContext(ctx, tools.Bun, "build",
+		filepath.FromSlash(v.Entrypoint),
+		"--target", "browser",
+		"--format", "esm",
+		"--external", SDKModule,
+		"--external", SDKModule+"/jsx-runtime",
+		"--outfile", outfile,
+	)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("bundling view %q of app %q failed:\n%s", v.Name, m.Name, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// versionHash is the version's identity: the frozen declaration and every
+// artifact the version holds, hashed together.
+//
+// Hashing the handler bundle alone would be wrong in two ways that are easy to
+// miss. The generated types are erased at build time, so a manifest edit that
+// changes what the app declares — a new collection, a changed description — can
+// leave that bundle byte-identical; the version row would then be reused and its
+// frozen declaration would describe the *previous* manifest. And a view is built
+// from its own entrypoint, so editing only a view leaves both the declaration
+// and the handler bundle untouched: without the views in here, saving a
+// component would reuse a version row whose artifacts had moved under it.
+//
+// Views are hashed by name as well as content, in name order, so the digest does
+// not depend on declaration order and two views cannot swap names unnoticed.
+func versionHash(declaration string, bundle []byte, views []ViewArtifact) string {
 	h := sha256.New()
 	h.Write([]byte(declaration))
 	h.Write([]byte{0})
 	h.Write(bundle)
+	ordered := append([]ViewArtifact(nil), views...)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].Name < ordered[j].Name })
+	for _, v := range ordered {
+		h.Write([]byte{0})
+		h.Write([]byte(v.Name))
+		h.Write([]byte{0})
+		h.Write(v.Content)
+	}
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-// VersionHash recomputes a built version's identity from its two inputs. The
-// daemon uses it to check that the artifact it is about to record is the one the
+// VersionHash recomputes a built version's identity from its inputs. The daemon
+// uses it to check that the artifacts it is about to record are the ones the
 // hash claims, so a commit never points a version row at content that does not
 // match its own name.
-func VersionHash(declaration string, bundle []byte) string { return versionHash(declaration, bundle) }
+//
+// An app with no views hashes exactly as it did before views existed: the loop
+// writes nothing, so re-applying an app built by an older attn lands on the row
+// it already had.
+func VersionHash(declaration string, bundle []byte, views []ViewArtifact) string {
+	return versionHash(declaration, bundle, views)
+}
+
+// ReadViewArtifacts reads the built modules of the named views out of a
+// version's directory in the store.
+//
+// It is how the daemon assembles the inputs to VersionHash: the declaration
+// names the views, and a version whose directory is missing one of them is a
+// version whose hash cannot be checked — so a missing artifact is an error
+// naming the view and the path, not a silently shorter list.
+func ReadViewArtifacts(storeDir, name, hash string, views []string) ([]ViewArtifact, error) {
+	out := make([]ViewArtifact, 0, len(views))
+	for _, view := range views {
+		path := ViewArtifactPath(storeDir, name, hash, view)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading the built view %q of app %q at %s: %w", view, name, path, err)
+		}
+		out = append(out, ViewArtifact{Name: view, Content: content})
+	}
+	return out, nil
+}
 
 // placeArtifact moves a staged build into the content-addressed store, and
 // reports whether it had to.

--- a/internal/appbuild/build_test.go
+++ b/internal/appbuild/build_test.go
@@ -2,6 +2,9 @@ package appbuild
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -337,6 +340,183 @@ func TestBuild_FailureLeavesTheStoreUntouched(t *testing.T) {
 	staging, err := os.ReadDir(filepath.Join(env.store, ".staging"))
 	if err == nil && len(staging) != 0 {
 		t.Fatalf("staging left %d directories behind", len(staging))
+	}
+}
+
+// The view fixtures below import nothing that has to resolve. A view's real
+// imports are the SDK's, and the SDK is a package this slice does not build yet
+// — so these prove the build step (browser target, whole import graph, one
+// artifact per view, hash over all of them) with source that stands alone.
+const viewHelperMarker = "helper-from-the-import-graph"
+
+// addView writes a view's source and declares it in the manifest.
+func (e buildEnv) addView(t *testing.T, name, source string) {
+	t.Helper()
+	path := filepath.Join(e.dir, "src", "views", name+".tsx")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifest := filepath.Join(e.dir, ManifestName)
+	data, err := os.ReadFile(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block := fmt.Sprintf("\n[[views]]\nname = %q\nkind = \"tile\"\ntitle = \"Pending\"\nentrypoint = \"src/views/%s.tsx\"\n", name, name)
+	if err := os.WriteFile(manifest, append(data, []byte(block)...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The artifact layout the whole stage rests on: one module per declared view,
+// beside the handler bundle, in the same content-addressed version directory.
+func TestBuild_EachViewIsItsOwnArtifactBesideTheBundle(t *testing.T) {
+	env := newBuildEnv(t, "viewed-app")
+	env.addView(t, "approvals", "export default function Approvals(): string { return \"approvals\" }\n")
+	env.addView(t, "history", "export default function History(): string { return \"history\" }\n")
+
+	res := env.mustBuild(t)
+
+	if len(res.ViewBytes) != 2 {
+		t.Fatalf("ViewBytes = %+v, want one entry per view", res.ViewBytes)
+	}
+	for _, v := range res.ViewBytes {
+		if v.Bytes == 0 {
+			t.Errorf("view %q built to nothing", v.Name)
+		}
+		want := ViewArtifactPath(env.store, "viewed-app", res.ContentHash, v.Name)
+		if v.Path != want {
+			t.Errorf("view %q is at %s, want %s", v.Name, v.Path, want)
+		}
+		if _, err := os.Stat(want); err != nil {
+			t.Errorf("view %q has no artifact: %v", v.Name, err)
+		}
+	}
+	if filepath.Dir(filepath.Dir(res.ViewBytes[0].Path)) != filepath.Dir(res.ArtifactPath) {
+		t.Errorf("views are not in the version directory: %s vs %s", res.ViewBytes[0].Path, res.ArtifactPath)
+	}
+}
+
+// The entrypoint is where the build starts, not what it contains: a view's local
+// imports land inside its one artifact, so one view is one file is one URL.
+func TestBuild_ViewCarriesItsWholeImportGraph(t *testing.T) {
+	env := newBuildEnv(t, "graph-app")
+	if err := os.MkdirAll(filepath.Join(env.dir, "src", "lib"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(env.dir, "src", "lib", "format.ts"),
+		[]byte("export const MARKER = \""+viewHelperMarker+"\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	env.addView(t, "approvals", "import { MARKER } from \"../lib/format\"\nexport default function Approvals(): string { return MARKER }\n")
+
+	res := env.mustBuild(t)
+
+	built, err := os.ReadFile(res.ViewBytes[0].Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(built), viewHelperMarker) {
+		t.Errorf("the view's local import is not inside its artifact:\n%s", built)
+	}
+}
+
+// The SDK specifiers stay external, so the module the frontend imports resolves
+// them against attn's own React rather than carrying a second copy.
+func TestBuild_ViewLeavesTheSDKSpecifierUnresolved(t *testing.T) {
+	env := newBuildEnv(t, "external-app")
+	env.addView(t, "approvals",
+		"import { useState } from \""+SDKModule+"\"\nexport default function Approvals(): unknown { return useState }\n")
+
+	res := env.mustBuild(t)
+
+	built, err := os.ReadFile(res.ViewBytes[0].Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(built), "from \""+SDKModule+"\"") {
+		t.Errorf("the SDK import was resolved into the artifact:\n%s", built)
+	}
+}
+
+// A view-only edit has to mint a new version. The declaration and the handler
+// bundle are both untouched by it, so a hash over those alone would reuse a row
+// whose artifacts had moved under it.
+func TestBuild_ViewOnlyEditIsANewVersion(t *testing.T) {
+	env := newBuildEnv(t, "reviewed-app")
+	env.addView(t, "approvals", "export default function Approvals(): string { return \"before\" }\n")
+	first := env.mustBuild(t)
+
+	env.edit(t, "src/views/approvals.tsx", `"before"`, `"after"`)
+	second := env.mustBuild(t)
+
+	if second.ContentHash == first.ContentHash {
+		t.Fatal("editing a view left the version hash unchanged, so the version row would name the old artifact")
+	}
+	if _, err := os.Stat(first.ViewBytes[0].Path); err != nil {
+		t.Errorf("the previous version's view must survive for rollback: %v", err)
+	}
+	if _, err := os.Stat(second.ViewBytes[0].Path); err != nil {
+		t.Errorf("the new version has no view artifact: %v", err)
+	}
+}
+
+// An app with no views hashes exactly as it did before views existed, so
+// re-applying an app built by an older attn lands on the row it already had.
+func TestBuild_ViewlessAppHashesAsItDidBeforeViews(t *testing.T) {
+	env := newBuildEnv(t, "unchanged-app")
+	res := env.mustBuild(t)
+
+	bundle, err := os.ReadFile(res.ArtifactPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := sha256.New()
+	legacy.Write([]byte(res.Declaration))
+	legacy.Write([]byte{0})
+	legacy.Write(bundle)
+	if got := hex.EncodeToString(legacy.Sum(nil)); got != res.ContentHash {
+		t.Fatalf("hash of a view-less app moved: %s, was %s", res.ContentHash, got)
+	}
+}
+
+// A view is something that runs, so an app that declares one and no
+// subscriptions builds and applies — a tile that only reads the document store
+// is a legitimate whole app.
+func TestBuild_AppWithAViewAndNoSubscriptionsBuilds(t *testing.T) {
+	env := newBuildEnv(t, "board-app")
+	env.addView(t, "approvals", "export default function Approvals(): string { return \"approvals\" }\n")
+	env.editManifest(t, "[[subscribe]]\nevents = [\"session.state.changed\"]\n", "")
+	env.edit(t, "src/index.ts",
+		"export default {\n  \"session.state.changed\": onSessionState,\n} satisfies Handlers",
+		"export default {} satisfies Handlers")
+
+	res := env.mustBuild(t)
+
+	if len(res.Manifest.Subscribe) != 0 || len(res.ViewBytes) != 1 {
+		t.Fatalf("manifest = %+v, views = %+v", res.Manifest, res.ViewBytes)
+	}
+}
+
+// A broken view fails the apply with the bundler's own words, and leaves the
+// store as it found it — the same guarantee the handler bundle already had.
+func TestBuild_BrokenViewFailsTheWholeApply(t *testing.T) {
+	env := newBuildEnv(t, "brokenview-app")
+	env.addView(t, "approvals", "import { missing } from \"./nowhere\"\nexport default function A(): unknown { return missing }\n")
+
+	_, err := env.build(t)
+	if err == nil {
+		t.Fatal("build accepted a view whose import does not resolve")
+	}
+	for _, want := range []string{"approvals", "brokenview-app"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error does not name %q: %v", want, err)
+		}
+	}
+	if entries, err := os.ReadDir(filepath.Join(env.store, "brokenview-app")); err == nil && len(entries) != 0 {
+		t.Fatalf("store holds %d version directories, want none", len(entries))
 	}
 }
 

--- a/internal/appbuild/build_test.go
+++ b/internal/appbuild/build_test.go
@@ -463,6 +463,34 @@ func TestBuild_ViewOnlyEditIsANewVersion(t *testing.T) {
 	}
 }
 
+// The digest is over a set of named artifacts, not a list: reordering two
+// [[views]] blocks changes nothing about what the version holds, so it must not
+// mint a new one. The claim rests on one sort inside versionHash, which is
+// exactly the kind of line a later refactor drops while the claim quietly dies.
+func TestVersionHash_DoesNotDependOnViewOrder(t *testing.T) {
+	declaration := `{"name":"ordered","attn_app_api":1}`
+	bundle := []byte("export default {}\n")
+	approvals := ViewArtifact{Name: "approvals", Content: []byte("export default 1\n")}
+	history := ViewArtifact{Name: "history", Content: []byte("export default 2\n")}
+
+	forward := VersionHash(declaration, bundle, []ViewArtifact{approvals, history})
+	backward := VersionHash(declaration, bundle, []ViewArtifact{history, approvals})
+	if forward != backward {
+		t.Fatalf("reordering the views moved the hash: %s then %s", forward, backward)
+	}
+
+	// The names are hashed too, so two views cannot swap contents unnoticed —
+	// which is what stops the ordering rule from collapsing the whole digest into
+	// "some bytes, in some order".
+	swapped := VersionHash(declaration, bundle, []ViewArtifact{
+		{Name: approvals.Name, Content: history.Content},
+		{Name: history.Name, Content: approvals.Content},
+	})
+	if swapped == forward {
+		t.Fatal("two views swapping contents left the version hash unchanged")
+	}
+}
+
 // An app with no views hashes exactly as it did before views existed, so
 // re-applying an app built by an older attn lands on the row it already had.
 func TestBuild_ViewlessAppHashesAsItDidBeforeViews(t *testing.T) {

--- a/internal/appbuild/manifest.go
+++ b/internal/appbuild/manifest.go
@@ -53,6 +53,7 @@ type Manifest struct {
 	Entrypoint  string       `toml:"entrypoint" json:"entrypoint"`
 	Subscribe   []Subscribe  `toml:"subscribe" json:"subscribe,omitempty"`
 	Collections []Collection `toml:"collections" json:"collections,omitempty"`
+	Views       []View       `toml:"views" json:"views,omitempty"`
 }
 
 // Subscribe is one `[[subscribe]]` block: the event patterns that wake this app.
@@ -69,10 +70,48 @@ type Collection struct {
 	Fields []string `toml:"fields" json:"fields,omitempty"`
 }
 
+// View is one `[[views]]` block: a named component this app offers attn to
+// render, and the title the UI puts on it.
+//
+// A view is what the app declares; a tile is a place in a workspace layout.
+// Keeping the two words apart is what makes a second mount surface an addition
+// rather than a rework — a later kind changes the accepted set below and the
+// component that mounts it, and nothing between here and the artifact moves.
+type View struct {
+	Name string `toml:"name" json:"name"`
+	// Kind is where attn is willing to put this view. Optional in app api 1 and
+	// resolved to ViewKindTile before the declaration is frozen, so a default
+	// that changes later cannot rewrite what an old version meant.
+	Kind       string      `toml:"kind" json:"kind"`
+	Title      string      `toml:"title" json:"title"`
+	Entrypoint string      `toml:"entrypoint" json:"entrypoint"`
+	Params     *ViewParams `toml:"params" json:"params,omitempty"`
+}
+
+// ViewParams is the optional `params = { … }` declaration: it makes the dock UI
+// ask for one line of text before placing the view, and that string is what
+// makes two tiles of one view show different things.
+//
+// The string is opaque to attn — no schema, no types — exactly as a markdown
+// tile's file path is opaque to the layout. An app that needs richer input
+// renders it inside its own view.
+type ViewParams struct {
+	Label       string `toml:"label" json:"label"`
+	Placeholder string `toml:"placeholder" json:"placeholder,omitempty"`
+}
+
+// ViewKindTile is the only mount surface this attn builds. Panels and windows
+// are designed for and unbuilt; a manifest naming one is refused by name rather
+// than installed as a view nothing can render.
+const ViewKindTile = "tile"
+
+// viewKinds is what `kind` may say, and what a refusal lists.
+var viewKinds = []string{ViewKindTile}
+
 // knownTables is what a manifest may declare, named in the error an unknown
 // table produces. Future stages add entries here as they add the runtime that
-// honors them — A5 `[[tiles]]`, C1 `[[hooks]]`, B2 `[[workflows]]`.
-var knownTables = []string{"subscribe", "collections"}
+// honors them — C1 `[[hooks]]`, B2 `[[workflows]]`.
+var knownTables = []string{"subscribe", "collections", "views"}
 
 // LoadManifest reads and validates the manifest in dir.
 func LoadManifest(dir string) (Manifest, error) {
@@ -130,6 +169,12 @@ func ParseManifest(text string) (Manifest, error) {
 		return Manifest{}, fmt.Errorf("entrypoint %q must be relative to the app directory", m.Entrypoint)
 	}
 	if err := m.checkSubscriptions(); err != nil {
+		return Manifest{}, err
+	}
+	if err := m.checkViews(); err != nil {
+		return Manifest{}, err
+	}
+	if err := m.checkSomethingRuns(); err != nil {
 		return Manifest{}, err
 	}
 	if err := m.checkCollections(); err != nil {
@@ -199,7 +244,6 @@ func (m Manifest) checkAPIVersion() error {
 // they declared twice and can only bind once.
 func (m Manifest) checkSubscriptions() error {
 	seen := map[string]bool{}
-	total := 0
 	for _, block := range m.Subscribe {
 		for _, raw := range block.Events {
 			pattern := strings.TrimSpace(raw)
@@ -210,15 +254,23 @@ func (m Manifest) checkSubscriptions() error {
 				return fmt.Errorf("subscribes to %q twice; each event pattern binds one handler, so list it once", pattern)
 			}
 			seen[pattern] = true
-			total++
 		}
 	}
-	if total == 0 {
-		// An app with no subscriptions has no way to run: nothing dispatches to
-		// it, and it would install as a version that can never execute.
-		return fmt.Errorf("declares no subscriptions, so nothing would ever run it; add a [[subscribe]] block with events = [\"session.state.changed\"] (patterns end in .* to match a family)")
-	}
 	return nil
+}
+
+// checkSomethingRuns refuses an app nothing would ever reach.
+//
+// A subscription is one way in and a view is the other: a view renders when
+// somebody docks it, so an app that is all view and no handler is a whole app —
+// a tile that only reads the document store is the shape this exists to allow.
+// What is still refused is a manifest declaring neither, which would install as
+// a version that can never execute and never render.
+func (m Manifest) checkSomethingRuns() error {
+	if len(m.EventPatterns()) > 0 || len(m.Views) > 0 {
+		return nil
+	}
+	return fmt.Errorf("declares neither a subscription nor a view, so nothing would ever run it; add a [[subscribe]] block with events = [\"session.state.changed\"] (patterns end in .* to match a family), or a [[views]] block naming a component to render")
 }
 
 // validateEventPattern accepts what internal/bus can match: an exact dotted fact
@@ -242,6 +294,55 @@ func validateEventPattern(pattern string) error {
 		}
 		if strings.Contains(segment, "*") {
 			return fmt.Errorf("subscribes to %q; a wildcard is only valid as a trailing .* (session.* matches session.state.changed)", pattern)
+		}
+	}
+	return nil
+}
+
+// checkViews validates every `[[views]]` block and resolves each one's kind.
+//
+// Resolving here rather than at render time is what makes the frozen
+// declaration honest: it records the kind this attn understood the view to
+// have, so a default that changes in a later api version cannot rewrite what an
+// old version meant.
+func (m *Manifest) checkViews() error {
+	seen := map[string]bool{}
+	for i := range m.Views {
+		v := &m.Views[i]
+		v.Name = strings.TrimSpace(v.Name)
+		v.Kind = strings.TrimSpace(v.Kind)
+		v.Title = strings.TrimSpace(v.Title)
+		v.Entrypoint = strings.TrimSpace(v.Entrypoint)
+
+		if err := apps.ValidateViewName(v.Name); err != nil {
+			return err
+		}
+		if seen[v.Name] {
+			return fmt.Errorf("declares view %q twice; a view name addresses one component, so name each one once", v.Name)
+		}
+		seen[v.Name] = true
+		if v.Kind == "" {
+			v.Kind = ViewKindTile
+		}
+		if v.Kind != ViewKindTile {
+			return fmt.Errorf("view %q is of kind %q, which this attn cannot mount anywhere; it mounts %s",
+				v.Name, v.Kind, strings.Join(quoteAll(viewKinds), ", "))
+		}
+		if v.Title == "" {
+			return fmt.Errorf("view %q has no title, and the title is what the tile header and the dock picker show; add title = \"Pending approvals\"", v.Name)
+		}
+		if v.Entrypoint == "" {
+			return fmt.Errorf("view %q has no entrypoint; add one as a path relative to the app directory (for example entrypoint = \"src/views/%s.tsx\")", v.Name, v.Name)
+		}
+		if filepath.IsAbs(v.Entrypoint) {
+			return fmt.Errorf("view %q has entrypoint %q, which must be relative to the app directory", v.Name, v.Entrypoint)
+		}
+		if v.Params != nil {
+			v.Params.Label = strings.TrimSpace(v.Params.Label)
+			v.Params.Placeholder = strings.TrimSpace(v.Params.Placeholder)
+			if v.Params.Label == "" {
+				return fmt.Errorf("view %q declares params with no label, and the label is what the dock picker puts on the field it asks for; add label = \"Repository\", or drop params to take none", v.Name)
+			}
 		}
 	}
 	return nil
@@ -281,23 +382,36 @@ func (m Manifest) checkCollections() error {
 	return nil
 }
 
-// checkEntrypoint is the one rule that needs the directory: the file has to be
-// there, inside the app, and a file.
+// checkEntrypoint is the one rule that needs the directory: every entrypoint the
+// manifest names — the app's own and one per view — has to be there, inside the
+// app, and a file.
 func (m Manifest) checkEntrypoint(dir string) error {
-	abs := filepath.Clean(filepath.Join(dir, m.Entrypoint))
+	if err := checkEntrypointFile(dir, m.Entrypoint, "entrypoint"); err != nil {
+		return err
+	}
+	for _, v := range m.Views {
+		if err := checkEntrypointFile(dir, v.Entrypoint, fmt.Sprintf("view %q's entrypoint", v.Name)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkEntrypointFile(dir, entrypoint, what string) error {
+	abs := filepath.Clean(filepath.Join(dir, entrypoint))
 	root := filepath.Clean(dir)
 	if abs != root && !strings.HasPrefix(abs, root+string(os.PathSeparator)) {
-		return fmt.Errorf("entrypoint %q points outside the app directory", m.Entrypoint)
+		return fmt.Errorf("%s %q points outside the app directory", what, entrypoint)
 	}
 	info, err := os.Stat(abs)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("entrypoint %q does not exist (looked for %s)", m.Entrypoint, abs)
+			return fmt.Errorf("%s %q does not exist (looked for %s)", what, entrypoint, abs)
 		}
-		return fmt.Errorf("entrypoint %q: %w", m.Entrypoint, err)
+		return fmt.Errorf("%s %q: %w", what, entrypoint, err)
 	}
 	if !info.Mode().IsRegular() {
-		return fmt.Errorf("entrypoint %q is not a regular file", m.Entrypoint)
+		return fmt.Errorf("%s %q is not a regular file", what, entrypoint)
 	}
 	return nil
 }
@@ -313,6 +427,35 @@ func (m Manifest) EventPatterns() []string {
 		}
 	}
 	return out
+}
+
+// ViewNames is every declared view, in declaration order — one artifact each.
+func (m Manifest) ViewNames() []string {
+	out := make([]string, 0, len(m.Views))
+	for _, v := range m.Views {
+		out = append(out, v.Name)
+	}
+	return out
+}
+
+// DeclaredViewNames reads the views back out of a frozen declaration. The daemon
+// uses it to know which artifacts a version is made of before it has a manifest
+// — the declaration is the only description of a version it ever holds.
+func DeclaredViewNames(declaration string) ([]string, error) {
+	var snapshot struct {
+		Views []View `json:"views"`
+	}
+	if err := json.Unmarshal([]byte(declaration), &snapshot); err != nil {
+		return nil, fmt.Errorf("reading the views of a declaration snapshot: %w", err)
+	}
+	out := make([]string, 0, len(snapshot.Views))
+	for _, v := range snapshot.Views {
+		if err := apps.ValidateViewName(v.Name); err != nil {
+			return nil, err
+		}
+		out = append(out, v.Name)
+	}
+	return out, nil
 }
 
 // Declaration is the frozen snapshot stored on the version row: what this

--- a/internal/appbuild/manifest_test.go
+++ b/internal/appbuild/manifest_test.go
@@ -175,6 +175,190 @@ entrypoint = "src/index.ts"
 	})
 }
 
+// viewBlock is the declaration everything below mutates one field of.
+const viewBlock = `
+[[views]]
+name = "approvals"
+kind = "tile"
+title = "Pending approvals"
+entrypoint = "src/views/Approvals.tsx"
+`
+
+func TestParseManifest_Views(t *testing.T) {
+	m, err := ParseManifest(validManifest(t, viewBlock))
+	if err != nil {
+		t.Fatalf("ParseManifest: %v", err)
+	}
+	if len(m.Views) != 1 {
+		t.Fatalf("views = %+v", m.Views)
+	}
+	v := m.Views[0]
+	if v.Name != "approvals" || v.Kind != ViewKindTile || v.Title != "Pending approvals" || v.Entrypoint != "src/views/Approvals.tsx" {
+		t.Fatalf("view = %+v", v)
+	}
+	if v.Params != nil {
+		t.Errorf("params = %+v, want none when the manifest declares none", v.Params)
+	}
+	if got := m.ViewNames(); len(got) != 1 || got[0] != "approvals" {
+		t.Errorf("ViewNames() = %v", got)
+	}
+}
+
+// kind is optional and the declaration records the resolved value, so a default
+// that changes in a later api version cannot rewrite what an old version meant.
+func TestParseManifest_ViewKindDefaultsToTileAndIsFrozenResolved(t *testing.T) {
+	m, err := ParseManifest(validManifest(t, strings.Replace(viewBlock, "kind = \"tile\"\n", "", 1)))
+	if err != nil {
+		t.Fatalf("ParseManifest: %v", err)
+	}
+	if m.Views[0].Kind != ViewKindTile {
+		t.Fatalf("kind = %q, want %q", m.Views[0].Kind, ViewKindTile)
+	}
+	declaration, err := m.Declaration()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(declaration, `"kind":"tile"`) {
+		t.Errorf("the frozen declaration does not record the resolved kind: %s", declaration)
+	}
+}
+
+// A kind attn cannot mount is refused at apply, naming the kinds it does mount.
+// Installing it would give the app a view nothing renders — half-loaded, with
+// nothing saying so.
+func TestParseManifest_UnmountableViewKindIsRefused(t *testing.T) {
+	_, err := ParseManifest(validManifest(t, strings.Replace(viewBlock, `kind = "tile"`, `kind = "panel"`, 1)))
+	if err == nil {
+		t.Fatal("ParseManifest accepted a kind this attn cannot mount")
+	}
+	for _, want := range []string{"panel", ViewKindTile, "approvals"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not carry %q", err, want)
+		}
+	}
+}
+
+func TestParseManifest_ViewRefusals(t *testing.T) {
+	cases := map[string]struct{ old, new, want string }{
+		"no name":        {`name = "approvals"`, `name = ""`, "view name is required"},
+		"illegal name":   {`name = "approvals"`, `name = "Approvals!"`, "Approvals!"},
+		"no title":       {"title = \"Pending approvals\"\n", "", "no title"},
+		"no entrypoint":  {"entrypoint = \"src/views/Approvals.tsx\"\n", "", "no entrypoint"},
+		"abs entrypoint": {`entrypoint = "src/views/Approvals.tsx"`, `entrypoint = "/etc/passwd"`, "relative"},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			text := validManifest(t, strings.Replace(viewBlock, c.old, c.new, 1))
+			_, err := ParseManifest(text)
+			if err == nil {
+				t.Fatalf("ParseManifest accepted %s", name)
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Errorf("error %q does not carry %q", err, c.want)
+			}
+		})
+	}
+
+	t.Run("duplicate", func(t *testing.T) {
+		_, err := ParseManifest(validManifest(t, viewBlock+viewBlock))
+		if err == nil || !strings.Contains(err.Error(), "twice") {
+			t.Fatalf("err = %v, want a refusal naming the repeated view", err)
+		}
+	})
+}
+
+// The view name rule is internal/apps', because the same string is a file name
+// in the version directory and a segment of the `app:<app>/<view>` tile kind.
+func TestParseManifest_ViewNameRuleIsTheRegistrys(t *testing.T) {
+	names := []string{
+		"approvals", "a", "9lives", "pending-v2",
+		"", "-leading", "Approvals", "with_underscore", "with space",
+		"app/name", "trailing-", strings.Repeat("a", apps.MaxViewNameLength+1),
+	}
+	for _, name := range names {
+		text := validManifest(t, strings.Replace(viewBlock, `name = "approvals"`, fmt.Sprintf("name = %q", name), 1))
+		_, parseErr := ParseManifest(text)
+		registryErr := apps.ValidateViewName(name)
+		if (parseErr == nil) != (registryErr == nil) {
+			t.Errorf("view name %q: parser err=%v, registry err=%v — the two disagree", name, parseErr, registryErr)
+		}
+	}
+}
+
+func TestParseManifest_ViewParams(t *testing.T) {
+	declared := viewBlock + `params = { label = "Repository", placeholder = "victorarias/attn" }` + "\n"
+	m, err := ParseManifest(validManifest(t, declared))
+	if err != nil {
+		t.Fatalf("ParseManifest: %v", err)
+	}
+	if m.Views[0].Params == nil || m.Views[0].Params.Label != "Repository" || m.Views[0].Params.Placeholder != "victorarias/attn" {
+		t.Fatalf("params = %+v", m.Views[0].Params)
+	}
+
+	// A params block with nothing to put on the field is a picker asking for an
+	// unlabelled string, which is a question the user cannot answer.
+	unlabelled := viewBlock + `params = { placeholder = "victorarias/attn" }` + "\n"
+	_, err = ParseManifest(validManifest(t, unlabelled))
+	if err == nil || !strings.Contains(err.Error(), "label") {
+		t.Fatalf("err = %v, want a refusal naming the missing label", err)
+	}
+}
+
+// The relaxation A5 makes to A4's rule: a view is something that runs, so an app
+// that is all view and no handler is a whole app. What stays refused is a
+// manifest declaring neither.
+func TestParseManifest_AViewCountsAsSomethingThatRuns(t *testing.T) {
+	text := `
+name = "board"
+attn_app_api = 1
+entrypoint = "src/index.ts"
+` + viewBlock
+	m, err := ParseManifest(text)
+	if err != nil {
+		t.Fatalf("ParseManifest refused an app that is all view: %v", err)
+	}
+	if len(m.EventPatterns()) != 0 || len(m.Views) != 1 {
+		t.Fatalf("manifest = %+v", m)
+	}
+
+	neither := `
+name = "inert"
+attn_app_api = 1
+entrypoint = "src/index.ts"
+`
+	_, err = ParseManifest(neither)
+	if err == nil || !strings.Contains(err.Error(), "nothing would ever run it") {
+		t.Fatalf("err = %v, want a refusal explaining the app could never run", err)
+	}
+	// The refusal has to name both ways in, or it teaches half the rule.
+	if !strings.Contains(err.Error(), "[[views]]") || !strings.Contains(err.Error(), "[[subscribe]]") {
+		t.Errorf("error %q does not name both ways an app can run", err)
+	}
+}
+
+// The daemon holds a version's declaration and nothing else, so reading the
+// views back out of it is what tells it which artifacts the version is made of.
+func TestDeclaredViewNames(t *testing.T) {
+	m, err := ParseManifest(validManifest(t, viewBlock))
+	if err != nil {
+		t.Fatal(err)
+	}
+	declaration, err := m.Declaration()
+	if err != nil {
+		t.Fatal(err)
+	}
+	names, err := DeclaredViewNames(declaration)
+	if err != nil || len(names) != 1 || names[0] != "approvals" {
+		t.Fatalf("DeclaredViewNames() = %v, %v", names, err)
+	}
+
+	// A view name is a path segment by the time it is a file, so a declaration
+	// carrying one that is not a name is refused rather than joined into a path.
+	if _, err := DeclaredViewNames(`{"name":"x","views":[{"name":"../../etc/passwd"}]}`); err == nil {
+		t.Fatal("DeclaredViewNames accepted a name that is not a view name")
+	}
+}
+
 // A collection name the document store would refuse at write time is refused
 // here, at apply, with the app's real namespace in the message.
 func TestParseManifest_CollectionsAreCheckedAgainstTheStore(t *testing.T) {

--- a/internal/apps/apps.go
+++ b/internal/apps/apps.go
@@ -110,6 +110,41 @@ func ValidateName(name string) error {
 	return nil
 }
 
+// MaxViewNameLength bounds a view name, for the same reason MaxNameLength
+// bounds an app's: the name is addressed, not just displayed. It is a file name
+// under the version directory and a segment of the tile kind an app view docks
+// as, and 64 is far past any real name.
+const MaxViewNameLength = 64
+
+// ValidateViewName reports whether a string can name one of an app's views.
+//
+// It is the app-name rule again, minus the reserved set: a view name is scoped
+// to its app, so nothing it could collide with is global. It lives here rather
+// than in the manifest parser because the same string is a file name in the
+// version directory and a segment of the `app:<app>/<view>` tile kind, and a
+// parser with its own opinion is how those drift apart.
+func ValidateViewName(name string) error {
+	if name == "" {
+		return fmt.Errorf("a view name is required, as lowercase letters, digits and dashes (for example approvals)")
+	}
+	if len(name) > MaxViewNameLength {
+		return fmt.Errorf("view name %q is %d characters, over the %d-character limit", name, len(name), MaxViewNameLength)
+	}
+	if !nameRe.MatchString(name) {
+		return fmt.Errorf("view name %q must be lowercase letters, digits and dashes, starting with a letter or digit (for example pending-approvals)", name)
+	}
+	return nil
+}
+
+// NoSubscriptionsPattern is the bus filter of an app that declared no
+// subscriptions — a fact name nothing publishes. A filter has to be *something*,
+// and every other candidate ("", "*") means "everything" somewhere in the bus.
+//
+// It lives here because two surfaces that cannot see each other need the same
+// string: the daemon derives it, and the CLI recognises it to say "nothing"
+// where it would otherwise print a fact name no reader could look up.
+const NoSubscriptionsPattern = "app.subscribes.to.nothing"
+
 // ConsumerName is the app's durable bus consumer. The prefix is what keeps an
 // app from colliding with a platform consumer, and what makes `attn bus status`
 // readable at a glance.

--- a/internal/apps/apps_test.go
+++ b/internal/apps/apps_test.go
@@ -84,6 +84,26 @@ func TestRuntimeIsReserved(t *testing.T) {
 	}
 }
 
+// A view name is scoped to its app, so the reserved set does not apply to it —
+// and an app's own name is a legal view name, which is what proves the two rules
+// are the same charset rather than two regexps that happen to agree today.
+func TestValidateViewName(t *testing.T) {
+	for _, ok := range []string{"approvals", "a", "pending-v2", "9lives", "runtime", "status"} {
+		if err := ValidateViewName(ok); err != nil {
+			t.Errorf("ValidateViewName(%q) = %v, want nil", ok, err)
+		}
+	}
+	for _, bad := range []string{"", "-leading", "Approvals", "with_underscore", "with space", "app/name", "..", strings.Repeat("a", MaxViewNameLength+1)} {
+		if err := ValidateViewName(bad); err == nil {
+			t.Errorf("ValidateViewName(%q) = nil, want an error", bad)
+		}
+	}
+	err := ValidateViewName(strings.Repeat("a", MaxViewNameLength+1))
+	if err == nil || !strings.Contains(err.Error(), "65") || !strings.Contains(err.Error(), "64") {
+		t.Fatalf("error does not name the ask and the limit: %v", err)
+	}
+}
+
 func TestDerivedIdentities(t *testing.T) {
 	if got := ConsumerName("approval-gate"); got != "app:approval-gate" {
 		t.Errorf("ConsumerName = %q", got)

--- a/internal/daemon/app_apply.go
+++ b/internal/daemon/app_apply.go
@@ -80,10 +80,25 @@ func (d *Daemon) handleAppApply(conn net.Conn, msg *protocol.AppApplyMessage) {
 			name, path, err, d.appsDir))
 		return
 	}
-	if actual := appbuild.VersionHash(declaration, bundle); actual != hash {
+	// A version is its handler bundle *and* one module per declared view, so the
+	// check reads all of them. The declaration is the only description of the
+	// version the daemon holds, which is what names the views to look for.
+	viewNames, err := appbuild.DeclaredViewNames(declaration)
+	if err != nil {
+		d.sendError(conn, fmt.Sprintf("app apply %s: %v", name, err))
+		return
+	}
+	views, err := appbuild.ReadViewArtifacts(d.appsDir, name, hash, viewNames)
+	if err != nil {
 		d.sendError(conn, fmt.Sprintf(
-			"app apply %s: the artifact at %s hashes to %s, not the %s this apply claims; nothing was recorded",
-			name, path, actual, hash))
+			"app apply %s: %v; the build places every declared view beside the bundle before asking the daemon to record it, so this apply was not built by this attn's data directory (%s)",
+			name, err, d.appsDir))
+		return
+	}
+	if actual := appbuild.VersionHash(declaration, bundle, views); actual != hash {
+		d.sendError(conn, fmt.Sprintf(
+			"app apply %s: the artifacts at %s hash to %s, not the %s this apply claims; nothing was recorded",
+			name, appbuild.ArtifactDir(d.appsDir, name, hash), actual, hash))
 		return
 	}
 

--- a/internal/daemon/app_apply_test.go
+++ b/internal/daemon/app_apply_test.go
@@ -34,7 +34,15 @@ func appApplyDaemon(t *testing.T) *Daemon {
 // returns the hash that names it.
 func stageArtifact(t *testing.T, d *Daemon, name, declaration, bundle string) string {
 	t.Helper()
-	hash := appbuild.VersionHash(declaration, []byte(bundle))
+	return stageArtifacts(t, d, name, declaration, bundle, nil)
+}
+
+// stageArtifacts is stageArtifact for a version that also holds views: every
+// artifact goes where the daemon derives its path, and the hash covers all of
+// them.
+func stageArtifacts(t *testing.T, d *Daemon, name, declaration, bundle string, views []appbuild.ViewArtifact) string {
+	t.Helper()
+	hash := appbuild.VersionHash(declaration, []byte(bundle), views)
 	path := appbuild.ArtifactPath(d.appsDir, name, hash)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
@@ -42,11 +50,27 @@ func stageArtifact(t *testing.T, d *Daemon, name, declaration, bundle string) st
 	if err := os.WriteFile(path, []byte(bundle), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	for _, v := range views {
+		viewPath := appbuild.ViewArtifactPath(d.appsDir, name, hash, v.Name)
+		if err := os.MkdirAll(filepath.Dir(viewPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(viewPath, v.Content, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
 	return hash
 }
 
 func declarationFor(name, note string) string {
 	return fmt.Sprintf(`{"name":%q,"attn_app_api":1,"entrypoint":"src/index.ts","note":%q}`, name, note)
+}
+
+// declarationWithView is the frozen snapshot of an app that declares one view —
+// the shape the daemon reads back to know which artifacts a version is made of.
+func declarationWithView(name, view string) string {
+	return fmt.Sprintf(`{"name":%q,"attn_app_api":1,"entrypoint":"src/index.ts","views":[{"name":%q,"kind":"tile","title":"Pending","entrypoint":"src/views/%s.tsx"}]}`,
+		name, view, view)
 }
 
 func appApply(t *testing.T, d *Daemon, name, hash, declaration string) protocol.Response {
@@ -213,7 +237,7 @@ func TestAppApplyRefusesAnArtifactThatDoesNotMatchItsHash(t *testing.T) {
 func TestAppApplyRefusesAMissingArtifact(t *testing.T) {
 	d := appApplyDaemon(t)
 	declaration := declarationFor("approval-gate", "first")
-	hash := appbuild.VersionHash(declaration, []byte("never written"))
+	hash := appbuild.VersionHash(declaration, []byte("never written"), nil)
 
 	resp := appApply(t, d, "approval-gate", hash, declaration)
 	if resp.Ok {
@@ -221,6 +245,61 @@ func TestAppApplyRefusesAMissingArtifact(t *testing.T) {
 	}
 	if msg := protocol.Deref(resp.Error); !strings.Contains(msg, d.appsDir) {
 		t.Errorf("error does not name where it looked: %s", msg)
+	}
+}
+
+// A version is every artifact it holds. The daemon reads the views its
+// declaration names and hashes them with the bundle, so a version whose views
+// moved cannot be recorded under a hash that describes the old ones.
+func TestAppApplyHashesTheViewsToo(t *testing.T) {
+	d := appApplyDaemon(t)
+	declaration := declarationWithView("approval-gate", "approvals")
+	views := []appbuild.ViewArtifact{{Name: "approvals", Content: []byte("export default function A(){}\n")}}
+	hash := stageArtifacts(t, d, "approval-gate", declaration, "export default {}\n", views)
+
+	if resp := appApply(t, d, "approval-gate", hash, declaration); !resp.Ok {
+		t.Fatalf("apply refused a correctly built version: %s", protocol.Deref(resp.Error))
+	}
+
+	// The same bundle and declaration with a different view is a different
+	// version, and claiming the old hash for it is refused.
+	edited := []appbuild.ViewArtifact{{Name: "approvals", Content: []byte("export default function B(){}\n")}}
+	if same := appbuild.VersionHash(declaration, []byte("export default {}\n"), edited); same == hash {
+		t.Fatal("editing only a view left the version hash unchanged")
+	}
+	viewPath := appbuild.ViewArtifactPath(d.appsDir, "approval-gate", hash, "approvals")
+	if err := os.WriteFile(viewPath, edited[0].Content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	resp := appApply(t, d, "approval-gate", hash, declaration)
+	if resp.Ok {
+		t.Fatal("apply accepted a version whose view does not hash to its name")
+	}
+	if msg := protocol.Deref(resp.Error); !strings.Contains(msg, "nothing was recorded") {
+		t.Errorf("error does not say nothing was recorded: %s", msg)
+	}
+}
+
+// A declared view with no artifact is refused by name: the daemon cannot check a
+// hash over content it does not have, and recording the version anyway would
+// leave a row naming a view nothing can serve.
+func TestAppApplyRefusesADeclaredViewWithNoArtifact(t *testing.T) {
+	d := appApplyDaemon(t)
+	declaration := declarationWithView("approval-gate", "approvals")
+	hash := stageArtifact(t, d, "approval-gate", declaration, "export default {}\n")
+
+	resp := appApply(t, d, "approval-gate", hash, declaration)
+	if resp.Ok {
+		t.Fatal("apply accepted a version missing a declared view's artifact")
+	}
+	msg := protocol.Deref(resp.Error)
+	for _, want := range []string{"approvals", "views/approvals.js"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error does not carry %q: %s", want, msg)
+		}
+	}
+	if count, err := d.store.CountAppVersions("approval-gate"); err != nil || count != 0 {
+		t.Fatalf("versions = %d (%v), want none", count, err)
 	}
 }
 

--- a/internal/daemon/app_consumers.go
+++ b/internal/daemon/app_consumers.go
@@ -198,15 +198,10 @@ func (d *Daemon) appFilter(name string) (bus.Filter, error) {
 	}
 	patterns := manifest.EventPatterns()
 	if len(patterns) == 0 {
-		return bus.Filter{appNoSubscriptionsPattern}, nil
+		return bus.Filter{apps.NoSubscriptionsPattern}, nil
 	}
 	return bus.Filter(patterns), nil
 }
-
-// appNoSubscriptionsPattern is a fact name nothing publishes, used as the filter
-// of an app that declared no subscriptions. A filter has to be *something*, and
-// every other candidate — empty, "*" — means "everything" somewhere in the bus.
-const appNoSubscriptionsPattern = "app.subscribes.to.nothing"
 
 // appDeclaration loads an app's current version and the manifest frozen into it.
 // The zero AppVersion with a nil error means the app exists but has no version.

--- a/internal/daemon/app_runtime_test.go
+++ b/internal/daemon/app_runtime_test.go
@@ -846,7 +846,7 @@ func TestAppWithNoSubscriptionsSubscribesToNothing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("appFilter: %v", err)
 	}
-	if len(filter) != 1 || filter[0] != appNoSubscriptionsPattern {
+	if len(filter) != 1 || filter[0] != apps.NoSubscriptionsPattern {
 		t.Fatalf("filter = %v, want the nothing-matches pattern", filter)
 	}
 	for _, name := range []string{"ticket.created", "session.state.changed", "app.enabled.changed"} {


### PR DESCRIPTION
Slice 1 of A5 ([the plan](https://github.com/victorarias/attn/blob/main/docs/plans/2026-08-13-ext-a5-ui-host-and-app-sdk.md)): an app declares views and the build compiles them. Nothing renders one yet — the bundle route, the tile host and the SDK are slices 2 and 3.

## What an author writes

```toml
[[views]]
name = "approvals"                     # [a-z0-9-], unique within the app
kind = "tile"                          # optional, resolves to "tile"
title = "Pending approvals"
entrypoint = "src/views/approvals.tsx"
params = { label = "Repository", placeholder = "victorarias/attn" }
```

`attn app apply` then bundles each view for the browser into the version's content-addressed directory:

```
apps/viewboard/6cb24f1545ae…/
├── bundle.js            278 bytes   the handlers, target bun
└── views/approvals.js   234 bytes   one per declared view, target browser
```

## The four things this changes

**A view is a declaration, a tile is a place.** `kind` is a manifest field with one accepted value; a second mount surface adds a value and a host component, and nothing between here and the artifact moves. `kind = "panel"` is refused by name today rather than installed as a view nothing renders. The frozen declaration records the *resolved* kind, so a default that changes in a later api version cannot rewrite what an old version meant.

**The version hash covers every artifact.** A view is built from its own entrypoint, so editing only a component leaves both the declaration and the handler bundle untouched — hashing those two alone would reuse a version row whose artifacts had moved under it. Views are hashed by name as well as content, in name order, so the digest does not depend on declaration order. An app with no views hashes exactly as before, which is why re-applying an app built by an older attn lands on the row it already had (there is a test pinning that against the pre-views digest).

**The daemon checks all of them.** `handleAppApply` re-derives the hash from what is on disk; it now reads the view names back out of the declaration — the only description of a version it holds — and reads every artifact. A declared view with no artifact is a refusal naming the view and the path, not a silently shorter list.

**A view counts as something that runs.** A4 refused an app with no `[[subscribe]]`; it now refuses an app with neither a subscription nor a view. A tile that only reads the document store is a whole app. This lands on a path A4 already built and could not reach: an app with no patterns gets the `app.subscribes.to.nothing` filter, which `attn app status` used to print verbatim — a fact name no reader could look up. The CLI now says `nothing — it declares no subscriptions`, and the constant moved to `internal/apps` because the daemon derives it and the CLI recognises it.

## No cap, but the numbers

There is deliberately no bundle size cap — nothing measured yet would justify one, and a number picked from nothing fires on the first legitimately large view. What apply owes an author instead is the number, per artifact, which is what the byte lines above are.

## Verification — CLI tier

Unit tests (`internal/appbuild`, `internal/apps`, `internal/daemon`) plus the built binary against real app directories, with a daemon on an isolated `ATTN_DATA_DIR` and its own WS port. Full `go test ./internal/... ./cmd/...` is green.

| What | Result |
| --- | --- |
| view-less app applies | version 1, `278 bytes` — unchanged behavior |
| two views declared | `bundling view approvals from src/views/approvals.tsx`, artifacts at `views/approvals.js` |
| local import inside a view | `src/lib/format.ts` inlined into the one artifact |
| edit only the view source | version 2 → 3, `bundle.js` byte-identical at 278 |
| `attn app dev` | view-only save → new version in 190ms |
| `kind = "panel"` | `view "approvals" is of kind "panel", which this attn cannot mount anywhere; it mounts "tile"` |
| view entrypoint missing | `view "approvals"'s entrypoint … does not exist (looked for …)` |
| view import that does not resolve | bun's own error with file and line; nothing recorded |
| all view, no subscriptions | applies; `subscribes: nothing — it declares no subscriptions` |
| neither | `declares neither a subscription nor a view, so nothing would ever run it` |

No recording: nothing about this slice is visible in the app.

## For slice 3 (the host)

- `appbuild.ViewArtifactPath(storeDir, app, hash, view)` is where a view's bytes are, derived rather than stored — the bundle route should use it rather than a path of its own.
- `appbuild.DeclaredViewNames(declaration)` reads a version's views back out of its frozen declaration, which is what the daemon holds. It validates each name, so a declaration cannot smuggle a path segment into a file path.
- View names are `apps.ValidateViewName` — the app-name charset minus the reserved set, since a view is scoped to its app. It is the same rule that will parse the `app:<app>/<view>` tile kind.
- **Views are not on the wire yet.** `attn app status` shows no `views:` line and the `apps` snapshot does not exist: both need a protocol field, and slice 3 owns that bump with the registry snapshot. The way to see a view today is `attn app apply`'s per-artifact byte lines and the version directory.
- **Views are bundled but not typechecked.** The handler entrypoint is typechecked against the generated `Handlers` type; a view's `.tsx` is only bundled, so a type error in a view is not caught at apply. That waits on slice 2 — the SDK package and `jsxImportSource` are what a view typechecks against, and there is nothing to check it against until they exist.

## Scope

No protocol bump, no migration, no frontend. The fixtures import nothing from the SDK, per the slice brief — the one test that names `@victorarias/attn-app` asserts the specifier is left *unresolved* in the artifact, which is what proves the externals are in place for slice 2 rather than a dependency on it.
