### PR TITLE
feat(apps): let a docked view read live documents

### DIFF
--- a/app/src/appSdk.useQuery.test.tsx
+++ b/app/src/appSdk.useQuery.test.tsx
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest"
+import { act, render, screen } from "@testing-library/react"
+import {
+  AppViewRuntimeProvider,
+  useQuery,
+  type AppViewRuntime,
+  type DocumentSubscriber,
+} from "@victorarias/attn-app"
+
+// useQuery holds A3.4's delivery contract so a view never meets it. What is
+// asserted here is that contract from the view's side: render `order`, take each
+// body from `upsert` or the cache, forget the rest — and, across a remount,
+// resume by declaring what is still held so only what changed travels.
+
+type Body = { status: string }
+
+function doc(id: string, rev: number, status: string) {
+  return { id, body: JSON.stringify({ status }), rev, created_at: "", updated_at: "" }
+}
+
+/** A host stand-in that hands the test the subscriber the SDK registered. */
+function fakeRuntime() {
+  const subscribers: DocumentSubscriber[] = []
+  let unsubscribes = 0
+  const runtime: AppViewRuntime = {
+    namespace: "app/approval-gate",
+    subscribe: (subscriber) => {
+      subscribers.push(subscriber)
+      subscriber.onLive(true)
+      return () => {
+        unsubscribes += 1
+      }
+    },
+  }
+  return {
+    runtime,
+    subscribers,
+    latest: () => subscribers[subscribers.length - 1],
+    unsubscribeCount: () => unsubscribes,
+  }
+}
+
+function View({ collection }: { collection: string }) {
+  const { docs, live, error, asOfSeq } = useQuery<Body>(collection, {
+    filters: [{ field: "status", op: "eq", value: "pending" }],
+  })
+  if (error) return <div data-testid="error">{error.code}</div>
+  return (
+    <div>
+      <div data-testid="live">{live ? "live" : "not live"}</div>
+      <div data-testid="seq">{asOfSeq}</div>
+      <div data-testid="ids">{docs.map((d) => `${d.id}:${d.body.status}`).join(",")}</div>
+    </div>
+  )
+}
+
+function mount(runtime: AppViewRuntime, collection = "requests") {
+  return render(
+    <AppViewRuntimeProvider value={runtime}>
+      <View collection={collection} />
+    </AppViewRuntimeProvider>,
+  )
+}
+
+describe("useQuery", () => {
+  it("renders the window in the server's order, from bodies it was sent", () => {
+    const host = fakeRuntime()
+    mount(host.runtime, "renders")
+
+    act(() => {
+      host.latest().onDelivery({
+        delivery: 1,
+        asOfSeq: 9,
+        order: ["b", "a"],
+        upsert: [doc("a", 1, "pending"), doc("b", 1, "pending")],
+      })
+    })
+
+    expect(screen.getByTestId("ids").textContent).toBe("b:pending,a:pending")
+    expect(screen.getByTestId("seq").textContent).toBe("9")
+    expect(screen.getByTestId("live").textContent).toBe("live")
+  })
+
+  it("takes an unchanged body from its cache and forgets what left the window", () => {
+    const host = fakeRuntime()
+    mount(host.runtime, "forgets")
+
+    act(() => {
+      host.latest().onDelivery({
+        delivery: 1,
+        asOfSeq: 1,
+        order: ["a", "b"],
+        upsert: [doc("a", 1, "pending"), doc("b", 1, "pending")],
+      })
+    })
+    // b left the window; a's body did not travel, because the view already holds it.
+    act(() => {
+      host.latest().onDelivery({ delivery: 2, asOfSeq: 2, order: ["a"], upsert: [] })
+    })
+
+    expect(screen.getByTestId("ids").textContent).toBe("a:pending")
+    // The forget rule reaches the resume token too: b is no longer claimed.
+    expect(host.latest().have()).toEqual([{ id: "a", rev: 1 }])
+  })
+
+  it("resumes a remount by declaring what it still holds", () => {
+    const host = fakeRuntime()
+    const first = mount(host.runtime, "resumes")
+
+    act(() => {
+      host.latest().onDelivery({
+        delivery: 1,
+        asOfSeq: 1,
+        order: ["a"],
+        upsert: [doc("a", 3, "pending")],
+      })
+    })
+    first.unmount()
+    expect(host.unsubscribeCount()).toBe(1)
+
+    mount(host.runtime, "resumes")
+    expect(host.latest().have()).toEqual([{ id: "a", rev: 3 }])
+  })
+
+  it("starts over when a delivery names a body nobody holds", () => {
+    const host = fakeRuntime()
+    mount(host.runtime, "invariant")
+
+    act(() => {
+      host.latest().onDelivery({
+        delivery: 1,
+        asOfSeq: 1,
+        order: ["a"],
+        upsert: [doc("a", 1, "pending")],
+      })
+    })
+    const before = host.subscribers.length
+    // A window ordering a document whose body was neither sent nor held: the
+    // subscription is broken, and the remedy is a fresh one with no `have`.
+    act(() => {
+      host.latest().onDelivery({ delivery: 2, asOfSeq: 2, order: ["ghost"], upsert: [] })
+    })
+
+    expect(host.subscribers.length).toBe(before + 1)
+    expect(host.latest().have()).toEqual([])
+  })
+
+  it("surfaces an ended subscription as a state the view can render", () => {
+    const host = fakeRuntime()
+    mount(host.runtime, "ends")
+
+    act(() => {
+      host.latest().onEnded("collection_undefined", "the collection was removed")
+    })
+
+    expect(screen.getByTestId("error").textContent).toBe("collection_undefined")
+  })
+
+  it("says so when the daemon is not serving the query right now", () => {
+    const host = fakeRuntime()
+    mount(host.runtime, "offline")
+
+    act(() => {
+      host.latest().onLive(false)
+    })
+
+    expect(screen.getByTestId("live").textContent).toBe("not live")
+  })
+
+  it("refuses a cursor rather than subscribing to a window that walks", () => {
+    const host = fakeRuntime()
+    function Cursor() {
+      const { error } = useQuery("requests", { after: "a" } as never)
+      return <div data-testid="error">{error?.code ?? ""}</div>
+    }
+    render(
+      <AppViewRuntimeProvider value={host.runtime}>
+        <Cursor />
+      </AppViewRuntimeProvider>,
+    )
+
+    expect(screen.getByTestId("error").textContent).toBe("invalid_query")
+    expect(host.subscribers).toHaveLength(0)
+  })
+
+  it("reports having no host rather than pretending to query one", () => {
+    render(<View collection="hostless" />)
+    expect(screen.getByTestId("error").textContent).toBe("no_runtime")
+  })
+})

--- a/app/src/components/appViews/AppTileHost.tsx
+++ b/app/src/components/appViews/AppTileHost.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { FocusEvent as ReactFocusEvent } from 'react';
+import { AppViewRuntimeProvider, type AppViewRuntime } from '@victorarias/attn-app';
 import { useDaemonApi } from '../../contexts/DaemonApiContext';
 import { useDaemonStore } from '../../store/daemonSessions';
 import { appBundleURL } from '../../utils/appBundle';
