### PR TITLE
feat(crew): give a session a name it keeps for the day

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -408,6 +408,11 @@ forgets that position and `--since <RFC3339>` replays from an instant.
   live here. `Status.RequireHome` is the fence every garden/crew surface calls;
   reach it from the daemon through `Daemon.requireHome`, never by reading the
   record yourself
+- `internal/crew`: what a crew member IS — the id rule, the stored registry
+  record, and how a home directory under `~/.attn/crew/` becomes one. Files stay
+  canonical: the registry records where a home lives, never what it says. The
+  daemon half (`internal/daemon/crew.go`) owns the binding a session launches
+  with and the one-active-binding-per-member rule over it
 - `internal/bus`: durable event bus (domain facts, per-consumer cursors)
 - `internal/docstore`: document-store query semantics, SQL compilation, and the
   physical naming (no DB handle; `internal/store/documents.go` executes what it

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -240,7 +240,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '241';
+export const PROTOCOL_VERSION = '242';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentMsgMessage, AgentMsgResult, AgentMsgStatus, AgentPeekMessage, AgentPeekResult, AgentPeekScreen, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, AppApplyMessage, AppApplyResult, AppConsumerInfo, AppInvocationInfo, AppListMessage, AppListResult, AppLogsMessage, AppLogsResult, AppRemoveMessage, AppRemoveResult, AppRollbackMessage, AppRollbackResult, AppRuntimeInfo, AppRuntimeRestartMessage, AppRuntimeRestartResult, AppRuntimeStatusMessage, AppRuntimeStatusResult, AppSetEnabledMessage, AppSetEnabledResult, AppStallInfo, AppStatusMessage, AppStatusResult, AppSummary, AppVersionInfo, AppWatchMessage, AppWatchResult, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, BusConsumerStatus, BusHealthEntry, BusProducerStatus, BusSetConsumerEnabledMessage, BusSetConsumerEnabledResultMessage, BusStatusGetMessage, BusStatusResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocUndefineMessage, DocUndefineResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GardenSeedsUpdatedMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, OpenSentFilesMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyInputProbeResultMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Seed, SeedEdge, SeedLinkMessage, SeedLinkResult, SeedListMessage, SeedListResult, SeedNote, SeedNoteMessage, SeedNoteResult, SeedNotesMessage, SeedNotesResult, SeedPlantMessage, SeedPlantResult, SeedReadyMessage, SeedReadyResult, SeedRelation, SeedShowMessage, SeedShowResult, SeedTransitionMessage, SeedTransitionResult, SeedVar, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessageWindowStatus, SessionMessagesChangedMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketRow, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentMsgMessage, AgentMsgResult, AgentMsgStatus, AgentPeekMessage, AgentPeekResult, AgentPeekScreen, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, AppApplyMessage, AppApplyResult, AppConsumerInfo, AppInvocationInfo, AppListMessage, AppListResult, AppLogsMessage, AppLogsResult, AppRemoveMessage, AppRemoveResult, AppRollbackMessage, AppRollbackResult, AppRuntimeInfo, AppRuntimeRestartMessage, AppRuntimeRestartResult, AppRuntimeStatusMessage, AppRuntimeStatusResult, AppSetEnabledMessage, AppSetEnabledResult, AppStallInfo, AppStatusMessage, AppStatusResult, AppSummary, AppVersionInfo, AppWatchMessage, AppWatchResult, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, BusConsumerStatus, BusHealthEntry, BusProducerStatus, BusSetConsumerEnabledMessage, BusSetConsumerEnabledResultMessage, BusStatusGetMessage, BusStatusResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, CrewListMessage, CrewListResult, CrewMember, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocUndefineMessage, DocUndefineResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GardenSeedsUpdatedMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, OpenSentFilesMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyInputProbeResultMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Seed, SeedEdge, SeedLinkMessage, SeedLinkResult, SeedListMessage, SeedListResult, SeedNote, SeedNoteMessage, SeedNoteResult, SeedNotesMessage, SeedNotesResult, SeedPlantMessage, SeedPlantResult, SeedReadyMessage, SeedReadyResult, SeedRelation, SeedShowMessage, SeedShowResult, SeedTransitionMessage, SeedTransitionResult, SeedVar, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessageWindowStatus, SessionMessagesChangedMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketRow, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const activityStatusMessage = Convert.toActivityStatusMessage(json);
 //   const activityStatusResult = Convert.toActivityStatusResult(json);
@@ -103,6 +103,9 @@
 //   const createWorktreeFromBranchMessage = Convert.toCreateWorktreeFromBranchMessage(json);
 //   const createWorktreeMessage = Convert.toCreateWorktreeMessage(json);
 //   const createWorktreeResultMessage = Convert.toCreateWorktreeResultMessage(json);
+//   const crewListMessage = Convert.toCrewListMessage(json);
+//   const crewListResult = Convert.toCrewListResult(json);
+//   const crewMember = Convert.toCrewMember(json);
 //   const daemonWarning = Convert.toDaemonWarning(json);
 //   const delegateMessage = Convert.toDelegateMessage(json);
 //   const delegateResult = Convert.toDelegateResult(json);
@@ -657,6 +660,7 @@ export enum AgentPeekMessageCmd {
 
 export interface AgentPeekResult {
     agent:                   string;
+    crew_member?:            string;
     label:                   string;
     last_assistant_message?: string;
     last_seen:               string;
@@ -1507,6 +1511,7 @@ export interface SessionObject {
     branch?:                    string;
     chief_of_staff?:            boolean;
     context_window_cap?:        number;
+    crew_member?:               string;
     delegated_from_chief?:      boolean;
     directory:                  string;
     endpoint_id?:               string;
@@ -1936,6 +1941,40 @@ export interface CreateWorktreeResultMessage {
 
 export enum CreateWorktreeResultMessageEvent {
     CreateWorktreeResult = "create_worktree_result",
+}
+
+export interface CrewListMessage {
+    cmd: CrewListMessageCmd;
+    [property: string]: any;
+}
+
+export enum CrewListMessageCmd {
+    CrewList = "crew_list",
+}
+
+export interface CrewListResult {
+    members: MemberElement[];
+    [property: string]: any;
+}
+
+export interface MemberElement {
+    awareness_dirs:   string[];
+    binding_session?: string;
+    charter_path:     string;
+    cwd?:             string;
+    home_dir:         string;
+    id:               string;
+    [property: string]: any;
+}
+
+export interface CrewMember {
+    awareness_dirs:   string[];
+    binding_session?: string;
+    charter_path:     string;
+    cwd?:             string;
+    home_dir:         string;
+    id:               string;
+    [property: string]: any;
 }
 
 export interface DaemonWarning {
@@ -4999,6 +5038,7 @@ export interface RegisterMessage {
     dir:          string;
     id:           string;
     label?:       string;
+    member?:      string;
     workspace_id: string;
     [property: string]: any;
 }
@@ -5143,6 +5183,7 @@ export interface Response {
     app_status_result?:                    AppStatusResultObject;
     app_watch_result?:                     AppWatchResultObject;
     authors?:                              AuthorElement[];
+    crew_list_result?:                     CrewListResultObject;
     data?:                                 string;
     delegate_result?:                      DelegateResultObject;
     delegation_operation?:                 DelegationOperationObject;
@@ -5215,6 +5256,7 @@ export interface AgentMsgResultObject {
 
 export interface AgentPeekResultObject {
     agent:                   string;
+    crew_member?:            string;
     label:                   string;
     last_assistant_message?: string;
     last_seen:               string;
@@ -5309,6 +5351,11 @@ export interface AppStatusResultObject {
 
 export interface AppWatchResultObject {
     invocation: InvocationElement;
+    [property: string]: any;
+}
+
+export interface CrewListResultObject {
+    members: MemberElement[];
     [property: string]: any;
 }
 
@@ -5974,6 +6021,7 @@ export interface Session {
     branch?:                    string;
     chief_of_staff?:            boolean;
     context_window_cap?:        number;
+    crew_member?:               string;
     delegated_from_chief?:      boolean;
     directory:                  string;
     endpoint_id?:               string;
@@ -8693,6 +8741,30 @@ export class Convert {
 
     public static createWorktreeResultMessageToJson(value: CreateWorktreeResultMessage): string {
         return JSON.stringify(uncast(value, r("CreateWorktreeResultMessage")), null, 2);
+    }
+
+    public static toCrewListMessage(json: string): CrewListMessage {
+        return cast(JSON.parse(json), r("CrewListMessage"));
+    }
+
+    public static crewListMessageToJson(value: CrewListMessage): string {
+        return JSON.stringify(uncast(value, r("CrewListMessage")), null, 2);
+    }
+
+    public static toCrewListResult(json: string): CrewListResult {
+        return cast(JSON.parse(json), r("CrewListResult"));
+    }
+
+    public static crewListResultToJson(value: CrewListResult): string {
+        return JSON.stringify(uncast(value, r("CrewListResult")), null, 2);
+    }
+
+    public static toCrewMember(json: string): CrewMember {
+        return cast(JSON.parse(json), r("CrewMember"));
+    }
+
+    public static crewMemberToJson(value: CrewMember): string {
+        return JSON.stringify(uncast(value, r("CrewMember")), null, 2);
     }
 
     public static toDaemonWarning(json: string): DaemonWarning {
@@ -12284,6 +12356,7 @@ const typeMap: any = {
     ], "any"),
     "AgentPeekResult": o([
         { json: "agent", js: "agent", typ: "" },
+        { json: "crew_member", js: "crew_member", typ: u(undefined, "") },
         { json: "label", js: "label", typ: "" },
         { json: "last_assistant_message", js: "last_assistant_message", typ: u(undefined, "") },
         { json: "last_seen", js: "last_seen", typ: "" },
@@ -12825,6 +12898,7 @@ const typeMap: any = {
         { json: "branch", js: "branch", typ: u(undefined, "") },
         { json: "chief_of_staff", js: "chief_of_staff", typ: u(undefined, true) },
         { json: "context_window_cap", js: "context_window_cap", typ: u(undefined, 0) },
+        { json: "crew_member", js: "crew_member", typ: u(undefined, "") },
         { json: "delegated_from_chief", js: "delegated_from_chief", typ: u(undefined, true) },
         { json: "directory", js: "directory", typ: "" },
         { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
@@ -13088,6 +13162,28 @@ const typeMap: any = {
         { json: "event", js: "event", typ: r("CreateWorktreeResultMessageEvent") },
         { json: "path", js: "path", typ: u(undefined, "") },
         { json: "success", js: "success", typ: true },
+    ], "any"),
+    "CrewListMessage": o([
+        { json: "cmd", js: "cmd", typ: r("CrewListMessageCmd") },
+    ], "any"),
+    "CrewListResult": o([
+        { json: "members", js: "members", typ: a(r("MemberElement")) },
+    ], "any"),
+    "MemberElement": o([
+        { json: "awareness_dirs", js: "awareness_dirs", typ: a("") },
+        { json: "binding_session", js: "binding_session", typ: u(undefined, "") },
+        { json: "charter_path", js: "charter_path", typ: "" },
+        { json: "cwd", js: "cwd", typ: u(undefined, "") },
+        { json: "home_dir", js: "home_dir", typ: "" },
+        { json: "id", js: "id", typ: "" },
+    ], "any"),
+    "CrewMember": o([
+        { json: "awareness_dirs", js: "awareness_dirs", typ: a("") },
+        { json: "binding_session", js: "binding_session", typ: u(undefined, "") },
+        { json: "charter_path", js: "charter_path", typ: "" },
+        { json: "cwd", js: "cwd", typ: u(undefined, "") },
+        { json: "home_dir", js: "home_dir", typ: "" },
+        { json: "id", js: "id", typ: "" },
     ], "any"),
     "DaemonWarning": o([
         { json: "code", js: "code", typ: "" },
@@ -14918,6 +15014,7 @@ const typeMap: any = {
         { json: "dir", js: "dir", typ: "" },
         { json: "id", js: "id", typ: "" },
         { json: "label", js: "label", typ: u(undefined, "") },
+        { json: "member", js: "member", typ: u(undefined, "") },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
     "RegisterWorkspaceMessage": o([
@@ -14998,6 +15095,7 @@ const typeMap: any = {
         { json: "app_status_result", js: "app_status_result", typ: u(undefined, r("AppStatusResultObject")) },
         { json: "app_watch_result", js: "app_watch_result", typ: u(undefined, r("AppWatchResultObject")) },
         { json: "authors", js: "authors", typ: u(undefined, a(r("AuthorElement"))) },
+        { json: "crew_list_result", js: "crew_list_result", typ: u(undefined, r("CrewListResultObject")) },
         { json: "data", js: "data", typ: u(undefined, "") },
         { json: "delegate_result", js: "delegate_result", typ: u(undefined, r("DelegateResultObject")) },
         { json: "delegation_operation", js: "delegation_operation", typ: u(undefined, r("DelegationOperationObject")) },
@@ -15064,6 +15162,7 @@ const typeMap: any = {
     ], "any"),
     "AgentPeekResultObject": o([
         { json: "agent", js: "agent", typ: "" },
+        { json: "crew_member", js: "crew_member", typ: u(undefined, "") },
         { json: "label", js: "label", typ: "" },
         { json: "last_assistant_message", js: "last_assistant_message", typ: u(undefined, "") },
         { json: "last_seen", js: "last_seen", typ: "" },
@@ -15138,6 +15237,9 @@ const typeMap: any = {
     ], "any"),
     "AppWatchResultObject": o([
         { json: "invocation", js: "invocation", typ: r("InvocationElement") },
+    ], "any"),
+    "CrewListResultObject": o([
+        { json: "members", js: "members", typ: a(r("MemberElement")) },
     ], "any"),
     "DocCollectionsResultObject": o([
         { json: "collections", js: "collections", typ: a(r("Schema")) },
@@ -15603,6 +15705,7 @@ const typeMap: any = {
         { json: "branch", js: "branch", typ: u(undefined, "") },
         { json: "chief_of_staff", js: "chief_of_staff", typ: u(undefined, true) },
         { json: "context_window_cap", js: "context_window_cap", typ: u(undefined, 0) },
+        { json: "crew_member", js: "crew_member", typ: u(undefined, "") },
         { json: "delegated_from_chief", js: "delegated_from_chief", typ: u(undefined, true) },
         { json: "directory", js: "directory", typ: "" },
         { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
@@ -16937,6 +17040,9 @@ const typeMap: any = {
     ],
     "CreateWorktreeResultMessageEvent": [
         "create_worktree_result",
+    ],
+    "CrewListMessageCmd": [
+        "crew_list",
     ],
     "DelegateMessageCmd": [
         "delegate",

--- a/changelog.d/crew-registry-and-binding.yaml
+++ b/changelog.d/crew-registry-and-binding.yaml
@@ -1,0 +1,15 @@
+kind: added
+area: cli
+change: >
+  attn now knows the crew. A crew member is a durable named identity — its
+  home stays plain, hand-editable markdown at `~/.attn/crew/<name>/`, and the
+  daemon registers every home it finds there at startup, including one you add
+  by hand. `attn crew list` names the roster and says who is awake. A session
+  launches as a member with `attn <agent> --member <name>`, which is what makes
+  it that member: the binding is stamped at launch, `attn agent list` and
+  `attn agent peek` show it, and two agents with the same identity never run at
+  once — waking a member whose day is already live is refused, naming the
+  session that holds it. Where a garden tender's name matches a registered
+  member it now resolves to that member; workers and errand sessions keep
+  tending under any name they like. Nothing changes for a session launched
+  without `--member`.

--- a/cmd/attn/agent.go
+++ b/cmd/attn/agent.go
@@ -79,8 +79,10 @@ type agentListRow struct {
 	State     string `json:"state"`
 	TurnOwed  bool   `json:"turn_owed"`
 	// Member is the crew member this session is bound as — "this session is
-	// trellis today" — empty for the unbound majority.
-	Member string `json:"member,omitempty"`
+	// trellis today" — empty for the unbound majority. Always written, like
+	// every other column: a key that disappears makes every reader of this
+	// address book guard for it.
+	Member string `json:"member"`
 }
 
 func runAgentList(args []string) {

--- a/cmd/attn/agent.go
+++ b/cmd/attn/agent.go
@@ -78,6 +78,9 @@ type agentListRow struct {
 	Directory string `json:"directory"`
 	State     string `json:"state"`
 	TurnOwed  bool   `json:"turn_owed"`
+	// Member is the crew member this session is bound as — "this session is
+	// trellis today" — empty for the unbound majority.
+	Member string `json:"member,omitempty"`
 }
 
 func runAgentList(args []string) {
@@ -115,6 +118,7 @@ func agentListRows(result *client.ListResult) []agentListRow {
 			Directory: session.Directory,
 			State:     string(session.State),
 			TurnOwed:  protocol.Deref(session.TurnOwed),
+			Member:    protocol.Deref(session.CrewMember),
 		})
 	}
 	sort.Slice(rows, func(i, j int) bool {
@@ -131,7 +135,7 @@ func printAgentList(w io.Writer, rows []agentListRow) {
 		fmt.Fprintln(w, "No sessions on this daemon.")
 		return
 	}
-	fmt.Fprintf(w, "%-*s  %-18s  %-8s  %-20s  %-16s  %s\n", agentShortIDLength, "ID", "NAME", "AGENT", "WORKSPACE", "STATE", "TURN")
+	fmt.Fprintf(w, "%-*s  %-18s  %-8s  %-10s  %-20s  %-16s  %s\n", agentShortIDLength, "ID", "NAME", "AGENT", "MEMBER", "WORKSPACE", "STATE", "TURN")
 	for _, row := range rows {
 		turn := "-"
 		if row.TurnOwed {
@@ -139,10 +143,11 @@ func printAgentList(w io.Writer, rows []agentListRow) {
 		}
 		fmt.Fprintf(
 			w,
-			"%-*s  %-18s  %-8s  %-20s  %-16s  %s\n",
+			"%-*s  %-18s  %-8s  %-10s  %-20s  %-16s  %s\n",
 			agentShortIDLength, agentShortID(row.ID),
 			agentListCell(row.Label, 18),
 			agentListCell(row.Agent, 8),
+			agentListCell(row.Member, 10),
 			agentListCell(row.Workspace, 20),
 			agentListCell(row.State, 16),
 			turn,
@@ -228,6 +233,9 @@ func agentPeekErrorMessage(target string, err error) string {
 
 func printAgentPeek(w io.Writer, result *protocol.AgentPeekResult) {
 	fmt.Fprintf(w, "session %s (%s) — %s\n", result.SessionID, result.Agent, result.Label)
+	if member := strings.TrimSpace(protocol.Deref(result.CrewMember)); member != "" {
+		fmt.Fprintf(w, "crew member: this session is %s today\n", member)
+	}
 	workspace := strings.TrimSpace(protocol.Deref(result.WorkspaceTitle))
 	if workspace != "" {
 		fmt.Fprintf(w, "workspace: %s\n", workspace)

--- a/cmd/attn/crew.go
+++ b/cmd/attn/crew.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/victorarias/attn/internal/client"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// `attn crew` is the roster's agent surface. A crew member is a durable named
+// identity — charter, handoff line, address — whose sessions are its days; the
+// registry serves reads over the plain-markdown homes at `~/.attn/crew/`.
+// Launching bound is `attn <agent> --member <name>`; this command answers who
+// exists and who is awake.
+
+func runCrew() {
+	if len(os.Args) < 3 || os.Args[2] == "-h" || os.Args[2] == "--help" {
+		writeCrewHelp(os.Stdout)
+		return
+	}
+	switch os.Args[2] {
+	case "list", "ls":
+		runCrewList(os.Args[3:])
+	default:
+		fmt.Fprintf(os.Stderr, "crew: unknown command %q\n", os.Args[2])
+		writeCrewHelp(os.Stderr)
+		os.Exit(2)
+	}
+}
+
+func writeCrewHelp(w io.Writer) {
+	fmt.Fprint(w, `usage: attn crew <command>
+
+The crew is the roster of durable named identities. A member's home is plain
+markdown at ~/.attn/crew/<name>/; the registry serves reads over it, and a
+session becomes a member by launching as one: attn <agent> --member <name>.
+
+The crew lives at the home daemon. On an outpost every command here refuses,
+naming the home to run it on.
+
+commands:
+  list [--json]
+        every registered member, awake or asleep. An awake member names the
+        session living its current day.
+`)
+}
+
+type crewListArgs struct {
+	json bool
+}
+
+func parseCrewListArgs(args []string) (crewListArgs, error) {
+	fs := flag.NewFlagSet("crew list", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	jsonOut := fs.Bool("json", false, "print the machine result as JSON")
+	if err := fs.Parse(args); err != nil {
+		return crewListArgs{}, err
+	}
+	if fs.NArg() != 0 {
+		return crewListArgs{}, errors.New("crew list takes no arguments")
+	}
+	return crewListArgs{json: *jsonOut}, nil
+}
+
+func runCrewList(args []string) {
+	parsed, err := parseCrewListArgs(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "crew list: %v\n", err)
+		writeCrewHelp(os.Stderr)
+		os.Exit(2)
+	}
+	result, err := client.New("").CrewList()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "crew list: %v\n", err)
+		os.Exit(1)
+	}
+	if parsed.json {
+		printJSON(result.Members)
+		return
+	}
+	printCrewList(os.Stdout, result.Members)
+}
+
+func printCrewList(w io.Writer, members []protocol.CrewMember) {
+	if len(members) == 0 {
+		fmt.Fprintln(w, "No crew members are registered. A home at ~/.attn/crew/<name>/CHARTER.md joins the roster at the daemon's next start.")
+		return
+	}
+	fmt.Fprintf(w, "%-12s  %-8s  %-10s  %s\n", "MEMBER", "STATE", "SESSION", "HOME")
+	for _, member := range members {
+		state, session := "asleep", "-"
+		if id := strings.TrimSpace(protocol.Deref(member.BindingSession)); id != "" {
+			state, session = "awake", agentShortID(id)
+		}
+		fmt.Fprintf(w, "%-12s  %-8s  %-10s  %s\n", member.ID, state, session, member.HomeDir)
+	}
+	fmt.Fprintf(w, "\nAn awake member's SESSION is what `attn agent peek <id>` takes.\n")
+}

--- a/cmd/attn/crew_test.go
+++ b/cmd/attn/crew_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -66,6 +67,15 @@ func TestAgentListRows_CarryTheCrewMember(t *testing.T) {
 	}
 	if rows[1].Member != "" {
 		t.Errorf("unbound row member = %q, want empty", rows[1].Member)
+	}
+	// The column is always on the wire, empty rather than absent: a reader of
+	// the address book must not have to guard for a missing key.
+	encoded, err := json.Marshal(rows[1])
+	if err != nil {
+		t.Fatalf("marshal row: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"member"`) {
+		t.Errorf("an unbound row drops the member key: %s", encoded)
 	}
 
 	var out bytes.Buffer

--- a/cmd/attn/crew_test.go
+++ b/cmd/attn/crew_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/client"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+func TestParseCrewListArgs(t *testing.T) {
+	parsed, err := parseCrewListArgs([]string{"--json"})
+	if err != nil || !parsed.json {
+		t.Fatalf("parseCrewListArgs(--json) = %+v, %v", parsed, err)
+	}
+	for _, args := range [][]string{{"extra"}, {"--nope"}} {
+		if _, err := parseCrewListArgs(args); err == nil {
+			t.Errorf("parseCrewListArgs(%v) accepted what it should refuse", args)
+		}
+	}
+}
+
+// The roster shows every member, awake or asleep — a sleeping member is one
+// action from waking, never something to go find.
+func TestPrintCrewList_ShowsSleepingAndAwakeMembers(t *testing.T) {
+	var out bytes.Buffer
+	printCrewList(&out, []protocol.CrewMember{
+		{ID: "keel", HomeDir: "/home/.attn/crew/keel"},
+		{ID: "trellis", HomeDir: "/home/.attn/crew/trellis", BindingSession: protocol.Ptr("sess-abcdef123456")},
+	})
+	text := out.String()
+	for _, want := range []string{"keel", "asleep", "trellis", "awake", "sess-abc", "/home/.attn/crew/keel"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("crew list output is missing %q:\n%s", want, text)
+		}
+	}
+	// The session column is the short id `attn agent peek` takes, not the full one.
+	if strings.Contains(text, "sess-abcdef123456") {
+		t.Errorf("crew list printed a full session id:\n%s", text)
+	}
+}
+
+// An empty roster says how a member joins it, rather than leaving the reader
+// with nothing to act on.
+func TestPrintCrewList_EmptyRosterSaysHowToJoinIt(t *testing.T) {
+	var out bytes.Buffer
+	printCrewList(&out, nil)
+	if !strings.Contains(out.String(), "CHARTER.md") {
+		t.Errorf("an empty roster does not say what makes a home:\n%s", out.String())
+	}
+}
+
+// `agent list` is the address book, and a bound session's row says who it is
+// today.
+func TestAgentListRows_CarryTheCrewMember(t *testing.T) {
+	rows := agentListRows(&client.ListResult{
+		Sessions: []protocol.Session{
+			{ID: "aaaa1111", Label: "alpha", Agent: "claude", WorkspaceID: "ws-1", State: "idle", CrewMember: protocol.Ptr("trellis")},
+			{ID: "bbbb2222", Label: "beta", Agent: "codex", WorkspaceID: "ws-1", State: "idle"},
+		},
+		Workspaces: []protocol.Workspace{{ID: "ws-1", Title: "attn"}},
+	})
+	if rows[0].Member != "trellis" {
+		t.Errorf("bound row member = %q, want trellis", rows[0].Member)
+	}
+	if rows[1].Member != "" {
+		t.Errorf("unbound row member = %q, want empty", rows[1].Member)
+	}
+
+	var out bytes.Buffer
+	printAgentList(&out, rows)
+	text := out.String()
+	if !strings.Contains(text, "MEMBER") || !strings.Contains(text, "trellis") {
+		t.Errorf("agent list does not show the member column:\n%s", text)
+	}
+	// An unbound session's cell is the same placeholder every empty cell uses,
+	// not a blank that shifts the columns.
+	if strings.Contains(text, "beta") && !strings.Contains(text, "-") {
+		t.Errorf("an unbound row has no placeholder:\n%s", text)
+	}
+}

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -251,6 +251,9 @@ func main() {
 	case "seed":
 		maybePrintProfileBanner()
 		runSeed()
+	case "crew":
+		maybePrintProfileBanner()
+		runCrew()
 	case "doc":
 		maybePrintProfileBanner()
 		runDoc()
@@ -661,6 +664,7 @@ commands:
   bus <command>                     event bus: consumer cursors, lag, kill switch
   enrollment <command>              this daemon's home: status, enroll, leave
   seed <command>                    the garden: plant, tend, harvest, note, ls
+  crew <command>                    the crew roster: who exists, who is awake
   doc <command>                     document store: collections, documents, live queries
   app <command>                     apps: list, status, enable, disable, remove
   vision-check <image> <question>   answer a question about an image (single LLM call)
@@ -2903,6 +2907,7 @@ type directLaunchArgs struct {
 	resumePicker      bool
 	yoloMode          bool
 	initialPromptFile string
+	member            string
 }
 
 func readInitialPromptFile(path string) (string, error) {
@@ -2915,8 +2920,8 @@ func readInitialPromptFile(path string) (string, error) {
 }
 
 // parseDirectLaunchArgs parses the wrapper launch flags. attn understands only
-// -s, --resume, --yolo, and the internal --initial-prompt-file flag; any other
-// argument is an error. We deliberately do not forward unrecognized args to the underlying agent — that implicit
+// -s, --resume, --yolo, --member, and the internal --initial-prompt-file flag;
+// any other argument is an error. We deliberately do not forward unrecognized args to the underlying agent — that implicit
 // passthrough was never used by attn itself and only created confusion (e.g.
 // `attn --help` printing the agent's help instead of attn's).
 func parseDirectLaunchArgs(args []string) (directLaunchArgs, error) {
@@ -2940,6 +2945,12 @@ func parseDirectLaunchArgs(args []string) (directLaunchArgs, error) {
 			}
 		case "--yolo":
 			parsed.yoloMode = true
+		case "--member":
+			if i+1 >= len(args) {
+				return directLaunchArgs{}, fmt.Errorf("flag --member needs a value: the crew member this session launches as (`attn crew list` names the roster)")
+			}
+			parsed.member = args[i+1]
+			i++
 		case "--initial-prompt-file":
 			if i+1 >= len(args) {
 				return directLaunchArgs{}, fmt.Errorf("flag --initial-prompt-file needs a value")
@@ -2951,7 +2962,12 @@ func parseDirectLaunchArgs(args []string) (directLaunchArgs, error) {
 		}
 	}
 	if label == "" {
-		label = wrapper.DefaultLabel()
+		// A member's day is named after the member; -s still overrides.
+		if parsed.member != "" {
+			label = parsed.member
+		} else {
+			label = wrapper.DefaultLabel()
+		}
 	}
 	parsed.label = label
 	return parsed, nil
@@ -3033,8 +3049,21 @@ func runAgentDirectly(requestedAgent string) {
 	if sessionID == "" {
 		sessionID = wrapper.GenerateSessionID()
 	}
+	if managedMode && parsed.member != "" {
+		// The daemon-owned spawn path does not carry a binding yet (the wake
+		// slice adds it); running anyway would silently drop the identity.
+		fmt.Fprintf(os.Stderr, "attn: --member is not supported on daemon-managed launches yet\n")
+		os.Exit(1)
+	}
 	if !managedMode {
-		if err := c.RegisterWithAgent(sessionID, parsed.label, cwd, driver.Name()); err != nil {
+		err := c.RegisterAsMember(sessionID, parsed.label, cwd, driver.Name(), parsed.member)
+		switch {
+		case err != nil && parsed.member != "":
+			// The binding IS the identity: a member launch that cannot bind does
+			// not run, or two trellises could exist the moment the daemon is down.
+			fmt.Fprintf(os.Stderr, "attn: %v\n", err)
+			os.Exit(1)
+		case err != nil:
 			fmt.Fprintf(os.Stderr, "warning: could not register session: %v\n", err)
 		}
 	}

--- a/cmd/attn/main_test.go
+++ b/cmd/attn/main_test.go
@@ -256,8 +256,34 @@ func TestParseDirectLaunchArgs_LabelAndYolo(t *testing.T) {
 	}
 }
 
-// parseDirectLaunchArgs understands only -s/--resume/--yolo. Everything else is
-// rejected rather than silently forwarded to the underlying agent.
+// A member launch names who the session is. The label follows the member, so a
+// member's day is titled after it without anybody typing -s.
+func TestParseDirectLaunchArgs_MemberNamesTheSession(t *testing.T) {
+	parsed, err := parseDirectLaunchArgs([]string{"--member", "trellis"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parsed.member != "trellis" {
+		t.Fatalf("member = %q, want trellis", parsed.member)
+	}
+	if parsed.label != "trellis" {
+		t.Fatalf("label = %q, want the member's name", parsed.label)
+	}
+}
+
+// -s still wins: the member decides identity, the label decides display.
+func TestParseDirectLaunchArgs_LabelOverridesTheMemberName(t *testing.T) {
+	parsed, err := parseDirectLaunchArgs([]string{"--member", "trellis", "-s", "crew slice 1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parsed.member != "trellis" || parsed.label != "crew slice 1" {
+		t.Fatalf("member/label = %q/%q, want trellis/crew slice 1", parsed.member, parsed.label)
+	}
+}
+
+// parseDirectLaunchArgs understands only -s/--resume/--yolo/--member.
+// Everything else is rejected rather than silently forwarded to the agent.
 func TestParseDirectLaunchArgs_RejectsUnrecognizedArgs(t *testing.T) {
 	for _, args := range [][]string{
 		{"--model", "foo"}, // arbitrary agent flag
@@ -265,6 +291,7 @@ func TestParseDirectLaunchArgs_RejectsUnrecognizedArgs(t *testing.T) {
 		{"--help"},         // must not reach the agent
 		{"random"},         // bare positional
 		{"-s"},             // missing label value
+		{"--member"},       // missing member value
 	} {
 		if _, err := parseDirectLaunchArgs(args); err == nil {
 			t.Fatalf("expected error for args %#v, got nil", args)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -481,6 +481,42 @@ independent.
 Plan:
 [docs/plans/2026-08-06-the-garden-vertical-slices.md](plans/2026-08-06-the-garden-vertical-slices.md).
 
+## The crew
+
+The **crew** is the roster of durable named identities. A **crew member** —
+keel, alder, trellis — is a charter, a handoff line, and an address; its
+sessions are its **days**. A member belongs to a home daemon, for the same
+reason the garden does: one roster across a fleet is its whole point.
+
+A member's **home** is plain markdown on disk at `~/.attn/crew/<name>/`: a
+`CHARTER.md` saying what it cares about, and dated **handoffs** it writes to
+its successor at the end of a day. Files are canonical and hand-editable —
+which is what lets any agent be a member, claude or codex or something later.
+The **registry** is the daemon's index over those homes (member id, charter
+path, home dir, cwd, awareness dirs, active binding); it serves reads and is
+never a second authority for the prose. A home the user adds by hand joins the
+roster at the daemon's next start.
+
+**Identity is the invocation, never the files.** A session is a member because
+it was launched as one — the daemon stamps a **binding** at launch
+(`attn <agent> --member <name>`), and that binding is what `attn agent list`
+and `attn agent peek` report. Reading a charter confers nothing. One member has
+one active binding: **two agents with the same identity never run at once**, and
+waking a member whose day is live is refused rather than duplicated.
+Parallelism means another member, never a second copy. A binding naming a
+session the daemon no longer knows has let go on its own, the same liveness
+rule a seed's tender follows.
+
+Tending is not a crew privilege: workers and errand sessions tend seeds too,
+under any free-string name. Where a tender's name happens to match a registered
+member it resolves to that member's id, so the claim compares addresses rather
+than spellings — but the registry is never a requirement to tend. The two
+handoffs stay apart on purpose: a **seed handoff** is the work item's thread,
+written by whoever tends it; a **crew handoff** is the member's day-line.
+
+Plan:
+[docs/plans/2026-08-11-the-crew-primitive.md](plans/2026-08-11-the-crew-primitive.md).
+
 ## Home daemon
 
 A daemon that is **its own home** — standalone, complete, owning its garden,

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -218,6 +218,14 @@ func (c *Client) Register(id, label, dir string) error {
 // RegisterWithAgent registers a new session with an explicit agent.
 // agent should be "claude", "codex", or "copilot"; empty preserves daemon default behavior.
 func (c *Client) RegisterWithAgent(id, label, dir, agent string) error {
+	return c.RegisterAsMember(id, label, dir, agent, "")
+}
+
+// RegisterAsMember is RegisterWithAgent with a crew member binding: the daemon
+// resolves the name against the registry and stamps the binding, or refuses
+// the whole registration — the caller must treat that as launch-fatal, because
+// a member launch that runs unbound is an identity silently dropped.
+func (c *Client) RegisterAsMember(id, label, dir, agent, member string) error {
 	msg := protocol.RegisterMessage{
 		Cmd:         protocol.CmdRegister,
 		ID:          id,
@@ -228,6 +236,9 @@ func (c *Client) RegisterWithAgent(id, label, dir, agent string) error {
 	if agent != "" {
 		normalized := protocol.NormalizeSessionAgentString(agent, string(protocol.SessionAgentCodex))
 		msg.Agent = protocol.Ptr(normalized)
+	}
+	if member != "" {
+		msg.Member = protocol.Ptr(member)
 	}
 	_, err := c.send(msg)
 	return err

--- a/internal/client/crew.go
+++ b/internal/client/crew.go
@@ -1,0 +1,19 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// CrewList reads the crew roster: every registered member, awake or asleep.
+func (c *Client) CrewList() (*protocol.CrewListResult, error) {
+	resp, err := c.send(protocol.CrewListMessage{Cmd: protocol.CmdCrewList})
+	if err != nil {
+		return nil, err
+	}
+	if resp.CrewListResult == nil {
+		return nil, fmt.Errorf("the daemon answered without a roster")
+	}
+	return resp.CrewListResult, nil
+}

--- a/internal/crew/crew.go
+++ b/internal/crew/crew.go
@@ -1,0 +1,186 @@
+// Package crew is attn's roster of durable named identities. A crew member is
+// a charter, a handoff line, and an address; its sessions are its days. The
+// member's home stays plain hand-editable markdown on disk — this package owns
+// the registry over those homes: what a member record IS, how a home directory
+// becomes one, and how a free-string member name resolves to a registered id.
+//
+// It holds no database handle and knows nothing about the daemon —
+// internal/daemon stores what is built here, under the collection declared
+// here. Identity is the invocation, never the files: a session is a member
+// because the daemon stamped a binding at its launch, and reading a charter
+// confers nothing.
+//
+// Design: docs/plans/2026-08-11-the-crew-primitive.md.
+package crew
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/victorarias/attn/internal/docstore"
+)
+
+// Surface is what the enrollment fence refuses by name on an outpost. One
+// string, so every crew verb refuses in the same words.
+const Surface = "the crew"
+
+// The crew's document-store address. `core/` is attn's own namespace owner.
+const (
+	Namespace         = "core/crew"
+	CollectionMembers = "members"
+)
+
+// HomesDirName is where members live under the data dir: `~/.attn/crew/<id>/`,
+// plain markdown, hand-editable by design. The registry serves reads over it
+// and never becomes a second authority for the prose.
+const HomesDirName = "crew"
+
+// CharterFileName is the one file that makes a directory a member's home.
+const CharterFileName = "CHARTER.md"
+
+// Member is a member's stored body — the registry record, without the store's
+// own envelope. Every declared field is written unconditionally, empty string
+// included, so a filter on `binding_session = ""` matches the members that are
+// asleep.
+//
+// The whole designed schema is here from the first slice even though only part
+// of it moves: `cwd` and `awareness_dirs` are written and returned, and the
+// wake slice gives them meaning without touching a single stored body.
+type Member struct {
+	// ID is the member's durable address — the home directory's name, lowercase,
+	// sayable. It is what recognition will later ride, so nothing renames it.
+	ID string `json:"id"`
+	// CharterPath and HomeDir point at the canonical files; the registry never
+	// copies their prose.
+	CharterPath string `json:"charter_path"`
+	HomeDir     string `json:"home_dir"`
+	// CWD is where the member's sessions launch; empty until the wake slice
+	// records one.
+	CWD string `json:"cwd"`
+	// AwarenessDirs are the places the member's charter is about.
+	AwarenessDirs []string `json:"awareness_dirs"`
+	// BindingSession is the session living this member's current day, or empty.
+	// One active binding per member is the single-holder rule; whether a
+	// non-empty value still binds is judged at read against live sessions, so a
+	// day that ended without ceremony releases on its own.
+	BindingSession string `json:"binding_session"`
+}
+
+// MembersSchema declares which fields a query may name. Everything else in the
+// body is stored and returned untouched.
+func MembersSchema() docstore.CollectionSchema {
+	return docstore.CollectionSchema{
+		Namespace:  Namespace,
+		Collection: CollectionMembers,
+		Fields: []docstore.FieldSpec{
+			{Name: "binding_session", Type: docstore.FieldString},
+		},
+	}
+}
+
+// Encode renders a member as its stored body.
+func (m Member) Encode() ([]byte, error) {
+	if m.AwarenessDirs == nil {
+		m.AwarenessDirs = []string{}
+	}
+	return json.Marshal(m)
+}
+
+// Decode reads a stored body. Unknown keys are ignored on purpose: a record
+// written by a later attn stays readable by an older one.
+func Decode(body []byte) (Member, error) {
+	var member Member
+	if err := json.Unmarshal(body, &member); err != nil {
+		return Member{}, fmt.Errorf("this member's stored record is not readable: %w", err)
+	}
+	return member, nil
+}
+
+// MaxIDChars bounds a member id. A member's name is said out loud and typed
+// into a flag; the longest real one is 7 characters (`trellis`), so 40 is a
+// tripwire only a generated string touches.
+const MaxIDChars = 40
+
+var memberIDRe = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+
+// ValidateID accepts a member id, naming the shape it wanted. The rule is the
+// home directory's: lowercase, starts with a letter, sayable.
+func ValidateID(id string) error {
+	if id == "" {
+		return fmt.Errorf("a member id is required")
+	}
+	if len(id) > MaxIDChars {
+		return fmt.Errorf("%q is %d characters and a member id's limit is %d — a member's name is said out loud", id, len(id), MaxIDChars)
+	}
+	if !memberIDRe.MatchString(id) {
+		return fmt.Errorf("%q is not a member id: lowercase letters, digits and - only, starting with a letter, like `trellis`", id)
+	}
+	return docstore.ValidateDocumentID(id)
+}
+
+// Resolve finds the registered member a free-string name addresses, folding
+// case so `Trellis` reaches `trellis`. The second return is false when nothing
+// is registered under that name — which is a normal answer, not an error: the
+// garden's free-string members keep tending unregistered.
+func Resolve(name string, members []Member) (Member, bool) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return Member{}, false
+	}
+	for _, m := range members {
+		if strings.EqualFold(m.ID, name) {
+			return m, true
+		}
+	}
+	return Member{}, false
+}
+
+// ScanHomes reads a crew directory into the member records it holds: every
+// subdirectory with a CHARTER.md is a home. Loose files beside the homes
+// (CREW.md, notes) are not members and are skipped silently; a directory whose
+// name is not a member id is skipped with its reason, so a typo'd home is
+// named rather than quietly absent from the roster.
+//
+// A missing crew directory is an empty roster, not an error: every fresh
+// install starts without one.
+func ScanHomes(dir string, warn func(format string, args ...any)) ([]Member, error) {
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading crew homes at %s: %w", dir, err)
+	}
+	if warn == nil {
+		warn = func(string, ...any) {}
+	}
+	var members []Member
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		id := entry.Name()
+		home := filepath.Join(dir, id)
+		charter := filepath.Join(home, CharterFileName)
+		if _, err := os.Stat(charter); err != nil {
+			continue
+		}
+		if err := ValidateID(id); err != nil {
+			warn("crew: skipping home %s: %v", home, err)
+			continue
+		}
+		members = append(members, Member{
+			ID:            id,
+			CharterPath:   charter,
+			HomeDir:       home,
+			AwarenessDirs: []string{},
+		})
+	}
+	sort.Slice(members, func(i, j int) bool { return members[i].ID < members[j].ID })
+	return members, nil
+}

--- a/internal/crew/crew_test.go
+++ b/internal/crew/crew_test.go
@@ -1,0 +1,206 @@
+package crew
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeCrewFixture builds a copy of the real `~/.attn/crew` shape: three
+// members, each with a charter and dated handoff files, plus the loose CREW.md
+// that sits beside the homes. Copied by shape, never from the live directory.
+func writeCrewFixture(t *testing.T) string {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "crew")
+	mustWrite(t, filepath.Join(root, "CREW.md"), "# The crew\n\nkeel, alder, trellis.\n")
+	for _, member := range []struct {
+		id       string
+		handoffs []string
+	}{
+		{"alder", []string{"2026-08-06T22-51Z-alder.md", "2026-08-10T19-20Z-alder.md"}},
+		{"keel", []string{"2026-08-06T00-30Z-keel.md", "2026-08-13T22-10Z-keel.md"}},
+		{"trellis", []string{"2026-08-13T22-20Z-trellis.md"}},
+	} {
+		home := filepath.Join(root, member.id)
+		mustWrite(t, filepath.Join(home, CharterFileName), "# "+member.id+"\n\nWhat I care about.\n")
+		for _, name := range member.handoffs {
+			mustWrite(t, filepath.Join(home, "handoffs", name), "Where I left off.\n")
+		}
+	}
+	return root
+}
+
+func mustWrite(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestScanHomes_ReadsEveryHomeAndPointsAtItsFiles(t *testing.T) {
+	root := writeCrewFixture(t)
+
+	members, err := ScanHomes(root, nil)
+	if err != nil {
+		t.Fatalf("ScanHomes: %v", err)
+	}
+
+	var ids []string
+	for _, m := range members {
+		ids = append(ids, m.ID)
+	}
+	if got, want := strings.Join(ids, ","), "alder,keel,trellis"; got != want {
+		t.Fatalf("members = %q, want %q", got, want)
+	}
+	for _, m := range members {
+		if want := filepath.Join(root, m.ID); m.HomeDir != want {
+			t.Errorf("%s home = %q, want %q", m.ID, m.HomeDir, want)
+		}
+		if want := filepath.Join(root, m.ID, CharterFileName); m.CharterPath != want {
+			t.Errorf("%s charter = %q, want %q", m.ID, m.CharterPath, want)
+		}
+		if _, err := os.Stat(m.CharterPath); err != nil {
+			t.Errorf("%s charter does not exist: %v", m.ID, err)
+		}
+	}
+}
+
+// The registry records where a home lives; the prose stays on disk. Nothing a
+// scan produces carries the charter's text.
+func TestScanHomes_CarriesNoProse(t *testing.T) {
+	root := writeCrewFixture(t)
+	body := "the charter's own words"
+	mustWrite(t, filepath.Join(root, "keel", CharterFileName), body)
+
+	members, err := ScanHomes(root, nil)
+	if err != nil {
+		t.Fatalf("ScanHomes: %v", err)
+	}
+	for _, m := range members {
+		encoded, err := m.Encode()
+		if err != nil {
+			t.Fatalf("encode %s: %v", m.ID, err)
+		}
+		if strings.Contains(string(encoded), body) {
+			t.Fatalf("%s's record carries the charter's prose: %s", m.ID, encoded)
+		}
+	}
+}
+
+func TestScanHomes_SkipsWhatIsNotAHome(t *testing.T) {
+	root := writeCrewFixture(t)
+	// A directory with no charter is not a home — a stray notes folder.
+	mustWrite(t, filepath.Join(root, "scratch", "note.md"), "not a member\n")
+	// A directory whose name cannot be a member id is named, not swallowed.
+	mustWrite(t, filepath.Join(root, "Not A Member", CharterFileName), "# nope\n")
+
+	var warnings []string
+	members, err := ScanHomes(root, func(format string, args ...any) {
+		warnings = append(warnings, format)
+	})
+	if err != nil {
+		t.Fatalf("ScanHomes: %v", err)
+	}
+	if len(members) != 3 {
+		t.Fatalf("members = %d, want the 3 real homes", len(members))
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %d (%v), want exactly the unusable home named", len(warnings), warnings)
+	}
+}
+
+// A fresh install has no crew directory. That is an empty roster, not a
+// failure: nothing should log or refuse over it.
+func TestScanHomes_MissingDirectoryIsAnEmptyRoster(t *testing.T) {
+	members, err := ScanHomes(filepath.Join(t.TempDir(), "no-crew-here"), func(string, ...any) {
+		t.Error("a missing crew directory warned")
+	})
+	if err != nil {
+		t.Fatalf("ScanHomes: %v", err)
+	}
+	if len(members) != 0 {
+		t.Fatalf("members = %d, want none", len(members))
+	}
+}
+
+func TestValidateID(t *testing.T) {
+	for _, ok := range []string{"trellis", "keel", "a", "night-shift", "k2"} {
+		if err := ValidateID(ok); err != nil {
+			t.Errorf("ValidateID(%q) = %v, want accepted", ok, err)
+		}
+	}
+	for _, bad := range []string{"", "Trellis", "2keel", "with space", "with/slash", "-lead", strings.Repeat("a", MaxIDChars+1)} {
+		if err := ValidateID(bad); err == nil {
+			t.Errorf("ValidateID(%q) = nil, want refused", bad)
+		}
+	}
+}
+
+// The limit failure names the limit, its value, and the ask.
+func TestValidateID_LongNameNamesTheLimitAndTheAsk(t *testing.T) {
+	asked := strings.Repeat("a", MaxIDChars+7)
+	err := ValidateID(asked)
+	if err == nil {
+		t.Fatal("ValidateID accepted an over-long id")
+	}
+	for _, want := range []string{"47", "40"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not carry %q", err, want)
+		}
+	}
+}
+
+func TestResolve_FoldsCaseAndAnswersNoForStrangers(t *testing.T) {
+	members := []Member{{ID: "keel"}, {ID: "trellis"}}
+
+	for _, name := range []string{"trellis", "Trellis", " TRELLIS "} {
+		member, ok := Resolve(name, members)
+		if !ok || member.ID != "trellis" {
+			t.Errorf("Resolve(%q) = %v, %v; want trellis", name, member.ID, ok)
+		}
+	}
+	// A worker's free-string name is not a member and resolving says so rather
+	// than erroring: unregistered tenders keep tending.
+	if _, ok := Resolve("some-worker", members); ok {
+		t.Error("Resolve matched an unregistered name")
+	}
+	if _, ok := Resolve("", members); ok {
+		t.Error("Resolve matched the empty name")
+	}
+}
+
+// A record written by a later attn stays readable: unknown keys are ignored,
+// which is what lets the schema move without migrating anything.
+func TestDecode_IgnoresUnknownKeys(t *testing.T) {
+	member, err := Decode([]byte(`{"id":"keel","home_dir":"/h","mood":"curious"}`))
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if member.ID != "keel" || member.HomeDir != "/h" {
+		t.Fatalf("Decode = %+v", member)
+	}
+}
+
+// A declared field a query filters on must exist in every stored body, or a
+// filter on `binding_session = ""` would not match the sleeping members.
+func TestEncode_WritesDeclaredFieldsEvenWhenEmpty(t *testing.T) {
+	encoded, err := Member{ID: "keel"}.Encode()
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	for _, field := range MembersSchema().Fields {
+		if !strings.Contains(string(encoded), `"`+field.Name+`"`) {
+			t.Errorf("declared field %q is missing from an empty member's body: %s", field.Name, encoded)
+		}
+	}
+}
+
+func TestMembersSchema_IsAValidDeclaration(t *testing.T) {
+	if err := MembersSchema().Validate(); err != nil {
+		t.Fatalf("MembersSchema is not declarable: %v", err)
+	}
+}

--- a/internal/daemon/agent_peek.go
+++ b/internal/daemon/agent_peek.go
@@ -84,6 +84,7 @@ func (d *Daemon) agentPeekResult(session *protocol.Session) *protocol.AgentPeekR
 		StateReason: decorated.StateReason,
 		TurnOwed:    decorated.TurnOwed,
 		Todos:       decorated.Todos,
+		CrewMember:  decorated.CrewMember,
 	}
 	if result.Todos == nil {
 		result.Todos = []string{}

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -52,6 +52,7 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdSeedNotes:                  commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdSeedLink:                   commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdSeedReady:                  commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdCrewList:                   commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdStop:                       commandMetadata(ScopeSession, false, true),
 	protocol.CmdTodos:                      commandMetadata(ScopeSession, false, true),
 	protocol.CmdFilesEdited:                commandMetadata(ScopeSession, false, true),

--- a/internal/daemon/crew.go
+++ b/internal/daemon/crew.go
@@ -1,0 +1,341 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/crew"
+	"github.com/victorarias/attn/internal/docstore"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// The crew's daemon half: the registry collection, the binding a session
+// launches with, and the single-holder rule over it.
+//
+// The daemon is where a binding is decided. Registration carries the member
+// name, the daemon resolves it against the registry and writes the claim
+// against the revision it read — so two launches racing for the same member
+// produce one binding and one named refusal, not two trellises.
+//
+// Every crew verb passes the enrollment fence first: the crew has exactly one
+// owner — the home daemon — and an outpost holds no part of it.
+//
+// Whether a stored binding still binds is judged at read, the same liveness
+// rule the garden's Tender.Holds uses: a binding naming a session the daemon
+// no longer knows has released on its own. Session teardown also clears the
+// record, so a roster read shows the truth rather than a stale day.
+
+// ensureCrewCollections declares the registry at startup. Like the garden's,
+// it runs on every daemon, home or outpost, because a declaration is schema
+// and not state: an outpost's roster stays empty (the fence refuses every
+// write), and declaring it anyway means `attn enrollment leave` makes a daemon
+// a working home immediately rather than at its next restart.
+func (d *Daemon) ensureCrewCollections() {
+	if d.store == nil {
+		return
+	}
+	schema := crew.MembersSchema()
+	redeclared, err := d.store.DefineDocumentCollection(schema, time.Now())
+	if err != nil {
+		d.logf("crew: declaring %s/%s: %v", schema.Namespace, schema.Collection, err)
+		return
+	}
+	if redeclared {
+		d.publishCollectionRedeclared(schema.Namespace, schema.Collection)
+	}
+}
+
+// importCrewHomes registers every home under `<data-dir>/crew/` that the
+// registry does not know yet. Files are canonical: the import records where a
+// home lives, never what it says, and an existing registry record is never
+// touched — the write is create-only, so re-running at every startup costs
+// nothing and picks up a home the user added by hand since the last one.
+func (d *Daemon) importCrewHomes() {
+	if d.store == nil {
+		return
+	}
+	if err := d.requireHome(crew.Surface); err != nil {
+		// An outpost imports nothing; not an error — startup is not a crew ask.
+		return
+	}
+	members, err := crew.ScanHomes(filepath.Join(d.dataRoot, crew.HomesDirName), d.logf)
+	if err != nil {
+		d.logf("crew: %v", err)
+		return
+	}
+	schema, err := d.crewCollection()
+	if err != nil {
+		d.logf("crew: importing homes: %v", err)
+		return
+	}
+	for _, member := range members {
+		if err := d.writeCrewMember(*schema, member, docstore.ExpectAbsent); err != nil {
+			if docstore.IsConflict(err) {
+				continue // already registered; the record is authoritative
+			}
+			d.logf("crew: importing %s: %v", member.ID, err)
+			continue
+		}
+		d.logf("crew: imported member %s from %s", member.ID, member.HomeDir)
+	}
+}
+
+// crewCollection reads the members declaration, which carries the minted table
+// name every query compiles against.
+func (d *Daemon) crewCollection() (*docstore.CollectionSchema, error) {
+	if d.store == nil {
+		return nil, errors.New("no database")
+	}
+	return d.collectionFor(crew.Namespace, crew.CollectionMembers)
+}
+
+// writeCrewMember stores one member record against the revision the caller
+// read (docstore.ExpectAbsent for a create), committing the document with the
+// docstore's own change fact so live queries on the roster wake like any other
+// write.
+func (d *Daemon) writeCrewMember(schema docstore.CollectionSchema, member crew.Member, expected int64) error {
+	body, err := member.Encode()
+	if err != nil {
+		return err
+	}
+	fact := documentChangedFact(crew.Namespace, crew.CollectionMembers, member.ID, false)
+	written, err := d.store.CommitDocumentWrite(store.DocumentWrite{
+		Schema: schema, ID: member.ID, Body: body, Expected: &expected,
+	}, fact, time.Now())
+	if err != nil {
+		return err
+	}
+	d.announceCommittedWrite(fact, written.Seq)
+	return nil
+}
+
+// readCrewMembers reads the whole roster. The crew is people the user named
+// one by one — three today — so docstore.MaxLimit is not a bound anything
+// real approaches; a roster past it would be a different product.
+func (d *Daemon) readCrewMembers() ([]crew.Member, map[string]docstore.Document, error) {
+	read, _, err := d.runDocQuery(docstore.Query{
+		Namespace:  crew.Namespace,
+		Collection: crew.CollectionMembers,
+		Sort:       &docstore.Sort{Field: docstore.FieldCreatedAt, Desc: false},
+		Limit:      docstore.MaxLimit,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	members := make([]crew.Member, 0, len(read.Documents))
+	docs := make(map[string]docstore.Document, len(read.Documents))
+	for _, doc := range read.Documents {
+		member, err := crew.Decode(doc.Body)
+		if err != nil {
+			// One unreadable record must not blank the roster; name it and go on.
+			d.logf("crew: member %s has an unreadable record: %v", doc.ID, err)
+			continue
+		}
+		members = append(members, member)
+		docs[member.ID] = doc
+	}
+	return members, docs, nil
+}
+
+// crewBindingLive reports whether a stored binding still binds: a non-empty
+// session the daemon still knows. The read-time judgment, shared by the
+// single-holder claim, the roster read, and session decoration.
+func (d *Daemon) crewBindingLive(member crew.Member) bool {
+	return member.BindingSession != "" && d.sessionExists(member.BindingSession)
+}
+
+// claimCrewBinding stamps sessionID as memberName's active binding — the
+// identity mechanism: the session is the member because this claim succeeded
+// at its launch. It refuses an unregistered name, and refuses a member whose
+// current day is still live, because two agents with the same identity never
+// run at once. Re-claiming the binding a session already holds is idempotent,
+// so a client re-announcing a live session keeps its identity.
+//
+// A conflict is not a refusal — the record moved between the read and the
+// write, so the decision is remade against what is there now. Three attempts
+// is a tripwire — two launches contending is one retry.
+func (d *Daemon) claimCrewBinding(memberName, sessionID string) (string, error) {
+	if err := d.requireHome(crew.Surface); err != nil {
+		return "", err
+	}
+	schema, err := d.crewCollection()
+	if err != nil {
+		return "", err
+	}
+	const attempts = 3
+	for range attempts {
+		members, docs, err := d.readCrewMembers()
+		if err != nil {
+			return "", err
+		}
+		member, ok := crew.Resolve(memberName, members)
+		if !ok {
+			return "", fmt.Errorf("no crew member %q is registered; `attn crew list` names the roster", memberName)
+		}
+		if member.BindingSession == sessionID {
+			return member.ID, nil
+		}
+		if d.crewBindingLive(member) {
+			return "", fmt.Errorf("%s is already awake in session %s; two agents with the same identity never run at once — wait for that day to end, or wake another member",
+				member.ID, shortSessionID(member.BindingSession))
+		}
+		member.BindingSession = sessionID
+		err = d.writeCrewMember(*schema, member, docs[member.ID].Rev)
+		if err == nil {
+			d.logf("crew: session %s bound as %s", sessionID, member.ID)
+			return member.ID, nil
+		}
+		if !docstore.IsConflict(err) {
+			return "", err
+		}
+	}
+	return "", fmt.Errorf("the registry record for %q was rewritten under all %d attempts to bind it; try again", memberName, attempts)
+}
+
+// releaseCrewBindingIfSession clears any binding naming sessionID. Called from
+// every session-removal path, mirroring the chief-of-staff role clear; a path
+// that misses it costs nothing but a stale record the liveness judgment
+// already ignores. It is quiet by design — most sessions were never bound, and
+// on an outpost the roster is empty — so it reads before it fences.
+func (d *Daemon) releaseCrewBindingIfSession(sessionID string) {
+	if d.store == nil || strings.TrimSpace(sessionID) == "" {
+		return
+	}
+	schema, err := d.crewCollection()
+	if err != nil {
+		return
+	}
+	members, docs, err := d.readCrewMembers()
+	if err != nil {
+		if !docstore.IsUndeclaredCollection(err) {
+			d.logf("crew: reading roster to release %s: %v", sessionID, err)
+		}
+		return
+	}
+	for _, member := range members {
+		if member.BindingSession != sessionID {
+			continue
+		}
+		member.BindingSession = ""
+		if err := d.writeCrewMember(*schema, member, docs[member.ID].Rev); err != nil {
+			d.logf("crew: releasing %s's binding for session %s: %v", member.ID, sessionID, err)
+			continue
+		}
+		d.logf("crew: session %s released %s's binding", sessionID, member.ID)
+	}
+}
+
+// crewMembersBySession maps live bindings for one broadcast, so decorating a
+// session list costs one roster read rather than one per session. Empty —
+// never an error — when the roster is empty or unreadable: decoration must not
+// fail a broadcast.
+func (d *Daemon) crewMembersBySession() map[string]string {
+	if d.store == nil {
+		return nil
+	}
+	members, _, err := d.readCrewMembers()
+	if err != nil {
+		if !docstore.IsUndeclaredCollection(err) {
+			d.logf("crew: reading roster for broadcast: %v", err)
+		}
+		return nil
+	}
+	var out map[string]string
+	for _, member := range members {
+		if !d.crewBindingLive(member) {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]string)
+		}
+		out[member.BindingSession] = member.ID
+	}
+	return out
+}
+
+// decorateCrewMember marks the session living a member's current day. Mirrors
+// decorateChiefOfStaffWithSessionID: set only when bound, cleared otherwise so
+// it round-trips as an omitted field.
+func (d *Daemon) decorateCrewMember(session *protocol.Session, membersBySession map[string]string) {
+	if session == nil {
+		return
+	}
+	if member := membersBySession[session.ID]; member != "" {
+		session.CrewMember = protocol.Ptr(member)
+		return
+	}
+	session.CrewMember = nil
+}
+
+// resolveTenderMember snaps a garden actor's free-string member name to its
+// registered id where one exists — `Tender.Is` then compares real addresses —
+// and fills the name from the session's own binding when the caller named
+// nobody, because a bound session IS its member. An unregistered name passes
+// through untouched: the registry never becomes a requirement to tend.
+func (d *Daemon) resolveTenderMember(memberName, sessionID string) string {
+	memberName = strings.TrimSpace(memberName)
+	members, _, err := d.readCrewMembers()
+	if err != nil {
+		if !docstore.IsUndeclaredCollection(err) {
+			d.logf("crew: reading roster to resolve %q: %v", memberName, err)
+		}
+		return memberName
+	}
+	if memberName != "" {
+		if member, ok := crew.Resolve(memberName, members); ok {
+			return member.ID
+		}
+		return memberName
+	}
+	for _, member := range members {
+		if member.BindingSession == sessionID && sessionID != "" && d.crewBindingLive(member) {
+			return member.ID
+		}
+	}
+	return ""
+}
+
+// IPC handlers.
+
+func (d *Daemon) sendCrewError(conn net.Conn, verb string, err error) {
+	d.sendError(conn, fmt.Sprintf("crew %s: %v", verb, err))
+}
+
+func (d *Daemon) handleCrewList(conn net.Conn, _ *protocol.CrewListMessage) {
+	if err := d.requireHome(crew.Surface); err != nil {
+		d.sendCrewError(conn, "list", err)
+		return
+	}
+	members, _, err := d.readCrewMembers()
+	if err != nil {
+		d.sendCrewError(conn, "list", err)
+		return
+	}
+	out := make([]protocol.CrewMember, 0, len(members))
+	for _, member := range members {
+		wire := protocol.CrewMember{
+			ID:          member.ID,
+			CharterPath: member.CharterPath,
+			HomeDir:     member.HomeDir,
+		}
+		if member.CWD != "" {
+			wire.Cwd = protocol.Ptr(member.CWD)
+		}
+		wire.AwarenessDirs = append([]string{}, member.AwarenessDirs...)
+		// The wire carries only a binding that still binds: whether a session is
+		// live is judged here, at read, so a caller never has to.
+		if d.crewBindingLive(member) {
+			wire.BindingSession = protocol.Ptr(member.BindingSession)
+		}
+		out = append(out, wire)
+	}
+	d.sendGardenResponse(conn, protocol.Response{
+		Ok:             true,
+		CrewListResult: &protocol.CrewListResult{Members: out},
+	})
+}

--- a/internal/daemon/crew.go
+++ b/internal/daemon/crew.go
@@ -117,6 +117,10 @@ func (d *Daemon) writeCrewMember(schema docstore.CollectionSchema, member crew.M
 // readCrewMembers reads the whole roster. The crew is people the user named
 // one by one — three today — so docstore.MaxLimit is not a bound anything
 // real approaches; a roster past it would be a different product.
+//
+// Every crew read is this one query, so one receipt covers them all: measured
+// 2026-08-14 at a three-member roster, 25µs on an M5. That is what a session
+// broadcast pays, and what a garden action pays to resolve its tender.
 func (d *Daemon) readCrewMembers() ([]crew.Member, map[string]docstore.Document, error) {
 	read, _, err := d.runDocQuery(docstore.Query{
 		Namespace:  crew.Namespace,
@@ -154,7 +158,8 @@ func (d *Daemon) crewBindingLive(member crew.Member) bool {
 // at its launch. It refuses an unregistered name, and refuses a member whose
 // current day is still live, because two agents with the same identity never
 // run at once. Re-claiming the binding a session already holds is idempotent,
-// so a client re-announcing a live session keeps its identity.
+// so a client re-announcing a live session keeps its identity, and claiming a
+// second member for one session moves it rather than doubling it.
 //
 // A conflict is not a refusal — the record moved between the read and the
 // write, so the decision is remade against what is there now. Three attempts
@@ -184,6 +189,10 @@ func (d *Daemon) claimCrewBinding(memberName, sessionID string) (string, error) 
 			return "", fmt.Errorf("%s is already awake in session %s; two agents with the same identity never run at once — wait for that day to end, or wake another member",
 				member.ID, shortSessionID(member.BindingSession))
 		}
+		// Past every refusal, so the claim is going to land: drop any other name
+		// this session already answered to. A refused claim is not reached here,
+		// and leaves the session the member it already was.
+		d.releaseCrewBindingsExcept(*schema, members, docs, member.ID, sessionID)
 		member.BindingSession = sessionID
 		err = d.writeCrewMember(*schema, member, docs[member.ID].Rev)
 		if err == nil {
@@ -217,12 +226,19 @@ func (d *Daemon) releaseCrewBindingIfSession(sessionID string) {
 		}
 		return
 	}
+	d.releaseCrewBindingsExcept(*schema, members, docs, "", sessionID)
+}
+
+// releaseCrewBindingsExcept clears every binding naming sessionID other than
+// keepID's, against a roster the caller already read. One session answers to
+// one name: a session that becomes somebody drops whoever it was first.
+func (d *Daemon) releaseCrewBindingsExcept(schema docstore.CollectionSchema, members []crew.Member, docs map[string]docstore.Document, keepID, sessionID string) {
 	for _, member := range members {
-		if member.BindingSession != sessionID {
+		if member.BindingSession != sessionID || member.ID == keepID {
 			continue
 		}
 		member.BindingSession = ""
-		if err := d.writeCrewMember(*schema, member, docs[member.ID].Rev); err != nil {
+		if err := d.writeCrewMember(schema, member, docs[member.ID].Rev); err != nil {
 			d.logf("crew: releasing %s's binding for session %s: %v", member.ID, sessionID, err)
 			continue
 		}
@@ -233,11 +249,7 @@ func (d *Daemon) releaseCrewBindingIfSession(sessionID string) {
 // crewMembersBySession maps live bindings for one broadcast, so decorating a
 // session list costs one roster read rather than one per session. Empty —
 // never an error — when the roster is empty or unreadable: decoration must not
-// fail a broadcast.
-//
-// This rides every session broadcast, which runs all day. Measured 2026-08-14
-// at a three-member roster: 25µs per read on an M5. The crew is people the
-// user named one by one, so that size is the real one.
+// fail a broadcast. Receipt for the read on readCrewMembers.
 func (d *Daemon) crewMembersBySession() map[string]string {
 	if d.store == nil {
 		return nil
@@ -283,6 +295,9 @@ func (d *Daemon) decorateCrewMember(session *protocol.Session, membersBySession 
 // through untouched: the registry never becomes a requirement to tend.
 func (d *Daemon) resolveTenderMember(memberName, sessionID string) string {
 	memberName = strings.TrimSpace(memberName)
+	if memberName == "" && sessionID == "" {
+		return ""
+	}
 	members, _, err := d.readCrewMembers()
 	if err != nil {
 		if !docstore.IsUndeclaredCollection(err) {

--- a/internal/daemon/crew.go
+++ b/internal/daemon/crew.go
@@ -234,6 +234,10 @@ func (d *Daemon) releaseCrewBindingIfSession(sessionID string) {
 // session list costs one roster read rather than one per session. Empty —
 // never an error — when the roster is empty or unreadable: decoration must not
 // fail a broadcast.
+//
+// This rides every session broadcast, which runs all day. Measured 2026-08-14
+// at a three-member roster: 25µs per read on an M5. The crew is people the
+// user named one by one, so that size is the real one.
 func (d *Daemon) crewMembersBySession() map[string]string {
 	if d.store == nil {
 		return nil

--- a/internal/daemon/crew_test.go
+++ b/internal/daemon/crew_test.go
@@ -157,6 +157,56 @@ func TestCrew_SecondClaimOnALiveMemberIsRefusedByName(t *testing.T) {
 	}
 }
 
+// One session answers to one name. Binding a session that already holds a
+// member to a second member moves the identity rather than handing that session
+// both — otherwise "two agents with the same identity never run at once" holds
+// while one agent quietly runs as two.
+func TestCrew_ASessionTakingASecondNameDropsTheFirst(t *testing.T) {
+	d := newCrewDaemon(t)
+	addSession(t, d, "sess-one")
+
+	if _, err := d.claimCrewBinding("keel", "sess-one"); err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	if _, err := d.claimCrewBinding("trellis", "sess-one"); err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+
+	members := crewList(t, d)
+	if got := protocol.Deref(memberByID(t, members, "trellis").BindingSession); got != "sess-one" {
+		t.Errorf("trellis binding = %q, want sess-one", got)
+	}
+	if got := protocol.Deref(memberByID(t, members, "keel").BindingSession); got != "" {
+		t.Errorf("keel is still bound to %q after the session became trellis", got)
+	}
+	// The session decorates as exactly one member, not whichever the roster
+	// order happened to reach first.
+	if got := d.crewMembersBySession()["sess-one"]; got != "trellis" {
+		t.Errorf("session decorates as %q, want trellis", got)
+	}
+}
+
+// A refused second name leaves the session the member it already was: the
+// release runs only once the claim is certain to land.
+func TestCrew_ARefusedSecondNameKeepsTheFirst(t *testing.T) {
+	d := newCrewDaemon(t)
+	addSession(t, d, "sess-one")
+	addSession(t, d, "sess-two")
+
+	if _, err := d.claimCrewBinding("keel", "sess-one"); err != nil {
+		t.Fatalf("claim keel: %v", err)
+	}
+	if _, err := d.claimCrewBinding("trellis", "sess-two"); err != nil {
+		t.Fatalf("claim trellis: %v", err)
+	}
+	if _, err := d.claimCrewBinding("trellis", "sess-one"); err == nil {
+		t.Fatal("a live trellis was handed to a second session")
+	}
+	if got := protocol.Deref(memberByID(t, crewList(t, d), "keel").BindingSession); got != "sess-one" {
+		t.Errorf("keel binding = %q, want sess-one — a refused claim wrote something", got)
+	}
+}
+
 // A binding naming a session the daemon no longer knows has let go on its own —
 // the same liveness rule the garden's tender uses — so a member whose day ended
 // without ceremony can be woken again.

--- a/internal/daemon/crew_test.go
+++ b/internal/daemon/crew_test.go
@@ -1,0 +1,362 @@
+package daemon
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/crew"
+	"github.com/victorarias/attn/internal/enrollment"
+	"github.com/victorarias/attn/internal/garden"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// writeCrewHomes builds a copy of the real `~/.attn/crew` shape under a
+// daemon's data dir: three members, each with a charter and dated handoff
+// files, plus the loose CREW.md beside them. Copied by shape — the live
+// directory is never read.
+func writeCrewHomes(t *testing.T, dataRoot string) {
+	t.Helper()
+	root := filepath.Join(dataRoot, crew.HomesDirName)
+	write := func(path, body string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	write(filepath.Join(root, "CREW.md"), "# The crew\n")
+	for _, member := range []struct{ id, handoff string }{
+		{"alder", "2026-08-10T19-20Z-alder.md"},
+		{"keel", "2026-08-13T22-10Z-keel.md"},
+		{"trellis", "2026-08-13T22-20Z-trellis.md"},
+	} {
+		home := filepath.Join(root, member.id)
+		write(filepath.Join(home, crew.CharterFileName), "# "+member.id+"\n\nWhat I care about.\n")
+		write(filepath.Join(home, "handoffs", member.handoff), "Where I left off.\n")
+	}
+}
+
+// newCrewDaemon returns a home daemon whose roster was imported from homes on
+// disk, which is how every real daemon starts.
+func newCrewDaemon(t *testing.T) *Daemon {
+	t.Helper()
+	d := newEnrolledDaemon(t, "")
+	t.Cleanup(d.stopEventBus)
+	writeCrewHomes(t, d.dataRoot)
+	d.ensureCrewCollections()
+	d.importCrewHomes()
+	return d
+}
+
+func crewList(t *testing.T, d *Daemon) []protocol.CrewMember {
+	t.Helper()
+	resp := gardenCall(t, func(c net.Conn) {
+		d.handleCrewList(c, &protocol.CrewListMessage{Cmd: protocol.CmdCrewList})
+	})
+	if !resp.Ok {
+		t.Fatalf("crew list: %v", protocol.Deref(resp.Error))
+	}
+	return resp.CrewListResult.Members
+}
+
+// addSession puts a live session in the store, the thing a binding names.
+func addSession(t *testing.T, d *Daemon, id string) {
+	t.Helper()
+	now := string(protocol.TimestampNow())
+	d.store.Add(&protocol.Session{
+		ID: id, Label: id, State: "idle",
+		StateSince: now, StateUpdatedAt: now, LastSeen: now,
+	})
+}
+
+func memberByID(t *testing.T, members []protocol.CrewMember, id string) protocol.CrewMember {
+	t.Helper()
+	for _, m := range members {
+		if m.ID == id {
+			return m
+		}
+	}
+	t.Fatalf("no member %q in the roster", id)
+	return protocol.CrewMember{}
+}
+
+// The slice's acceptance: homes on disk become a roster, a session launches
+// bound, the binding is what `agent list` and `peek` show, and it is released
+// when the day ends.
+func TestCrew_AMemberIsImportedBoundAndReleased(t *testing.T) {
+	d := newCrewDaemon(t)
+
+	members := crewList(t, d)
+	if len(members) != 3 {
+		t.Fatalf("roster = %d members, want the 3 homes on disk", len(members))
+	}
+	trellis := memberByID(t, members, "trellis")
+	if trellis.BindingSession != nil {
+		t.Fatalf("a freshly imported member is awake: %v", *trellis.BindingSession)
+	}
+	// Files stay canonical: the registry points at the home rather than copying it.
+	if _, err := os.Stat(trellis.CharterPath); err != nil {
+		t.Fatalf("charter path does not point at a real file: %v", err)
+	}
+
+	addSession(t, d, "sess-trellis")
+	memberID, err := d.claimCrewBinding("trellis", "sess-trellis")
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if memberID != "trellis" {
+		t.Fatalf("claim returned %q, want trellis", memberID)
+	}
+
+	// `agent list` and `agent peek` both say who this session is today.
+	session := d.sessionForBroadcast(d.store.Get("sess-trellis"))
+	if got := protocol.Deref(session.CrewMember); got != "trellis" {
+		t.Fatalf("broadcast session's crew_member = %q, want trellis", got)
+	}
+	if got := protocol.Deref(d.agentPeekResult(d.store.Get("sess-trellis")).CrewMember); got != "trellis" {
+		t.Fatalf("peek's crew_member = %q, want trellis", got)
+	}
+	if got := protocol.Deref(memberByID(t, crewList(t, d), "trellis").BindingSession); got != "sess-trellis" {
+		t.Fatalf("roster binding = %q, want sess-trellis", got)
+	}
+
+	// The day ends: the binding is released and the member is asleep again.
+	d.forgetSession("sess-trellis")
+	if binding := memberByID(t, crewList(t, d), "trellis").BindingSession; binding != nil {
+		t.Fatalf("the binding survived its session: %v", *binding)
+	}
+}
+
+// Two agents with the same identity never run at once. The refusal names the
+// member and the session holding it, so the caller can go look.
+func TestCrew_SecondClaimOnALiveMemberIsRefusedByName(t *testing.T) {
+	d := newCrewDaemon(t)
+	addSession(t, d, "sess-first")
+	addSession(t, d, "sess-second")
+
+	if _, err := d.claimCrewBinding("keel", "sess-first"); err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	_, err := d.claimCrewBinding("keel", "sess-second")
+	if err == nil {
+		t.Fatal("a second keel was allowed to wake")
+	}
+	for _, want := range []string{"keel", "sess-fir"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal %q does not name %q", err, want)
+		}
+	}
+	// The first session keeps its identity: a refused claim writes nothing.
+	if got := protocol.Deref(memberByID(t, crewList(t, d), "keel").BindingSession); got != "sess-first" {
+		t.Fatalf("binding after the refusal = %q, want sess-first", got)
+	}
+}
+
+// A binding naming a session the daemon no longer knows has let go on its own —
+// the same liveness rule the garden's tender uses — so a member whose day ended
+// without ceremony can be woken again.
+func TestCrew_ABindingWhoseSessionIsGoneDoesNotHold(t *testing.T) {
+	d := newCrewDaemon(t)
+	addSession(t, d, "sess-crashed")
+	if _, err := d.claimCrewBinding("alder", "sess-crashed"); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	// The session vanishes without any release path running (a crash, a reap
+	// the daemon never saw).
+	d.store.Remove("sess-crashed")
+
+	if binding := memberByID(t, crewList(t, d), "alder").BindingSession; binding != nil {
+		t.Fatalf("the roster reports a dead session as awake: %v", *binding)
+	}
+	addSession(t, d, "sess-fresh")
+	if _, err := d.claimCrewBinding("alder", "sess-fresh"); err != nil {
+		t.Fatalf("a member whose session died could not be woken: %v", err)
+	}
+}
+
+// Re-claiming the binding a session already holds is idempotent: a client
+// re-announcing a live session must not lose its own identity to itself.
+func TestCrew_ReclaimingItsOwnBindingIsIdempotent(t *testing.T) {
+	d := newCrewDaemon(t)
+	addSession(t, d, "sess-keel")
+	if _, err := d.claimCrewBinding("keel", "sess-keel"); err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	if _, err := d.claimCrewBinding("keel", "sess-keel"); err != nil {
+		t.Fatalf("re-announcing a live session lost its binding: %v", err)
+	}
+}
+
+func TestCrew_ClaimingAnUnregisteredNameIsRefusedWithWhereToLook(t *testing.T) {
+	d := newCrewDaemon(t)
+	addSession(t, d, "sess-a")
+	_, err := d.claimCrewBinding("nobody", "sess-a")
+	if err == nil {
+		t.Fatal("an unregistered name was bound")
+	}
+	if !strings.Contains(err.Error(), "attn crew list") {
+		t.Errorf("refusal %q does not say where the roster is", err)
+	}
+}
+
+// Importing is create-only: a home rescanned at every startup never overwrites
+// the registry record, which is where a live binding lives.
+func TestCrew_ReimportingHomesLeavesLiveRecordsAlone(t *testing.T) {
+	d := newCrewDaemon(t)
+	addSession(t, d, "sess-keel")
+	if _, err := d.claimCrewBinding("keel", "sess-keel"); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	d.importCrewHomes() // the next daemon start
+
+	if got := protocol.Deref(memberByID(t, crewList(t, d), "keel").BindingSession); got != "sess-keel" {
+		t.Fatalf("re-import clobbered a live binding: binding = %q", got)
+	}
+	if len(crewList(t, d)) != 3 {
+		t.Fatal("re-import duplicated the roster")
+	}
+}
+
+// A home the user adds by hand joins the roster at the next start; nothing has
+// to be registered through attn.
+func TestCrew_AHandAddedHomeJoinsTheRoster(t *testing.T) {
+	d := newCrewDaemon(t)
+	home := filepath.Join(d.dataRoot, crew.HomesDirName, "sable")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, crew.CharterFileName), []byte("# sable\n"), 0o644); err != nil {
+		t.Fatalf("write charter: %v", err)
+	}
+
+	d.importCrewHomes()
+
+	if got := len(crewList(t, d)); got != 4 {
+		t.Fatalf("roster = %d members, want 4 after a home was added by hand", got)
+	}
+	memberByID(t, crewList(t, d), "sable")
+}
+
+// The crew has exactly one owner. An outpost holds no part of it: the read
+// refuses by name, and startup imports nothing.
+func TestCrew_AnOutpostIsFenced(t *testing.T) {
+	const home = "d-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	d := newEnrolledDaemon(t, home)
+	t.Cleanup(d.stopEventBus)
+	writeCrewHomes(t, d.dataRoot)
+	d.ensureCrewCollections()
+	d.importCrewHomes()
+
+	resp := gardenCall(t, func(c net.Conn) {
+		d.handleCrewList(c, &protocol.CrewListMessage{Cmd: protocol.CmdCrewList})
+	})
+	if resp.Ok {
+		t.Fatal("an outpost served the crew roster")
+	}
+	message := protocol.Deref(resp.Error)
+	if !strings.Contains(message, home) {
+		t.Errorf("refusal %q does not name the home", message)
+	}
+	if !strings.Contains(message, enrollment.PlanPath) {
+		t.Errorf("refusal %q does not name the plan tracking the gap", message)
+	}
+
+	addSession(t, d, "sess-a")
+	if _, err := d.claimCrewBinding("keel", "sess-a"); err == nil {
+		t.Fatal("an outpost bound a crew member")
+	}
+}
+
+// The garden touches the registry lightly. A member's free-string name becomes
+// its registry id so Tender.Is compares real addresses — and a name nobody
+// registered passes through, because tending never required a registry.
+func TestCrew_TenderNamesResolveWhereAMemberExists(t *testing.T) {
+	d := newCrewDaemon(t)
+	addSession(t, d, "sess-keel")
+	if _, err := d.claimCrewBinding("keel", "sess-keel"); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	if got := d.resolveTenderMember("Keel", ""); got != "keel" {
+		t.Errorf("a registered name resolved to %q, want keel", got)
+	}
+	if got := d.resolveTenderMember("some-worker", ""); got != "some-worker" {
+		t.Errorf("an unregistered name became %q; workers keep tending unbound", got)
+	}
+	// A bound session that named nobody IS its member — the invocation already
+	// said who it is.
+	if got := d.resolveTenderMember("", "sess-keel"); got != "keel" {
+		t.Errorf("a bound session resolved to %q, want keel", got)
+	}
+	// An unbound session that named nobody stays nobody: a worker in a pane is
+	// not silently given an identity.
+	addSession(t, d, "sess-worker")
+	if got := d.resolveTenderMember("", "sess-worker"); got != "" {
+		t.Errorf("an unbound session resolved to %q, want no member", got)
+	}
+}
+
+// The slice's safety property: nothing changes for a session with no binding.
+// A worker plants, tends and hands off exactly as it did before the registry
+// existed, and its broadcast carries no crew field at all.
+func TestCrew_UnboundSessionsBehaveExactlyAsBefore(t *testing.T) {
+	d := newGardenDaemon(t)
+	d.ensureCrewCollections()
+	writeCrewHomes(t, d.dataRoot)
+	d.importCrewHomes()
+
+	seed := plant(t, d, protocol.SeedPlantMessage{Title: "work an unbound session picks up"})
+	// A free-string member nobody registered is stored as typed.
+	tended := move(t, d, "sess-a", seed.ID, garden.VerbTend, "", "some-worker")
+	if tended.TenderMember != "some-worker" {
+		t.Fatalf("tender member = %q, want the free string as typed", tended.TenderMember)
+	}
+	if tended.TenderSession != "sess-a" {
+		t.Fatalf("tender session = %q, want sess-a", tended.TenderSession)
+	}
+	// The claim still holds against another session: one tender at a time is
+	// unchanged for tenders the registry knows nothing about.
+	addGardenSession(t, d, "sess-b")
+	resp := transition(t, d, "sess-b", seed.ID, garden.VerbTend, "", "")
+	if resp.Ok {
+		t.Fatal("another session took a seed held by an unbound tender")
+	}
+	if !strings.Contains(protocol.Deref(resp.Error), "one tender at a time") {
+		t.Fatalf("refusal changed shape for an unbound tender: %v", protocol.Deref(resp.Error))
+	}
+	move(t, d, "sess-a", seed.ID, garden.VerbHarvest, "done", "some-worker")
+
+	session := d.sessionForBroadcast(d.store.Get("sess-a"))
+	if session.CrewMember != nil {
+		t.Fatalf("an unbound session broadcasts a crew member: %q", *session.CrewMember)
+	}
+}
+
+// A registered member tending under a differently-typed name still holds its
+// own seed: resolution is what makes the claim an address rather than a
+// spelling.
+func TestCrew_AMemberHoldsItsSeedHoweverTheNameIsTyped(t *testing.T) {
+	d := newGardenDaemon(t)
+	d.ensureCrewCollections()
+	writeCrewHomes(t, d.dataRoot)
+	d.importCrewHomes()
+
+	seed := plant(t, d, protocol.SeedPlantMessage{Title: "a member's work"})
+	// Tended from a terminal pane, which carries no session id — so the member
+	// name is the whole identity, and its spelling is what decides.
+	move(t, d, "", seed.ID, garden.VerbTend, "", "trellis")
+	if resp := transition(t, d, "", seed.ID, garden.VerbTend, "", "Trellis"); !resp.Ok {
+		t.Fatalf("a member could not re-tend its own seed under another spelling: %v", protocol.Deref(resp.Error))
+	}
+	// Somebody else is still refused: resolution widens who counts as the same
+	// person, never who may take the claim.
+	if resp := transition(t, d, "", seed.ID, garden.VerbTend, "", "keel"); resp.Ok {
+		t.Fatal("another member took a seed trellis holds")
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1011,6 +1011,8 @@ func (d *Daemon) Start() error {
 		return fmt.Errorf("ensure enrollment record: %w", err)
 	}
 	d.ensureGardenCollections()
+	d.ensureCrewCollections()
+	d.importCrewHomes()
 	if d.hubManager == nil {
 		d.hubManager = hub.NewManager(
 			d.store,
@@ -2112,6 +2114,7 @@ func (d *Daemon) unregisterSession(sessionID string, sig syscall.Signal) *protoc
 func (d *Daemon) forgetSession(sessionID string) {
 	d.dropSessionRecord(sessionID)
 	d.clearChiefOfStaffIfSession(sessionID)
+	d.releaseCrewBindingIfSession(sessionID)
 	if d.hubManager != nil {
 		d.hubManager.ForgetSession(sessionID)
 	}
@@ -2122,6 +2125,7 @@ func (d *Daemon) forgetSession(sessionID string) {
 func (d *Daemon) removeReapedSession(sessionID string) {
 	d.dropSessionRecord(sessionID)
 	d.clearChiefOfStaffIfSession(sessionID)
+	d.releaseCrewBindingIfSession(sessionID)
 	d.dissociateSessionFromWorkspace(sessionID)
 	d.removeWorkspaceLayoutPaneForSession(sessionID)
 }
@@ -2764,6 +2768,8 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleSeedLink(conn, msg.(*protocol.SeedLinkMessage))
 	case protocol.CmdSeedReady: // wire: seed_ready
 		d.handleSeedReady(conn, msg.(*protocol.SeedReadyMessage))
+	case protocol.CmdCrewList: // wire: crew_list
+		d.handleCrewList(conn, msg.(*protocol.CrewListMessage))
 	case protocol.CmdStop: // wire: stop
 		d.handleStop(conn, msg.(*protocol.StopMessage))
 	case protocol.CmdTodos: // wire: todos
@@ -2888,6 +2894,21 @@ func (d *Daemon) handleRegister(conn net.Conn, msg *protocol.RegisterMessage) {
 	if workspaceID == "" {
 		d.sendError(conn, "missing workspace_id")
 		return
+	}
+	// A member binding is claimed before any row is written: identity is the
+	// invocation, so a launch that cannot be its member does not register at
+	// all — the CLI surfaces the refusal and the agent never runs as nobody.
+	// A registration without a member is one: it releases any binding a prior
+	// invocation of this session id held.
+	if member := strings.TrimSpace(protocol.Deref(msg.Member)); member != "" {
+		memberID, err := d.claimCrewBinding(member, msg.ID)
+		if err != nil {
+			d.sendError(conn, fmt.Sprintf("crew bind %q: %v", member, err))
+			return
+		}
+		d.logf("session %s registering as crew member %s", msg.ID, memberID)
+	} else {
+		d.releaseCrewBindingIfSession(msg.ID)
 	}
 	session.WorkspaceID = workspaceID
 	// Re-deriving the workspace title from the session label would clobber a
@@ -3297,6 +3318,7 @@ func (d *Daemon) sessionForBroadcast(session *protocol.Session) *protocol.Sessio
 		session,
 		d.chiefOfStaffSessionID(),
 		d.delegatedFromChiefSessionIDs(),
+		d.crewMembersBySession(),
 	)
 }
 
@@ -3304,6 +3326,7 @@ func (d *Daemon) sessionForBroadcastWithChiefOfStaff(
 	session *protocol.Session,
 	chiefOfStaffSessionID string,
 	delegatedFromChief map[string]bool,
+	crewBySession map[string]string,
 ) *protocol.Session {
 	clone := cloneSession(session)
 	if clone == nil {
@@ -3315,6 +3338,7 @@ func (d *Daemon) sessionForBroadcastWithChiefOfStaff(
 	d.decorateSessionWithSnooze(clone)
 	d.decorateChiefOfStaffWithSessionID(clone, chiefOfStaffSessionID)
 	d.decorateDelegatedFromChief(clone, delegatedFromChief)
+	d.decorateCrewMember(clone, crewBySession)
 	d.decorateSessionWithWorkspace(clone)
 	d.decorateSessionWithWorkspaceMute(clone)
 	// Last: turn ownership reads the chief flag and the workspace the earlier
@@ -3329,9 +3353,10 @@ func (d *Daemon) sessionsForBroadcast(sessions []*protocol.Session) []protocol.S
 	}
 	chiefOfStaffSessionID := d.chiefOfStaffSessionID()
 	delegatedFromChief := d.delegatedFromChiefSessionIDs()
+	crewBySession := d.crewMembersBySession()
 	out := make([]protocol.Session, 0, len(sessions))
 	for _, session := range sessions {
-		if decorated := d.sessionForBroadcastWithChiefOfStaff(session, chiefOfStaffSessionID, delegatedFromChief); decorated != nil {
+		if decorated := d.sessionForBroadcastWithChiefOfStaff(session, chiefOfStaffSessionID, delegatedFromChief, crewBySession); decorated != nil {
 			out = append(out, *decorated)
 		}
 	}

--- a/internal/daemon/garden.go
+++ b/internal/daemon/garden.go
@@ -413,7 +413,7 @@ func (d *Daemon) handleSeedPlant(conn net.Conn, msg *protocol.SeedPlantMessage) 
 		StepSlug:       garden.StepSlug(title),
 		WorkspaceID:    workspaceID,
 		PlanterSession: sessionID,
-		PlanterMember:  strings.TrimSpace(protocol.Deref(msg.Member)),
+		PlanterMember:  d.resolveTenderMember(protocol.Deref(msg.Member), sessionID),
 		Edges:          []garden.Edge{},
 		Vars:           []garden.Var{},
 	}
@@ -791,9 +791,13 @@ func (d *Daemon) handleSeedTransition(conn net.Conn, msg *protocol.SeedTransitio
 		d.sendGardenError(conn, string(verb), err)
 		return
 	}
+	sessionID := strings.TrimSpace(protocol.Deref(msg.SourceSessionID))
 	actor := garden.Tender{
-		Session: strings.TrimSpace(protocol.Deref(msg.SourceSessionID)),
-		Member:  strings.TrimSpace(protocol.Deref(msg.Member)),
+		Session: sessionID,
+		// A registered member's free-string name becomes its registry id, so
+		// Tender.Is compares real addresses; an unregistered name passes through
+		// and keeps tending exactly as before.
+		Member: d.resolveTenderMember(protocol.Deref(msg.Member), sessionID),
 	}
 	seed, doc, err := d.applySeedTransition(msg.SeedID, verb, actor, protocol.Deref(msg.Reason))
 	if err != nil {
@@ -888,12 +892,13 @@ func (d *Daemon) handleSeedNote(conn net.Conn, msg *protocol.SeedNoteMessage) {
 		d.sendGardenError(conn, "note", err)
 		return
 	}
+	authorSession := strings.TrimSpace(protocol.Deref(msg.SourceSessionID))
 	note := garden.Note{
 		Seed:          seed.ID,
 		Kind:          kind,
 		Body:          msg.Body,
-		AuthorSession: strings.TrimSpace(protocol.Deref(msg.SourceSessionID)),
-		AuthorMember:  strings.TrimSpace(protocol.Deref(msg.Member)),
+		AuthorSession: authorSession,
+		AuthorMember:  d.resolveTenderMember(protocol.Deref(msg.Member), authorSession),
 	}
 	written, doc, err := d.mintAndWriteNote(*schema, note)
 	if err != nil {

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "241"
+const ProtocolVersion = "242"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only
@@ -193,6 +193,7 @@ const (
 	CmdSeedNotes                             = "seed_notes"
 	CmdSeedLink                              = "seed_link"
 	CmdSeedReady                             = "seed_ready"
+	CmdCrewList                              = "crew_list"
 	CmdStop                                  = "stop"
 	CmdTodos                                 = "todos"
 	CmdFilesEdited                           = "files_edited"
@@ -1178,6 +1179,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdAgentMsg:
 		var msg AgentMsgMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdCrewList:
+		var msg CrewListMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -142,6 +142,9 @@ type AgentPeekResult struct {
 	// Agent corresponds to the JSON schema field "agent".
 	Agent string `json:"agent"`
 
+	// CrewMember corresponds to the JSON schema field "crew_member".
+	CrewMember *string `json:"crew_member,omitempty,omitzero"`
+
 	// Label corresponds to the JSON schema field "label".
 	Label string `json:"label"`
 
@@ -1613,6 +1616,36 @@ type CreateWorktreeResultMessage struct {
 
 	// Success corresponds to the JSON schema field "success".
 	Success bool `json:"success"`
+}
+
+type CrewListMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+}
+
+type CrewListResult struct {
+	// Members corresponds to the JSON schema field "members".
+	Members []CrewMember `json:"members"`
+}
+
+type CrewMember struct {
+	// AwarenessDirs corresponds to the JSON schema field "awareness_dirs".
+	AwarenessDirs []string `json:"awareness_dirs"`
+
+	// BindingSession corresponds to the JSON schema field "binding_session".
+	BindingSession *string `json:"binding_session,omitempty,omitzero"`
+
+	// CharterPath corresponds to the JSON schema field "charter_path".
+	CharterPath string `json:"charter_path"`
+
+	// Cwd corresponds to the JSON schema field "cwd".
+	Cwd *string `json:"cwd,omitempty,omitzero"`
+
+	// HomeDir corresponds to the JSON schema field "home_dir".
+	HomeDir string `json:"home_dir"`
+
+	// ID corresponds to the JSON schema field "id".
+	ID string `json:"id"`
 }
 
 type DaemonWarning struct {
@@ -4984,6 +5017,9 @@ type RegisterMessage struct {
 	// Label corresponds to the JSON schema field "label".
 	Label *string `json:"label,omitempty,omitzero"`
 
+	// Member corresponds to the JSON schema field "member".
+	Member *string `json:"member,omitempty,omitzero"`
+
 	// WorkspaceID corresponds to the JSON schema field "workspace_id".
 	WorkspaceID string `json:"workspace_id"`
 }
@@ -5179,6 +5215,9 @@ type Response struct {
 
 	// Authors corresponds to the JSON schema field "authors".
 	Authors []AuthorState `json:"authors,omitempty,omitzero"`
+
+	// CrewListResult corresponds to the JSON schema field "crew_list_result".
+	CrewListResult *CrewListResult `json:"crew_list_result,omitempty,omitzero"`
 
 	// Data corresponds to the JSON schema field "data".
 	Data *string `json:"data,omitempty,omitzero"`
@@ -5744,6 +5783,9 @@ type Session struct {
 
 	// ContextWindowCap corresponds to the JSON schema field "context_window_cap".
 	ContextWindowCap *int `json:"context_window_cap,omitempty,omitzero"`
+
+	// CrewMember corresponds to the JSON schema field "crew_member".
+	CrewMember *string `json:"crew_member,omitempty,omitzero"`
 
 	// DelegatedFromChief corresponds to the JSON schema field "delegated_from_chief".
 	DelegatedFromChief *bool `json:"delegated_from_chief,omitempty,omitzero"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -133,6 +133,7 @@ model Session {
   state_updated_at: string;     // ISO timestamp, always set
   state_reason?: string;        // Why the resolver reached this state (e.g. "stuck", "classifier_verdict"); absent for states it does not own
   chief_of_staff?: boolean;     // True when this session holds the profile-wide coordinator role
+  crew_member?: string;         // The crew member whose active binding this session is — "this session is trellis today". Stamped by the daemon at launch, judged live at broadcast, absent for every unbound session.
   delegated_from_chief?: boolean; // True when this session was delegated from the chief of staff (assignee of a chief-authored ticket)
   ticket_unread?: boolean;      // True when this session has unread ticket events (drives the incoming-nudge indicator)
   nudge_fires_at?: string;      // ISO timestamp a pending ticket-nudge countdown will fire; absent when paused (active session) or no countdown
@@ -641,6 +642,11 @@ model RegisterMessage {
   agent?: string;               // Optional for registered plugin IDs
   dir: string;
   workspace_id: string;
+  // The crew member this session launches as. The daemon resolves it against
+  // the registry and stamps the binding — identity is the invocation — or
+  // refuses the whole registration: an unknown name, an outpost daemon, or a
+  // member whose day is already live all fail here, before the agent runs.
+  member?: string;
 }
 
 model UnregisterMessage {
@@ -4880,6 +4886,7 @@ model Response {
   state_explain_result?: StateExplainResult;
   agent_peek_result?: AgentPeekResult;
   agent_msg_result?: AgentMsgResult;
+  crew_list_result?: CrewListResult;
   seed_plant_result?: SeedPlantResult;
   seed_list_result?: SeedListResult;
   seed_show_result?: SeedShowResult;
@@ -4968,6 +4975,39 @@ model AgentPeekResult {
   last_assistant_message?: string;
   // Absent when the backend cannot serve a snapshot (old worker, no frame).
   screen?: AgentPeekScreen;
+  // The crew member whose active binding this session is; absent when unbound.
+  crew_member?: string;
+}
+
+// ============================================================================
+// Crew
+// ============================================================================
+
+// Read the crew roster: every registered member, awake or asleep. The registry
+// serves the read; the member's home stays plain markdown on disk and is never
+// copied onto the wire. Home-only — an outpost is refused by the enrollment
+// fence.
+model CrewListMessage {
+  cmd: "crew_list";
+}
+
+// One registered crew member. Paths point at the canonical files.
+model CrewMember {
+  id: string;
+  charter_path: string;
+  home_dir: string;
+  // Where the member's sessions launch; absent until the wake slice records one.
+  cwd?: string;
+  // The places the member's charter is about.
+  awareness_dirs: string[];
+  // The session living this member's current day. Present only while that
+  // session is live — the daemon judges the binding at read, so presence IS
+  // "awake" and a caller never re-derives liveness.
+  binding_session?: string;
+}
+
+model CrewListResult {
+  members: CrewMember[];
 }
 
 // What became of a message. Never a silent drop: a message that could not be


### PR DESCRIPTION
Slice 1 of [the crew primitive](https://github.com/victorarias/attn/blob/crew-plan/docs/plans/2026-08-11-the-crew-primitive.md): the registry and the binding.

## What a crew member is

A durable named identity — a charter, a handoff line, an address — whose sessions are its days. keel, alder and trellis have existed since 2026-08-06 as a hand-run skill simulation: three homes of plain markdown under `~/.attn/crew/`, 18 filed handoffs, and a `/wake` skill that reads them. attn itself knew none of it. `attn agent list` could not say "this session is trellis today", nothing stopped two trellises from running at once, and `agent msg trellis` had nothing to resolve against.

This slice puts the roster in the daemon without taking the files away from the user.

## Files stay canonical

The daemon scans `~/.attn/crew/` at startup and records what it finds in a docstore collection (`core/crew`): member id, charter path, home dir, cwd, awareness dirs, active binding. It records **where a home lives, never what it says** — no prose is copied, and a test asserts a member's stored record cannot contain its charter's text. That is what keeps a home hand-editable and lets any agent be a member, claude or codex or a future host. A home the user creates by hand joins the roster at the next daemon start; the import is create-only, so re-running it every startup never touches a record that already exists.

## Identity is the invocation, never the files

Reading a charter confers nothing. `attn <agent> --member <name>` claims a binding **before** the session registers, and that binding is the identity:

- `attn agent list` grows a MEMBER column; `attn agent peek` says "this session is trellis today".
- One member has one active binding. A claim on a member whose day is already live is refused, naming the session that holds it — and the refusal is launch-fatal, because a member launch that quietly ran unbound would be an identity dropped on the floor. Parallelism means another member, never a second copy.
- Whether a stored binding still binds is judged **at read** against live sessions — the same liveness rule a seed's tender follows — so a day that ended without ceremony releases itself. Session teardown clears the record too, on both removal paths.

`attn crew list` is the roster's read surface: every member, awake or asleep, with the short session id `agent peek` takes.

## The garden touches it lightly

Where a tender's free-string name matches a registered member it now resolves to that member's id, so a claim compares addresses rather than spellings (`--member Trellis` and `--member trellis` are the same person). A bound session that names nobody is its own member. **An unregistered name passes through untouched** — the registry never becomes a requirement to tend, and workers and errand sessions are unaffected.

## No behavior change for unbound sessions

The slice's safety property, stated because it is the thing most worth checking, and tested directly (`TestCrew_UnboundSessionsBehaveExactlyAsBefore`): a session launched without `--member` registers, plants, tends, refuses a contended claim and broadcasts exactly as before, with no crew field on the wire at all. Verified live as well as in tests.

## Surfaces walked

- **CLI** — `attn crew list`, the `--member` launch flag, the MEMBER column, the peek line.
- **Daemon** — registry, binding, single-holder, release on both session-removal paths, broadcast decoration.
- **Protocol** — `crew_member` on `Session` and `AgentPeekResult`, `member` on `RegisterMessage`, the `crew_list` command and its models; `ProtocolVersion` 241 → 242 in all three lockstep spots. Generated files regenerated, never hand-edited.
- **Fence** — every crew read and write passes `requireHome`; the crew has one owner, and an outpost gets the named refusal (tested).
- **Linux** — `cmd/attn` and `internal/**` cross-compile clean for linux/arm64; nothing here is Darwin-specific.
- **Docs** — a glossary section for the crew, the architecture map in AGENTS.md, a changelog fragment.
- **App** — none needed. `agent list`/`peek` are CLI-only surfaces (nothing under `app/src` consumes them), so this slice ships CLI + daemon; the sidebar crew surface is slice 2. The app's only obligation was the protocol bump, which is why there is no evidence recording: there is nothing new to see in the window.

## Live verification

Throwaway profile `crewbind`, full `make install PROFILE=crewbind`, bundled preflight PASS (0 failed, 0 warnings; `protocol.cli_app` and `protocol.app_daemon` both 242). Crew homes seeded by copying the real directory's *shape* — three members, charters, dated handoff files — never the live directory. Against the running daemon:

| check | result |
| --- | --- |
| import homes from disk | three homes became the roster |
| launch bound as trellis | `crew list` awake; `agent list` MEMBER=trellis; peek "this session is trellis today" |
| second trellis | refused by name, exit 1, agent never started |
| wake keel alongside | both awake at once |
| unbound session | no crew line in peek, `-` in list, planted and tended normally |
| tender resolution | `--member Trellis` stored as `trellis` |
| sessions end | all three members released, roster back to asleep |

Profile cleaned afterwards.

## Receipts

- The roster read rides every session broadcast, so it was measured rather than assumed: **25µs at a three-member roster** (M5). The crew is people the user named one by one, so that is the real size; the number is recorded beside the code.
- `MaxIDChars = 40` is a tripwire — the longest real member name is 7 characters (`trellis`).

## Two things worth a reviewer's attention

1. **The glossary links to the plan doc, which is not on main yet** — it lands via its own PR from `crew-plan`. The link goes live when that merges; it is dead until then. Flagging rather than dropping the link, since the glossary's convention is to name the plan.
2. **`--member` is refused on daemon-managed launches** (the app's spawn path) with a named error, because that path cannot carry a binding until the wake slice builds it. Refusing loudly beats launching an agent that silently is not who it was asked to be.

## Out of scope (later slices)

The wake app surface and CLI verb, priming injection, handoff filing, the reload nap, the activity subsystem and auto-sleep, `agent msg <member>` addressing, chief migration, and write-refusal on member homes. The `/wake` and `/handoff` skills keep running beside this unchanged.