@@ -36,7 +37,7 @@ interface Mounted {
 }
 
 export function AppTileHost({ app, view, workspaceId, sessionId, tileId, params }: AppTileHostProps) {
-  const { sendAppViewCrash } = useDaemonApi();
+  const { sendAppViewCrash, subscribeDocuments } = useDaemonApi();
   const entry = useDaemonStore((state) => state.apps.find((a) => a.name === app));
 
   const declared = entry?.views?.some((v) => v.name === view) ?? false;
@@ -121,6 +122,14 @@ export function AppTileHost({ app, view, workspaceId, sessionId, tileId, params 
     [workspaceId, sessionId, tileId, params],
   );
 
+  // The namespace is composed here, from the mount's identity, and never taken
+  // from the view: an app addresses its own documents because that is the only
+  // namespace it is handed.
+  const runtime = useMemo<AppViewRuntime>(
+    () => ({ namespace: `app/${app}`, subscribe: subscribeDocuments }),
+    [app, subscribeDocuments],
+  );
+
   const body = (() => {
     if (!entry) {
       return (
@@ -188,7 +197,9 @@ export function AppTileHost({ app, view, workspaceId, sessionId, tileId, params 
           />
         )}
       >
-        <View {...viewProps} />
+        <AppViewRuntimeProvider value={runtime}>
+          <View {...viewProps} />
+        </AppViewRuntimeProvider>
       </AppViewBoundary>
     );
   })();

--- a/app/src/hooks/daemonDocumentEvents.test.ts
+++ b/app/src/hooks/daemonDocumentEvents.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DocumentSubscriptions,
+  documentSubscribePayload,
+  type DocumentSubscriber,
+} from './daemonDocumentEvents';
+
+// The registry's whole job: route each delivery to the right subscriber, forget
+// one the daemon has ended, and remember the rest across a reconnect so they can
+// be re-sent — carrying what the subscriber holds at that moment, not what it
+// held when it first subscribed.
+
+function subscriber(overrides: Partial<DocumentSubscriber> = {}): DocumentSubscriber {
+  return {
+    request: { namespace: 'app/approval-gate', collection: 'requests' },
+    have: () => [],
+    onDelivery: vi.fn(),
+    onEnded: vi.fn(),
+    onLive: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('DocumentSubscriptions', () => {
+  it('routes a delivery to the subscription that asked for it', () => {
+    const registry = new DocumentSubscriptions();
+    const first = subscriber();
+    const second = subscriber();
+    const firstId = registry.add(first);
+    registry.add(second);
+
+    const handled = registry.handleEvent({
+      event: 'doc_subscription_delivery',
+      subscription_id: firstId,
+      delivery: 1,
+      as_of_seq: 42,
+      order: ['a'],
+      upsert: [{ id: 'a', body: '{}', rev: 1, created_at: '', updated_at: '' }],
+    });
+
+    expect(handled).toBe(true);
+    expect(first.onDelivery).toHaveBeenCalledWith({
+      delivery: 1,
+      asOfSeq: 42,
+      order: ['a'],
+      upsert: [{ id: 'a', body: '{}', rev: 1, created_at: '', updated_at: '' }],
+    });
+    expect(second.onDelivery).not.toHaveBeenCalled();
+  });
+
+  it('leaves events it does not own to the rest of the dispatch', () => {
+    const registry = new DocumentSubscriptions();
+    expect(registry.handleEvent({ event: 'fs_changed' })).toBe(false);
+  });
+
+  it('ignores a delivery for a subscription this client has already dropped', () => {
+    const registry = new DocumentSubscriptions();
+    const sub = subscriber();
+    const id = registry.add(sub);
+    registry.remove(id);
+
+    expect(registry.handleEvent({
+      event: 'doc_subscription_delivery',
+      subscription_id: id,
+      delivery: 1,
+      as_of_seq: 1,
+      order: [],
+      upsert: [],
+    })).toBe(true);
+    expect(sub.onDelivery).not.toHaveBeenCalled();
+  });
+
+  it('forgets an ended subscription before telling the subscriber', () => {
+    const registry = new DocumentSubscriptions();
+    // A subscriber that resubscribes in response must get a fresh id, not the
+    // one the daemon has just dropped.
+    let idAtEnding = '';
+    const sub = subscriber({
+      onEnded: () => {
+        idAtEnding = registry.add(subscriber());
+      },
+    });
+    const id = registry.add(sub);
+
+    registry.handleEvent({
+      event: 'doc_subscription_ended',
+      subscription_id: id,
+      code: 'collection_undefined',
+      error: 'gone',
+    });
+
+    expect(idAtEnding).not.toBe(id);
+    expect(registry.size).toBe(1);
+  });
+
+  it('re-sends every wanted subscription on a new socket, with what it holds now', () => {
+    const registry = new DocumentSubscriptions();
+    let held = [{ id: 'a', rev: 1 }];
+    const sub = subscriber({ have: () => held });
+    const id = registry.add(sub);
+
+    held = [{ id: 'a', rev: 7 }];
+    const sent: Array<Record<string, unknown>> = [];
+    registry.resubscribeAll((payload) => sent.push(payload));
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0].cmd).toBe('doc_subscribe');
+    expect(sent[0].subscription_id).toBe(id);
+    expect(sent[0].have).toEqual([{ id: 'a', rev: 7 }]);
+    expect(sub.onLive).toHaveBeenCalledWith(true);
+  });
+
+  it('tells every subscriber it is no longer being served, and keeps it', () => {
+    const registry = new DocumentSubscriptions();
+    const sub = subscriber();
+    registry.add(sub);
+
+    registry.markDisconnected();
+
+    expect(sub.onLive).toHaveBeenCalledWith(false);
+    expect(registry.size).toBe(1);
+  });
+});
+
+describe('documentSubscribePayload', () => {
+  it('sends a filter bound as JSON text, which is what the daemon type-checks', () => {
+    const payload = documentSubscribePayload('sub-1', subscriber({
+      request: {
+        namespace: 'app/approval-gate',
+        collection: 'requests',
+        filters: [{ field: 'status', op: 'eq', value: 'pending' }],
+        sort: { field: 'updated_at', desc: true },
+        limit: 20,
+      },
+    }));
+
+    expect(payload.query).toEqual({
+      namespace: 'app/approval-gate',
+      collection: 'requests',
+      filters: [{ field: 'status', op: 'eq', value_json: '"pending"' }],
+      sort: { field: 'updated_at', desc: true },
+      limit: 20,
+    });
+  });
+
+  it('omits have entirely when the subscriber holds nothing', () => {
+    const payload = documentSubscribePayload('sub-1', subscriber());
+    expect(payload.have).toBeUndefined();
+  });
+});

--- a/app/src/hooks/daemonDocumentEvents.ts
+++ b/app/src/hooks/daemonDocumentEvents.ts
@@ -1,0 +1,174 @@
+/**
+ * Live document queries: the `doc_subscription_delivery` and
+ * `doc_subscription_ended` events, and the registry that says which subscriber
+ * each one belongs to.
+ *
+ * Deliberately not `daemonPendingRequests`: that module correlates one command
+ * with one `*_result`, and a subscription is a stream — many deliveries under
+ * one id, ended by either side.
+ *
+ * The registry is also what survives a reconnect. A subscription lives on the
+ * daemon's connection, so a dropped socket ends every one of them there; here
+ * they are still wanted, and the hook resubscribes each on the next open. Each
+ * subscriber is asked for its `have()` at that moment, so the resume carries
+ * only what changed while the socket was down.
+ */
+
+import type { StoredDocument } from '../types/generated';
+
+export interface DocumentRevision {
+  id: string;
+  rev: number;
+}
+
+/** A query, as the wire takes it. `after` is absent by construction: a live query is a window. */
+export interface DocumentQueryRequest {
+  namespace: string;
+  collection: string;
+  filters?: Array<{ field: string; op: string; value: unknown }>;
+  sort?: { field: string; desc?: boolean };
+  limit?: number;
+}
+
+/**
+ * One delivery. The client rule is the whole contract: render `order`, take each
+ * body from `upsert` if it is there else from your cache, forget every cached
+ * document not named in `order`.
+ */
+export interface DocumentDelivery {
+  delivery: number;
+  asOfSeq: number;
+  order: string[];
+  upsert: StoredDocument[];
+}
+
+export interface DocumentSubscriber {
+  request: DocumentQueryRequest;
+  /** What this subscriber holds, read at every (re)subscribe. */
+  have: () => DocumentRevision[];
+  onDelivery: (delivery: DocumentDelivery) => void;
+  /** The daemon will not answer this query again as written. Terminal. */
+  onEnded: (code: string, message: string) => void;
+  /** Whether the daemon is serving this subscription right now. */
+  onLive: (live: boolean) => void;
+}
+
+/** The event shapes this module reads, loosely typed off the wire union. */
+type DocumentEvent = {
+  event: string;
+  subscription_id?: unknown;
+  delivery?: unknown;
+  as_of_seq?: unknown;
+  order?: unknown;
+  upsert?: unknown;
+  code?: unknown;
+  error?: unknown;
+};
+
+/** What the registry needs to put a command on the wire, when there is one. */
+export type DocumentCommandSender = (payload: Record<string, unknown>) => void;
+
+export function documentSubscribePayload(id: string, sub: DocumentSubscriber): Record<string, unknown> {
+  const have = sub.have();
+  return {
+    cmd: 'doc_subscribe',
+    subscription_id: id,
+    query: {
+      namespace: sub.request.namespace,
+      collection: sub.request.collection,
+      filters: (sub.request.filters ?? []).map((f) => ({
+        field: f.field,
+        op: f.op,
+        // The one polymorphic leaf on the wire: a filter's bound travels as JSON
+        // text so the daemon can type-check it against the declared field.
+        value_json: JSON.stringify(f.value ?? null),
+      })),
+      sort: sub.request.sort ? { field: sub.request.sort.field, desc: !!sub.request.sort.desc } : undefined,
+      limit: sub.request.limit,
+    },
+    have: have.length > 0 ? have : undefined,
+  };
+}
+
+/**
+ * The live subscriptions this client holds, by the id it minted for each. Ids
+ * are minted here and never reused, so a delivery from a subscription the client
+ * has already dropped names nothing and is discarded.
+ */
+export class DocumentSubscriptions {
+  private subs = new Map<string, DocumentSubscriber>();
+  private nextId = 0;
+
+  /** Registers a subscriber and returns the id its deliveries will carry. */
+  add(sub: DocumentSubscriber): string {
+    this.nextId += 1;
+    const id = `docsub-${this.nextId}`;
+    this.subs.set(id, sub);
+    return id;
+  }
+
+  remove(id: string): boolean {
+    return this.subs.delete(id);
+  }
+
+  entries(): Array<[string, DocumentSubscriber]> {
+    return Array.from(this.subs.entries());
+  }
+
+  get size(): number {
+    return this.subs.size;
+  }
+
+  /** Re-sends every wanted subscription over a freshly opened socket. */
+  resubscribeAll(send: DocumentCommandSender): void {
+    for (const [id, sub] of this.subs) {
+      send(documentSubscribePayload(id, sub));
+      sub.onLive(true);
+    }
+  }
+
+  /** The socket went away, so nothing is being served. The subscriptions stay wanted. */
+  markDisconnected(): void {
+    for (const sub of this.subs.values()) {
+      sub.onLive(false);
+    }
+  }
+
+  /**
+   * Handle one document event. Returns false when the event is not one of ours,
+   * so the caller can keep its own dispatch exhaustive.
+   */
+  handleEvent(event: DocumentEvent): boolean {
+    switch (event.event) {
+      case 'doc_subscription_delivery': {
+        const sub = this.subs.get(String(event.subscription_id ?? ''));
+        if (!sub) return true;
+        sub.onDelivery({
+          delivery: typeof event.delivery === 'number' ? event.delivery : 0,
+          asOfSeq: typeof event.as_of_seq === 'number' ? event.as_of_seq : 0,
+          order: Array.isArray(event.order) ? (event.order as string[]) : [],
+          upsert: Array.isArray(event.upsert) ? (event.upsert as StoredDocument[]) : [],
+        });
+        return true;
+      }
+
+      case 'doc_subscription_ended': {
+        const id = String(event.subscription_id ?? '');
+        const sub = this.subs.get(id);
+        if (!sub) return true;
+        // The daemon has already dropped it, so there is nothing to unsubscribe
+        // from: forget it here before telling the subscriber, so a resubscribe it
+        // starts in response mints a fresh id rather than colliding with this one.
+        this.subs.delete(id);
+        sub.onEnded(
+          typeof event.code === 'string' ? event.code : '',
+          typeof event.error === 'string' ? event.error : 'The subscription ended.',
+        );
+        return true;
+      }
+
+      default:
+        return false;
+    }
+  }
+}

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -73,6 +73,11 @@ import { handleBusDaemonEvent, type BusStatus } from './daemonBusEvents';
 import { handleFsDaemonEvent } from './daemonFsEvents';
 import { handleNotebookDaemonEvent } from './daemonNotebookEvents';
 import {
+  DocumentSubscriptions,
+  documentSubscribePayload,
+  type DocumentSubscriber,
+} from './daemonDocumentEvents';
+import {
   annotationToWire,
   handleSessionAnnotationDaemonEvent,
   type DaemonSessionAnnotation,
@@ -246,7 +251,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '242';
+export const PROTOCOL_VERSION = '243';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a
@@ -1028,6 +1033,9 @@ export function useDaemonSocket({
   const pendingOutboundCommandsRef = useRef<string[]>([]);
   const recoveryNoticeTimeoutRef = useRef<number | null>(null);
   const gitStatusSubscriptionRef = useRef<string | null>(null);
+  // Live document queries. They live on the daemon's connection, so a reconnect
+  // has to re-send them; the registry is what remembers they are still wanted.
+  const docSubscriptionsRef = useRef(new DocumentSubscriptions());
   const ptyTransportRef = useRef(createPtyTransportState<AttachRequestContext>());
   const canceledAttachIdsRef = useRef(new Set<string>());
   // Per-session attach serialization chain — see sendAttachSession.
@@ -1427,6 +1435,11 @@ export function useDaemonSocket({
       if (gitStatusSubscriptionRef.current) {
         ws.send(JSON.stringify({ cmd: 'subscribe_git_status', directory: gitStatusSubscriptionRef.current }));
       }
+
+      // Every live query the daemon lost when this socket's predecessor closed.
+      // Each subscriber is asked for its `have()` right now, so the resume
+      // carries only what changed while we were away.
+      docSubscriptionsRef.current.resubscribeAll((payload) => ws.send(JSON.stringify(payload)));
 
       if (selectedSessionRef.current) {
         ws.send(JSON.stringify({ cmd: 'session_selected', id: selectedSessionRef.current }));
@@ -2988,6 +3001,7 @@ export function useDaemonSocket({
               }
             })) break;
             if (handleBusDaemonEvent(data, pending)) break;
+            if (docSubscriptionsRef.current.handleEvent(data)) break;
             break;
           }
         }
@@ -3000,6 +3014,7 @@ export function useDaemonSocket({
       wsRef.current = null;
       hasReceivedInitialStateRef.current = false;
       canceledAttachIdsRef.current.clear();
+      docSubscriptionsRef.current.markDisconnected();
 
       // Circuit breaker: if open, don't retry
       if (circuitOpenRef.current) {
@@ -3394,6 +3409,35 @@ export function useDaemonSocket({
   // authoring agent reads in `attn app logs`, stamped with the version that
   // served the bundle, and a report the daemon never answers must not become a
   // second failure inside an error boundary.
+  /**
+   * Open a live document query. Returns the way to close it, which the caller
+   * must call: a subscription left open makes the daemon re-run its query on
+   * every write to that collection, for nobody.
+   *
+   * The subscribe never goes through the outbound queue. A queued one would be
+   * flushed on the next open *and* re-sent by `resubscribeAll`, and the daemon
+   * refuses the second id as already open — so when the socket is down the
+   * registry alone carries it, and the connect handler sends it once.
+   */
+  const subscribeDocuments = useCallback((subscriber: DocumentSubscriber) => {
+    const registry = docSubscriptionsRef.current;
+    const id = registry.add(subscriber);
+    const ws = wsRef.current;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(documentSubscribePayload(id, subscriber)));
+      subscriber.onLive(true);
+    } else {
+      subscriber.onLive(false);
+    }
+    return () => {
+      if (!registry.remove(id)) return;
+      const open = wsRef.current;
+      if (open && open.readyState === WebSocket.OPEN) {
+        open.send(JSON.stringify({ cmd: 'doc_unsubscribe', subscription_id: id }));
+      }
+    };
+  }, []);
+
   const sendAppViewCrash = useCallback((report: {
     app: string;
     view: string;
@@ -5587,6 +5631,7 @@ export function useDaemonSocket({
     sendSetClientPresence,
     sendSetTerminalTheme,
     sendAppViewCrash,
+    subscribeDocuments,
     isRuntimeAttached,
     sendGetFileDiff,
     getRepoInfo,

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -1035,7 +1035,8 @@ export function useDaemonSocket({
   const gitStatusSubscriptionRef = useRef<string | null>(null);
   // Live document queries. They live on the daemon's connection, so a reconnect
   // has to re-send them; the registry is what remembers they are still wanted.
-  const docSubscriptionsRef = useRef(new DocumentSubscriptions());
+  const docSubscriptionsRef = useRef<DocumentSubscriptions | null>(null);
+  const docSubscriptions = (docSubscriptionsRef.current ??= new DocumentSubscriptions());
   const ptyTransportRef = useRef(createPtyTransportState<AttachRequestContext>());
   const canceledAttachIdsRef = useRef(new Set<string>());
   // Per-session attach serialization chain — see sendAttachSession.
@@ -1439,7 +1440,7 @@ export function useDaemonSocket({
       // Every live query the daemon lost when this socket's predecessor closed.
       // Each subscriber is asked for its `have()` right now, so the resume
       // carries only what changed while we were away.
-      docSubscriptionsRef.current.resubscribeAll((payload) => ws.send(JSON.stringify(payload)));
+      docSubscriptions.resubscribeAll((payload) => ws.send(JSON.stringify(payload)));
 
       if (selectedSessionRef.current) {
         ws.send(JSON.stringify({ cmd: 'session_selected', id: selectedSessionRef.current }));
@@ -3001,7 +3002,7 @@ export function useDaemonSocket({
               }
             })) break;
             if (handleBusDaemonEvent(data, pending)) break;
-            if (docSubscriptionsRef.current.handleEvent(data)) break;
+            if (docSubscriptions.handleEvent(data)) break;
             break;
           }
         }
@@ -3014,7 +3015,7 @@ export function useDaemonSocket({
       wsRef.current = null;
       hasReceivedInitialStateRef.current = false;
       canceledAttachIdsRef.current.clear();
-      docSubscriptionsRef.current.markDisconnected();
+      docSubscriptions.markDisconnected();
 
       // Circuit breaker: if open, don't retry
       if (circuitOpenRef.current) {
@@ -3420,7 +3421,7 @@ export function useDaemonSocket({
    * registry alone carries it, and the connect handler sends it once.
    */
   const subscribeDocuments = useCallback((subscriber: DocumentSubscriber) => {
-    const registry = docSubscriptionsRef.current;
+    const registry = docSubscriptions;
     const id = registry.add(subscriber);
     const ws = wsRef.current;
     if (ws && ws.readyState === WebSocket.OPEN) {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentMsgMessage, AgentMsgResult, AgentMsgStatus, AgentPeekMessage, AgentPeekResult, AgentPeekScreen, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, AppApplyMessage, AppApplyResult, AppConsumerInfo, AppInvocationInfo, AppListMessage, AppListResult, AppLogsMessage, AppLogsResult, AppRegistryEntry, AppRemoveMessage, AppRemoveResult, AppRollbackMessage, AppRollbackResult, AppRuntimeInfo, AppRuntimeRestartMessage, AppRuntimeRestartResult, AppRuntimeStatusMessage, AppRuntimeStatusResult, AppSetEnabledMessage, AppSetEnabledResult, AppStallInfo, AppStatusMessage, AppStatusResult, AppSummary, AppVersionInfo, AppViewCrashMessage, AppViewInfo, AppWatchMessage, AppWatchResult, ApprovePRMessage, AppsUpdatedMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, BusConsumerStatus, BusHealthEntry, BusProducerStatus, BusSetConsumerEnabledMessage, BusSetConsumerEnabledResultMessage, BusStatusGetMessage, BusStatusResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocUndefineMessage, DocUndefineResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GardenSeedsUpdatedMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, OpenSentFilesMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyInputProbeResultMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Seed, SeedEdge, SeedLinkMessage, SeedLinkResult, SeedListMessage, SeedListResult, SeedNote, SeedNoteMessage, SeedNoteResult, SeedNotesMessage, SeedNotesResult, SeedPlantMessage, SeedPlantResult, SeedReadyMessage, SeedReadyResult, SeedRelation, SeedShowMessage, SeedShowResult, SeedTransitionMessage, SeedTransitionResult, SeedVar, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessageWindowStatus, SessionMessagesChangedMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketRow, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentMsgMessage, AgentMsgResult, AgentMsgStatus, AgentPeekMessage, AgentPeekResult, AgentPeekScreen, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, AppApplyMessage, AppApplyResult, AppConsumerInfo, AppInvocationInfo, AppListMessage, AppListResult, AppLogsMessage, AppLogsResult, AppRegistryEntry, AppRemoveMessage, AppRemoveResult, AppRollbackMessage, AppRollbackResult, AppRuntimeInfo, AppRuntimeRestartMessage, AppRuntimeRestartResult, AppRuntimeStatusMessage, AppRuntimeStatusResult, AppSetEnabledMessage, AppSetEnabledResult, AppStallInfo, AppStatusMessage, AppStatusResult, AppSummary, AppVersionInfo, AppViewCrashMessage, AppViewInfo, AppWatchMessage, AppWatchResult, ApprovePRMessage, AppsUpdatedMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, BusConsumerStatus, BusHealthEntry, BusProducerStatus, BusSetConsumerEnabledMessage, BusSetConsumerEnabledResultMessage, BusStatusGetMessage, BusStatusResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocSubscriptionDeliveryMessage, DocSubscriptionEndedMessage, DocUndefineMessage, DocUndefineResult, DocUnsubscribeMessage, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GardenSeedsUpdatedMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, OpenSentFilesMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyInputProbeResultMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Seed, SeedEdge, SeedLinkMessage, SeedLinkResult, SeedListMessage, SeedListResult, SeedNote, SeedNoteMessage, SeedNoteResult, SeedNotesMessage, SeedNotesResult, SeedPlantMessage, SeedPlantResult, SeedReadyMessage, SeedReadyResult, SeedRelation, SeedShowMessage, SeedShowResult, SeedTransitionMessage, SeedTransitionResult, SeedVar, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessageWindowStatus, SessionMessagesChangedMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketRow, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const activityStatusMessage = Convert.toActivityStatusMessage(json);
 //   const activityStatusResult = Convert.toActivityStatusResult(json);
@@ -137,8 +137,11 @@
 //   const docQueryResult = Convert.toDocQueryResult(json);
 //   const docSubscribeMessage = Convert.toDocSubscribeMessage(json);
 //   const docSubscribeResult = Convert.toDocSubscribeResult(json);
+//   const docSubscriptionDeliveryMessage = Convert.toDocSubscriptionDeliveryMessage(json);
+//   const docSubscriptionEndedMessage = Convert.toDocSubscriptionEndedMessage(json);
 //   const docUndefineMessage = Convert.toDocUndefineMessage(json);
 //   const docUndefineResult = Convert.toDocUndefineResult(json);
+//   const docUnsubscribeMessage = Convert.toDocUnsubscribeMessage(json);
 //   const documentCollectionSchema = Convert.toDocumentCollectionSchema(json);
 //   const documentConflict = Convert.toDocumentConflict(json);
 //   const documentFieldSpec = Convert.toDocumentFieldSpec(json);
@@ -2368,9 +2371,10 @@ export interface DocQueryResult {
 }
 
 export interface DocSubscribeMessage {
-    cmd:   DocSubscribeMessageCmd;
-    have?: HasElement[];
-    query: Query;
+    cmd:              DocSubscribeMessageCmd;
+    have?:            HasElement[];
+    query:            Query;
+    subscription_id?: string;
     [property: string]: any;
 }
 
@@ -2392,6 +2396,32 @@ export interface DocSubscribeResult {
     [property: string]: any;
 }
 
+export interface DocSubscriptionDeliveryMessage {
+    as_of_seq:       number;
+    delivery:        number;
+    event:           DocSubscriptionDeliveryMessageEvent;
+    order:           string[];
+    subscription_id: string;
+    upsert:          Document[];
+    [property: string]: any;
+}
+
+export enum DocSubscriptionDeliveryMessageEvent {
+    DocSubscriptionDelivery = "doc_subscription_delivery",
+}
+
+export interface DocSubscriptionEndedMessage {
+    code:            string;
+    error:           string;
+    event:           DocSubscriptionEndedMessageEvent;
+    subscription_id: string;
+    [property: string]: any;
+}
+
+export enum DocSubscriptionEndedMessageEvent {
+    DocSubscriptionEnded = "doc_subscription_ended",
+}
+
 export interface DocUndefineMessage {
     cmd:        DocUndefineMessageCmd;
     collection: string;
@@ -2408,6 +2438,16 @@ export interface DocUndefineResult {
     documents_removed: number;
     namespace:         string;
     [property: string]: any;
+}
+
+export interface DocUnsubscribeMessage {
+    cmd:             DocUnsubscribeMessageCmd;
+    subscription_id: string;
+    [property: string]: any;
+}
+
+export enum DocUnsubscribeMessageCmd {
+    DocUnsubscribe = "doc_unsubscribe",
 }
 
 export interface DocumentCollectionSchema {
@@ -9036,6 +9076,22 @@ export class Convert {
         return JSON.stringify(uncast(value, r("DocSubscribeResult")), null, 2);
     }
 
+    public static toDocSubscriptionDeliveryMessage(json: string): DocSubscriptionDeliveryMessage {
+        return cast(JSON.parse(json), r("DocSubscriptionDeliveryMessage"));
+    }
+
+    public static docSubscriptionDeliveryMessageToJson(value: DocSubscriptionDeliveryMessage): string {
+        return JSON.stringify(uncast(value, r("DocSubscriptionDeliveryMessage")), null, 2);
+    }
+
+    public static toDocSubscriptionEndedMessage(json: string): DocSubscriptionEndedMessage {
+        return cast(JSON.parse(json), r("DocSubscriptionEndedMessage"));
+    }
+
+    public static docSubscriptionEndedMessageToJson(value: DocSubscriptionEndedMessage): string {
+        return JSON.stringify(uncast(value, r("DocSubscriptionEndedMessage")), null, 2);
+    }
+
     public static toDocUndefineMessage(json: string): DocUndefineMessage {
         return cast(JSON.parse(json), r("DocUndefineMessage"));
     }
@@ -9050,6 +9106,14 @@ export class Convert {
 
     public static docUndefineResultToJson(value: DocUndefineResult): string {
         return JSON.stringify(uncast(value, r("DocUndefineResult")), null, 2);
+    }
+
+    public static toDocUnsubscribeMessage(json: string): DocUnsubscribeMessage {
+        return cast(JSON.parse(json), r("DocUnsubscribeMessage"));
+    }
+
+    public static docUnsubscribeMessageToJson(value: DocUnsubscribeMessage): string {
+        return JSON.stringify(uncast(value, r("DocUnsubscribeMessage")), null, 2);
     }
 
     public static toDocumentCollectionSchema(json: string): DocumentCollectionSchema {
@@ -13459,6 +13523,7 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("DocSubscribeMessageCmd") },
         { json: "have", js: "have", typ: u(undefined, a(r("HasElement"))) },
         { json: "query", js: "query", typ: r("Query") },
+        { json: "subscription_id", js: "subscription_id", typ: u(undefined, "") },
     ], "any"),
     "HasElement": o([
         { json: "id", js: "id", typ: "" },
@@ -13470,6 +13535,20 @@ const typeMap: any = {
         { json: "order", js: "order", typ: a("") },
         { json: "upsert", js: "upsert", typ: a(r("Document")) },
     ], "any"),
+    "DocSubscriptionDeliveryMessage": o([
+        { json: "as_of_seq", js: "as_of_seq", typ: 0 },
+        { json: "delivery", js: "delivery", typ: 0 },
+        { json: "event", js: "event", typ: r("DocSubscriptionDeliveryMessageEvent") },
+        { json: "order", js: "order", typ: a("") },
+        { json: "subscription_id", js: "subscription_id", typ: "" },
+        { json: "upsert", js: "upsert", typ: a(r("Document")) },
+    ], "any"),
+    "DocSubscriptionEndedMessage": o([
+        { json: "code", js: "code", typ: "" },
+        { json: "error", js: "error", typ: "" },
+        { json: "event", js: "event", typ: r("DocSubscriptionEndedMessageEvent") },
+        { json: "subscription_id", js: "subscription_id", typ: "" },
+    ], "any"),
     "DocUndefineMessage": o([
         { json: "cmd", js: "cmd", typ: r("DocUndefineMessageCmd") },
         { json: "collection", js: "collection", typ: "" },
@@ -13479,6 +13558,10 @@ const typeMap: any = {
         { json: "collection", js: "collection", typ: "" },
         { json: "documents_removed", js: "documents_removed", typ: 0 },
         { json: "namespace", js: "namespace", typ: "" },
+    ], "any"),
+    "DocUnsubscribeMessage": o([
+        { json: "cmd", js: "cmd", typ: r("DocUnsubscribeMessageCmd") },
+        { json: "subscription_id", js: "subscription_id", typ: "" },
     ], "any"),
     "DocumentCollectionSchema": o([
         { json: "collection", js: "collection", typ: "" },
@@ -17147,8 +17230,17 @@ const typeMap: any = {
     "DocSubscribeMessageCmd": [
         "doc_subscribe",
     ],
+    "DocSubscriptionDeliveryMessageEvent": [
+        "doc_subscription_delivery",
+    ],
+    "DocSubscriptionEndedMessageEvent": [
+        "doc_subscription_ended",
+    ],
     "DocUndefineMessageCmd": [
         "doc_undefine",
+    ],
+    "DocUnsubscribeMessageCmd": [
+        "doc_unsubscribe",
     ],
     "EndpointActionResultMessageEvent": [
         "endpoint_action_result",

--- a/changelog.d/app-views-read-live-documents.yaml
+++ b/changelog.d/app-views-read-live-documents.yaml
@@ -1,0 +1,11 @@
+kind: added
+area: apps
+change: >
+  A docked app view can now read its app's documents and stay current. The view
+  calls `useQuery` from the app SDK and gets back the matching documents, in the
+  server's order, re-rendered whenever one of them changes — no polling, no
+  refresh button, and no subscription bookkeeping in the view. A tile that is
+  closed and reopened picks up where it left off: it tells the daemon what it
+  already holds, so only what changed while it was gone comes back. When the
+  collection a view reads is removed, or redeclared without a field the query
+  uses, the tile says so instead of sitting empty.

--- a/docs/plans/2026-08-13-ext-a5-ui-host-and-app-sdk.md
+++ b/docs/plans/2026-08-13-ext-a5-ui-host-and-app-sdk.md
@@ -928,6 +928,45 @@ is not built with `--external`, so a handler importing an SDK **value** fails at
 bundle time with a resolution error naming the specifier — unchanged from A4,
 where the ambient declaration had no JavaScript either.
 
+## Slice 4 as-built
+
+The four envelopes and `useQuery` landed as designed. Four things the design did
+not name, all found by building it.
+
+**The refusal and the ending are one envelope.** The design gave
+`doc_subscription_ended` the post-acceptance codes and left refusals implicit. On
+a multiplexed connection a refusal has to name the subscription it refused, and
+`command_error` cannot — so every way a subscription is not running arrives as
+`doc_subscription_ended`, told apart by code: `invalid_query`,
+`undeclared_collection` and `subscription_limit` refuse one that never started,
+`collection_undefined` and `collection_redeclared` end one that did. A client has
+exactly one place to learn a query is not being served.
+
+**The subscribe never goes through the outbound queue.** The frontend queues a
+command issued while the socket is down and flushes it on the next open — and the
+connect handler also re-sends every wanted subscription, because the daemon lost
+them all with the old connection. Both together would send one subscription
+twice, and the second is refused as an id already open. So a subscribe is sent
+only over an open socket; when there is none, the registry alone carries it and
+the connect handler is what sends it. That registry is also what makes a resume
+correct across a reconnect rather than only across a remount: each subscriber is
+asked for its `have()` at re-send time, not at first subscribe.
+
+**`useQuery`'s cache outlives its mount, so it needs a bound.** Resume-by-`have`
+means the bodies survive unmount, which makes them a module-level cache keyed by
+the query's identity. It keeps 64, the same receipt as the per-client
+subscription tripwire: a client cannot hold more live queries than that, so
+retaining more caches is retaining for tiles that cannot all exist. Eviction
+costs one fuller first delivery and nothing else, which is why this bound is the
+one limit in the slice that is deliberately silent.
+
+**The host composes the namespace; the SDK cannot.** `sdk/attn-app` is its own
+package and cannot import the app's socket, so it exports the seam
+(`AppViewRuntimeProvider`, `AppViewRuntime`) and `AppTileHost` implements it —
+handing over `app/<app>` and the frontend's `subscribeDocuments`. That is what
+makes "a view cannot read another app's documents" structural: a view is given a
+namespace, and there is no call that takes one.
+
 ## Out of scope
 
 - Panels, windows, and any mount kind other than tiles. Designed for, not

--- a/internal/appbuild/sdkdist/index.d.ts
+++ b/internal/appbuild/sdkdist/index.d.ts
@@ -107,3 +107,7 @@ export interface ViewProps {
     /** Opaque to attn — the app decides what it means. Empty when none was given. */
     readonly params: string;
 }
+export { useQuery } from "./useQuery";
+export type { LiveQueryOptions, QueryError, QueryResult } from "./useQuery";
+export { AppViewRuntimeProvider, useAppViewRuntime } from "./runtime";
+export type { AppViewRuntime, DocumentRevision, DocumentSubscriber, LiveQueryRequest, QueryDelivery, RawDocument, } from "./runtime";

--- a/internal/appbuild/sdkdist/runtime.d.ts
+++ b/internal/appbuild/sdkdist/runtime.d.ts
@@ -1,0 +1,66 @@
+/** One document a resuming subscriber already holds, and at which revision. */
+export interface DocumentRevision {
+    id: string;
+    rev: number;
+}
+/** A stored document exactly as the wire carries it: the body is still JSON text. */
+export interface RawDocument {
+    id: string;
+    body: string;
+    rev: number;
+    created_at: string;
+    updated_at: string;
+}
+/** A query a live subscription can answer. No cursor: a live query is a window. */
+export interface LiveQueryRequest {
+    namespace: string;
+    collection: string;
+    filters?: Array<{
+        field: string;
+        op: string;
+        value: unknown;
+    }>;
+    sort?: {
+        field: string;
+        desc?: boolean;
+    };
+    limit?: number;
+}
+/**
+ * One delivery, and the whole client contract is one rule:
+ *
+ *   Render `order`. Take each body from `upsert` if it is there, else from your
+ *   cache. Forget every cached document not named in `order`.
+ */
+export interface QueryDelivery {
+    delivery: number;
+    asOfSeq: number;
+    order: string[];
+    upsert: RawDocument[];
+}
+/** What the host calls back as a subscription runs. */
+export interface DocumentSubscriber {
+    request: LiveQueryRequest;
+    /** What this subscriber holds, read by the host at every subscribe and resubscribe. */
+    have: () => DocumentRevision[];
+    onDelivery: (delivery: QueryDelivery) => void;
+    /** Terminal: the daemon will not answer this query again as written. */
+    onEnded: (code: string, message: string) => void;
+    /** Whether the daemon is serving this subscription right now. */
+    onLive: (live: boolean) => void;
+}
+/** What the host provides to everything it mounts. */
+export interface AppViewRuntime {
+    /** The document namespace this mount reads. A view cannot widen it. */
+    readonly namespace: string;
+    /** Opens a live query; the returned function closes it and must be called. */
+    subscribe: (subscriber: DocumentSubscriber) => () => void;
+}
+/** The host wraps every mounted view in this. */
+export declare const AppViewRuntimeProvider: import("react").Provider<AppViewRuntime | null>;
+/**
+ * The runtime this view is mounted in. Null outside a host — which is a real
+ * state for a component rendered in an app's own tests, so the hooks report it
+ * rather than throwing.
+ */
+export declare function useAppViewRuntime(): AppViewRuntime | null;

--- a/internal/appbuild/sdkdist/useQuery.d.ts
+++ b/internal/appbuild/sdkdist/useQuery.d.ts
@@ -1,0 +1,49 @@
+import type { Document, Filter } from "./index";
+/** What a live query takes. No `after`: a live query is a window, a cursor is a walk. */
+export interface LiveQueryOptions {
+    filters?: Filter[];
+    sort?: {
+        field: string;
+        desc?: boolean;
+    };
+    /** Defaults to the store's own 100, and refuses more than 1000. */
+    limit?: number;
+}
+export interface QueryError {
+    /**
+     * What to act on. `collection_undefined` and `collection_redeclared` mean this
+     * query is over; `invalid_query`, `undeclared_collection` and
+     * `subscription_limit` mean it never started.
+     */
+    code: string;
+    message: string;
+}
+export interface QueryResult<Body> {
+    /** The window, in the server's order. */
+    docs: Array<Document<Body>>;
+    /** The log position this window was true at. Opaque and monotonic. */
+    asOfSeq: number;
+    /** Whether the daemon is serving this query right now. */
+    live: boolean;
+    /**
+     * Set when the subscription ended and will not resume on its own. It is a
+     * state to render, not an exception: a tile that spins forever because its
+     * collection was removed is worse than one that says so.
+     */
+    error: QueryError | null;
+}
+/**
+ * Subscribe to a collection and stay current.
+ *
+ * ```tsx
+ * const { docs, live } = useQuery("requests", {
+ *   filters: [{ field: "status", op: "eq", value: "pending" }],
+ *   sort: { field: "updated_at", desc: true },
+ *   limit: 20,
+ * })
+ * ```
+ *
+ * The collection is this app's — the namespace comes from where the tile is
+ * mounted, so a view cannot read another app's documents by asking.
+ */
+export declare function useQuery<Body = unknown>(collection: string, options?: LiveQueryOptions): QueryResult<Body>;

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -200,6 +200,7 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdDocQuery:       commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdDocCount:       commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdDocSubscribe:   commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdDocUnsubscribe: commandMetadata(ScopeHubLocal, false, true),
 	// The app registry is the daemon's own database and its own bus, so a hub
 	// answers these itself. None touches a PTY, so none blocks during recovery.
 	protocol.CmdAppList:       commandMetadata(ScopeHubLocal, false, true),

--- a/internal/daemon/documents.go
+++ b/internal/daemon/documents.go
@@ -16,7 +16,9 @@ import (
 )
 
 // The document store's daemon half: the fact a write publishes, the live
-// queries that fact wakes, and the IPC surface `attn doc` speaks.
+// queries that fact wakes, and the IPC surface `attn doc` speaks. One
+// subscription loop serves both transports through a sink; the WebSocket half
+// of it is in documents_ws.go.
 //
 // A subscription re-runs the whole query per delivery — never patches — and
 // diffs bodies against what the subscriber holds. A delivery is safe to drop
@@ -579,40 +581,53 @@ func (d *Daemon) handleDocCount(conn net.Conn, msg *protocol.DocCountMessage) {
 	}})
 }
 
-// handleDocSubscribe is the only handler that keeps its connection: the current
-// window immediately, then a fresh one per relevant write, ending on disconnect
-// or when the collection can no longer answer. A delivery is ids in order plus
-// only the bodies the subscriber does not hold, tracked as one {id: rev} map.
-func (d *Daemon) handleDocSubscribe(conn net.Conn, msg *protocol.DocSubscribeMessage) {
+// docSink is where one subscription's deliveries and its ending go, and it is
+// the whole difference between the two transports: the unix socket writes both
+// onto the connection that asked, the WebSocket wraps each in an envelope naming
+// the subscription, because one socket there carries many. The loop above it
+// knows neither.
+//
+// deliver returning an error ends the subscription silently — the transport has
+// already lost the caller, so there is nobody left to tell.
+type docSink struct {
+	deliver func(*protocol.DocSubscribeResult) error
+	end     func(err error, code string)
+}
+
+// docSubscriptionQuery decodes a subscribe request and refuses the one query a
+// live subscription cannot answer.
+func docSubscriptionQuery(msg *protocol.DocSubscribeMessage) (docstore.Query, error) {
 	q, err := documentQueryFromProtocol(msg.Query)
 	if err != nil {
-		d.sendDocError(conn, err)
-		return
+		return docstore.Query{}, err
 	}
 	if q.After != "" {
-		d.sendDocError(conn, docstore.InvalidQuery(fmt.Errorf(
+		return docstore.Query{}, docstore.InvalidQuery(fmt.Errorf(
 			"docstore: %s/%s cannot subscribe with the after cursor %q: a live query is a window and a cursor is a walk, so the document the cursor names moves out from under the subscription. Set a limit instead and render each delivery's window; a delivery already carries only what changed.",
-			q.Namespace, q.Collection, q.After)))
-		return
+			q.Namespace, q.Collection, q.After))
 	}
+	return q, nil
+}
 
+// runDocSubscription is the one live-query loop, shared by both transports: the
+// current window immediately, then a fresh one per relevant write, ending when
+// `done` closes or when the collection can no longer answer. A delivery is ids
+// in order plus only the bodies the subscriber does not hold, tracked as one
+// {id: rev} map.
+//
+// It blocks until the subscription ends, and it must never run inside the bus
+// fan-out: a delivery writes a socket, and the bus holds its publish lock across
+// that fan-out. What the fact handler does is poke this loop's wake channel.
+func (d *Daemon) runDocSubscription(q docstore.Query, have []protocol.DocumentRevision, sink docSink, done <-chan struct{}) {
 	// Registered before the first query: the other order drops a write landing
 	// in between; this one only risks a redundant ids-only delivery.
 	sub := d.addDocSubscription(q)
 	defer d.removeDocSubscription(sub.id)
 
-	// The caller never speaks again, so anything the read returns means gone.
-	gone := make(chan struct{})
-	go func() {
-		defer close(gone)
-		_, _ = io.Copy(io.Discard, conn)
-	}()
-
 	// What the subscriber holds: seeded from `have`, replaced by each delivered
 	// window, never growing past the query's limit.
-	held := heldRevisions(msg.Have)
+	held := heldRevisions(have)
 
-	encoder := json.NewEncoder(conn)
 	for delivery := 1; ; delivery++ {
 		// Re-read the declaration per delivery (inside the query's transaction): an
 		// undefine or a field-dropping redeclare must END the subscription, told
@@ -623,21 +638,52 @@ func (d *Daemon) handleDocSubscribe(conn net.Conn, msg *protocol.DocSubscribeMes
 			if delivery > 1 {
 				code = subscriptionEndCode(err)
 			}
-			d.sendDocErrorAs(conn, err, code)
+			sink.end(err, code)
 			return
 		}
 		d.logSlowDocFanOut(sub, read.Schema, took)
 		window, next := windowDelivery(delivery, read, held)
-		if err := encoder.Encode(protocol.Response{Ok: true, DocSubscribeResult: window}); err != nil {
+		if err := sink.deliver(window); err != nil {
 			return
 		}
 		held = next
 		select {
 		case <-sub.wake:
-		case <-gone:
+		case <-done:
 			return
 		}
 	}
+}
+
+// handleDocSubscribe is the only IPC handler that keeps its connection: here the
+// connection IS the subscription, so it needs no id and refuses one.
+func (d *Daemon) handleDocSubscribe(conn net.Conn, msg *protocol.DocSubscribeMessage) {
+	if msg.SubscriptionID != nil {
+		d.sendDocError(conn, docstore.InvalidQuery(fmt.Errorf(
+			"docstore: doc_subscribe over the unix socket takes no subscription_id (got %q): this connection is the subscription, so an id would name nothing. Drop the field here, or subscribe over the WebSocket, where one connection carries many.",
+			*msg.SubscriptionID)))
+		return
+	}
+	q, err := docSubscriptionQuery(msg)
+	if err != nil {
+		d.sendDocError(conn, err)
+		return
+	}
+
+	// The caller never speaks again, so anything the read returns means gone.
+	gone := make(chan struct{})
+	go func() {
+		defer close(gone)
+		_, _ = io.Copy(io.Discard, conn)
+	}()
+
+	encoder := json.NewEncoder(conn)
+	d.runDocSubscription(q, msg.Have, docSink{
+		deliver: func(window *protocol.DocSubscribeResult) error {
+			return encoder.Encode(protocol.Response{Ok: true, DocSubscribeResult: window})
+		},
+		end: func(err error, code string) { d.sendDocErrorAs(conn, err, code) },
+	}, gone)
 }
 
 // heldRevisions turns the subscriber's declared `have` into the diff map. A

--- a/internal/daemon/documents_ws.go
+++ b/internal/daemon/documents_ws.go
@@ -1,0 +1,162 @@
+package daemon
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/victorarias/attn/internal/docstore"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// Live queries on the WebSocket. The subscription loop, the wake channel and the
+// windowed delivery are documents.go's; what is here is the identity a
+// multiplexed connection needs — a client-minted id, the way out that matches
+// the way in, and the per-client ceiling on how many may be open at once.
+//
+// Design: docs/plans/2026-08-13-ext-a5-ui-host-and-app-sdk.md, "Protocol
+// envelopes".
+
+// clientDocSubscriptions is one client's live queries: id → the channel whose
+// close ends that subscription's loop. Its own lock, because a subscription ends
+// from three directions (the client asking, the client disconnecting, the daemon
+// giving up) and none of them holds the other's.
+type clientDocSubscriptions struct {
+	mu   sync.Mutex
+	subs map[string]chan struct{}
+}
+
+// open registers a subscription, or says why it cannot. The count comes back so
+// the refusal can name the ask alongside the limit.
+func (s *clientDocSubscriptions) open(id string) (done chan struct{}, held int, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.subs == nil {
+		s.subs = map[string]chan struct{}{}
+	}
+	if _, exists := s.subs[id]; exists {
+		return nil, len(s.subs), fmt.Errorf("already open")
+	}
+	if len(s.subs) >= protocol.DocSubscriptionsPerClient {
+		return nil, len(s.subs), fmt.Errorf("limit reached")
+	}
+	done = make(chan struct{})
+	s.subs[id] = done
+	return done, len(s.subs), nil
+}
+
+// close ends one subscription and reports whether it was there — an unsubscribe
+// racing the daemon's own ending is ordinary, not an error.
+func (s *clientDocSubscriptions) close(id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	done, ok := s.subs[id]
+	if !ok {
+		return false
+	}
+	delete(s.subs, id)
+	close(done)
+	return true
+}
+
+// closeAll ends every subscription this client holds. A client that vanished
+// leaves loops that would otherwise re-run its queries on every write to their
+// collections, forever.
+func (s *clientDocSubscriptions) closeAll() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, done := range s.subs {
+		delete(s.subs, id)
+		close(done)
+	}
+}
+
+func (s *clientDocSubscriptions) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.subs)
+}
+
+// handleDocSubscribeWS accepts a live query on the WebSocket. Every refusal and
+// every ending leaves by the same envelope, so a client has exactly one place to
+// learn a subscription is not running.
+func (d *Daemon) handleDocSubscribeWS(client *wsClient, msg *protocol.DocSubscribeMessage) {
+	id := protocol.Deref(msg.SubscriptionID)
+	if id == "" {
+		d.sendCommandError(client, protocol.CmdDocSubscribe,
+			"doc_subscribe over the WebSocket requires a client-minted subscription_id: one connection carries many subscriptions, so a delivery has to say which one it belongs to")
+		return
+	}
+	q, err := docSubscriptionQuery(msg)
+	if err != nil {
+		d.endDocSubscriptionWS(client, id, err, docErrorCode(err))
+		return
+	}
+
+	done, held, err := client.docSubscriptions.open(id)
+	if err != nil {
+		if held >= protocol.DocSubscriptionsPerClient {
+			d.endDocSubscriptionWS(client, id, fmt.Errorf(
+				"docstore: this client already holds %d live subscriptions, which is the limit (%d), so %q was refused. Unsubscribe what is no longer on screen; a tile that unmounts must send doc_unsubscribe.",
+				held, protocol.DocSubscriptionsPerClient, id), protocol.ErrorCodeSubscriptionLimit)
+			return
+		}
+		d.endDocSubscriptionWS(client, id, docstore.InvalidQuery(fmt.Errorf(
+			"docstore: subscription_id %q is already open on this connection; mint a fresh id per subscribe, or doc_unsubscribe the first one",
+			id)), protocol.ErrorCodeInvalidQuery)
+		return
+	}
+
+	// Its own goroutine: the loop blocks between deliveries, and the message pump
+	// that got us here processes this client's commands in order — including the
+	// doc_unsubscribe that ends this.
+	go func() {
+		defer client.docSubscriptions.close(id)
+		d.runDocSubscription(q, msg.Have, docSink{
+			deliver: func(window *protocol.DocSubscribeResult) error {
+				// A non-blocking hand-off to the write pump, which is what keeps a
+				// slow client from stalling a delivery loop. Its failure means the
+				// client is gone or too far behind to keep, and the subscription ends.
+				if !d.sendToClient(client, protocol.DocSubscriptionDeliveryMessage{
+					Event:          protocol.EventDocSubscriptionDelivery,
+					SubscriptionID: id,
+					Delivery:       window.Delivery,
+					AsOfSeq:        window.AsOfSeq,
+					Order:          window.Order,
+					Upsert:         window.Upsert,
+				}) {
+					return fmt.Errorf("client gone")
+				}
+				return nil
+			},
+			end: func(err error, code string) { d.endDocSubscriptionWS(client, id, err, code) },
+		}, done)
+	}()
+}
+
+// handleDocUnsubscribeWS is the way out for the way in. An id nobody holds is
+// ignored: an unsubscribe racing the daemon's own ending is the ordinary case.
+func (d *Daemon) handleDocUnsubscribeWS(client *wsClient, msg *protocol.DocUnsubscribeMessage) {
+	client.docSubscriptions.close(msg.SubscriptionID)
+}
+
+// endDocSubscriptionWS tells the client one subscription is over, and why. Code
+// is what a host acts on; the message is what a person reads.
+func (d *Daemon) endDocSubscriptionWS(client *wsClient, id string, err error, code string) {
+	if code == "" {
+		code = protocol.ErrorCodeInvalidQuery
+	}
+	d.sendToClient(client, protocol.DocSubscriptionEndedMessage{
+		Event:          protocol.EventDocSubscriptionEnded,
+		SubscriptionID: id,
+		Code:           code,
+		Error:          err.Error(),
+	})
+}
+
+// dropDocSubscriptions ends every live query a departing client held.
+func (d *Daemon) dropDocSubscriptions(client *wsClient) {
+	if client == nil {
+		return
+	}
+	client.docSubscriptions.closeAll()
+}

--- a/internal/daemon/documents_ws_test.go
+++ b/internal/daemon/documents_ws_test.go
@@ -1,0 +1,373 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// Live queries over the WebSocket. The delivery semantics themselves are pinned
+// in documents_windowed_test.go against the IPC transport; what these assert is
+// what the second transport adds — an identity per subscription, a way out, a
+// ceiling, and a teardown that survives every way a client can leave.
+
+// wsSubscriber is one WebSocket client's view of its live queries: the send
+// channel the daemon queues into, decoded into the two envelopes this surface
+// speaks.
+type wsSubscriber struct {
+	client *wsClient
+}
+
+func newWSSubscriber() *wsSubscriber {
+	return &wsSubscriber{client: &wsClient{send: make(chan outboundMessage, 256)}}
+}
+
+// nextEvent reads the next queued message, failing rather than hanging if the
+// daemon sends nothing. The timeout is a tripwire on a deadlock, not a wait for
+// something slow: every assertion here is woken by a real write.
+func (s *wsSubscriber) nextEvent(t *testing.T) map[string]any {
+	t.Helper()
+	select {
+	case msg := <-s.client.send:
+		var out map[string]any
+		if err := json.Unmarshal(msg.payload, &out); err != nil {
+			t.Fatalf("decode outbound message: %v", err)
+		}
+		return out
+	case <-time.After(5 * time.Second):
+		t.Fatal("the daemon sent nothing to this client")
+		return nil
+	}
+}
+
+// nextDelivery reads one doc_subscription_delivery for the given id.
+func (s *wsSubscriber) nextDelivery(t *testing.T, id string) map[string]any {
+	t.Helper()
+	event := s.nextEvent(t)
+	if event["event"] != protocol.EventDocSubscriptionDelivery {
+		t.Fatalf("expected a delivery, got %v", event)
+	}
+	if event["subscription_id"] != id {
+		t.Fatalf("delivery carried subscription_id %v, want %q", event["subscription_id"], id)
+	}
+	return event
+}
+
+func deliveryOrder(t *testing.T, event map[string]any) []string {
+	t.Helper()
+	raw, _ := event["order"].([]any)
+	out := make([]string, 0, len(raw))
+	for _, id := range raw {
+		out = append(out, fmt.Sprint(id))
+	}
+	return out
+}
+
+func upsertIDs(t *testing.T, event map[string]any) []string {
+	t.Helper()
+	raw, _ := event["upsert"].([]any)
+	out := make([]string, 0, len(raw))
+	for _, doc := range raw {
+		entry, _ := doc.(map[string]any)
+		out = append(out, fmt.Sprint(entry["id"]))
+	}
+	return out
+}
+
+func wsSubscribe(d *Daemon, s *wsSubscriber, id string, have []protocol.DocumentRevision) {
+	d.handleDocSubscribeWS(s.client, &protocol.DocSubscribeMessage{
+		Cmd:            protocol.CmdDocSubscribe,
+		Query:          testQuery(),
+		Have:           have,
+		SubscriptionID: protocol.Ptr(id),
+	})
+}
+
+// A WebSocket subscription behaves exactly as the IPC one does, plus an id: the
+// current window arrives immediately, and a write brings the next.
+func TestWebSocketSubscriptionDeliversAndStaysLive(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "already-here", `{"status":"pending"}`)
+
+	sub := newWSSubscriber()
+	wsSubscribe(d, sub, "tile-1", nil)
+
+	first := sub.nextDelivery(t, "tile-1")
+	if got := deliveryOrder(t, first); len(got) != 1 || got[0] != "already-here" {
+		t.Fatalf("first delivery ordered %v", got)
+	}
+	if first["delivery"] != float64(1) {
+		t.Fatalf("first delivery counted %v, want 1", first["delivery"])
+	}
+
+	putDoc(t, d, "b", `{"status":"pending"}`)
+	second := sub.nextDelivery(t, "tile-1")
+	if got := deliveryOrder(t, second); len(got) != 2 {
+		t.Fatalf("second delivery ordered %v, want both documents", got)
+	}
+	// Only the new body travels: the subscriber was already sent the other one.
+	if got := upsertIDs(t, second); len(got) != 1 || got[0] != "b" {
+		t.Fatalf("second delivery carried bodies %v, want only b", got)
+	}
+}
+
+// One connection carries many, so a delivery has to say which subscription it
+// belongs to — and each one runs its own query.
+func TestWebSocketSubscriptionsAreIndependentOnOneConnection(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+
+	sub := newWSSubscriber()
+	wsSubscribe(d, sub, "tile-1", nil)
+	sub.nextDelivery(t, "tile-1")
+	wsSubscribe(d, sub, "tile-2", nil)
+	sub.nextDelivery(t, "tile-2")
+
+	if got := d.documentSubscriptionCount(); got != 2 {
+		t.Fatalf("daemon holds %d subscriptions, want 2", got)
+	}
+
+	putDoc(t, d, "a", `{"status":"pending"}`)
+	seen := map[string]bool{}
+	for range 2 {
+		event := sub.nextEvent(t)
+		seen[fmt.Sprint(event["subscription_id"])] = true
+	}
+	if !seen["tile-1"] || !seen["tile-2"] {
+		t.Fatalf("the write woke %v, want both subscriptions", seen)
+	}
+}
+
+// The way out for the way in: an unsubscribed query stops costing the daemon a
+// re-run on every write to its collection.
+func TestUnsubscribeEndsTheSubscription(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+
+	sub := newWSSubscriber()
+	wsSubscribe(d, sub, "tile-1", nil)
+	sub.nextDelivery(t, "tile-1")
+
+	d.handleDocUnsubscribeWS(sub.client, &protocol.DocUnsubscribeMessage{
+		Cmd: protocol.CmdDocUnsubscribe, SubscriptionID: "tile-1",
+	})
+	waitForSubscriptionCount(t, d, 0)
+
+	// An id nobody holds is ignored rather than refused: an unsubscribe racing
+	// the daemon's own ending is the ordinary case.
+	d.handleDocUnsubscribeWS(sub.client, &protocol.DocUnsubscribeMessage{
+		Cmd: protocol.CmdDocUnsubscribe, SubscriptionID: "tile-1",
+	})
+}
+
+// A client that vanishes leaves loops that would re-run its queries forever.
+func TestDisconnectDropsEveryLiveQueryTheClientHeld(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+
+	sub := newWSSubscriber()
+	wsSubscribe(d, sub, "tile-1", nil)
+	sub.nextDelivery(t, "tile-1")
+	wsSubscribe(d, sub, "tile-2", nil)
+	sub.nextDelivery(t, "tile-2")
+
+	d.dropDocSubscriptions(sub.client)
+	waitForSubscriptionCount(t, d, 0)
+	if got := sub.client.docSubscriptions.count(); got != 0 {
+		t.Fatalf("the client still holds %d subscriptions", got)
+	}
+}
+
+// The tripwire: past the per-client limit a subscription is refused by name,
+// never silently dropped. A refusal a client cannot read is a tile that renders
+// nothing forever with nothing to look up.
+func TestTooManySubscriptionsIsARefusalThatNamesTheLimit(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+
+	sub := newWSSubscriber()
+	for i := range protocol.DocSubscriptionsPerClient {
+		wsSubscribe(d, sub, fmt.Sprintf("tile-%d", i), nil)
+		sub.nextDelivery(t, fmt.Sprintf("tile-%d", i))
+	}
+
+	wsSubscribe(d, sub, "one-too-many", nil)
+	event := sub.nextEvent(t)
+	if event["event"] != protocol.EventDocSubscriptionEnded {
+		t.Fatalf("expected the subscription to be refused, got %v", event)
+	}
+	if event["code"] != protocol.ErrorCodeSubscriptionLimit {
+		t.Fatalf("refusal code = %v, want %q", event["code"], protocol.ErrorCodeSubscriptionLimit)
+	}
+	message := fmt.Sprint(event["error"])
+	if !strings.Contains(message, fmt.Sprint(protocol.DocSubscriptionsPerClient)) {
+		t.Fatalf("refusal does not name the limit: %s", message)
+	}
+	if !strings.Contains(message, "one-too-many") {
+		t.Fatalf("refusal does not name the ask: %s", message)
+	}
+	if got := sub.client.docSubscriptions.count(); got != protocol.DocSubscriptionsPerClient {
+		t.Fatalf("the refused subscription changed the count to %d", got)
+	}
+}
+
+// Two live subscriptions under one id would make every delivery ambiguous.
+func TestASecondSubscriptionUnderOneIDIsRefused(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+
+	sub := newWSSubscriber()
+	wsSubscribe(d, sub, "tile-1", nil)
+	sub.nextDelivery(t, "tile-1")
+
+	wsSubscribe(d, sub, "tile-1", nil)
+	event := sub.nextEvent(t)
+	if event["event"] != protocol.EventDocSubscriptionEnded ||
+		event["code"] != protocol.ErrorCodeInvalidQuery {
+		t.Fatalf("expected an invalid_query refusal, got %v", event)
+	}
+	if got := d.documentSubscriptionCount(); got != 1 {
+		t.Fatalf("the refusal disturbed the live subscription: count = %d", got)
+	}
+}
+
+// The WebSocket has one failure channel, so a query that never starts and a
+// subscription that ends after acceptance both arrive as doc_subscription_ended
+// — told apart by code, which is what lets a host pick between "kill the tile"
+// and "the caller asked for the wrong thing".
+func TestSubscribeRefusalsAndEndingsShareOneEnvelope(t *testing.T) {
+	d := newDaemonForTest(t)
+
+	sub := newWSSubscriber()
+	// Never declared: a refusal, before the subscription exists.
+	wsSubscribe(d, sub, "tile-1", nil)
+	refusal := sub.nextEvent(t)
+	if refusal["event"] != protocol.EventDocSubscriptionEnded ||
+		refusal["code"] != protocol.ErrorCodeUndeclaredCollection {
+		t.Fatalf("expected an undeclared_collection refusal, got %v", refusal)
+	}
+
+	// Declared, subscribed, then removed underneath it: an ending, after
+	// acceptance.
+	defineTestCollection(t, d)
+	wsSubscribe(d, sub, "tile-2", nil)
+	sub.nextDelivery(t, "tile-2")
+
+	undefineTestCollection(t, d)
+	ended := sub.nextEvent(t)
+	if ended["event"] != protocol.EventDocSubscriptionEnded ||
+		ended["code"] != protocol.ErrorCodeCollectionUndefined {
+		t.Fatalf("expected a collection_undefined ending, got %v", ended)
+	}
+	waitForSubscriptionCount(t, d, 0)
+}
+
+// A cursor names a document that moves out from under a live window, so a
+// subscription refuses one — on both transports, from the one check.
+func TestSubscribingWithACursorIsRefusedOnTheWebSocket(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+
+	sub := newWSSubscriber()
+	q := testQuery()
+	q.After = protocol.Ptr("a")
+	d.handleDocSubscribeWS(sub.client, &protocol.DocSubscribeMessage{
+		Cmd: protocol.CmdDocSubscribe, Query: q, SubscriptionID: protocol.Ptr("tile-1"),
+	})
+	event := sub.nextEvent(t)
+	if event["event"] != protocol.EventDocSubscriptionEnded ||
+		event["code"] != protocol.ErrorCodeInvalidQuery {
+		t.Fatalf("expected an invalid_query refusal, got %v", event)
+	}
+	if !strings.Contains(fmt.Sprint(event["error"]), "after cursor") {
+		t.Fatalf("refusal does not say what was wrong: %v", event["error"])
+	}
+}
+
+// Resume is the same on this transport as on the other: what the client declares
+// it holds is what the first delivery does not re-send.
+func TestWebSocketResumeSendsOnlyWhatChanged(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "kept", `{"status":"pending"}`)
+	putDoc(t, d, "moved", `{"status":"pending"}`)
+
+	sub := newWSSubscriber()
+	wsSubscribe(d, sub, "tile-1", nil)
+	first := sub.nextDelivery(t, "tile-1")
+	held := map[string]int{}
+	for _, doc := range first["upsert"].([]any) {
+		entry := doc.(map[string]any)
+		held[fmt.Sprint(entry["id"])] = int(entry["rev"].(float64))
+	}
+	d.handleDocUnsubscribeWS(sub.client, &protocol.DocUnsubscribeMessage{
+		Cmd: protocol.CmdDocUnsubscribe, SubscriptionID: "tile-1",
+	})
+	waitForSubscriptionCount(t, d, 0)
+
+	// One of the two moved while nobody was watching.
+	putDoc(t, d, "moved", `{"status":"approved"}`)
+
+	have := []protocol.DocumentRevision{
+		{ID: "kept", Rev: held["kept"]},
+		{ID: "moved", Rev: held["moved"]},
+	}
+	wsSubscribe(d, sub, "tile-2", have)
+	resumed := sub.nextDelivery(t, "tile-2")
+	if got := len(deliveryOrder(t, resumed)); got != 2 {
+		t.Fatalf("resumed window holds %d documents, want 2", got)
+	}
+	if got := upsertIDs(t, resumed); len(got) != 1 || got[0] != "moved" {
+		t.Fatalf("resume carried bodies %v, want only the one that changed", got)
+	}
+}
+
+// On the unix socket the connection IS the subscription, so an id there would
+// name nothing — and a client that sends one has misread the surface badly
+// enough that answering it would be worse than refusing.
+func TestIPCSubscribeRefusesASubscriptionID(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocSubscribe(c, &protocol.DocSubscribeMessage{
+			Cmd: protocol.CmdDocSubscribe, Query: testQuery(), SubscriptionID: protocol.Ptr("tile-1"),
+		})
+	})
+	if resp.Ok {
+		t.Fatal("the unix socket accepted a subscription_id")
+	}
+	if got := protocol.Deref(resp.ErrorCode); got != protocol.ErrorCodeInvalidQuery {
+		t.Fatalf("refusal code = %q, want %q", got, protocol.ErrorCodeInvalidQuery)
+	}
+}
+
+// undefineTestCollection removes the collection these subscriptions watch, which
+// is what ends an accepted one with collection_undefined.
+func undefineTestCollection(t *testing.T, d *Daemon) {
+	t.Helper()
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocUndefine(c, &protocol.DocUndefineMessage{
+			Cmd: protocol.CmdDocUndefine, Namespace: testDocNS, Collection: testDocColl,
+		})
+	})
+	if !resp.Ok {
+		t.Fatalf("undefine: %v", protocol.Deref(resp.Error))
+	}
+}
+
+// waitForSubscriptionCount watches the daemon's own registry: a subscription
+// loop ends on its own goroutine, and the count moving IS the signal that it
+// did.
+func waitForSubscriptionCount(t *testing.T, d *Daemon, want int) {
+	t.Helper()
+	waitFor(t, fmt.Sprintf("the daemon to hold %d live subscriptions", want), func() bool {
+		return d.documentSubscriptionCount() == want
+	})
+}

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -54,6 +54,10 @@ type wsClient struct {
 	pendingRemote   map[string]struct{}          // remote runtime IDs awaiting attach_result
 	attachMu        sync.Mutex
 
+	// Live document queries this client holds, by client-minted id. See
+	// documents_ws.go; the ceiling is protocol.DocSubscriptionsPerClient.
+	docSubscriptions clientDocSubscriptions
+
 	// Docked tile content subscriptions keyed by workspace + tile ID.
 	tileContentSubscriptions map[string]struct{}
 	tileContentPending       map[string]time.Time
@@ -963,6 +967,7 @@ func (d *Daemon) wsReadPump(client *wsClient) {
 		d.dropPendingInitialState(client)
 		d.cleanupRemoteGitStatusSubscription(client)
 		d.dropFsWatchClient(client)
+		d.dropDocSubscriptions(client)
 		d.detachAllSessions(client)
 		close(client.recv) // signal wsMsgPump to exit
 		d.wsHub.unregister <- client
@@ -1342,6 +1347,10 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		d.handleWorkspaceLayoutSetSplitRatio(client, msg.(*protocol.WorkspaceLayoutSetSplitRatioMessage))
 	case protocol.CmdAppViewCrash: // wire: app_view_crash
 		d.handleAppViewCrash(client, msg.(*protocol.AppViewCrashMessage))
+	case protocol.CmdDocSubscribe: // wire: doc_subscribe
+		d.handleDocSubscribeWS(client, msg.(*protocol.DocSubscribeMessage))
+	case protocol.CmdDocUnsubscribe: // wire: doc_unsubscribe
+		d.handleDocUnsubscribeWS(client, msg.(*protocol.DocUnsubscribeMessage))
 	case protocol.CmdWorkspaceLayoutDockTile: // wire: workspace_layout_dock_tile
 		d.handleWorkspaceLayoutDockTile(client, msg.(*protocol.WorkspaceLayoutDockTileMessage))
 	case protocol.CmdWorkspaceLayoutUndockTile: // wire: workspace_layout_undock_tile
@@ -1839,12 +1848,15 @@ func (d *Daemon) sendCommandError(client *wsClient, cmd, errMsg string) {
 	d.sendToClient(client, event)
 }
 
-func (d *Daemon) sendToClient(client *wsClient, message interface{}) {
+// sendToClient queues one message for a client. The bool says whether it was
+// queued — a caller that keeps state alive for this client (a live subscription)
+// needs to know it has lost them; the rest of the callers do not, and ignore it.
+func (d *Daemon) sendToClient(client *wsClient, message interface{}) bool {
 	data, err := json.Marshal(message)
 	if err != nil {
-		return
+		return false
 	}
-	_ = d.sendOutbound(client, outboundMessage{
+	return d.sendOutbound(client, outboundMessage{
 		kind:    messageKindText,
 		payload: data,
 	})

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "242"
+const ProtocolVersion = "243"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only
@@ -44,7 +44,23 @@ const (
 	// never be answered again as written, so the tile's query is what has to
 	// change; resubscribing unchanged would fail the same way.
 	ErrorCodeCollectionRedeclared = "collection_redeclared"
+	// ErrorCodeSubscriptionLimit refuses a live query because the client already
+	// holds DocSubscriptionsPerClient of them. The refusal names the limit and
+	// the ask, because a silently dropped subscription is a tile that renders
+	// nothing forever with nothing to read.
+	ErrorCodeSubscriptionLimit = "subscription_limit"
 )
+
+// DocSubscriptionsPerClient bounds how many live queries one WebSocket client
+// may hold at once.
+//
+// Measured 2026-08-13 against Victor's production database: seven live
+// workspaces, of which three hold exactly one docked tile and four hold none. A
+// view can reasonably open more than one query, so the healthy ceiling is single
+// digits and this sits an order of magnitude past it. It is a tripwire — a
+// working client never learns it exists — and reaching it is a named refusal,
+// never a dropped subscription.
+const DocSubscriptionsPerClient = 64
 
 // AgentMessageMaxChars bounds one agent_msg. Measured 2026-08-10 against a live
 // session: a bracketed paste through the doorbell's own mechanics arrived intact
@@ -126,6 +142,7 @@ const (
 	CmdDocQuery                              = "doc_query"
 	CmdDocCount                              = "doc_count"
 	CmdDocSubscribe                          = "doc_subscribe"
+	CmdDocUnsubscribe                        = "doc_unsubscribe"
 	CmdAppList                               = "app_list"
 	CmdAppStatus                             = "app_status"
 	CmdAppSetEnabled                         = "app_set_enabled"
@@ -366,6 +383,8 @@ const (
 	EventTicketsUpdated                  = "tickets_updated"
 	EventGardenSeedsUpdated              = "garden_seeds_updated"
 	EventAppsUpdated                     = "apps_updated"
+	EventDocSubscriptionDelivery         = "doc_subscription_delivery"
+	EventDocSubscriptionEnded            = "doc_subscription_ended"
 	EventTicketResult                    = "ticket_result"
 	EventTicketActionResult              = "ticket_action_result"
 	EventTicketAttachResult              = "ticket_attach_result"
@@ -753,6 +772,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdDocSubscribe:
 		var msg DocSubscribeMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdDocUnsubscribe:
+		var msg DocUnsubscribeMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -2083,6 +2083,9 @@ type DocSubscribeMessage struct {
 
 	// Query corresponds to the JSON schema field "query".
 	Query DocumentQuery `json:"query"`
+
+	// SubscriptionID corresponds to the JSON schema field "subscription_id".
+	SubscriptionID *string `json:"subscription_id,omitempty,omitzero"`
 }
 
 type DocSubscribeResult struct {
@@ -2097,6 +2100,40 @@ type DocSubscribeResult struct {
 
 	// Upsert corresponds to the JSON schema field "upsert".
 	Upsert []StoredDocument `json:"upsert"`
+}
+
+type DocSubscriptionDeliveryMessage struct {
+	// AsOfSeq corresponds to the JSON schema field "as_of_seq".
+	AsOfSeq int `json:"as_of_seq"`
+
+	// Delivery corresponds to the JSON schema field "delivery".
+	Delivery int `json:"delivery"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// Order corresponds to the JSON schema field "order".
+	Order []string `json:"order"`
+
+	// SubscriptionID corresponds to the JSON schema field "subscription_id".
+	SubscriptionID string `json:"subscription_id"`
+
+	// Upsert corresponds to the JSON schema field "upsert".
+	Upsert []StoredDocument `json:"upsert"`
+}
+
+type DocSubscriptionEndedMessage struct {
+	// Code corresponds to the JSON schema field "code".
+	Code string `json:"code"`
+
+	// Error corresponds to the JSON schema field "error".
+	Error string `json:"error"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// SubscriptionID corresponds to the JSON schema field "subscription_id".
+	SubscriptionID string `json:"subscription_id"`
 }
 
 type DocUndefineMessage struct {
@@ -2119,6 +2156,14 @@ type DocUndefineResult struct {
 
 	// Namespace corresponds to the JSON schema field "namespace".
 	Namespace string `json:"namespace"`
+}
+
+type DocUnsubscribeMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// SubscriptionID corresponds to the JSON schema field "subscription_id".
+	SubscriptionID string `json:"subscription_id"`
 }
 
 type DocumentCollectionSchema struct {

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -4206,10 +4206,28 @@ model DocumentRevision {
 // page it named a write ago. Use `limit` and let each delivery carry the current
 // window. One-shot doc_query keeps `after` exactly as it is, because a single
 // read has one instant and nothing to move under it.
+// On the WebSocket the connection is multiplexed, so the subscription needs an
+// identity of its own: `subscription_id` is client-minted, required there, and
+// refused on the unix socket where a second subscription means a second
+// connection and an id would name nothing. Deliveries then arrive as
+// DocSubscriptionDeliveryMessage rather than as responses on this connection,
+// and doc_unsubscribe is the way out.
 model DocSubscribeMessage {
   "cmd": "doc_subscribe";
   "query": DocumentQuery;
   "have"?: DocumentRevision[];
+  "subscription_id"?: string;
+}
+
+// End one live query. The way out for doc_subscribe's way in, and the only one
+// a WebSocket client has short of dropping the socket: a tile that unmounts must
+// stop the daemon re-running its query on every write to that collection.
+//
+// Unknown ids are ignored rather than refused — an unsubscribe racing the
+// daemon's own doc_subscription_ended is the ordinary case, not an error.
+model DocUnsubscribeMessage {
+  "cmd": "doc_unsubscribe";
+  "subscription_id": string;
 }
 
 // One delivery of a live query's window, and the whole client contract is one
@@ -4243,6 +4261,40 @@ model DocSubscribeResult {
   "as_of_seq": safeint;
   "order": string[];
   "upsert": StoredDocument[];
+}
+
+// One delivery of a WebSocket subscription: DocSubscribeResult's four fields
+// verbatim, plus the id that says which subscription they belong to. The client
+// rule is unchanged — render `order`, take bodies from `upsert` or cache, forget
+// the rest — because this is the same delivery travelling over a multiplexed
+// connection rather than a dedicated one.
+model DocSubscriptionDeliveryMessage {
+  event: "doc_subscription_delivery";
+  "subscription_id": string;
+  "delivery": int32;
+  "as_of_seq": safeint;
+  "order": string[];
+  "upsert": StoredDocument[];
+}
+
+// A WebSocket subscription is over, and no further delivery carries its id.
+//
+// It is the only failure channel a subscription has: a refusal at subscribe time
+// (an invalid query, an `after` cursor, a collection never declared, or one
+// client holding too many subscriptions) and an ending after acceptance (the
+// collection was undefined, or redeclared without a field the query reads) both
+// arrive here. `code` is what a host acts on and `error` is what a person reads;
+// nothing may match on the English.
+//
+// The codes: `invalid_query`, `undeclared_collection`, `subscription_limit`
+// refuse a subscription that never started; `collection_undefined` and
+// `collection_redeclared` end one that did — which is what lets a UI host tell
+// "kill the tile" from "resubscribe".
+model DocSubscriptionEndedMessage {
+  event: "doc_subscription_ended";
+  "subscription_id": string;
+  "code": string;
+  "error": string;
 }
 
 // ============================================================================
@@ -5782,4 +5834,6 @@ alias DaemonEvent =
   | PastConversationsResultMessage
   | BusStatusResultMessage
   | BusSetConsumerEnabledResultMessage
-  | AppsUpdatedMessage;
+  | AppsUpdatedMessage
+  | DocSubscriptionDeliveryMessage
+  | DocSubscriptionEndedMessage;

--- a/sdk/attn-app/src/index.ts
+++ b/sdk/attn-app/src/index.ts
@@ -145,3 +145,17 @@ export interface ViewProps {
   /** Opaque to attn — the app decides what it means. Empty when none was given. */
   readonly params: string
 }
+
+// Live queries. The runtime seam is exported because the HOST implements it;
+// a view only ever calls the hook.
+export { useQuery } from "./useQuery"
+export type { LiveQueryOptions, QueryError, QueryResult } from "./useQuery"
+export { AppViewRuntimeProvider, useAppViewRuntime } from "./runtime"
+export type {
+  AppViewRuntime,
+  DocumentRevision,
+  DocumentSubscriber,
+  LiveQueryRequest,
+  QueryDelivery,
+  RawDocument,
+} from "./runtime"

--- a/sdk/attn-app/src/runtime.ts
+++ b/sdk/attn-app/src/runtime.ts
@@ -1,0 +1,82 @@
+// The seam between a view and the attn frontend hosting it.
+//
+// A view never holds a socket. The host mounts it inside a provider carrying two
+// things: the document namespace this mount may read — composed by the host from
+// the tile's identity, never by the view — and the transport that opens a live
+// query over it. Everything in the SDK's hooks sits on this.
+//
+// Design: docs/plans/2026-08-13-ext-a5-ui-host-and-app-sdk.md, "Protocol
+// envelopes".
+
+import { createContext, useContext } from "react"
+
+/** One document a resuming subscriber already holds, and at which revision. */
+export interface DocumentRevision {
+  id: string
+  rev: number
+}
+
+/** A stored document exactly as the wire carries it: the body is still JSON text. */
+export interface RawDocument {
+  id: string
+  body: string
+  rev: number
+  created_at: string
+  updated_at: string
+}
+
+/** A query a live subscription can answer. No cursor: a live query is a window. */
+export interface LiveQueryRequest {
+  namespace: string
+  collection: string
+  filters?: Array<{ field: string; op: string; value: unknown }>
+  sort?: { field: string; desc?: boolean }
+  limit?: number
+}
+
+/**
+ * One delivery, and the whole client contract is one rule:
+ *
+ *   Render `order`. Take each body from `upsert` if it is there, else from your
+ *   cache. Forget every cached document not named in `order`.
+ */
+export interface QueryDelivery {
+  delivery: number
+  asOfSeq: number
+  order: string[]
+  upsert: RawDocument[]
+}
+
+/** What the host calls back as a subscription runs. */
+export interface DocumentSubscriber {
+  request: LiveQueryRequest
+  /** What this subscriber holds, read by the host at every subscribe and resubscribe. */
+  have: () => DocumentRevision[]
+  onDelivery: (delivery: QueryDelivery) => void
+  /** Terminal: the daemon will not answer this query again as written. */
+  onEnded: (code: string, message: string) => void
+  /** Whether the daemon is serving this subscription right now. */
+  onLive: (live: boolean) => void
+}
+
+/** What the host provides to everything it mounts. */
+export interface AppViewRuntime {
+  /** The document namespace this mount reads. A view cannot widen it. */
+  readonly namespace: string
+  /** Opens a live query; the returned function closes it and must be called. */
+  subscribe: (subscriber: DocumentSubscriber) => () => void
+}
+
+const AppViewRuntimeContext = createContext<AppViewRuntime | null>(null)
+
+/** The host wraps every mounted view in this. */
+export const AppViewRuntimeProvider = AppViewRuntimeContext.Provider
+
+/**
+ * The runtime this view is mounted in. Null outside a host — which is a real
+ * state for a component rendered in an app's own tests, so the hooks report it
+ * rather than throwing.
+ */
+export function useAppViewRuntime(): AppViewRuntime | null {
+  return useContext(AppViewRuntimeContext)
+}

--- a/sdk/attn-app/src/useQuery.ts
+++ b/sdk/attn-app/src/useQuery.ts
@@ -1,0 +1,222 @@
+// useQuery — a live document query, as a view sees it.
+//
+// The whole A3.4 delivery contract lives here so a view never meets it: render
+// `order`, take each body from `upsert` or from the cache, forget everything
+// else. What a view gets is an array that stays current.
+//
+// Design: docs/plans/2026-08-05-ext-a3.4-doc-store-positions-and-windows.md
+// (delivery semantics) and docs/plans/2026-08-13-ext-a5-ui-host-and-app-sdk.md
+// ("What an author writes").
+
+import { useEffect, useMemo, useState } from "react"
+import type { Document, Filter } from "./index"
+import {
+  useAppViewRuntime,
+  type DocumentRevision,
+  type QueryDelivery,
+  type RawDocument,
+} from "./runtime"
+
+/** What a live query takes. No `after`: a live query is a window, a cursor is a walk. */
+export interface LiveQueryOptions {
+  filters?: Filter[]
+  sort?: { field: string; desc?: boolean }
+  /** Defaults to the store's own 100, and refuses more than 1000. */
+  limit?: number
+}
+
+export interface QueryError {
+  /**
+   * What to act on. `collection_undefined` and `collection_redeclared` mean this
+   * query is over; `invalid_query`, `undeclared_collection` and
+   * `subscription_limit` mean it never started.
+   */
+  code: string
+  message: string
+}
+
+export interface QueryResult<Body> {
+  /** The window, in the server's order. */
+  docs: Array<Document<Body>>
+  /** The log position this window was true at. Opaque and monotonic. */
+  asOfSeq: number
+  /** Whether the daemon is serving this query right now. */
+  live: boolean
+  /**
+   * Set when the subscription ended and will not resume on its own. It is a
+   * state to render, not an exception: a tile that spins forever because its
+   * collection was removed is worse than one that says so.
+   */
+  error: QueryError | null
+}
+
+/**
+ * How many unmounted queries keep their bodies for a resume.
+ *
+ * Same receipt as the daemon's per-client subscription tripwire (measured
+ * 2026-08-13 against Victor's production database: seven live workspaces, three
+ * of them holding one docked tile): a client cannot hold more live queries than
+ * that, so retaining more caches than that is retaining for tiles that cannot
+ * all exist. Evicting costs one full first delivery instead of a diffed one —
+ * bytes, never correctness — so this bound is silent by design.
+ */
+const RESUME_CACHE_LIMIT = 64
+
+/**
+ * Bodies by query, kept past unmount so a remount resumes with `have` and the
+ * daemon sends only what changed. Insertion-ordered, refreshed on write, so the
+ * oldest untouched query is the one evicted.
+ */
+const resumeCaches = new Map<string, Map<string, RawDocument>>()
+
+function cacheFor(key: string): Map<string, RawDocument> {
+  const existing = resumeCaches.get(key)
+  if (existing) {
+    resumeCaches.delete(key)
+    resumeCaches.set(key, existing)
+    return existing
+  }
+  const fresh = new Map<string, RawDocument>()
+  resumeCaches.set(key, fresh)
+  while (resumeCaches.size > RESUME_CACHE_LIMIT) {
+    const oldest = resumeCaches.keys().next()
+    if (oldest.done) break
+    resumeCaches.delete(oldest.value)
+  }
+  return fresh
+}
+
+/** The identity of a query, which is what a resume cache is keyed by. */
+function queryKey(namespace: string, collection: string, options: LiveQueryOptions): string {
+  return JSON.stringify([
+    namespace,
+    collection,
+    (options.filters ?? []).map((f) => [f.field, f.op, f.value]),
+    options.sort ? [options.sort.field, !!options.sort.desc] : null,
+    options.limit ?? null,
+  ])
+}
+
+function parseBody<Body>(raw: RawDocument): Document<Body> {
+  return {
+    id: raw.id,
+    body: JSON.parse(raw.body) as Body,
+    rev: raw.rev,
+    created_at: raw.created_at,
+    updated_at: raw.updated_at,
+  }
+}
+
+/**
+ * Subscribe to a collection and stay current.
+ *
+ * ```tsx
+ * const { docs, live } = useQuery("requests", {
+ *   filters: [{ field: "status", op: "eq", value: "pending" }],
+ *   sort: { field: "updated_at", desc: true },
+ *   limit: 20,
+ * })
+ * ```
+ *
+ * The collection is this app's — the namespace comes from where the tile is
+ * mounted, so a view cannot read another app's documents by asking.
+ */
+export function useQuery<Body = unknown>(
+  collection: string,
+  options: LiveQueryOptions = {},
+): QueryResult<Body> {
+  const runtime = useAppViewRuntime()
+  const namespace = runtime?.namespace ?? ""
+  const key = queryKey(namespace, collection, options)
+
+  const [state, setState] = useState<{ docs: Array<Document<Body>>; asOfSeq: number }>({
+    docs: [],
+    asOfSeq: 0,
+  })
+  const [live, setLive] = useState(false)
+  const [error, setError] = useState<QueryError | null>(null)
+  // Bumped when a delivery names a body nobody holds. That is the one invariant
+  // violation the contract anticipates, and its remedy is to start over with no
+  // `have` — invisible to the view beyond one fuller delivery.
+  const [generation, setGeneration] = useState(0)
+
+  useEffect(() => {
+    if (!runtime) {
+      setError({
+        code: "no_runtime",
+        message:
+          "useQuery was called outside an attn app view host, so there is no daemon to query.",
+      })
+      return
+    }
+    const after = (options as { after?: unknown }).after
+    if (after !== undefined) {
+      setError({
+        code: "invalid_query",
+        message:
+          `useQuery cannot take an after cursor (${String(after)}): a live query is a window and a cursor is a walk, ` +
+          "so the document it names moves out from under the subscription. Set a limit and render each window.",
+      })
+      return
+    }
+
+    setError(null)
+    // Survives this effect, and this mount: it is what `have()` reads on a
+    // resubscribe, and what a remount resumes from.
+    const cache = cacheFor(key)
+    let dropped = false
+
+    const apply = (delivery: QueryDelivery) => {
+      for (const doc of delivery.upsert) cache.set(doc.id, doc)
+      const docs: Array<Document<Body>> = []
+      for (const id of delivery.order) {
+        const raw = cache.get(id)
+        if (!raw) {
+          // A body we neither hold nor were sent. The subscription is broken;
+          // start over with an empty cache so the next first delivery is whole.
+          cache.clear()
+          if (!dropped) setGeneration((n) => n + 1)
+          return
+        }
+        docs.push(parseBody<Body>(raw))
+      }
+      // The forget rule: anything not named in `order` is gone from the window,
+      // so holding its body would resume a query that no longer wants it.
+      const named = new Set(delivery.order)
+      for (const id of Array.from(cache.keys())) {
+        if (!named.has(id)) cache.delete(id)
+      }
+      setState({ docs, asOfSeq: delivery.asOfSeq })
+    }
+
+    const unsubscribe = runtime.subscribe({
+      request: {
+        namespace: runtime.namespace,
+        collection,
+        filters: options.filters?.map((f) => ({ field: f.field, op: f.op, value: f.value })),
+        sort: options.sort,
+        limit: options.limit,
+      },
+      have: (): DocumentRevision[] =>
+        Array.from(cache.values()).map((doc) => ({ id: doc.id, rev: doc.rev })),
+      onDelivery: apply,
+      onEnded: (code, message) => {
+        setLive(false)
+        setError({ code, message })
+      },
+      onLive: setLive,
+    })
+
+    return () => {
+      dropped = true
+      unsubscribe()
+    }
+    // `key` is the query's whole identity, so it stands in for the options object
+    // a caller rebuilds on every render.
+  }, [runtime, collection, key, generation])
+
+  return useMemo(
+    () => ({ docs: state.docs, asOfSeq: state.asOfSeq, live, error }),
+    [state, live, error],
+  )
+}


### PR DESCRIPTION
A5 slice 4: a docked app view reads its app's documents and stays current.

Slices 1–3 gave an app a frozen view declaration, a bundle route, and a tile
host that mounts the view with its `ViewProps`. The view could render, but it
could not read anything. This slice gives it a live query.

## What it does

A view calls `useQuery` from the app SDK and gets back the matching documents,
in the server's order, re-rendered whenever one of them changes. No polling, no
refresh button, and no subscription bookkeeping in the view.

## The wire

Four envelopes and a protocol bump to 243 (`main.tsp` → `make generate-types` →
`constants.go` → `useDaemonSocket.ts`):

- `doc_subscribe` gains an optional `subscription_id` — required on the
  WebSocket, refused on the unix socket, where a second subscription means a
  second connection and an id would name nothing.
- `doc_unsubscribe` ends one by id.
- `doc_subscription_delivery` carries `{as_of_seq, order, upsert}`.
- `doc_subscription_ended` carries the code and the message.

`handleDocSubscribe` is refactored into a sink-driven loop (`runDocSubscription`
in `internal/daemon/documents.go`): the loop knows the query and the resume
token, and a `docSink` — two closures — knows the transport. The IPC sink writes
the connection's encoder; the WebSocket sink wraps each delivery in an envelope
and hands it to the client's write pump. The A3 deadlock rule survives
unchanged: the bus fan-out holds the publish lock and only pokes a one-slot wake
channel, and every socket write happens on the subscription's own goroutine.

## Delivery semantics

A3.4 Stage 2's contract, held by `useQuery` so a view never meets it: render
`order`, take each body from `upsert` or the cache, forget everything not in
`order`. Resume is by `have` — `{id, rev}` pairs for what the client still
holds — so a remounted tile gets only what changed while it was gone, not a log
replay. A subscription refuses an `after` cursor: a live query is a window, a
cursor is a walk.

A subscription the collection can no longer answer ends rather than lingering:
`collection_undefined` when the collection is removed, `collection_redeclared`
when it loses a field the query uses. `useQuery` surfaces that as a state the
view renders.

## The limit

`DocSubscriptionsPerClient = 64`, measured against the production database:
seven live workspaces, three holding exactly one docked tile and four holding
none. A view can reasonably open more than one query, so the healthy ceiling is
single digits and this sits an order of magnitude past it. Reaching it is a
named refusal — the limit, its value, and the ask — never a dropped
subscription. Both the refusal and the ending ride the same
`doc_subscription_ended` envelope, because `command_error` cannot name the
subscription it refused.

## Live verification

Throwaway profile `a5slice4`, full app install from this branch, bundled
preflight green (protocol 243 across CLI, app, and daemon). A fixture app
declares a `seen` collection and a tile view calling `useQuery`; the tile is
docked through `workspace_layout_dock_tile` and read back through
`app_view_get_state`.

1. dock, empty collection → `live · 0 document(s) · as of 257`
2. `attn doc put` from outside the app → the document appears
3. a second write, then an edit → both land, the edit bumps the rev
4. `attn doc delete` → the row leaves the window through `order` alone
5. undock, write while it is gone, re-dock → the remount resumes current
6. re-dock with tile params → the params become the query's filter
7. redeclare without the queried field → `collection_redeclared`, rendered
8. undefine the collection → `collection_undefined`, rendered

![clip](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/63e236365762b32b3c7fd7bf04e595d1ad1aca16/feat-a5-slice4-live-queries/clip.gif)

[Full-quality recording (mp4)](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/63e236365762b32b3c7fd7bf04e595d1ad1aca16/feat-a5-slice4-live-queries/clip.mp4)

## Surfaces walked

- **Protocol** — `generated.go` and `generated.ts` regenerated together,
  `ProtocolVersion` 243. `command_meta.go` is a fourth lockstep spot beyond the
  three AGENTS.md names: `TestEveryProtocolCommandIsClassified` fails without an
  entry for `doc_unsubscribe`.
- **Daemon and app** — `daemonDocumentEvents.ts` handles the two new events from
  the socket switch's `default` chain; `AppTileHost` composes the namespace and
  provides the runtime.
- **CLI** — unchanged: `attn doc` already reads and writes; a subscription is a
  client concept and the unix socket keeps the connection-scoped form it had.
- **SDK** — `useQuery` and the runtime context, with declarations regenerated
  into `internal/appbuild/sdkdist` (`make check-sdk` green).
- **Linux** — `go build` for `linux/amd64` green; nothing here is Darwin-only.
- **Docs** — a "Slice 4 as-built" section in the plan doc, and a changelog
  fragment.

## Notes for slice 5

- Slice 5's protocol bump renumbers from 243.
- `command_meta.go` needs an entry for every new command.
- A view's namespace is composed by the host, not the SDK — the SDK never sees
  the app name.
