### PR TITLE
feat(apps): let a docked view act, and look like attn

### DIFF
--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -179,6 +179,13 @@ importers:
         version: 8.18.3
 
   ../sdk/attn-app:
+    dependencies:
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.7)(react@19.2.1)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
     devDependencies:
       '@types/react':
         specifier: ^19.1.8

--- a/app/src/appSdk.useQuery.test.tsx
+++ b/app/src/appSdk.useQuery.test.tsx
@@ -31,6 +31,7 @@ function fakeRuntime() {
         unsubscribes += 1
       }
     },
+    command: async () => undefined,
   }
   return {
     runtime,

--- a/app/src/components/appViews/AppTileHost.commands.test.tsx
+++ b/app/src/components/appViews/AppTileHost.commands.test.tsx
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { Button, useCommand } from '@victorarias/attn-app';
+import { AppTileHost } from './AppTileHost';
+import { DaemonApiProvider, type DaemonApi } from '../../contexts/DaemonApiContext';
+import { useDaemonStore } from '../../store/daemonSessions';
+import type { AppRegistryEntry } from '../../hooks/useDaemonSocket';
+
+// A view acting, from the click to the socket and back.
+//
+// The two claims worth pinning: a view names a command and never an app — the
+// host binds which app is asked, the same rule the document namespace follows —
+// and a command that fails reaches the view as a message it can render rather
+// than as a rejection nobody caught.
+
+const loadAppView = vi.hoisted(() => vi.fn());
+vi.mock('./loadAppView', async () => {
+  const actual = await vi.importActual<typeof import('./loadAppView')>('./loadAppView');
+  return { ...actual, loadAppView };
+});
+
+function ActingView() {
+  const approve = useCommand('approve');
+  return (
+    <>
+      <Button onClick={() => approve({ id: 'tk-1' })}>Approve</Button>
+      {approve.error && <div data-testid="command-error">{approve.error}</div>}
+    </>
+  );
+}
+
+function renderHost(sendAppCommand: DaemonApi['sendAppCommand']) {
+  loadAppView.mockResolvedValue(ActingView);
+  act(() => {
+    useDaemonStore.getState().setApps([{
+      name: 'reviewer',
+      enabled: true,
+      version_id: 7,
+      content_hash: 'a'.repeat(64),
+      views: [{ name: 'approvals', kind: 'tile', title: 'Pending approvals' }],
+    } as AppRegistryEntry]);
+  });
+  const api = { sendAppCommand, sendAppViewCrash: vi.fn() } as unknown as DaemonApi;
+  render(
+    <DaemonApiProvider api={api}>
+      <AppTileHost
+        app="reviewer"
+        view="approvals"
+        workspaceId="ws-1"
+        sessionId={null}
+        tileId="tile-7"
+        params=""
+      />
+    </DaemonApiProvider>,
+  );
+}
+
+beforeEach(() => {
+  loadAppView.mockReset();
+  act(() => {
+    useDaemonStore.getState().setApps([]);
+  });
+});
+
+describe('a view invoking a command', () => {
+  it('is addressed to the app the host mounted, not to one the view named', async () => {
+    const sendAppCommand = vi.fn().mockResolvedValue({ approved: true });
+    renderHost(sendAppCommand);
+    const button = await screen.findByRole('button', { name: 'Approve' });
+
+    // Awaited: the runner settles its own pending state after the answer, and
+    // asserting before that is asserting mid-update.
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(sendAppCommand).toHaveBeenCalledWith('reviewer', 'approve', { id: 'tk-1' });
+  });
+
+  it('shows the daemon’s own refusal instead of throwing it away', async () => {
+    const sendAppCommand = vi.fn().mockRejectedValue(
+      new Error('reviewer is disabled, so it runs nothing; `attn app enable reviewer` turns it back on'),
+    );
+    renderHost(sendAppCommand);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Approve' }));
+
+    const shown = await screen.findByTestId('command-error');
+    expect(shown.textContent).toContain('attn app enable reviewer');
+  });
+});

--- a/app/src/components/appViews/AppTileHost.tsx
+++ b/app/src/components/appViews/AppTileHost.tsx
@@ -7,6 +7,9 @@ import { appBundleURL } from '../../utils/appBundle';
 import { AppViewBoundary } from './AppViewBoundary';
 import { AppViewLoadError, errorText, loadAppView, type AppViewComponent } from './loadAppView';
 import './AppTileHost.css';
+// The SDK components a view renders are styled from attn's build, not the SDK's
+// own chunk — see the header of sdk/attn-app/src/components.tsx.
+import './appSdkComponents.css';
 
 // The host: what stands between a docked tile and an app author's component.
 //
@@ -37,7 +40,7 @@ interface Mounted {
 }
 
 export function AppTileHost({ app, view, workspaceId, sessionId, tileId, params }: AppTileHostProps) {
-  const { sendAppViewCrash, subscribeDocuments } = useDaemonApi();
+  const { sendAppCommand, sendAppViewCrash, subscribeDocuments } = useDaemonApi();
   const entry = useDaemonStore((state) => state.apps.find((a) => a.name === app));
 
   const declared = entry?.views?.some((v) => v.name === view) ?? false;
@@ -125,9 +128,15 @@ export function AppTileHost({ app, view, workspaceId, sessionId, tileId, params 
   // The namespace is composed here, from the mount's identity, and never taken
   // from the view: an app addresses its own documents because that is the only
   // namespace it is handed.
+  // The app a command is addressed to is bound here for the same reason: a view
+  // names the command, and where it runs is the mount's to decide.
   const runtime = useMemo<AppViewRuntime>(
-    () => ({ namespace: `app/${app}`, subscribe: subscribeDocuments }),
-    [app, subscribeDocuments],
+    () => ({
+      namespace: `app/${app}`,
+      subscribe: subscribeDocuments,
+      command: (command: string, payload?: unknown) => sendAppCommand(app, command, payload),
+    }),
+    [app, subscribeDocuments, sendAppCommand],
   );
 
   const body = (() => {

--- a/app/src/components/appViews/appSdkComponents.classes.test.tsx
+++ b/app/src/components/appViews/appSdkComponents.classes.test.tsx
@@ -1,5 +1,7 @@
+// @types/node isn't a direct dependency of this package (only a transitive peer
+// of vite/vitest), matching terminalOsc133.parity.test.ts's pattern.
+// @ts-expect-error -- see above
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import type { ReactElement } from 'react';
 import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
@@ -21,11 +23,9 @@ import {
 // fails on one the stylesheet does not define.
 
 // Read rather than imported: vitest stubs a CSS import, and this test is about
-// the file's contents. The path is from the app root, which is vitest's cwd.
-const css = readFileSync(
-  resolve(process.cwd(), 'src/components/appViews/appSdkComponents.css'),
-  'utf8',
-);
+// the file's contents. Relative to the vitest root (app/); import.meta.url is
+// not a file: URL here.
+const css: string = readFileSync('src/components/appViews/appSdkComponents.css', 'utf8');
 
 const defined = new Set(
   [...css.matchAll(/\.(attn-app-[a-z0-9-]+)/g)].map((match) => match[1]),

--- a/app/src/components/appViews/appSdkComponents.classes.test.tsx
+++ b/app/src/components/appViews/appSdkComponents.classes.test.tsx
@@ -1,0 +1,80 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { ReactElement } from 'react';
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import {
+  Button,
+  EmptyState,
+  List,
+  ListRow,
+  Markdown,
+  TextArea,
+  TextInput,
+} from '@victorarias/attn-app';
+
+// The SDK's components emit class names; the stylesheet that gives them meaning
+// lives here, in attn's build. Nothing links the two at compile time, and the
+// failure is silent — a view renders, looks foreign, and no test notices.
+//
+// So this renders every component in every state that changes its classes, and
+// fails on one the stylesheet does not define.
+
+// Read rather than imported: vitest stubs a CSS import, and this test is about
+// the file's contents. The path is from the app root, which is vitest's cwd.
+const css = readFileSync(
+  resolve(process.cwd(), 'src/components/appViews/appSdkComponents.css'),
+  'utf8',
+);
+
+const defined = new Set(
+  [...css.matchAll(/\.(attn-app-[a-z0-9-]+)/g)].map((match) => match[1]),
+);
+
+function classesRendered(ui: ReactElement): string[] {
+  const { container, unmount } = render(ui);
+  const found = new Set<string>();
+  for (const element of container.querySelectorAll('*')) {
+    for (const name of element.classList) {
+      if (name.startsWith('attn-app-')) found.add(name);
+    }
+  }
+  unmount();
+  return [...found];
+}
+
+describe('the SDK component slice', () => {
+  const cases: Array<[string, ReactElement]> = [
+    ['Button primary', <Button variant="primary">Approve</Button>],
+    ['Button secondary', <Button>Later</Button>],
+    ['Button danger', <Button variant="danger">Reject</Button>],
+    ['TextInput', <TextInput value="" onChange={() => {}} />],
+    ['TextInput invalid', <TextInput value="" onChange={() => {}} error="Say why" />],
+    ['TextArea', <TextArea value="" onChange={() => {}} />],
+    ['TextArea invalid', <TextArea value="" onChange={() => {}} error="Say why" />],
+    [
+      'List with rows',
+      <List>
+        <ListRow title="Static row" />
+        <ListRow title="Clickable" meta="2 minutes" selected onClick={() => {}} actions={<Button>Go</Button>} />
+      </List>,
+    ],
+    ['EmptyState', <EmptyState title="Nothing waiting" hint="reconnecting" />],
+    ['Markdown', <Markdown>{'# Title\n\nsome **text**'}</Markdown>],
+  ];
+
+  for (const [name, ui] of cases) {
+    it(`${name} renders only classes the stylesheet defines`, () => {
+      const rendered = classesRendered(ui);
+      expect(rendered.length).toBeGreaterThan(0);
+      expect(rendered.filter((cls) => !defined.has(cls))).toEqual([]);
+    });
+  }
+
+  it('covers every class the stylesheet defines', () => {
+    // The other direction: a rule left behind when a component stops emitting
+    // its class is dead weight nobody would ever notice.
+    const rendered = new Set(cases.flatMap(([, ui]) => classesRendered(ui)));
+    expect([...defined].filter((cls) => !rendered.has(cls)).sort()).toEqual([]);
+  });
+});

--- a/app/src/components/appViews/appSdkComponents.css
+++ b/app/src/components/appViews/appSdkComponents.css
@@ -1,0 +1,274 @@
+/* The SDK component slice's styles.
+
+   They live here, in attn's own build, and not in sdk/attn-app: the SDK is a
+   rollup entry the import map resolves a view's bare specifier to, so a CSS
+   import inside it would emit an asset no page links and every rule below would
+   silently vanish. AppTileHost.tsx imports this file, which is how a docked tile
+   gets them.
+
+   Everything is a token. That is the whole point of the slice — a view mounts
+   inside attn's DOM, so `var(--color-*)` and `var(--font-*)` already resolve,
+   and matching them is what "looks native" means. Nothing here animates or
+   transitions: these tiles sit beside GPU terminals in a window that is open all
+   day.
+
+   appSdkComponents.classes.test.tsx renders each component and fails on a class
+   it emits that this file does not define. */
+
+.attn-app-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-button);
+  color: var(--color-text-primary);
+  font-family: inherit;
+  font-size: var(--font-size-md);
+  line-height: 1.4;
+  cursor: pointer;
+}
+
+.attn-app-button:hover:not(:disabled) {
+  border-color: var(--color-border-hover);
+}
+
+.attn-app-button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}
+
+.attn-app-button:disabled {
+  color: var(--color-text-muted);
+  cursor: default;
+}
+
+.attn-app-button-primary {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: #fff;
+}
+
+.attn-app-button-primary:disabled {
+  /* The accent stays, dimmed: a primary action that greys out entirely reads as
+     a different button rather than the same one, momentarily unavailable. */
+  opacity: 0.5;
+  color: #fff;
+}
+
+.attn-app-button-secondary {
+  background: var(--color-bg-button);
+}
+
+.attn-app-button-danger {
+  background: transparent;
+  border-color: var(--color-error);
+  color: var(--color-error);
+}
+
+.attn-app-button-danger:hover:not(:disabled) {
+  background: var(--color-error);
+  color: #fff;
+}
+
+.attn-app-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.attn-app-input,
+.attn-app-textarea {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-input);
+  color: var(--color-text-primary);
+  font-family: inherit;
+  font-size: var(--font-size-md);
+  line-height: 1.5;
+}
+
+.attn-app-textarea {
+  resize: vertical;
+}
+
+.attn-app-input::placeholder,
+.attn-app-textarea::placeholder {
+  color: var(--color-text-muted);
+}
+
+.attn-app-input:focus,
+.attn-app-textarea:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.attn-app-input:disabled,
+.attn-app-textarea:disabled {
+  color: var(--color-text-muted);
+}
+
+.attn-app-input-invalid {
+  border-color: var(--color-error);
+}
+
+.attn-app-field-error {
+  color: var(--color-error);
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+}
+
+.attn-app-list {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: auto;
+}
+
+.attn-app-list-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.attn-app-list-row-interactive {
+  cursor: pointer;
+}
+
+.attn-app-list-row-interactive:hover {
+  background: var(--color-bg-elevated);
+}
+
+.attn-app-list-row-interactive:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
+.attn-app-list-row-selected {
+  background: var(--color-bg-elevated);
+}
+
+.attn-app-list-row-body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.attn-app-list-row-title {
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
+  line-height: 1.5;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.attn-app-list-row-meta {
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.attn-app-list-row-actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.attn-app-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 24px 18px;
+  text-align: center;
+}
+
+.attn-app-empty-title {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-md);
+}
+
+.attn-app-empty-hint {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  line-height: 1.6;
+}
+
+.attn-app-markdown {
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+}
+
+.attn-app-markdown h1,
+.attn-app-markdown h2,
+.attn-app-markdown h3 {
+  margin: 12px 0 6px;
+  font-size: var(--font-size);
+  font-weight: 600;
+}
+
+.attn-app-markdown p,
+.attn-app-markdown ul,
+.attn-app-markdown ol {
+  margin: 6px 0;
+}
+
+.attn-app-markdown ul,
+.attn-app-markdown ol {
+  padding-left: 20px;
+}
+
+.attn-app-markdown a {
+  color: var(--color-accent);
+}
+
+.attn-app-markdown code {
+  padding: 1px 4px;
+  border-radius: 3px;
+  background: var(--color-bg-elevated);
+  font-size: var(--font-size-sm);
+}
+
+.attn-app-markdown pre {
+  padding: 8px 10px;
+  border-radius: 4px;
+  background: var(--color-bg-elevated);
+  overflow-x: auto;
+}
+
+.attn-app-markdown pre code {
+  padding: 0;
+  background: none;
+}
+
+.attn-app-markdown blockquote {
+  margin: 6px 0;
+  padding-left: 10px;
+  border-left: 2px solid var(--color-border);
+  color: var(--color-text-secondary);
+}
+
+.attn-app-markdown table {
+  border-collapse: collapse;
+}
+
+.attn-app-markdown th,
+.attn-app-markdown td {
+  padding: 4px 8px;
+  border: 1px solid var(--color-border);
+  text-align: left;
+}

--- a/app/src/hooks/daemonAppEvents.ts
+++ b/app/src/hooks/daemonAppEvents.ts
@@ -1,0 +1,52 @@
+// App views acting: the one result an `app_command` waits on.
+//
+// Its own module rather than a case in the hook's switch, for the same reason
+// the bus and notebook domains have one — the switch is already long and this
+// domain is self-contained. Reached from the switch's `default` chain.
+
+import { type PendingRequests, settlePendingRequest } from './daemonPendingRequests';
+
+interface AppDaemonEvent {
+  event?: string;
+  request_id?: unknown;
+  success?: boolean;
+  error?: string;
+  /** The handler's return value, still JSON text, absent when it returned nothing. */
+  payload?: unknown;
+}
+
+/**
+ * What a settled command carries. The value is wrapped rather than returned bare
+ * because a command that succeeds and returns nothing is normal, and
+ * `settlePendingRequest` reads a bare `undefined` as failure.
+ */
+export interface AppCommandResult {
+  value: unknown;
+}
+
+/**
+ * Settles an app-command result, or returns false for an event this module does
+ * not own so the caller can keep looking.
+ */
+export function handleAppDaemonEvent(event: AppDaemonEvent, pending: PendingRequests): boolean {
+  if (event.event !== 'app_command_result') return false;
+  settlePendingRequest(
+    pending,
+    'app_command',
+    event,
+    (settled): AppCommandResult | undefined => {
+      if (typeof settled.payload !== 'string') return { value: undefined };
+      try {
+        return { value: JSON.parse(settled.payload) };
+      } catch {
+        // The daemon forwards what the handler returned without reading it, so a
+        // body that will not parse is the app's bug — and rejecting says so
+        // where the view can show it, instead of throwing in the socket's own
+        // message handler and leaving the caller to time out.
+        return undefined;
+      }
+    },
+    'The command answered with something that is not JSON',
+  );
+  return true;
+}

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -3675,3 +3675,89 @@ describe('useDaemonSocket notebook and annotation events', () => {
     unmount();
   });
 });
+
+// The app-command envelope, through the hook's public surface. What it pins is
+// the half a view cannot see: the payload travels as JSON text, a handler that
+// returned nothing is a success rather than a rejection, and a refusal reaches
+// the caller in the daemon's own words.
+describe('useDaemonSocket app commands', () => {
+  let originalWebSocket: typeof WebSocket;
+
+  beforeEach(() => {
+    originalWebSocket = globalThis.WebSocket;
+    FakeWebSocket.instances = [];
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+  });
+  afterEach(() => {
+    globalThis.WebSocket = originalWebSocket;
+    vi.clearAllMocks();
+  });
+
+  function renderAppHook() {
+    return renderHook(() =>
+      useDaemonSocket({
+        onSessionsUpdate: vi.fn(),
+        onWorkspacesUpdate: vi.fn(),
+        onPRsUpdate: vi.fn(),
+        onReposUpdate: vi.fn(),
+        onAuthorsUpdate: vi.fn(),
+        wsUrl: 'ws://localhost:9999/ws',
+      }),
+    );
+  }
+
+  function lastSent(ws: FakeWebSocket): { cmd: string; request_id: string; [k: string]: unknown } {
+    return JSON.parse(ws.sent[ws.sent.length - 1]);
+  }
+
+  it('sends the payload as JSON text and resolves with the handler’s answer', async () => {
+    const { result, unmount } = renderAppHook();
+    const ws = await waitForOpenSocket();
+
+    const promise = result.current.sendAppCommand('reviewer', 'approve', { id: 'tk-1' });
+    await Promise.resolve();
+    const sent = lastSent(ws);
+    expect(sent).toMatchObject({ cmd: 'app_command', app: 'reviewer', command: 'approve', payload: '{"id":"tk-1"}' });
+
+    ws.emit({
+      event: 'app_command_result',
+      request_id: sent.request_id,
+      success: true,
+      payload: '{"approved":true}',
+    });
+    await expect(promise).resolves.toEqual({ approved: true });
+    unmount();
+  });
+
+  it('carries no payload for a command that takes none, and resolves undefined when it answers nothing', async () => {
+    const { result, unmount } = renderAppHook();
+    const ws = await waitForOpenSocket();
+
+    const promise = result.current.sendAppCommand('reviewer', 'refresh');
+    await Promise.resolve();
+    const sent = lastSent(ws);
+    expect(sent.payload).toBeUndefined();
+
+    ws.emit({ event: 'app_command_result', request_id: sent.request_id, success: true });
+    await expect(promise).resolves.toBeUndefined();
+    unmount();
+  });
+
+  it('rejects with the daemon’s refusal, which is what the tile shows', async () => {
+    const { result, unmount } = renderAppHook();
+    const ws = await waitForOpenSocket();
+
+    const promise = result.current.sendAppCommand('reviewer', 'approve');
+    await Promise.resolve();
+    const sent = lastSent(ws);
+
+    ws.emit({
+      event: 'app_command_result',
+      request_id: sent.request_id,
+      success: false,
+      error: 'reviewer is disabled, so it runs nothing; `attn app enable reviewer` turns it back on',
+    });
+    await expect(promise).rejects.toThrow('attn app enable reviewer');
+    unmount();
+  });
+});

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -69,6 +69,7 @@ import { completeTerminalInputProbe, maybeStartTerminalInputProbe } from '../uti
 import { decodeBinaryFrame } from '../pty/binaryPtyFrame';
 import { kittyImageBlobFromResult, kittyImageCache } from '../utils/kittyImageCache';
 import { resolveDaemonWebSocketURL, type DaemonEndpointProfile } from '../utils/daemonEndpoint';
+import { handleAppDaemonEvent, type AppCommandResult } from './daemonAppEvents';
 import { handleBusDaemonEvent, type BusStatus } from './daemonBusEvents';
 import { handleFsDaemonEvent } from './daemonFsEvents';
 import { handleNotebookDaemonEvent } from './daemonNotebookEvents';
@@ -251,7 +252,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '243';
+export const PROTOCOL_VERSION = '244';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a
@@ -826,6 +827,11 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
 // of production, 209ms at 945k rows — so 30s is roughly a hundred times the
 // worst real log, a tripwire for a scan that has hung rather than a budget.
 const BUS_STATUS_TIMEOUT_MS = 30_000;
+// An app command is bounded by the daemon, which abandons a handler at 60s and
+// answers with a refusal naming the app, the command and that limit. This sits
+// past it so that refusal is what a view shows: a shorter one here would win the
+// race and replace it with "timed out".
+const APP_COMMAND_TIMEOUT_MS = 75_000;
 const GIT_METADATA_TIMEOUT_MS = 30 * 60_000;
 const GIT_DIFF_TIMEOUT_MS = 10 * 60_000;
 const GIT_WORKTREE_TIMEOUT_MS = 30 * 60_000;
@@ -3002,6 +3008,7 @@ export function useDaemonSocket({
               }
             })) break;
             if (handleBusDaemonEvent(data, pending)) break;
+            if (handleAppDaemonEvent(data, pending)) break;
             if (docSubscriptions.handleEvent(data)) break;
             break;
           }
@@ -3455,6 +3462,30 @@ export function useDaemonSocket({
       error: report.error,
     });
   }, [sendOrQueueCommand]);
+
+  /**
+   * Run one of an app's declared commands and resolve with what its handler
+   * returned. Which app is asked comes from the host that mounted the view, not
+   * from the view — the same rule the document namespace follows.
+   *
+   * The timeout is past the daemon's own dispatch budget (60s) on purpose. The
+   * daemon's refusal names the app, the command and the limit; a shorter one
+   * here would replace that with "timed out" and lose everything worth reading.
+   */
+  const sendAppCommand = useCallback((app: string, command: string, payload?: unknown): Promise<unknown> => {
+    return sendRequest<AppCommandResult>(
+      'app_command',
+      {
+        app,
+        command,
+        // JSON text, exactly as a document body travels. Absent when the command
+        // takes no argument.
+        ...(payload === undefined ? {} : { payload: JSON.stringify(payload) }),
+      },
+      `${app} did not answer the command “${command}”`,
+      APP_COMMAND_TIMEOUT_MS,
+    ).then((result) => result.value);
+  }, [sendRequest]);
 
   const sendPtyResize = useCallback((
     id: string,
@@ -5632,6 +5663,7 @@ export function useDaemonSocket({
     sendSetClientPresence,
     sendSetTerminalTheme,
     sendAppViewCrash,
+    sendAppCommand,
     subscribeDocuments,
     isRuntimeAttached,
     sendGetFileDiff,

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentMsgMessage, AgentMsgResult, AgentMsgStatus, AgentPeekMessage, AgentPeekResult, AgentPeekScreen, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, AppApplyMessage, AppApplyResult, AppConsumerInfo, AppInvocationInfo, AppListMessage, AppListResult, AppLogsMessage, AppLogsResult, AppRegistryEntry, AppRemoveMessage, AppRemoveResult, AppRollbackMessage, AppRollbackResult, AppRuntimeInfo, AppRuntimeRestartMessage, AppRuntimeRestartResult, AppRuntimeStatusMessage, AppRuntimeStatusResult, AppSetEnabledMessage, AppSetEnabledResult, AppStallInfo, AppStatusMessage, AppStatusResult, AppSummary, AppVersionInfo, AppViewCrashMessage, AppViewInfo, AppWatchMessage, AppWatchResult, ApprovePRMessage, AppsUpdatedMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, BusConsumerStatus, BusHealthEntry, BusProducerStatus, BusSetConsumerEnabledMessage, BusSetConsumerEnabledResultMessage, BusStatusGetMessage, BusStatusResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocSubscriptionDeliveryMessage, DocSubscriptionEndedMessage, DocUndefineMessage, DocUndefineResult, DocUnsubscribeMessage, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GardenSeedsUpdatedMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, OpenSentFilesMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyInputProbeResultMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Seed, SeedEdge, SeedLinkMessage, SeedLinkResult, SeedListMessage, SeedListResult, SeedNote, SeedNoteMessage, SeedNoteResult, SeedNotesMessage, SeedNotesResult, SeedPlantMessage, SeedPlantResult, SeedReadyMessage, SeedReadyResult, SeedRelation, SeedShowMessage, SeedShowResult, SeedTransitionMessage, SeedTransitionResult, SeedVar, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessageWindowStatus, SessionMessagesChangedMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketRow, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentMsgMessage, AgentMsgResult, AgentMsgStatus, AgentPeekMessage, AgentPeekResult, AgentPeekScreen, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, AppApplyMessage, AppApplyResult, AppCommandInfo, AppCommandMessage, AppCommandResultMessage, AppConsumerInfo, AppInvocationInfo, AppListMessage, AppListResult, AppLogsMessage, AppLogsResult, AppRegistryEntry, AppRemoveMessage, AppRemoveResult, AppRollbackMessage, AppRollbackResult, AppRuntimeInfo, AppRuntimeRestartMessage, AppRuntimeRestartResult, AppRuntimeStatusMessage, AppRuntimeStatusResult, AppSetEnabledMessage, AppSetEnabledResult, AppStallInfo, AppStatusMessage, AppStatusResult, AppSummary, AppVersionInfo, AppViewCrashMessage, AppViewInfo, AppWatchMessage, AppWatchResult, ApprovePRMessage, AppsUpdatedMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, BusConsumerStatus, BusHealthEntry, BusProducerStatus, BusSetConsumerEnabledMessage, BusSetConsumerEnabledResultMessage, BusStatusGetMessage, BusStatusResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocSubscriptionDeliveryMessage, DocSubscriptionEndedMessage, DocUndefineMessage, DocUndefineResult, DocUnsubscribeMessage, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GardenSeedsUpdatedMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, OpenSentFilesMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyInputProbeResultMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Seed, SeedEdge, SeedLinkMessage, SeedLinkResult, SeedListMessage, SeedListResult, SeedNote, SeedNoteMessage, SeedNoteResult, SeedNotesMessage, SeedNotesResult, SeedPlantMessage, SeedPlantResult, SeedReadyMessage, SeedReadyResult, SeedRelation, SeedShowMessage, SeedShowResult, SeedTransitionMessage, SeedTransitionResult, SeedVar, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessageWindowStatus, SessionMessagesChangedMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketRow, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const activityStatusMessage = Convert.toActivityStatusMessage(json);
 //   const activityStatusResult = Convert.toActivityStatusResult(json);
@@ -21,6 +21,9 @@
 //   const agentToolDetailMessage = Convert.toAgentToolDetailMessage(json);
 //   const appApplyMessage = Convert.toAppApplyMessage(json);
 //   const appApplyResult = Convert.toAppApplyResult(json);
+//   const appCommandInfo = Convert.toAppCommandInfo(json);
+//   const appCommandMessage = Convert.toAppCommandMessage(json);
+//   const appCommandResultMessage = Convert.toAppCommandResultMessage(json);
 //   const appConsumerInfo = Convert.toAppConsumerInfo(json);
 //   const appInvocationInfo = Convert.toAppInvocationInfo(json);
 //   const appListMessage = Convert.toAppListMessage(json);
@@ -751,6 +754,38 @@ export interface AppApplyResult {
     [property: string]: any;
 }
 
+export interface AppCommandInfo {
+    description?: string;
+    name:         string;
+    [property: string]: any;
+}
+
+export interface AppCommandMessage {
+    app:        string;
+    cmd:        AppCommandMessageCmd;
+    command:    string;
+    payload?:   string;
+    request_id: string;
+    [property: string]: any;
+}
+
+export enum AppCommandMessageCmd {
+    AppCommand = "app_command",
+}
+
+export interface AppCommandResultMessage {
+    error?:     string;
+    event:      AppCommandResultMessageEvent;
+    payload?:   string;
+    request_id: string;
+    success:    boolean;
+    [property: string]: any;
+}
+
+export enum AppCommandResultMessageEvent {
+    AppCommandResult = "app_command_result",
+}
+
 export interface AppConsumerInfo {
     cursor:  number;
     enabled: boolean;
@@ -789,12 +824,19 @@ export interface AppListResult {
 }
 
 export interface App {
+    commands?:        CommandElement[];
     consumer?:        Consumer;
     created_at:       string;
     current_version?: CurrentVersion;
     name:             string;
     updated_at:       string;
     views?:           ViewElement[];
+    [property: string]: any;
+}
+
+export interface CommandElement {
+    description?: string;
+    name:         string;
     [property: string]: any;
 }
 
@@ -1034,6 +1076,7 @@ export interface Stall {
 }
 
 export interface AppSummary {
+    commands?:        CommandElement[];
     consumer?:        Consumer;
     created_at:       string;
     current_version?: CurrentVersion;
@@ -8148,6 +8191,30 @@ export class Convert {
         return JSON.stringify(uncast(value, r("AppApplyResult")), null, 2);
     }
 
+    public static toAppCommandInfo(json: string): AppCommandInfo {
+        return cast(JSON.parse(json), r("AppCommandInfo"));
+    }
+
+    public static appCommandInfoToJson(value: AppCommandInfo): string {
+        return JSON.stringify(uncast(value, r("AppCommandInfo")), null, 2);
+    }
+
+    public static toAppCommandMessage(json: string): AppCommandMessage {
+        return cast(JSON.parse(json), r("AppCommandMessage"));
+    }
+
+    public static appCommandMessageToJson(value: AppCommandMessage): string {
+        return JSON.stringify(uncast(value, r("AppCommandMessage")), null, 2);
+    }
+
+    public static toAppCommandResultMessage(json: string): AppCommandResultMessage {
+        return cast(JSON.parse(json), r("AppCommandResultMessage"));
+    }
+
+    public static appCommandResultMessageToJson(value: AppCommandResultMessage): string {
+        return JSON.stringify(uncast(value, r("AppCommandResultMessage")), null, 2);
+    }
+
     public static toAppConsumerInfo(json: string): AppConsumerInfo {
         return cast(JSON.parse(json), r("AppConsumerInfo"));
     }
@@ -12504,6 +12571,24 @@ const typeMap: any = {
         { json: "version_created", js: "version_created", typ: true },
         { json: "version_id", js: "version_id", typ: 0 },
     ], "any"),
+    "AppCommandInfo": o([
+        { json: "description", js: "description", typ: u(undefined, "") },
+        { json: "name", js: "name", typ: "" },
+    ], "any"),
+    "AppCommandMessage": o([
+        { json: "app", js: "app", typ: "" },
+        { json: "cmd", js: "cmd", typ: r("AppCommandMessageCmd") },
+        { json: "command", js: "command", typ: "" },
+        { json: "payload", js: "payload", typ: u(undefined, "") },
+        { json: "request_id", js: "request_id", typ: "" },
+    ], "any"),
+    "AppCommandResultMessage": o([
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("AppCommandResultMessageEvent") },
+        { json: "payload", js: "payload", typ: u(undefined, "") },
+        { json: "request_id", js: "request_id", typ: "" },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
     "AppConsumerInfo": o([
         { json: "cursor", js: "cursor", typ: 0 },
         { json: "enabled", js: "enabled", typ: true },
@@ -12530,12 +12615,17 @@ const typeMap: any = {
         { json: "apps", js: "apps", typ: a(r("App")) },
     ], "any"),
     "App": o([
+        { json: "commands", js: "commands", typ: u(undefined, a(r("CommandElement"))) },
         { json: "consumer", js: "consumer", typ: u(undefined, r("Consumer")) },
         { json: "created_at", js: "created_at", typ: "" },
         { json: "current_version", js: "current_version", typ: u(undefined, r("CurrentVersion")) },
         { json: "name", js: "name", typ: "" },
         { json: "updated_at", js: "updated_at", typ: "" },
         { json: "views", js: "views", typ: u(undefined, a(r("ViewElement"))) },
+    ], "any"),
+    "CommandElement": o([
+        { json: "description", js: "description", typ: u(undefined, "") },
+        { json: "name", js: "name", typ: "" },
     ], "any"),
     "Consumer": o([
         { json: "cursor", js: "cursor", typ: 0 },
@@ -12699,6 +12789,7 @@ const typeMap: any = {
         { json: "since", js: "since", typ: "" },
     ], "any"),
     "AppSummary": o([
+        { json: "commands", js: "commands", typ: u(undefined, a(r("CommandElement"))) },
         { json: "consumer", js: "consumer", typ: u(undefined, r("Consumer")) },
         { json: "created_at", js: "created_at", typ: "" },
         { json: "current_version", js: "current_version", typ: u(undefined, r("CurrentVersion")) },
@@ -16979,6 +17070,12 @@ const typeMap: any = {
     ],
     "AppApplyMessageCmd": [
         "app_apply",
+    ],
+    "AppCommandMessageCmd": [
+        "app_command",
+    ],
+    "AppCommandResultMessageEvent": [
+        "app_command_result",
     ],
     "AppListMessageCmd": [
         "app_list",

--- a/apphost/src/dispatch.ts
+++ b/apphost/src/dispatch.ts
@@ -45,6 +45,26 @@ export interface DispatchResult {
   error?: string
 }
 
+/** What the daemon sends to run one command a view invoked. */
+export interface CommandParams {
+  dispatch: string
+  app: string
+  version_id: number
+  artifact: string
+  /** The `command:<name>` key to invoke — a key of the bundle's default export. */
+  handler: string
+  collections: string[]
+  /** The caller's argument, already parsed. Absent when the command takes none. */
+  payload?: unknown
+}
+
+/** What the daemon gets back from a command, plus whatever the handler returned. */
+export interface CommandResult {
+  ok: boolean
+  error?: string
+  payload?: unknown
+}
+
 type Handler = (event: DispatchParams["event"], ctx: unknown) => unknown
 
 /**
@@ -149,16 +169,7 @@ export async function runDispatch(
 
   const handler = handlers[params.handler]
   if (typeof handler !== "function") {
-    const declared = Object.keys(handlers)
-    return {
-      ok: false,
-      error:
-        `app ${params.app} version ${params.version_id} subscribes to ${params.handler} but its default export has no handler under that key. ` +
-        (declared.length > 0
-          ? `It exports: ${declared.join(", ")}.`
-          : "It exports no handlers at all.") +
-        " The generated Handlers type makes this a compile error — the bundle is out of step with its manifest.",
-    }
+    return { ok: false, error: missingHandler(handlers, params.app, params.version_id, params.handler) }
   }
 
   const ctx = {
@@ -185,6 +196,78 @@ export async function runDispatch(
   } finally {
     conn.notify("app_runtime.left", scope)
   }
+}
+
+/**
+ * Runs one command a view invoked, and describes what happened.
+ *
+ * It is runDispatch with a different argument and an answer that carries a
+ * value. Everything that makes a handler run — the module cache keyed by the
+ * content-addressed artifact, the app-scoped collections, the entered/left
+ * announcements that let the daemon name whoever froze the shared loop — is the
+ * same code, because a command is one more key of the same default export.
+ */
+export async function runCommand(
+  conn: RpcConnection,
+  params: CommandParams,
+): Promise<CommandResult> {
+  appByArtifact.set(params.artifact, params.app)
+
+  let handlers: Record<string, Handler>
+  try {
+    handlers = await loadHandlers(params.artifact)
+  } catch (err) {
+    return { ok: false, error: describeFailure(err) }
+  }
+
+  const handler = handlers[params.handler] as
+    | ((payload: unknown, ctx: unknown) => unknown)
+    | undefined
+  if (typeof handler !== "function") {
+    return { ok: false, error: missingHandler(handlers, params.app, params.version_id, params.handler) }
+  }
+
+  const ctx = {
+    app: params.app,
+    version: params.version_id,
+    collections: collectionsFor(conn, params.dispatch, params.collections),
+  }
+  const scope = { dispatch: params.dispatch, app: params.app }
+  conn.notify("app_runtime.entered", scope)
+  try {
+    const payload = await handler(params.payload, ctx)
+    // undefined is "returned nothing", and JSON has no word for it: leaving the
+    // field off is what tells the caller that apart from a handler that
+    // deliberately returned null.
+    return payload === undefined ? { ok: true } : { ok: true, payload }
+  } catch (err) {
+    return { ok: false, error: describeFailure(err) }
+  } finally {
+    conn.notify("app_runtime.left", scope)
+  }
+}
+
+/**
+ * What to say when the manifest declared something the bundle does not export.
+ *
+ * The generated Handlers type makes this a compile error at apply time, so
+ * reaching it means the bundle is out of step with the declaration it was
+ * stored beside — worth naming exactly, because nothing else in the system can.
+ */
+function missingHandler(
+  handlers: Record<string, unknown>,
+  app: string,
+  version: number,
+  key: string,
+): string {
+  const declared = Object.keys(handlers)
+  return (
+    `app ${app} version ${version} declares ${key} but its default export has no handler under that key. ` +
+    (declared.length > 0
+      ? `It exports: ${declared.join(", ")}.`
+      : "It exports no handlers at all.") +
+    " The generated Handlers type makes this a compile error — the bundle is out of step with its manifest."
+  )
 }
 
 function describeFailure(err: unknown): string {

--- a/apphost/src/dispatch.ts
+++ b/apphost/src/dispatch.ts
@@ -26,7 +26,7 @@ export interface DispatchParams {
   version_id: number
   /** Absolute path to this version's bundle. */
   artifact: string
-  /** The subscription pattern to invoke — a key of the bundle's default export. */
+  /** The subscription to invoke — a key of the bundle's `subscriptions` map. */
   handler: string
   /** The collections this version declared, by name. */
   collections: string[]
@@ -51,7 +51,7 @@ export interface CommandParams {
   app: string
   version_id: number
   artifact: string
-  /** The `command:<name>` key to invoke — a key of the bundle's default export. */
+  /** The command to invoke, by bare name — a key of the bundle's `commands` map. */
   handler: string
   collections: string[]
   /** The caller's argument, already parsed. Absent when the command takes none. */
@@ -65,7 +65,20 @@ export interface CommandResult {
   payload?: unknown
 }
 
-type Handler = (event: DispatchParams["event"], ctx: unknown) => unknown
+/** A handler of either kind: the first argument is the fact or the payload. */
+type Handler = (arg: unknown, ctx: unknown) => unknown
+
+/**
+ * What an app's entrypoint default-exports: one map per kind of handler.
+ *
+ * The kind is structure rather than a naming convention, and this is where that
+ * pays: which map to index in is decided by which method the daemon called, so
+ * a command and a subscription of the same name are two different handlers and
+ * no key can be ambiguous.
+ */
+type Bundle = Partial<Record<HandlerKind, Record<string, Handler>>>
+
+type HandlerKind = "subscriptions" | "commands"
 
 /**
  * Bundles already imported, by absolute path. It only ever grows, which is
@@ -73,7 +86,7 @@ type Handler = (event: DispatchParams["event"], ctx: unknown) => unknown
  * can run again on a rollback, and the entries are small. A runtime restart is
  * what empties it, and the supervisor provides those.
  */
-const modules = new Map<string, Promise<Record<string, Handler>>>()
+const modules = new Map<string, Promise<Bundle>>()
 
 /**
  * Which app each loaded bundle belongs to. It is how an error that escaped every
@@ -97,10 +110,10 @@ export function appForStack(stack: string): string {
   return ""
 }
 
-async function loadHandlers(artifact: string): Promise<Record<string, Handler>> {
+async function loadBundle(artifact: string): Promise<Bundle> {
   let pending = modules.get(artifact)
   if (!pending) {
-    pending = importHandlers(artifact)
+    pending = importBundle(artifact)
     modules.set(artifact, pending)
     // A bundle that fails to import must not be remembered as broken forever: the
     // artifact may be mid-write, or the disk may have had a bad moment, and the
@@ -110,15 +123,23 @@ async function loadHandlers(artifact: string): Promise<Record<string, Handler>> 
   return pending
 }
 
-async function importHandlers(artifact: string): Promise<Record<string, Handler>> {
+async function importBundle(artifact: string): Promise<Bundle> {
   const module = (await import(pathToFileURL(artifact).href)) as { default?: unknown }
-  const handlers = module.default
-  if (!handlers || typeof handlers !== "object") {
+  const bundle = module.default
+  if (!bundle || typeof bundle !== "object") {
     throw new Error(
-      `${artifact} has no default export; an app's entrypoint default-exports its handlers, as \`export default { "session.state.changed": onChange } satisfies Handlers\``,
+      `${artifact} has no default export; an app's entrypoint default-exports its handlers grouped by kind, as \`export default { subscriptions: { "session.state.changed": onChange }, commands: { approve } } satisfies Handlers\``,
     )
   }
-  return handlers as Record<string, Handler>
+  return bundle as Bundle
+}
+
+/** The handler the daemon named, or undefined with nothing guessed. */
+function handlerFor(bundle: Bundle, kind: HandlerKind, key: string): Handler | undefined {
+  const group = bundle[kind]
+  if (!group || typeof group !== "object") return undefined
+  const handler = group[key]
+  return typeof handler === "function" ? handler : undefined
 }
 
 /** Builds `ctx.collections`, one object per collection the version declared. */
@@ -160,16 +181,19 @@ export async function runDispatch(
 ): Promise<DispatchResult> {
   appByArtifact.set(params.artifact, params.app)
 
-  let handlers: Record<string, Handler>
+  let bundle: Bundle
   try {
-    handlers = await loadHandlers(params.artifact)
+    bundle = await loadBundle(params.artifact)
   } catch (err) {
     return { ok: false, error: describeFailure(err) }
   }
 
-  const handler = handlers[params.handler]
-  if (typeof handler !== "function") {
-    return { ok: false, error: missingHandler(handlers, params.app, params.version_id, params.handler) }
+  const handler = handlerFor(bundle, "subscriptions", params.handler)
+  if (!handler) {
+    return {
+      ok: false,
+      error: missingHandler(bundle, "subscriptions", params.app, params.version_id, params.handler),
+    }
   }
 
   const ctx = {
@@ -205,7 +229,7 @@ export async function runDispatch(
  * value. Everything that makes a handler run — the module cache keyed by the
  * content-addressed artifact, the app-scoped collections, the entered/left
  * announcements that let the daemon name whoever froze the shared loop — is the
- * same code, because a command is one more key of the same default export.
+ * same code, reading a different group of the same default export.
  */
 export async function runCommand(
   conn: RpcConnection,
@@ -213,18 +237,19 @@ export async function runCommand(
 ): Promise<CommandResult> {
   appByArtifact.set(params.artifact, params.app)
 
-  let handlers: Record<string, Handler>
+  let bundle: Bundle
   try {
-    handlers = await loadHandlers(params.artifact)
+    bundle = await loadBundle(params.artifact)
   } catch (err) {
     return { ok: false, error: describeFailure(err) }
   }
 
-  const handler = handlers[params.handler] as
-    | ((payload: unknown, ctx: unknown) => unknown)
-    | undefined
-  if (typeof handler !== "function") {
-    return { ok: false, error: missingHandler(handlers, params.app, params.version_id, params.handler) }
+  const handler = handlerFor(bundle, "commands", params.handler)
+  if (!handler) {
+    return {
+      ok: false,
+      error: missingHandler(bundle, "commands", params.app, params.version_id, params.handler),
+    }
   }
 
   const ctx = {
@@ -255,17 +280,18 @@ export async function runCommand(
  * stored beside — worth naming exactly, because nothing else in the system can.
  */
 function missingHandler(
-  handlers: Record<string, unknown>,
+  bundle: Bundle,
+  kind: HandlerKind,
   app: string,
   version: number,
   key: string,
 ): string {
-  const declared = Object.keys(handlers)
+  const exported = Object.keys(bundle[kind] ?? {})
   return (
-    `app ${app} version ${version} declares ${key} but its default export has no handler under that key. ` +
-    (declared.length > 0
-      ? `It exports: ${declared.join(", ")}.`
-      : "It exports no handlers at all.") +
+    `app ${app} version ${version} declares ${key} but its default export has no handler for it under ${kind}. ` +
+    (exported.length > 0
+      ? `Its ${kind} are: ${exported.join(", ")}.`
+      : `It exports no ${kind} at all.`) +
     " The generated Handlers type makes this a compile error — the bundle is out of step with its manifest."
   )
 }

--- a/apphost/src/index.ts
+++ b/apphost/src/index.ts
@@ -17,14 +17,20 @@
 
 import { AsyncLocalStorage } from "node:async_hooks"
 import { RpcConnection, RPC_METHOD_NOT_FOUND, describe, type RpcRequest } from "./rpc.ts"
-import { appForStack, runDispatch, type DispatchParams } from "./dispatch.ts"
+import {
+  appForStack,
+  runCommand,
+  runDispatch,
+  type CommandParams,
+  type DispatchParams,
+} from "./dispatch.ts"
 
 /**
  * The runtime contract this host speaks. The daemon refuses a host that does not
  * match, because a version skew between the daemon and a binary inside an old app
  * bundle is exactly the case a silent mismatch would turn into wrong behavior.
  */
-const APP_RUNTIME_API_VERSION = 2
+const APP_RUNTIME_API_VERSION = 3
 
 /**
  * Which app a line of output came from.
@@ -161,6 +167,10 @@ async function main(): Promise<void> {
         const params = request.params as DispatchParams
         // The tag follows the handler through every await it makes.
         return currentApp.run(params.app, () => runDispatch(connection, params))
+      }
+      case "app.command": {
+        const params = request.params as CommandParams
+        return currentApp.run(params.app, () => runCommand(connection, params))
       }
       case "app.runtime.ping":
         // A liveness answer the daemon can ask for without running app code.

--- a/apphost/src/index.ts
+++ b/apphost/src/index.ts
@@ -29,8 +29,10 @@ import {
  * The runtime contract this host speaks. The daemon refuses a host that does not
  * match, because a version skew between the daemon and a binary inside an old app
  * bundle is exactly the case a silent mismatch would turn into wrong behavior.
+ *
+ * Bump it together with appRuntimeAPIVersion in internal/daemon/app_runtime.go.
  */
-const APP_RUNTIME_API_VERSION = 3
+const APP_RUNTIME_API_VERSION = 4
 
 /**
  * Which app a line of output came from.

--- a/changelog.d/a5-slice5-views-act-and-look-native.yaml
+++ b/changelog.d/a5-slice5-views-act-and-look-native.yaml
@@ -21,5 +21,7 @@ notes: >
   A5 slice 5. Protocol 244: `app_command` and `app_command_result`. An app's
   bundle now default-exports one handler map per kind — `subscriptions`, keyed
   by event pattern, and `commands`, keyed by name — so an app installed before
-  this needs one `attn app apply` to keep dispatching. One command carries at
+  this needs one `attn app apply` to keep dispatching, and the app runtime's API
+  version goes to 4 so a stale sidecar binary is refused at hello rather than
+  served against the new shape. One command carries at
   most 256KB in either direction.

--- a/changelog.d/a5-slice5-views-act-and-look-native.yaml
+++ b/changelog.d/a5-slice5-views-act-and-look-native.yaml
@@ -1,0 +1,24 @@
+kind: added
+area: apps
+change: >
+  An app's view can now act, not only read. An app declares `[[commands]]` in
+  its manifest, exports a handler for each under `command:<name>`, and a view
+  invokes one by name — attn addresses it to the app that mounted the tile.
+  The handler runs where every other handler runs: the shared runtime, the same
+  document access, the same invocation log, the same sixty-second abandon.
+  What an app answers is what the version now serving declared, so a rollback
+  takes a command away with it, and a command that fails costs that click and
+  nothing else — it is reported in the handler's own words and never disables
+  the app. `attn app status` lists the commands the serving version declares.
+
+  The SDK now ships the controls a view needs to look like the rest of attn:
+  Button, TextInput, TextArea, List and ListRow, EmptyState, and Markdown. They
+  draw with attn's own tokens, and nothing in them animates. And `attn app new`
+  scaffolds a working tile rather than a stub — a live query, a command, and
+  those components — with an AGENTS.md that teaches views, params, reading,
+  acting and drawing.
+notes: >
+  A5 slice 5. Protocol 244: `app_command` and `app_command_result`. Command
+  handler keys carry a `command:` prefix; subscription keys stay the raw event
+  pattern, so no installed app's bundle changes meaning. One command carries at
+  most 256KB in either direction.

--- a/changelog.d/a5-slice5-views-act-and-look-native.yaml
+++ b/changelog.d/a5-slice5-views-act-and-look-native.yaml
@@ -2,7 +2,7 @@ kind: added
 area: apps
 change: >
   An app's view can now act, not only read. An app declares `[[commands]]` in
-  its manifest, exports a handler for each under `command:<name>`, and a view
+  its manifest, exports a handler for each under `commands`, and a view
   invokes one by name — attn addresses it to the app that mounted the tile.
   The handler runs where every other handler runs: the shared runtime, the same
   document access, the same invocation log, the same sixty-second abandon.
@@ -18,7 +18,8 @@ change: >
   those components — with an AGENTS.md that teaches views, params, reading,
   acting and drawing.
 notes: >
-  A5 slice 5. Protocol 244: `app_command` and `app_command_result`. Command
-  handler keys carry a `command:` prefix; subscription keys stay the raw event
-  pattern, so no installed app's bundle changes meaning. One command carries at
+  A5 slice 5. Protocol 244: `app_command` and `app_command_result`. An app's
+  bundle now default-exports one handler map per kind — `subscriptions`, keyed
+  by event pattern, and `commands`, keyed by name — so an app installed before
+  this needs one `attn app apply` to keep dispatching. One command carries at
   most 256KB in either direction.

--- a/cmd/attn/app.go
+++ b/cmd/attn/app.go
@@ -304,6 +304,19 @@ func runAppStatus(args []string) {
 			fmt.Printf("              dock as %s\n", apps.ViewTileKind(app.Name, v.Name))
 		}
 	}
+	if len(app.Commands) > 0 {
+		// A command is invoked from one of this app's views, so there is no CLI
+		// verb that runs one — this line is how an author confirms the command
+		// they declared reached the version that is serving.
+		fmt.Println("  commands:")
+		for _, c := range app.Commands {
+			line := fmt.Sprintf("              %s", c.Name)
+			if c.Description != nil && *c.Description != "" {
+				line += " — " + *c.Description
+			}
+			fmt.Println(line)
+		}
+	}
 	fmt.Printf("  runtime:    %s\n", appRuntimeCell(result.Runtime))
 	if result.Stall != nil {
 		// The stall clock is the only thing here that ends with the app being

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -310,6 +310,27 @@ will not load, exports no component, or throws while rendering — costs its own
 tile and nothing beyond it, and the failure is recorded as an invocation of the
 app stamped with the version that served it, so `attn app logs` has it.
 
+A **tile** is a place in a workspace layout: one pane the user split, dragged
+and sized. A view is what an app declares; a tile is where one instance of it
+sits. Keeping them separate words is what makes the mount surface extensible — a
+later kind of mount moves what a *tile* is, and leaves `[[views]]`, the registry
+row and the artifact untouched. Two tiles of one view are two independent
+mounts, told apart by their `params` and by a `tileId` stable for the life of
+each docked tile.
+
+A **command** is how a view acts. The app declares it in a `[[commands]]` block,
+the bundle exports a handler under `command:<name>`, and a view invokes it by
+name — never by app, because which app is asked comes from the mount, the same
+rule the document namespace follows. A command runs where every other handler
+runs: the shared sidecar, the same document access, the same invocation log, the
+same sixty-second abandon. What an app answers is what the *serving* version
+declared, so a rollback takes a command away with it.
+
+A command that fails costs that click and nothing else. It is recorded and
+reported to the view in the handler's own words, and it does not advance the
+clock that disables a stalled app — that clock exists for a consumer pinning the
+durable log, and a person pressing a button pins nothing.
+
 **Applying** is how a directory becomes a version: parse the manifest, generate
 the types the handlers are checked against, typecheck, bundle, hash, write the
 artifact, insert the row, move the pointer. Apply never evaluates the app's

--- a/docs/plans/2026-08-13-ext-a5-ui-host-and-app-sdk.md
+++ b/docs/plans/2026-08-13-ext-a5-ui-host-and-app-sdk.md
@@ -967,6 +967,49 @@ handing over `app/<app>` and the frontend's `subscribeDocuments`. That is what
 makes "a view cannot read another app's documents" structural: a view is given a
 namespace, and there is no call that takes one.
 
+## Slice 5 as-built
+
+Commands, the components, and the scaffold landed as designed. Four departures
+and receipts, all found by building it.
+
+**Only commands carry a handler-key prefix.** The design drew
+`"subscribe:doc.changed"` beside `"command:approve"`, but A4 shipped
+subscription keys as the raw event pattern, and every installed app's bundle
+already exports them that way. Prefixing subscriptions now would make every one
+of those apps silently stop dispatching until it was re-applied, for a
+namespacing problem that does not exist: a colon can appear in neither an event
+pattern nor a command name, so `command:<name>` cannot collide with any
+subscription key. So commands are prefixed and subscriptions are not, and the
+handler an invocation names is the key it was invoked by — `view:` for a caught
+render crash, `command:` for a command, the bare pattern for a subscription.
+
+**A command carries at most 256KB in either direction.** The same limit as a
+document body, and for the same reason: the payload lands in the sidecar's
+single-threaded loop and in the invocation log's error text. Over it, the
+refusal names the command, the app, the limit and the ask, and says where
+larger data belongs — a document, which is the surface built to hold it.
+
+**The frontend waits longer than the daemon.** `APP_COMMAND_TIMEOUT_MS` is 75s
+against the daemon's 60s dispatch budget. That ordering is the whole point: a
+handler that never yields is abandoned by the daemon, which knows which app and
+which command froze the shared loop, and its refusal reaches the view naming all
+three. A frontend that gave up first would replace that with "the daemon did not
+answer", which no agent can act on. A failed command never advances the app's
+stall clock — that clock exists for a consumer pinning the durable log's
+retention floor, and a docked tile pins nothing, so clicking must not be able to
+disable a healthy app.
+
+**Component styles live in the app, not in the SDK.** A CSS import inside the
+SDK's rollup entry emits an asset the import map's three fixed-name chunks
+cannot link, so the components emit `attn-app-*` class names only and
+`app/src/components/appViews/appSdkComponents.css` — imported by `AppTileHost` —
+carries every rule, over attn's own tokens. A test asserts both directions of
+that pairing, so a component that grows a class without a rule, or a rule with
+no component, fails rather than shipping unstyled. The shipped slice is Button,
+TextInput, TextArea, List, ListRow, EmptyState and Markdown; nothing in them
+animates, which is why the spinner and the relative-time label the design
+excluded stay excluded.
+
 ## Out of scope
 
 - Panels, windows, and any mount kind other than tiles. Designed for, not

--- a/docs/plans/2026-08-13-ext-a5-ui-host-and-app-sdk.md
+++ b/docs/plans/2026-08-13-ext-a5-ui-host-and-app-sdk.md
@@ -570,9 +570,9 @@ Dispatch reuses everything A4 built rather than adding a second path:
 attn-app.toml   [[commands]] name = "approve"
       ↓ codegen
 handlers.ts     type Handlers = {
-                  "subscribe:doc.changed": …   A4
-                  "command:approve": …         ← A5, missing = tsc error
-                }
+                  subscriptions: { "doc.changed": … }   A4
+                  commands: { approve: … }              ← A5,
+                }                                       missing = tsc error
       ↓ apply → sidecar
 runtime         ordinary dispatch: same invocation log, same timeout,
                 same drain on version flip, same failure attribution

--- a/docs/plans/2026-08-13-ext-a5-ui-host-and-app-sdk.md
+++ b/docs/plans/2026-08-13-ext-a5-ui-host-and-app-sdk.md
@@ -972,16 +972,28 @@ namespace, and there is no call that takes one.
 Commands, the components, and the scaffold landed as designed. Four departures
 and receipts, all found by building it.
 
-**Only commands carry a handler-key prefix.** The design drew
-`"subscribe:doc.changed"` beside `"command:approve"`, but A4 shipped
-subscription keys as the raw event pattern, and every installed app's bundle
-already exports them that way. Prefixing subscriptions now would make every one
-of those apps silently stop dispatching until it was re-applied, for a
-namespacing problem that does not exist: a colon can appear in neither an event
-pattern nor a command name, so `command:<name>` cannot collide with any
-subscription key. So commands are prefixed and subscriptions are not, and the
-handler an invocation names is the key it was invoked by — `view:` for a caught
-render crash, `command:` for a command, the bare pattern for a subscription.
+**Kind is structure, not a prefix on a key.** The design drew
+`"subscribe:doc.changed"` beside `"command:approve"` in one flat map, and the
+first build of this slice shipped half of that — raw patterns for subscriptions,
+a `command:` prefix for commands — defended by a proof that the two can never
+collide, since a colon appears in neither an event pattern nor a command name.
+That proof is a rule someone can break later. A bundle exports one map per kind
+instead: `subscriptions`, keyed by the raw event pattern, and `commands`, keyed
+by the bare name. The manifest already separates the kinds, so the bundle mirrors
+it rather than re-encoding kind as a string convention, codegen derives a typed
+group per kind — tsc enforces "every declared command has a command-shaped
+handler" structurally — and the sidecar indexes the map its dispatch context
+names (a fact arrived → `subscriptions`; a command envelope → `commands`),
+constructing no keys at all. Collision becomes inexpressible rather than
+proven-absent.
+
+Invocation **labels** are a separate thing: what `attn app logs` shows, so it
+names the kind — `command:approve`, `subscribe:ticket.*`, `view:approvals`. They
+have no dispatch meaning, which is what makes labelling every kind free.
+
+Existing installed apps export the flat shape and stop dispatching until they are
+re-applied. Pre-release, with no app installed anywhere but a dev profile, that
+costs one `attn app apply` and buys a shape that cannot be got wrong.
 
 **A command carries at most 256KB in either direction.** The same limit as a
 document body, and for the same reason: the payload lands in the sidecar's

--- a/internal/appbuild/build_test.go
+++ b/internal/appbuild/build_test.go
@@ -138,7 +138,7 @@ func (e buildEnv) dropScaffoldView(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(e.dir, ManifestName), []byte(text[:cut]+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	e.edit(t, "src/index.ts", "\n  \"command:forget\": forget,", "")
+	e.edit(t, "src/index.ts", "\n  commands: { forget },", "")
 	if err := os.RemoveAll(filepath.Join(e.dir, "src", "views")); err != nil {
 		t.Fatal(err)
 	}
@@ -238,13 +238,15 @@ func TestGeneratedTypesCarryTheAppsIdentityAndItsSubscriptions(t *testing.T) {
 	for _, want := range []string{
 		apps.ConsumerName("approval-gate"),
 		apps.Namespace("approval-gate"),
+		`  subscriptions: {`,
 		`"delegation.*": (event: AppEvent, ctx: Ctx)`,
 		`"session.state.changed": (event: AppEvent, ctx: Ctx)`,
 		`"decisions": Collection`,
-		// A command is one more key of the same map, under a prefix an event
-		// pattern can never collide with — that is the whole mechanism.
-		`"command:approve": (payload: unknown, ctx: Ctx) => unknown`,
-		`"command:reject": (payload: unknown, ctx: Ctx) => unknown`,
+		// A command lives in its own group, keyed by its bare name: the kind is
+		// structure, so nothing has to keep the two sets of keys apart.
+		`  commands: {`,
+		`"approve": (payload: unknown, ctx: Ctx) => unknown`,
+		`"reject": (payload: unknown, ctx: Ctx) => unknown`,
 	} {
 		if !strings.Contains(types, want) {
 			t.Errorf("generated.ts does not contain %q:\n%s", want, types)
@@ -274,7 +276,7 @@ func TestBuild_DeclaredSubscriptionWithNoHandlerIsACompilerError(t *testing.T) {
 	}
 }
 
-// The same arrow, for the other half of the map: a button a view could press
+// The same arrow, for the other group: a button a view could press
 // with nothing behind it is a compile error at apply, not a 404 at click time.
 func TestBuild_DeclaredCommandWithNoHandlerIsACompilerError(t *testing.T) {
 	env := newBuildEnv(t, "uncommanded-app")
@@ -288,7 +290,7 @@ func TestBuild_DeclaredCommandWithNoHandlerIsACompilerError(t *testing.T) {
 	if !tscError.MatchString(msg) {
 		t.Fatalf("error does not carry file(line,col): %s", msg)
 	}
-	if !strings.Contains(msg, `"command:remember"`) {
+	if !strings.Contains(msg, `"remember"`) {
 		t.Errorf("error does not name the unhandled command: %s", msg)
 	}
 }
@@ -614,7 +616,7 @@ func TestBuild_AppWithAViewAndNoSubscriptionsBuilds(t *testing.T) {
 	env.addView(t, "approvals", "export default function Approvals(): string { return \"approvals\" }\n")
 	env.editManifest(t, "[[subscribe]]\nevents = [\"session.state.changed\"]\n", "")
 	env.edit(t, "src/index.ts",
-		"export default {\n  \"session.state.changed\": onSessionState,\n} satisfies Handlers",
+		"export default {\n  subscriptions: { \"session.state.changed\": onSessionState },\n} satisfies Handlers",
 		"export default {} satisfies Handlers")
 
 	res := env.mustBuild(t)

--- a/internal/appbuild/build_test.go
+++ b/internal/appbuild/build_test.go
@@ -119,6 +119,44 @@ func (e buildEnv) edit(t *testing.T, rel, old, new string) {
 	}
 }
 
+// dropScaffoldView returns the app to a subscription-only shape. The scaffold
+// ships a working view and the command it calls, which is what an author should
+// get; these tests are about what a build does with the views they add
+// themselves, or with none at all.
+func (e buildEnv) dropScaffoldView(t *testing.T) {
+	t.Helper()
+	e.editManifest(t, "\n[[views]]\n", "\n[views_removed_by_test]\n#")
+	data, err := os.ReadFile(filepath.Join(e.dir, ManifestName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	cut := strings.Index(text, "\n[views_removed_by_test]\n")
+	if cut < 0 {
+		t.Fatal("the scaffold no longer declares a view where this helper expects one")
+	}
+	if err := os.WriteFile(filepath.Join(e.dir, ManifestName), []byte(text[:cut]+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	e.edit(t, "src/index.ts", "\n  \"command:forget\": forget,", "")
+	if err := os.RemoveAll(filepath.Join(e.dir, "src", "views")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// viewArtifact is the built view with this name, by name rather than by
+// position: the scaffold ships one of its own, so an index says nothing.
+func viewArtifact(t *testing.T, res Result, name string) ViewSize {
+	t.Helper()
+	for _, v := range res.ViewBytes {
+		if v.Name == name {
+			return v
+		}
+	}
+	t.Fatalf("no view named %q in %+v", name, res.ViewBytes)
+	return ViewSize{}
+}
+
 // The scaffold's bar: `new` then `apply`, untouched. A scaffold that needs an
 // edit first is a broken scaffold, and this is the whole assertion.
 func TestScaffoldAppliesWithNoEdits(t *testing.T) {
@@ -156,7 +194,13 @@ func TestScaffoldWritesClaudeMDAsASymlinkToAgentsMD(t *testing.T) {
 	// write an app from this file alone, so the things it cannot omit are the
 	// commands, the contract that binds manifest to code, and the rule that
 	// apply does not run what you wrote.
-	for _, want := range []string{"attn app apply", "attn app rollback", "satisfies Handlers", "never runs your code", "ctx.collections"} {
+	for _, want := range []string{
+		"attn app apply", "attn app rollback", "satisfies Handlers", "never runs your code",
+		"ctx.collections",
+		// Slice 5: a view is half of what an app is now, so the brief teaches all
+		// of it — where a view sits, how it reads, how it acts, what it draws with.
+		"useQuery", "useCommand", "params", "EmptyState",
+	} {
 		if !strings.Contains(string(agents), want) {
 			t.Errorf("AGENTS.md does not mention %q", want)
 		}
@@ -186,7 +230,7 @@ func TestScaffoldRefusesADirectoryNameThatIsNotAnAppName(t *testing.T) {
 }
 
 func TestGeneratedTypesCarryTheAppsIdentityAndItsSubscriptions(t *testing.T) {
-	m, err := ParseManifest(validManifest(t, ""))
+	m, err := ParseManifest(validManifest(t, viewBlock+commandBlock))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -197,6 +241,10 @@ func TestGeneratedTypesCarryTheAppsIdentityAndItsSubscriptions(t *testing.T) {
 		`"delegation.*": (event: AppEvent, ctx: Ctx)`,
 		`"session.state.changed": (event: AppEvent, ctx: Ctx)`,
 		`"decisions": Collection`,
+		// A command is one more key of the same map, under a prefix an event
+		// pattern can never collide with — that is the whole mechanism.
+		`"command:approve": (payload: unknown, ctx: Ctx) => unknown`,
+		`"command:reject": (payload: unknown, ctx: Ctx) => unknown`,
 	} {
 		if !strings.Contains(types, want) {
 			t.Errorf("generated.ts does not contain %q:\n%s", want, types)
@@ -223,6 +271,25 @@ func TestBuild_DeclaredSubscriptionWithNoHandlerIsACompilerError(t *testing.T) {
 	}
 	if !strings.Contains(msg, `"ticket.created"`) {
 		t.Errorf("error does not name the unhandled subscription: %s", msg)
+	}
+}
+
+// The same arrow, for the other half of the map: a button a view could press
+// with nothing behind it is a compile error at apply, not a 404 at click time.
+func TestBuild_DeclaredCommandWithNoHandlerIsACompilerError(t *testing.T) {
+	env := newBuildEnv(t, "uncommanded-app")
+	env.editManifest(t, "[[commands]]\nname = \"forget\"", "[[commands]]\nname = \"remember\"\n\n[[commands]]\nname = \"forget\"")
+
+	_, err := env.build(t)
+	if err == nil {
+		t.Fatal("build accepted a command with no handler")
+	}
+	msg := err.Error()
+	if !tscError.MatchString(msg) {
+		t.Fatalf("error does not carry file(line,col): %s", msg)
+	}
+	if !strings.Contains(msg, `"command:remember"`) {
+		t.Errorf("error does not name the unhandled command: %s", msg)
 	}
 }
 
@@ -374,6 +441,7 @@ func (e buildEnv) addView(t *testing.T, name, source string) {
 // beside the handler bundle, in the same content-addressed version directory.
 func TestBuild_EachViewIsItsOwnArtifactBesideTheBundle(t *testing.T) {
 	env := newBuildEnv(t, "viewed-app")
+	env.dropScaffoldView(t)
 	env.addView(t, "approvals", "export default function Approvals(): string { return \"approvals\" }\n")
 	env.addView(t, "history", "export default function History(): string { return \"history\" }\n")
 
@@ -414,7 +482,7 @@ func TestBuild_ViewCarriesItsWholeImportGraph(t *testing.T) {
 
 	res := env.mustBuild(t)
 
-	built, err := os.ReadFile(res.ViewBytes[0].Path)
+	built, err := os.ReadFile(viewArtifact(t, res, "approvals").Path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -432,7 +500,7 @@ func TestBuild_ViewLeavesTheSDKSpecifierUnresolved(t *testing.T) {
 
 	res := env.mustBuild(t)
 
-	built, err := os.ReadFile(res.ViewBytes[0].Path)
+	built, err := os.ReadFile(viewArtifact(t, res, "approvals").Path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -455,7 +523,7 @@ func TestBuild_ViewLinksAgainstTheProductionJSXRuntime(t *testing.T) {
 
 	res := env.mustBuild(t)
 
-	built, err := os.ReadFile(res.ViewBytes[0].Path)
+	built, err := os.ReadFile(viewArtifact(t, res, "approvals").Path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -481,10 +549,10 @@ func TestBuild_ViewOnlyEditIsANewVersion(t *testing.T) {
 	if second.ContentHash == first.ContentHash {
 		t.Fatal("editing a view left the version hash unchanged, so the version row would name the old artifact")
 	}
-	if _, err := os.Stat(first.ViewBytes[0].Path); err != nil {
+	if _, err := os.Stat(viewArtifact(t, first, "approvals").Path); err != nil {
 		t.Errorf("the previous version's view must survive for rollback: %v", err)
 	}
-	if _, err := os.Stat(second.ViewBytes[0].Path); err != nil {
+	if _, err := os.Stat(viewArtifact(t, second, "approvals").Path); err != nil {
 		t.Errorf("the new version has no view artifact: %v", err)
 	}
 }
@@ -521,6 +589,7 @@ func TestVersionHash_DoesNotDependOnViewOrder(t *testing.T) {
 // re-applying an app built by an older attn lands on the row it already had.
 func TestBuild_ViewlessAppHashesAsItDidBeforeViews(t *testing.T) {
 	env := newBuildEnv(t, "unchanged-app")
+	env.dropScaffoldView(t)
 	res := env.mustBuild(t)
 
 	bundle, err := os.ReadFile(res.ArtifactPath)
@@ -541,6 +610,7 @@ func TestBuild_ViewlessAppHashesAsItDidBeforeViews(t *testing.T) {
 // is a legitimate whole app.
 func TestBuild_AppWithAViewAndNoSubscriptionsBuilds(t *testing.T) {
 	env := newBuildEnv(t, "board-app")
+	env.dropScaffoldView(t)
 	env.addView(t, "approvals", "export default function Approvals(): string { return \"approvals\" }\n")
 	env.editManifest(t, "[[subscribe]]\nevents = [\"session.state.changed\"]\n", "")
 	env.edit(t, "src/index.ts",

--- a/internal/appbuild/build_test.go
+++ b/internal/appbuild/build_test.go
@@ -295,6 +295,26 @@ func TestBuild_DeclaredCommandWithNoHandlerIsACompilerError(t *testing.T) {
 	}
 }
 
+// The other direction, which is what grouping by kind buys: a handler under a
+// kind nothing declared is an excess property, so a command a view could never
+// reach cannot be exported by accident either.
+func TestBuild_UndeclaredCommandHandlerIsACompilerError(t *testing.T) {
+	env := newBuildEnv(t, "overcommanded-app")
+	env.edit(t, "src/index.ts", "commands: { forget },", "commands: { forget, remember: forget },")
+
+	_, err := env.build(t)
+	if err == nil {
+		t.Fatal("build accepted a command handler the manifest never declared")
+	}
+	msg := err.Error()
+	if !tscError.MatchString(msg) {
+		t.Fatalf("error does not carry file(line,col): %s", msg)
+	}
+	if !strings.Contains(msg, "remember") {
+		t.Errorf("error does not name the undeclared handler: %s", msg)
+	}
+}
+
 func TestBuild_WrongShapedHandlerIsACompilerError(t *testing.T) {
 	env := newBuildEnv(t, "misshapen-app")
 	env.edit(t, "src/index.ts", "event: AppEvent, ctx: Ctx", "event: string, ctx: Ctx")

--- a/internal/appbuild/codegen.go
+++ b/internal/appbuild/codegen.go
@@ -60,12 +60,20 @@ func GenerateTypes(m Manifest) string {
 	b.WriteString("// The context every handler of this app receives.\n")
 	b.WriteString("export type Ctx = AppContext<AppCollections>\n\n")
 
-	b.WriteString("// One entry per declared subscription. The entrypoint's default export must\n")
-	b.WriteString("// `satisfies Handlers`, so a subscription with no handler and a handler with\n")
-	b.WriteString("// the wrong shape are both compile errors here rather than silence at runtime.\n")
+	b.WriteString("// One entry per declared subscription, and one per declared command. The\n")
+	b.WriteString("// entrypoint's default export must `satisfies Handlers`, so a declaration with\n")
+	b.WriteString("// no handler and a handler with the wrong shape are both compile errors here\n")
+	b.WriteString("// rather than silence at runtime.\n")
+	b.WriteString("//\n")
+	b.WriteString("// A subscription's key is its event pattern; a command's carries the\n")
+	b.WriteString("// `command:` prefix, which is what keeps the two apart in one map — an event\n")
+	b.WriteString("// pattern is a dotted name and neither it nor a command name can hold a colon.\n")
 	b.WriteString("export type Handlers = {\n")
 	for _, pattern := range m.EventPatterns() {
 		b.WriteString(fmt.Sprintf("  %s: (event: AppEvent, ctx: Ctx) => void | Promise<void>\n", tsKey(pattern)))
+	}
+	for _, command := range m.CommandNames() {
+		b.WriteString(fmt.Sprintf("  %s: (payload: unknown, ctx: Ctx) => unknown\n", tsKey(apps.CommandHandlerKey(command))))
 	}
 	b.WriteString("}\n")
 	return b.String()

--- a/internal/appbuild/codegen.go
+++ b/internal/appbuild/codegen.go
@@ -60,23 +60,36 @@ func GenerateTypes(m Manifest) string {
 	b.WriteString("// The context every handler of this app receives.\n")
 	b.WriteString("export type Ctx = AppContext<AppCollections>\n\n")
 
-	b.WriteString("// One entry per declared subscription, and one per declared command. The\n")
-	b.WriteString("// entrypoint's default export must `satisfies Handlers`, so a declaration with\n")
-	b.WriteString("// no handler and a handler with the wrong shape are both compile errors here\n")
-	b.WriteString("// rather than silence at runtime.\n")
+	b.WriteString("// One group per kind, one entry per declaration. The entrypoint's default\n")
+	b.WriteString("// export must `satisfies Handlers`, so a declaration with no handler, a\n")
+	b.WriteString("// handler with the wrong shape, and a handler nothing declared are all\n")
+	b.WriteString("// compile errors here rather than silence at runtime.\n")
 	b.WriteString("//\n")
-	b.WriteString("// A subscription's key is its event pattern; a command's carries the\n")
-	b.WriteString("// `command:` prefix, which is what keeps the two apart in one map — an event\n")
-	b.WriteString("// pattern is a dotted name and neither it nor a command name can hold a colon.\n")
+	b.WriteString("// A subscription is keyed by its event pattern and a command by its bare\n")
+	b.WriteString("// name. They cannot collide because they are not in the same map: which kind\n")
+	b.WriteString("// is being run is what attn already knows when it dispatches.\n")
 	b.WriteString("export type Handlers = {\n")
-	for _, pattern := range m.EventPatterns() {
-		b.WriteString(fmt.Sprintf("  %s: (event: AppEvent, ctx: Ctx) => void | Promise<void>\n", tsKey(pattern)))
-	}
-	for _, command := range m.CommandNames() {
-		b.WriteString(fmt.Sprintf("  %s: (payload: unknown, ctx: Ctx) => unknown\n", tsKey(apps.CommandHandlerKey(command))))
-	}
+	writeHandlerGroup(&b, "subscriptions", m.EventPatterns(),
+		"(event: AppEvent, ctx: Ctx) => void | Promise<void>")
+	writeHandlerGroup(&b, "commands", m.CommandNames(),
+		"(payload: unknown, ctx: Ctx) => unknown")
 	b.WriteString("}\n")
 	return b.String()
+}
+
+// writeHandlerGroup renders one kind's group. A kind an app declared nothing of
+// is optional and empty, so the entrypoint omits it — and adding a key to it
+// stays an error rather than becoming a handler nothing will ever call.
+func writeHandlerGroup(b *strings.Builder, group string, keys []string, signature string) {
+	if len(keys) == 0 {
+		b.WriteString(fmt.Sprintf("  %s?: Record<string, never>\n", group))
+		return
+	}
+	b.WriteString(fmt.Sprintf("  %s: {\n", group))
+	for _, key := range keys {
+		b.WriteString(fmt.Sprintf("    %s: %s\n", tsKey(key), signature))
+	}
+	b.WriteString("  }\n")
 }
 
 // tsKey renders a manifest string as a TypeScript property key. Event patterns

--- a/internal/appbuild/manifest.go
+++ b/internal/appbuild/manifest.go
@@ -54,6 +54,21 @@ type Manifest struct {
 	Subscribe   []Subscribe  `toml:"subscribe" json:"subscribe,omitempty"`
 	Collections []Collection `toml:"collections" json:"collections,omitempty"`
 	Views       []View       `toml:"views" json:"views,omitempty"`
+	Commands    []Command    `toml:"commands" json:"commands,omitempty"`
+}
+
+// Command is one `[[commands]]` block: something a view can ask this app to do.
+//
+// A subscription is attn waking the app; a command is a person acting through
+// one of its views. Both end in the same place — a key of the generated
+// `Handlers` type, dispatched into the shared runtime — which is why a command
+// is a declaration here rather than a second mechanism.
+type Command struct {
+	Name string `toml:"name" json:"name"`
+	// Description is what the command does, for a reader of `attn app status`.
+	// Optional: attn renders no UI from it, so an app is not made to write prose
+	// for a button it draws itself.
+	Description string `toml:"description" json:"description,omitempty"`
 }
 
 // Subscribe is one `[[subscribe]]` block: the event patterns that wake this app.
@@ -111,7 +126,7 @@ var viewKinds = []string{ViewKindTile}
 // knownTables is what a manifest may declare, named in the error an unknown
 // table produces. Future stages add entries here as they add the runtime that
 // honors them — C1 `[[hooks]]`, B2 `[[workflows]]`.
-var knownTables = []string{"subscribe", "collections", "views"}
+var knownTables = []string{"subscribe", "collections", "views", "commands"}
 
 // LoadManifest reads and validates the manifest in dir.
 func LoadManifest(dir string) (Manifest, error) {
@@ -172,6 +187,9 @@ func ParseManifest(text string) (Manifest, error) {
 		return Manifest{}, err
 	}
 	if err := m.checkViews(); err != nil {
+		return Manifest{}, err
+	}
+	if err := m.checkCommands(); err != nil {
 		return Manifest{}, err
 	}
 	if err := m.checkSomethingRuns(); err != nil {
@@ -266,9 +284,15 @@ func (m Manifest) checkSubscriptions() error {
 // a tile that only reads the document store is the shape this exists to allow.
 // What is still refused is a manifest declaring neither, which would install as
 // a version that can never execute and never render.
+//
+// A command is not a third way in. It is invoked from a view of the same app,
+// so commands with no view are handlers nothing can reach.
 func (m Manifest) checkSomethingRuns() error {
 	if len(m.EventPatterns()) > 0 || len(m.Views) > 0 {
 		return nil
+	}
+	if len(m.Commands) > 0 {
+		return fmt.Errorf("declares commands but no view, and a command is invoked from one of this app's own views; add a [[views]] block naming the component that calls it, or a [[subscribe]] block if the app is meant to run on events instead")
 	}
 	return fmt.Errorf("declares neither a subscription nor a view, so nothing would ever run it; add a [[subscribe]] block with events = [\"session.state.changed\"] (patterns end in .* to match a family), or a [[views]] block naming a component to render")
 }
@@ -344,6 +368,29 @@ func (m *Manifest) checkViews() error {
 				return fmt.Errorf("view %q declares params with no label, and the label is what the dock picker puts on the field it asks for; add label = \"Repository\", or drop params to take none", v.Name)
 			}
 		}
+	}
+	return nil
+}
+
+// checkCommands validates every `[[commands]]` block.
+//
+// A duplicate is refused for the reason a duplicate subscription is: each name
+// becomes one key of the generated `Handlers` type, and two blocks naming the
+// same command would collapse into one slot an author believes they declared
+// twice.
+func (m *Manifest) checkCommands() error {
+	seen := map[string]bool{}
+	for i := range m.Commands {
+		c := &m.Commands[i]
+		c.Name = strings.TrimSpace(c.Name)
+		c.Description = strings.TrimSpace(c.Description)
+		if err := apps.ValidateCommandName(c.Name); err != nil {
+			return err
+		}
+		if seen[c.Name] {
+			return fmt.Errorf("declares command %q twice; a command name binds one handler, so name each one once", c.Name)
+		}
+		seen[c.Name] = true
 	}
 	return nil
 }
@@ -436,6 +483,39 @@ func (m Manifest) ViewNames() []string {
 		out = append(out, v.Name)
 	}
 	return out
+}
+
+// CommandNames is every declared command, in declaration order.
+func (m Manifest) CommandNames() []string {
+	out := make([]string, 0, len(m.Commands))
+	for _, c := range m.Commands {
+		out = append(out, c.Name)
+	}
+	return out
+}
+
+// DeclaredCommands reads the command names back out of a frozen declaration.
+//
+// The serving version's declaration is the contract, exactly as it is for
+// views: after a rollback, what an app answers is what the version now serving
+// declared, not what the manifest on disk says today. Every name is validated
+// rather than trusted — the declaration arrived over the wire, and the name
+// becomes a dispatch key.
+func DeclaredCommands(declaration string) ([]string, error) {
+	var snapshot struct {
+		Commands []Command `json:"commands"`
+	}
+	if err := json.Unmarshal([]byte(declaration), &snapshot); err != nil {
+		return nil, fmt.Errorf("reading the commands of a declaration snapshot: %w", err)
+	}
+	out := make([]string, 0, len(snapshot.Commands))
+	for _, c := range snapshot.Commands {
+		if err := apps.ValidateCommandName(c.Name); err != nil {
+			return nil, err
+		}
+		out = append(out, c.Name)
+	}
+	return out, nil
 }
 
 // DeclaredViews reads the views back out of a frozen declaration. The daemon

--- a/internal/appbuild/manifest_test.go
+++ b/internal/appbuild/manifest_test.go
@@ -336,6 +336,89 @@ entrypoint = "src/index.ts"
 	}
 }
 
+// commandBlock is what a view's button is bound to.
+const commandBlock = `
+[[commands]]
+name = "approve"
+description = "Approve the request."
+
+[[commands]]
+name = "reject"
+`
+
+func TestParseManifest_Commands(t *testing.T) {
+	m, err := ParseManifest(validManifest(t, viewBlock+commandBlock))
+	if err != nil {
+		t.Fatalf("ParseManifest: %v", err)
+	}
+	if names := m.CommandNames(); len(names) != 2 || names[0] != "approve" || names[1] != "reject" {
+		t.Fatalf("CommandNames() = %v", names)
+	}
+	if m.Commands[0].Description != "Approve the request." || m.Commands[1].Description != "" {
+		t.Fatalf("commands = %+v", m.Commands)
+	}
+}
+
+func TestParseManifest_CommandRefusals(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		block string
+		want  string
+	}{
+		{"no name", "\n[[commands]]\ndescription = \"x\"\n", "name"},
+		{"not a name", "\n[[commands]]\nname = \"Approve!\"\n", "Approve!"},
+		{"declared twice", commandBlock + "\n[[commands]]\nname = \"approve\"\n", "approve"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseManifest(validManifest(t, viewBlock+tc.block))
+			if err == nil {
+				t.Fatalf("ParseManifest accepted %s", tc.block)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want it to name %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// A command is invoked from a view. An app that declares one and has neither a
+// view nor a subscription could never run it, and the refusal says which of the
+// two is missing rather than repeating the generic "nothing would run it".
+func TestParseManifest_ACommandAloneIsNotSomethingThatRuns(t *testing.T) {
+	text := `
+name = "board"
+attn_app_api = 1
+entrypoint = "src/index.ts"
+` + commandBlock
+	_, err := ParseManifest(text)
+	if err == nil {
+		t.Fatal("ParseManifest accepted an app whose only declaration is a command")
+	}
+	if !strings.Contains(err.Error(), "[[views]]") || !strings.Contains(err.Error(), "invoked from") {
+		t.Fatalf("err = %v, want it to say a command needs a view", err)
+	}
+}
+
+// The daemon holds the frozen declaration and nothing else, so what an app
+// answers is read back out of it — same rule as the views beside it.
+func TestDeclaredCommands(t *testing.T) {
+	m, err := ParseManifest(validManifest(t, viewBlock+commandBlock))
+	if err != nil {
+		t.Fatal(err)
+	}
+	declaration, err := m.Declaration()
+	if err != nil {
+		t.Fatal(err)
+	}
+	names, err := DeclaredCommands(declaration)
+	if err != nil || len(names) != 2 || names[0] != "approve" {
+		t.Fatalf("DeclaredCommands() = %v, %v", names, err)
+	}
+	if _, err := DeclaredCommands(`{"name":"x","commands":[{"name":"Approve!"}]}`); err == nil {
+		t.Fatal("DeclaredCommands accepted a name that is not a command name")
+	}
+}
+
 // The daemon holds a version's declaration and nothing else, so reading the
 // views back out of it is what tells it which artifacts the version is made of.
 func TestDeclaredViewNames(t *testing.T) {

--- a/internal/appbuild/scaffold.go
+++ b/internal/appbuild/scaffold.go
@@ -156,8 +156,8 @@ entrypoint = "src/views/Sessions.tsx"
 params = { label = "Filter by session id", placeholder = "leave empty for all" }
 
 # A command is how a view acts. Each one becomes a required handler under
-# `+"`command:<name>`"+` in src/generated.ts, and it runs where every other handler
-# runs — same process, same document access, same log.
+# `+"`commands`"+` in src/generated.ts, and it runs where every other handler runs —
+# same process, same document access, same log.
 [[commands]]
 name = "forget"
 description = "Drop one session from the list."
@@ -193,9 +193,11 @@ async function forget(payload: unknown, ctx: Ctx): Promise<{ forgotten: boolean 
   return { forgotten: await ctx.collections.seen.delete(id) }
 }
 
+// Handlers are grouped by kind, and attn knows which kind it is running: a
+// command and a subscription can share a name without either becoming ambiguous.
 export default {
-  "session.state.changed": onSessionState,
-  "command:forget": forget,
+  subscriptions: { "session.state.changed": onSessionState },
+  commands: { forget },
 } satisfies Handlers
 `, SDKModule, ManifestName)
 }
@@ -346,7 +348,9 @@ applies; you find out when a handler runs.
 ## Writing a handler
 
 Every pattern under `+"`[[subscribe]]`"+` and every `+"`[[commands]]`"+` block becomes a
-required key of the `+"`Handlers`"+` type in src/generated.ts. The default export of
+required key of the `+"`Handlers`"+` type in src/generated.ts — a subscription under
+`+"`subscriptions`"+`, keyed by its event pattern; a command under `+"`commands`"+`, keyed
+by its bare name. The default export of
 src/index.ts must `+"`satisfies Handlers`"+`, so the compiler — not a convention, not a
 runtime check — is what tells you the manifest and the code disagree:
 
@@ -354,8 +358,12 @@ runtime check — is what tells you the manifest and the code disagree:
     import type { AppEvent } from %q
 
     export default {
-      "session.state.changed": async (event: AppEvent, ctx: Ctx) => { ... },
-      "command:forget": async (payload: unknown, ctx: Ctx) => { ... },
+      subscriptions: {
+        "session.state.changed": async (event: AppEvent, ctx: Ctx) => { ... },
+      },
+      commands: {
+        forget: async (payload: unknown, ctx: Ctx) => { ... },
+      },
     } satisfies Handlers
 
 Declare either one with no handler and apply fails with

--- a/internal/appbuild/scaffold.go
+++ b/internal/appbuild/scaffold.go
@@ -70,12 +70,16 @@ func Scaffold(opts ScaffoldOptions) (Manifest, error) {
 	if description == "" {
 		description = "An attn app."
 	}
+	if err := os.MkdirAll(filepath.Join(dir, "src", "views"), 0o755); err != nil {
+		return Manifest{}, fmt.Errorf("creating %s: %w", dir, err)
+	}
 	files := map[string]string{
-		ManifestName:    scaffoldManifest(name, description),
-		"src/index.ts":  scaffoldEntrypoint(),
-		"tsconfig.json": scaffoldTSConfig(),
-		".gitignore":    "node_modules/\n",
-		"AGENTS.md":     scaffoldAgentsMD(name),
+		ManifestName:             scaffoldManifest(name, description),
+		"src/index.ts":           scaffoldEntrypoint(),
+		"src/views/Sessions.tsx": scaffoldView(),
+		"tsconfig.json":          scaffoldTSConfig(),
+		".gitignore":             "node_modules/\n",
+		"AGENTS.md":              scaffoldAgentsMD(name),
 	}
 	for rel, content := range files {
 		path := filepath.Join(dir, filepath.FromSlash(rel))
@@ -139,6 +143,24 @@ events = ["session.state.changed"]
 [[collections]]
 name = "seen"
 fields = ["state"]
+
+# A view is a React component attn mounts as a tile in a workspace. The title is
+# what the dock picker and the tile header show. The optional params table makes
+# the dock ask for one line of text before placing the tile, and that string is
+# what makes two tiles of one view show different things — it is opaque to attn.
+[[views]]
+name = "sessions"
+kind = "tile"
+title = "Sessions"
+entrypoint = "src/views/Sessions.tsx"
+params = { label = "Filter by session id", placeholder = "leave empty for all" }
+
+# A command is how a view acts. Each one becomes a required handler under
+# `+"`command:<name>`"+` in src/generated.ts, and it runs where every other handler
+# runs — same process, same document access, same log.
+[[commands]]
+name = "forget"
+description = "Drop one session from the list."
 `, name, name, description, APIVersion, apps.Namespace(name))
 }
 
@@ -146,10 +168,10 @@ func scaffoldEntrypoint() string {
 	return fmt.Sprintf(`import type { Ctx, Handlers } from "./generated"
 import type { AppEvent } from %q
 
-// One handler per subscription in %s. The `+"`satisfies Handlers`"+` below is
-// what keeps the two in step: add an event to the manifest without a handler
-// here — or give a handler the wrong shape — and `+"`attn app apply`"+` fails with
-// the file and line, before anything is installed.
+// One handler per subscription and one per command in %s. The `+"`satisfies Handlers`"+` below is
+// what keeps the two in step: declare either one in the manifest without a
+// handler here — or give a handler the wrong shape — and `+"`attn app apply`"+` fails
+// with the file and line, before anything is installed.
 
 async function onSessionState(event: AppEvent, ctx: Ctx): Promise<void> {
   // A fact says something changed; it is not the new state. Read what you need.
@@ -159,10 +181,115 @@ async function onSessionState(event: AppEvent, ctx: Ctx): Promise<void> {
   })
 }
 
+// A command is what a view calls. The payload is whatever the view passed —
+// typed unknown, because attn never looks inside it — and what this returns
+// travels back to the view as the command's result.
+async function forget(payload: unknown, ctx: Ctx): Promise<{ forgotten: boolean }> {
+  const id = (payload as { id?: unknown } | null)?.id
+  if (typeof id !== "string" || id === "") {
+    // Throwing is how a command refuses. The view is told, in these words.
+    throw new Error("forget needs an id: { id: \"<session>\" }")
+  }
+  return { forgotten: await ctx.collections.seen.delete(id) }
+}
+
 export default {
   "session.state.changed": onSessionState,
+  "command:forget": forget,
 } satisfies Handlers
 `, SDKModule, ManifestName)
+}
+
+// scaffoldView is the tile `attn app new` ships: a live query, a command, and
+// the SDK's components, so an author reads a working example of all three
+// rather than a stub that renders "hello".
+func scaffoldView() string {
+	return fmt.Sprintf(`import {
+  Button,
+  EmptyState,
+  List,
+  ListRow,
+  TextInput,
+  useCommand,
+  useQuery,
+  useState,
+  type ReactElement,
+  type ViewProps,
+} from %q
+
+// A view is a React component attn mounts as a tile. It is a function of where
+// it sits: workspaceId, sessionId and tileId are ambient, and params is the line
+// the user typed when docking this tile.
+//
+// There is no react to import and no styling to write. The SDK re-exports the
+// hooks and the components, and a tile inherits attn's own tokens, so a view
+// that uses them looks like the rest of the app.
+
+interface Seen {
+  state: string
+  seq: number
+}
+
+export default function Sessions({ params }: ViewProps): ReactElement {
+  // A live query. It stays current on its own: attn re-runs it when a document
+  // this window would hold changes, and re-renders only what moved.
+  const { docs, live, error } = useQuery<Seen>("seen", {
+    sort: { field: "updated_at", desc: true },
+    limit: 50,
+  })
+  const [filter, setFilter] = useState(params)
+  const forget = useCommand("forget")
+
+  if (error) {
+    return <EmptyState title="This query stopped" hint={error.message} />
+  }
+
+  const shown = filter === "" ? docs : docs.filter((doc) => doc.id.includes(filter))
+  if (shown.length === 0) {
+    // Loading is a state, not a spinner. Nothing in a view may animate forever:
+    // attn is open all day beside GPU terminals, and a repaint loop is a battery
+    // bug no test catches.
+    return (
+      <EmptyState
+        title={live ? "No sessions yet" : "Connecting…"}
+        hint={live ? "This fills in as sessions change state." : ""}
+      />
+    )
+  }
+
+  return (
+    <>
+      <TextInput
+        value={filter}
+        onChange={setFilter}
+        placeholder="Filter by session id"
+        ariaLabel="Filter by session id"
+      />
+      <List>
+        {shown.map((doc) => (
+          <ListRow
+            key={doc.id}
+            title={doc.id}
+            meta={`+"`${doc.body.state} · seq ${doc.body.seq}`"+`}
+            actions={
+              <Button
+                variant="danger"
+                disabled={forget.pending}
+                onClick={() => forget({ id: doc.id })}
+              >
+                Forget
+              </Button>
+            }
+          />
+        ))}
+      </List>
+      {/* A command that failed says so where the click happened. The message is
+          the daemon's or the handler's own — it names the app and the command. */}
+      {forget.error && <EmptyState title="That did not work" hint={forget.error} />}
+    </>
+  )
+}
+`, SDKModule)
 }
 
 // scaffoldTSConfig carries the same flags apply typechecks with, so the author's
@@ -187,18 +314,20 @@ func scaffoldTSConfig() string {
 func scaffoldAgentsMD(name string) string {
 	return fmt.Sprintf("# %s — an attn app\n"+`
 This directory is one attn app. An app is an automation attn runs for you: attn
-wakes it when something happens, it keeps its own documents, and it is versioned
-by the content of what it builds so you can roll it back.
+wakes it when something happens, it keeps its own documents, it can show a tile
+in a workspace, and it is versioned by the content of what it builds so you can
+roll it back.
 
 You can write the whole thing from this file. Nothing else needs reading.
 
 ## The shape
 
-    `+ManifestName+`      what wakes the app and what state it owns
-    src/index.ts        your handlers — the only file you edit
-    src/generated.ts    derived from the manifest; do not edit
-    tsconfig.json       so your editor sees what apply sees
-    node_modules/       one symlink to the SDK, written by apply; do not commit
+    `+ManifestName+`         what wakes the app, what state it owns, what it shows
+    src/index.ts           your handlers — subscriptions and commands
+    src/views/Sessions.tsx a view: the component attn mounts as a tile
+    src/generated.ts       derived from the manifest; do not edit
+    tsconfig.json          so your editor sees what apply sees
+    node_modules/          one symlink to the SDK, written by apply; do not commit
 
 ## The loop
 
@@ -216,19 +345,20 @@ applies; you find out when a handler runs.
 
 ## Writing a handler
 
-Every pattern under `+"`[[subscribe]]`"+` becomes a required key of the `+"`Handlers`"+`
-type in src/generated.ts. The default export of src/index.ts must
-`+"`satisfies Handlers`"+`, so the compiler — not a convention, not a runtime check —
-is what tells you the manifest and the code disagree:
+Every pattern under `+"`[[subscribe]]`"+` and every `+"`[[commands]]`"+` block becomes a
+required key of the `+"`Handlers`"+` type in src/generated.ts. The default export of
+src/index.ts must `+"`satisfies Handlers`"+`, so the compiler — not a convention, not a
+runtime check — is what tells you the manifest and the code disagree:
 
     import type { Ctx, Handlers } from "./generated"
     import type { AppEvent } from %q
 
     export default {
       "session.state.changed": async (event: AppEvent, ctx: Ctx) => { ... },
+      "command:forget": async (payload: unknown, ctx: Ctx) => { ... },
     } satisfies Handlers
 
-Declare a subscription with no handler and apply fails with
+Declare either one with no handler and apply fails with
 `+"`src/index.ts(7,1): error TS1360`"+` — the file, the line, and what is missing.
 
 ## What a handler is given
@@ -245,6 +375,74 @@ scoped to this app's own namespace. `+"`get`"+`, `+"`put`"+`, `+"`delete`"+`, `+
 `+"`count`"+`. Only fields you declared can be filtered or sorted on; the rest of a
 document body is stored and read back untouched.
 
+## Views
+
+A `+"`[[views]]`"+` block declares a component attn can mount as a tile in a
+workspace. The user docks it from the command menu; the tile stays where they put
+it, across restarts, until they close it.
+
+A view is a function of where it sits. It is handed `+"`ViewProps`"+`:
+
+    workspaceId   the workspace this tile is in
+    sessionId     the session that workspace has selected, or null
+    tileId        stable for the life of this docked tile
+    params        the line the user typed when docking
+
+`+"`params`"+` is what makes two tiles of one view show different things — one
+filtered to a session, one showing everything. It is opaque to attn: declare a
+`+"`params`"+` table on the view and the dock asks for it with your label, and hands
+you the string exactly as typed (empty when the user left it blank).
+
+## Reading in a view: useQuery
+
+    const { docs, live, error } = useQuery<Seen>("seen", {
+      filters: [{ field: "state", op: "eq", value: "idle" }],
+      sort: { field: "updated_at", desc: true },
+      limit: 50,
+    })
+
+It is a live window, not a fetch: attn keeps it current as documents change, and
+re-renders only what moved. The collection is this app's — a view is handed its
+own namespace and cannot ask for another's.
+
+`+"`live`"+` says whether the daemon is serving the query right now. `+"`error`"+` is set
+when the subscription ended and will not resume — a collection you removed from
+the manifest, for instance. Render it; do not throw.
+
+Only declared fields can be filtered or sorted on. There is no cursor: a live
+query is a window, and a walk through pages is a different thing.
+
+## Acting from a view: commands
+
+    const forget = useCommand("forget")
+    <Button variant="danger" disabled={forget.pending} onClick={() => forget({ id })}>
+
+A command runs your handler, in the same process every other handler runs in,
+with the same document access. That is the point: the view asks, the app decides.
+A view never writes documents itself, so the app's rules live in one place.
+
+`+"`forget(payload)`"+` never rejects — it resolves with `+"`{ ok: true, value }`"+` or
+`+"`{ ok: false, error }`"+`, and mirrors a failure into `+"`forget.error`"+` for the
+common case of rendering it. Throwing inside the handler is how a command
+refuses; the message reaches the view.
+
+The whole payload and the whole result travel as JSON, and one command may carry
+256KB in either direction. A command is an action, not a data transfer — anything
+larger belongs in a document the handler reads.
+
+## Components
+
+The SDK ships the controls a view needs to look native: `+"`Button`"+`
+(primary / secondary / danger), `+"`TextInput`"+`, `+"`TextArea`"+`, `+"`List`"+` and
+`+"`ListRow`"+`, `+"`EmptyState`"+`, and `+"`Markdown`"+`. Everything else you draw
+inherits attn's own tokens — `+"`var(--color-text-primary)`"+`,
+`+"`var(--font-size-md)`"+` and friends already resolve inside a tile — so a plain
+element styled with them matches the app.
+
+There is no spinner and no relative-time label, on purpose: attn sits open all
+day beside GPU terminals, and a permanently animating element is a battery bug.
+A loading state is text.
+
 ## Failure
 
 A handler that throws fails that delivery. attn retries it with backoff rather
@@ -253,15 +451,21 @@ event for fifteen minutes, disables the app — one broken app must not hold
 everyone's event log open. `+"`attn app enable %s`"+` puts it back, with a clean
 slate.
 
+A command that throws fails that click and nothing else: the view is told, the
+attempt is recorded, and the app stays enabled. A view that throws while
+rendering shows the error in its own tile and leaves the rest of attn alone.
+
 Every app's handlers run in one shared process, so anything you print goes to a
 log attn tags per app: `+"`attn app logs %s`"+` reads your lines back, and
 `+"`attn app logs runtime`"+` shows the whole thing — which is where a runtime
-that will not start says why.
+that will not start says why. A handler that never returns is abandoned after
+sixty seconds; anything you await that is not one of attn's own APIs needs its
+own timeout.
 
 ## Rules worth knowing before you start
 
-- The manifest is the source of truth. Change what the app subscribes to there,
-  never in code, and let the compiler tell you what to fix.
+- The manifest is the source of truth. Change what the app subscribes to, shows
+  and answers there, never in code, and let the compiler tell you what to fix.
 - Never edit src/generated.ts. Apply rewrites it.
 - The SDK is `+"`"+SDKModule+"`"+`, and it is the only package you can import.
   Apply links it into node_modules; nothing is installed from a registry. There
@@ -270,7 +474,9 @@ that will not start says why.
 - An unknown table in the manifest is a hard error, not a warning. An app must
   not half-load.
 - Versions are content-addressed: applying the same content twice is the same
-  version, and `+"`attn app rollback`"+` is a pointer move, not a rebuild.
+  version, and `+"`attn app rollback`"+` is a pointer move, not a rebuild. What a
+  docked tile may call is what the *serving* version declared, so a rollback
+  takes a command away with it.
 - attn does not remember where this directory is. It is yours; keep it wherever
   you keep code.
 `, name, name, name, name, name, SDKModule, name, name)

--- a/internal/appbuild/sdkdist/components.d.ts
+++ b/internal/appbuild/sdkdist/components.d.ts
@@ -1,0 +1,78 @@
+import type { ReactElement, ReactNode } from "react";
+/**
+ * `primary` is the one action a view wants; `secondary` is everything else;
+ * `danger` is the one that destroys something. There is no fourth: a view that
+ * needs another meaning is telling the SDK about a component it is missing.
+ */
+export type ButtonVariant = "primary" | "secondary" | "danger";
+export interface ButtonProps {
+    children?: ReactNode;
+    variant?: ButtonVariant;
+    disabled?: boolean;
+    onClick?: () => void;
+    /** Buttons in a view are actions, never form submissions, so this defaults to "button". */
+    type?: "button" | "submit";
+    title?: string;
+    className?: string;
+}
+export declare function Button({ children, variant, disabled, onClick, type, title, className, }: ButtonProps): ReactElement;
+export interface TextInputProps {
+    value: string;
+    onChange: (value: string) => void;
+    placeholder?: string;
+    disabled?: boolean;
+    /** Rendered under the field, in the error colour. A refusal the user can read. */
+    error?: string;
+    ariaLabel?: string;
+    className?: string;
+}
+export declare function TextInput({ value, onChange, placeholder, disabled, error, ariaLabel, className, }: TextInputProps): ReactElement;
+export interface TextAreaProps extends TextInputProps {
+    /** Visible rows. The box does not grow on its own — a view that wants that says so. */
+    rows?: number;
+}
+export declare function TextArea({ value, onChange, placeholder, disabled, error, ariaLabel, className, rows, }: TextAreaProps): ReactElement;
+export interface ListProps {
+    children?: ReactNode;
+    className?: string;
+}
+/** The scrolling column a view's rows live in. */
+export declare function List({ children, className }: ListProps): ReactElement;
+export interface ListRowProps {
+    /** The line the user reads first. */
+    title: ReactNode;
+    /** The quieter second line: who, when, which session. */
+    meta?: ReactNode;
+    /** Trailing controls, laid out at the row's end. */
+    actions?: ReactNode;
+    /** A row that answers a click is focusable and reachable by keyboard. */
+    onClick?: () => void;
+    selected?: boolean;
+    className?: string;
+}
+export declare function ListRow({ title, meta, actions, onClick, selected, className, }: ListRowProps): ReactElement;
+export interface EmptyStateProps {
+    /** What is not there — "Nothing waiting", not "No data". */
+    title: string;
+    /** Why, or what to do about it. Empty is fine; a wrong guess is not. */
+    hint?: ReactNode;
+    className?: string;
+}
+/**
+ * The state a live-query view is in most of the time. It is text, on purpose:
+ * "nothing pending" rendered wrong is what makes a working tile look broken,
+ * and a spinner that never stops is worse than a sentence.
+ */
+export declare function EmptyState({ title, hint, className }: EmptyStateProps): ReactElement;
+export interface MarkdownProps {
+    /** The source. Agent-written content is markdown, which is why this is here. */
+    children: string;
+    className?: string;
+}
+/**
+ * Read-only markdown, with GitHub tables and task lists.
+ *
+ * No raw HTML and no scripts: what a view renders here is usually written by an
+ * agent, and an app that wants richer output composes components instead.
+ */
+export declare function Markdown({ children, className }: MarkdownProps): ReactElement;

--- a/internal/appbuild/sdkdist/index.d.ts
+++ b/internal/appbuild/sdkdist/index.d.ts
@@ -109,5 +109,9 @@ export interface ViewProps {
 }
 export { useQuery } from "./useQuery";
 export type { LiveQueryOptions, QueryError, QueryResult } from "./useQuery";
+export { useCommand } from "./useCommand";
+export type { CommandOutcome, CommandRunner } from "./useCommand";
+export { Button, EmptyState, List, ListRow, Markdown, TextArea, TextInput } from "./components";
+export type { ButtonProps, ButtonVariant, EmptyStateProps, ListProps, ListRowProps, MarkdownProps, TextAreaProps, TextInputProps, } from "./components";
 export { AppViewRuntimeProvider, useAppViewRuntime } from "./runtime";
 export type { AppViewRuntime, DocumentRevision, DocumentSubscriber, LiveQueryRequest, QueryDelivery, RawDocument, } from "./runtime";

--- a/internal/appbuild/sdkdist/runtime.d.ts
+++ b/internal/appbuild/sdkdist/runtime.d.ts
@@ -55,6 +55,17 @@ export interface AppViewRuntime {
     readonly namespace: string;
     /** Opens a live query; the returned function closes it and must be called. */
     subscribe: (subscriber: DocumentSubscriber) => () => void;
+    /**
+     * Invokes one command on the app this tile belongs to, and resolves with
+     * whatever its handler returned. Which app is asked is the host's to say, for
+     * the same reason the namespace is: a view names a command, never an app.
+     *
+     * It rejects when the command does not run — the app is disabled, the serving
+     * version declares no such command, the handler threw or never returned. The
+     * rejection carries the daemon's own words, which name the app, the command
+     * and what to do about it.
+     */
+    command: (command: string, payload?: unknown) => Promise<unknown>;
 }
 /** The host wraps every mounted view in this. */
 export declare const AppViewRuntimeProvider: import("react").Provider<AppViewRuntime | null>;

--- a/internal/appbuild/sdkdist/useCommand.d.ts
+++ b/internal/appbuild/sdkdist/useCommand.d.ts
@@ -32,7 +32,7 @@ export interface CommandRunner {
  * ```
  *
  * The command must appear in a `[[commands]]` block of attn-app.toml and the
- * bundle must export a handler under `command:<name>` — the generated `Handlers`
+ * bundle must export a handler under `commands` — the generated `Handlers`
  * type makes the second half a compile error at `attn app apply`.
  */
 export declare function useCommand(command: string): CommandRunner;

--- a/internal/appbuild/sdkdist/useCommand.d.ts
+++ b/internal/appbuild/sdkdist/useCommand.d.ts
@@ -1,0 +1,38 @@
+/** What one invocation did. Never a rejection — see the file header. */
+export type CommandOutcome = {
+    ok: true;
+    value: unknown;
+} | {
+    ok: false;
+    error: string;
+};
+/**
+ * A command, ready to invoke. It is a function first, because that is what a
+ * view does with it; `pending` and `error` are what it renders around the call.
+ */
+export interface CommandRunner {
+    (payload?: unknown): Promise<CommandOutcome>;
+    /** True from the call until the daemon answers. */
+    readonly pending: boolean;
+    /**
+     * The last failure, cleared by the next call. It is a message meant to be
+     * shown: it names the app, the command and the way forward.
+     */
+    readonly error: string | null;
+}
+/**
+ * Invoke one of this app's declared commands.
+ *
+ * ```tsx
+ * const approve = useCommand("approve")
+ * <Button variant="primary" disabled={approve.pending} onClick={() => approve({ id })}>
+ *   Approve
+ * </Button>
+ * {approve.error && <p>{approve.error}</p>}
+ * ```
+ *
+ * The command must appear in a `[[commands]]` block of attn-app.toml and the
+ * bundle must export a handler under `command:<name>` — the generated `Handlers`
+ * type makes the second half a compile error at `attn app apply`.
+ */
+export declare function useCommand(command: string): CommandRunner;

--- a/internal/apps/apps.go
+++ b/internal/apps/apps.go
@@ -136,6 +136,46 @@ func ValidateViewName(name string) error {
 	return nil
 }
 
+// MaxCommandNameLength bounds a command name. The name is addressed — it
+// travels on the wire and is a key of the generated Handlers type — so it is
+// bounded for the same reason a view name is.
+const MaxCommandNameLength = 64
+
+// ValidateCommandName reports whether a string can name one of an app's
+// commands.
+//
+// The view-name rule again, and deliberately the same one: a command name is
+// scoped to its app, and the shape that reads well as a tile kind reads well as
+// an action a button invokes. Living here rather than in the manifest parser is
+// what stops the parser, the daemon's dispatch key and the SDK's hook from
+// disagreeing about what a command may be called.
+func ValidateCommandName(name string) error {
+	if name == "" {
+		return fmt.Errorf("a command name is required, as lowercase letters, digits and dashes (for example approve)")
+	}
+	if len(name) > MaxCommandNameLength {
+		return fmt.Errorf("command name %q is %d characters, over the %d-character limit", name, len(name), MaxCommandNameLength)
+	}
+	if !nameRe.MatchString(name) {
+		return fmt.Errorf("command name %q must be lowercase letters, digits and dashes, starting with a letter or digit (for example approve-request)", name)
+	}
+	return nil
+}
+
+// CommandHandlerKey is the key a command binds to in an app's default export,
+// and the handler name its invocations are recorded under.
+//
+// The prefix is what keeps a command and a subscription apart in one map: an
+// event pattern is a dotted name and can never contain a colon, and neither can
+// a command name, so `command:approve` collides with nothing. Deriving it here
+// means the codegen that writes the type, the daemon that resolves the handler
+// and the host that looks it up cannot disagree.
+func CommandHandlerKey(command string) string { return CommandHandlerPrefix + command }
+
+// CommandHandlerPrefix is that prefix, shared with anything that has to
+// recognise a command among an app's handlers.
+const CommandHandlerPrefix = "command:"
+
 // ViewTileKindPrefix is what makes a workspace layout's `tile_kind` an app's
 // rather than a built-in one. The prefix is reserved from A5 on: a built-in tile
 // kind may never start with it, so a future kind cannot collide with an app's

--- a/internal/apps/apps.go
+++ b/internal/apps/apps.go
@@ -162,19 +162,14 @@ func ValidateCommandName(name string) error {
 	return nil
 }
 
-// CommandHandlerKey is the key a command binds to in an app's default export,
-// and the handler name its invocations are recorded under.
-//
-// The prefix is what keeps a command and a subscription apart in one map: an
-// event pattern is a dotted name and can never contain a colon, and neither can
-// a command name, so `command:approve` collides with nothing. Deriving it here
-// means the codegen that writes the type, the daemon that resolves the handler
-// and the host that looks it up cannot disagree.
-func CommandHandlerKey(command string) string { return CommandHandlerPrefix + command }
-
-// CommandHandlerPrefix is that prefix, shared with anything that has to
-// recognise a command among an app's handlers.
-const CommandHandlerPrefix = "command:"
+// The labels an invocation is recorded under. They are a rendering choice for
+// `attn app logs` and nothing else: what runs is looked up in the map for its
+// kind — the bundle exports one per kind — so a label never has to be unique
+// against anything, and every kind gets one because a reader of the log wants
+// to know which of them ran.
+func CommandLabel(command string) string      { return "command:" + command }
+func SubscriptionLabel(pattern string) string { return "subscribe:" + pattern }
+func ViewLabel(view string) string            { return "view:" + view }
 
 // ViewTileKindPrefix is what makes a workspace layout's `tile_kind` an app's
 // rather than a built-in one. The prefix is reserved from A5 on: a built-in tile

--- a/internal/daemon/app_commands.go
+++ b/internal/daemon/app_commands.go
@@ -161,6 +161,17 @@ func (d *Daemon) runAppCommand(msg *protocol.AppCommandMessage) (json.RawMessage
 		d.recordAppInvocation(invocation)
 		return nil, fmt.Errorf("%s threw running command %q: %s", name, command, firstLine(result.Error))
 
+	case len(result.Payload) > appCommandPayloadLimit:
+		// The same limit, kept on the way back: a handler answering with a
+		// megabyte would otherwise reach the tile unbounded, which is the
+		// direction nobody checks until a view is slow and nothing says why.
+		invocation.Status = appInvocationStatusError
+		invocation.Error = fmt.Sprintf("the answer is %d bytes, over the %d-byte limit", len(result.Payload), appCommandPayloadLimit)
+		d.recordAppInvocation(invocation)
+		return nil, fmt.Errorf(
+			"the handler for command %q of app %s answered with %d bytes, over the %d-byte limit for one command; a command is an action, and anything larger belongs in a document the view reads",
+			command, name, len(result.Payload), appCommandPayloadLimit)
+
 	default:
 		invocation.Status = appInvocationStatusOK
 		d.recordAppInvocation(invocation)

--- a/internal/daemon/app_commands.go
+++ b/internal/daemon/app_commands.go
@@ -133,7 +133,7 @@ func (d *Daemon) runAppCommand(msg *protocol.AppCommandMessage) (json.RawMessage
 		VersionID:    plan.versionID,
 		EventName:    appCommandEvent,
 		EventSubject: command,
-		Handler:      plan.handler,
+		Handler:      plan.label,
 		Duration:     took,
 		StartedAt:    started,
 	}
@@ -218,7 +218,8 @@ func (d *Daemon) planAppCommand(name, command string) (*appDispatchPlan, error) 
 		namespace: apps.Namespace(name),
 		versionID: version.ID,
 		artifact:  version.ArtifactPath,
-		handler:   apps.CommandHandlerKey(command),
+		handler:   command,
+		label:     apps.CommandLabel(command),
 	}
 	for _, collection := range manifest.Collections {
 		plan.collections = append(plan.collections, collection.Name)

--- a/internal/daemon/app_commands.go
+++ b/internal/daemon/app_commands.go
@@ -1,0 +1,310 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/victorarias/attn/internal/appbuild"
+	"github.com/victorarias/attn/internal/apps"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// A view acting: `app_command` in, `app_command_result` back.
+//
+// A view that can only read is a way in with no way out. What makes this a
+// small addition rather than a second runtime is that it ends where a
+// subscription ends — one key of the app's default export, dispatched into the
+// shared sidecar, recorded in the same invocation log, bounded by the same
+// timeout. The envelope is generic: attn carries an app, a command name and a
+// payload it never looks inside.
+//
+// Two rules the reader should not have to infer.
+//
+// The serving version's declaration is the contract. Which commands an app
+// answers comes from the version it is serving, never from the manifest on
+// disk — after a rollback those differ, and the running code is the honest
+// answer.
+//
+// A failing command does not advance the auto-disable clock. That clock exists
+// because an app stuck redelivering one bus event pins the durable log's
+// retention floor for every other consumer. A command pins nothing: it is a
+// person clicking a button, and letting that switch the app off would hand any
+// docked tile a way to disable an app whose handlers are healthy. It is the
+// same reasoning that keeps a caught render crash off the clock.
+//
+// Design: docs/plans/2026-08-13-ext-a5-ui-host-and-app-sdk.md, "Protocol
+// envelopes".
+
+// appCommandEvent is the event name a command invocation is recorded under. A
+// command has no fact behind it, so it names itself rather than borrowing a bus
+// fact's name and claiming a seq it does not have.
+const appCommandEvent = "app.command"
+
+// appCommandPayloadLimit bounds what one command may carry in either
+// direction.
+//
+// The tripwire is the socket and the invocation log, not the payload: a command
+// is an action ("approve this, with this note"), not a data transfer, and the
+// document store is what an app uses to move anything larger. 256KB is ~8x the
+// largest thing a view could plausibly hand a handler — the crash reporter's
+// own limit for a whole component stack is 32KB — so an app has to be using
+// this as a pipe to feel it.
+const appCommandPayloadLimit = 256 * 1024
+
+// handleAppCommand runs one command and answers the client that asked.
+//
+// It answers off the message pump because a dispatch may take as long as
+// appDispatchTimeout, and this client's other commands — including the
+// doc_unsubscribe of a tile the user just closed — are processed in order
+// behind it.
+func (d *Daemon) handleAppCommand(client *wsClient, msg *protocol.AppCommandMessage) {
+	requestID := strings.TrimSpace(msg.RequestID)
+	if requestID == "" {
+		// There is nothing to answer: the caller minted no id, so no promise on the
+		// other side is waiting for a result carrying one.
+		d.sendCommandError(client, protocol.CmdAppCommand,
+			"app_command requires a request_id: the result is correlated by it, and one without an id could never reach the caller")
+		return
+	}
+	go func() {
+		payload, err := d.runAppCommand(msg)
+		d.sendToClient(client, appCommandResult(requestID, payload, err))
+	}()
+}
+
+func appCommandResult(requestID string, payload json.RawMessage, err error) protocol.AppCommandResultMessage {
+	result := protocol.AppCommandResultMessage{
+		Event:     protocol.EventAppCommandResult,
+		RequestID: requestID,
+		Success:   err == nil,
+	}
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+		return result
+	}
+	if len(payload) > 0 {
+		result.Payload = protocol.Ptr(string(payload))
+	}
+	return result
+}
+
+// runAppCommand resolves the command against the serving version and dispatches
+// it. The returned error is what the caller reads in the tile, so every refusal
+// says what to do about it.
+func (d *Daemon) runAppCommand(msg *protocol.AppCommandMessage) (json.RawMessage, error) {
+	name := strings.TrimSpace(msg.App)
+	if err := apps.ValidateName(name); err != nil {
+		return nil, err
+	}
+	command := strings.TrimSpace(msg.Command)
+	if err := apps.ValidateCommandName(command); err != nil {
+		return nil, err
+	}
+	payload := json.RawMessage(strings.TrimSpace(protocol.Deref(msg.Payload)))
+	if len(payload) > appCommandPayloadLimit {
+		return nil, fmt.Errorf(
+			"the payload for %s/%s is %d bytes, over the %d-byte limit for one command; a command is an action, and anything larger belongs in a document the handler reads",
+			name, command, len(payload), appCommandPayloadLimit)
+	}
+	if len(payload) > 0 && !json.Valid(payload) {
+		return nil, fmt.Errorf("the payload for %s/%s is not valid JSON", name, command)
+	}
+	if d.store == nil {
+		return nil, fmt.Errorf("this daemon has no store, so it runs no apps")
+	}
+
+	plan, err := d.planAppCommand(name, command)
+	if err != nil {
+		return nil, err
+	}
+
+	started := d.appNow()
+	ctx, cancel := context.WithTimeout(context.Background(), d.appDispatchBudget())
+	defer cancel()
+	result, dispatchErr := d.dispatchAppCommand(ctx, plan, payload)
+	took := d.appNow().Sub(started)
+
+	invocation := store.AppInvocation{
+		AppName:      name,
+		VersionID:    plan.versionID,
+		EventName:    appCommandEvent,
+		EventSubject: command,
+		Handler:      plan.handler,
+		Duration:     took,
+		StartedAt:    started,
+	}
+	switch {
+	case dispatchErr != nil:
+		// Both classes are recorded — a reader looking at an app that did nothing
+		// deserves to see why — and neither is held against the app's stall clock.
+		// The runtime being down is not the app's fault, and a handler that threw
+		// on a click is not a stall.
+		if errors.Is(dispatchErr, context.DeadlineExceeded) {
+			dispatchErr = fmt.Errorf(
+				"the handler for command %q of app %s did not return within %s, so attn abandoned it; a handler awaits attn's own APIs, which always settle — an await on anything else needs its own timeout",
+				command, name, d.appDispatchBudget())
+			invocation.Status = appInvocationStatusError
+		} else {
+			invocation.Status = appInvocationStatusRuntimeError
+		}
+		invocation.Error = dispatchErr.Error()
+		d.recordAppInvocation(invocation)
+		return nil, dispatchErr
+
+	case !result.OK:
+		invocation.Status = appInvocationStatusError
+		invocation.Error = result.Error
+		d.recordAppInvocation(invocation)
+		return nil, fmt.Errorf("%s threw running command %q: %s", name, command, firstLine(result.Error))
+
+	default:
+		invocation.Status = appInvocationStatusOK
+		d.recordAppInvocation(invocation)
+		return result.Payload, nil
+	}
+}
+
+// planAppCommand answers whether this app can run this command right now, and
+// with what.
+func (d *Daemon) planAppCommand(name, command string) (*appDispatchPlan, error) {
+	_, ok, err := d.store.GetApp(name)
+	if err != nil {
+		return nil, fmt.Errorf("reading app %q: %w", name, err)
+	}
+	if !ok {
+		return nil, fmt.Errorf("no app named %s is installed; `attn app apply <path>` installs one", name)
+	}
+	consumer, found, err := d.store.GetBusConsumer(apps.ConsumerName(name))
+	if err != nil {
+		return nil, fmt.Errorf("reading the bus consumer of app %q: %w", name, err)
+	}
+	if !found || !consumer.Enabled {
+		return nil, fmt.Errorf("%s is disabled, so it runs nothing; `attn app enable %s` turns it back on", name, name)
+	}
+
+	manifest, version, err := d.appDeclaration(name)
+	if err != nil {
+		return nil, err
+	}
+	if version.ID == 0 {
+		return nil, fmt.Errorf("%s has no version serving, so there is no code to run; `attn app apply <path>` builds one", name)
+	}
+	declared := manifest.CommandNames()
+	if !containsString(declared, command) {
+		// The version, not the manifest on disk: after a rollback the two differ,
+		// and the running code is what the caller is actually talking to.
+		return nil, fmt.Errorf(
+			"the version of %s serving now (%d) declares no command %q; it declares %s. Add a [[commands]] block and `attn app apply`, or roll back to a version that has it",
+			name, version.ID, command, commandList(declared))
+	}
+
+	plan := &appDispatchPlan{
+		app:       name,
+		namespace: apps.Namespace(name),
+		versionID: version.ID,
+		artifact:  version.ArtifactPath,
+		handler:   apps.CommandHandlerKey(command),
+	}
+	for _, collection := range manifest.Collections {
+		plan.collections = append(plan.collections, collection.Name)
+	}
+	return plan, nil
+}
+
+func containsString(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func commandList(commands []string) string {
+	if len(commands) == 0 {
+		return "none"
+	}
+	return strings.Join(commands, ", ")
+}
+
+// dispatchAppCommand sends one command run to the sidecar. It is
+// dispatchToAppRuntime's shape — the same in-flight record scoping the
+// handler's document access, the same wait for a cold start, the same
+// attribution when the shared event loop is frozen — differing only in what
+// travels and what comes back.
+func (d *Daemon) dispatchAppCommand(ctx context.Context, plan *appDispatchPlan, payload json.RawMessage) (appCommandDispatchResult, error) {
+	runtime, err := d.awaitAppRuntime(ctx)
+	if err != nil {
+		return appCommandDispatchResult{}, err
+	}
+
+	dispatch := &appDispatch{
+		app:         plan.app,
+		namespace:   plan.namespace,
+		versionID:   plan.versionID,
+		collections: make(map[string]struct{}, len(plan.collections)),
+	}
+	for _, collection := range plan.collections {
+		dispatch.collections[collection] = struct{}{}
+	}
+	d.registerAppDispatch(dispatch)
+	// Released whatever happens, including the abandoned-timeout path: an id left
+	// behind would let a handler that finally woke up write documents from
+	// outside any invocation.
+	defer d.releaseAppDispatch(dispatch.id)
+
+	request := appCommandRequest{
+		Dispatch:    dispatch.id,
+		App:         plan.app,
+		VersionID:   plan.versionID,
+		Artifact:    plan.artifact,
+		Handler:     plan.handler,
+		Collections: plan.collections,
+		Payload:     payload,
+	}
+	if request.Collections == nil {
+		request.Collections = []string{}
+	}
+
+	result, err := runtime.command(ctx, request)
+	if err != nil {
+		if ctx.Err() != nil {
+			// Our own deadline: something in the sidecar is stuck, and which app is
+			// holding the loop is the host's to say. The answer is the same one a bus
+			// delivery gets — this dispatch is still in the in-flight set for it to
+			// be right.
+			return appCommandDispatchResult{}, d.attributeWedgedDispatch(context.Background(), runtime, plan.app)
+		}
+		// The transport failed — the socket died mid-call, or the process did.
+		return appCommandDispatchResult{}, runtimeFailure("%v", err)
+	}
+	return result, nil
+}
+
+// appDeclaredCommands reads a version's commands out of its frozen declaration,
+// for the CLI's `commands:` line. A declaration that will not parse costs the
+// reader that line, not the app.
+func appDeclaredCommands(declaration string, logf func(string, ...any)) []protocol.AppCommandInfo {
+	var snapshot struct {
+		Commands []appbuild.Command `json:"commands"`
+	}
+	if err := json.Unmarshal([]byte(declaration), &snapshot); err != nil {
+		if logf != nil {
+			logf("apps: reading the commands of a stored declaration: %v", err)
+		}
+		return nil
+	}
+	out := make([]protocol.AppCommandInfo, 0, len(snapshot.Commands))
+	for _, c := range snapshot.Commands {
+		info := protocol.AppCommandInfo{Name: c.Name}
+		if c.Description != "" {
+			info.Description = protocol.Ptr(c.Description)
+		}
+		out = append(out, info)
+	}
+	return out
+}

--- a/internal/daemon/app_commands_test.go
+++ b/internal/daemon/app_commands_test.go
@@ -1,0 +1,297 @@
+package daemon
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/appbuild"
+	"github.com/victorarias/attn/internal/apps"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// A view acting. What these pin: the envelope reaches the app's own handler with
+// the payload untouched, the answer comes back to the caller that asked, every
+// refusal says what to do about it, and a command that fails costs the app
+// nothing beyond that click.
+
+func commandManifest(commands ...appbuild.Command) appbuild.Manifest {
+	return appbuild.Manifest{
+		Views:    []appbuild.View{tileView("approvals", "Pending approvals")},
+		Commands: commands,
+	}
+}
+
+// appCommandCaller is one WebSocket client invoking commands, decoded into the
+// one envelope this surface answers with.
+type appCommandCaller struct {
+	client *wsClient
+}
+
+func newAppCommandCaller() *appCommandCaller {
+	return &appCommandCaller{client: &wsClient{send: make(chan outboundMessage, 16)}}
+}
+
+func (c *appCommandCaller) invoke(t *testing.T, d *Daemon, app, command, payload string) protocol.AppCommandResultMessage {
+	t.Helper()
+	msg := &protocol.AppCommandMessage{
+		Cmd:       protocol.CmdAppCommand,
+		RequestID: "req-1",
+		App:       app,
+		Command:   command,
+	}
+	if payload != "" {
+		msg.Payload = protocol.Ptr(payload)
+	}
+	d.handleAppCommand(c.client, msg)
+	return c.result(t)
+}
+
+func (c *appCommandCaller) result(t *testing.T) protocol.AppCommandResultMessage {
+	t.Helper()
+	select {
+	case msg := <-c.client.send:
+		var out protocol.AppCommandResultMessage
+		if err := json.Unmarshal(msg.payload, &out); err != nil {
+			t.Fatalf("decode the answer: %v", err)
+		}
+		if out.Event != protocol.EventAppCommandResult {
+			t.Fatalf("the daemon answered with %q", out.Event)
+		}
+		return out
+	case <-time.After(5 * time.Second):
+		t.Fatal("the daemon never answered the command")
+		return protocol.AppCommandResultMessage{}
+	}
+}
+
+func mustFail(t *testing.T, result protocol.AppCommandResultMessage, wants ...string) {
+	t.Helper()
+	if result.Success {
+		t.Fatalf("the command succeeded, want a refusal: %+v", result)
+	}
+	message := protocol.Deref(result.Error)
+	for _, want := range wants {
+		if !strings.Contains(message, want) {
+			t.Errorf("the refusal does not say %q: %s", want, message)
+		}
+	}
+}
+
+// The whole path: a declared command reaches the handler bound to it, carrying
+// the caller's payload byte for byte, and what the handler returned reaches the
+// caller.
+func TestAppCommandRunsTheHandlerAndAnswersTheCaller(t *testing.T) {
+	d := newAppDaemon(t)
+	version := installApp(t, d, "reviewer", commandManifest(appbuild.Command{Name: "approve"}))
+	runtime := startFakeAppRuntime(t, d, nil)
+	runtime.command = func(_ *fakeAppRuntime, req appCommandRequest) (json.RawMessage, error) {
+		return json.RawMessage(`{"approved":"tk-1"}`), nil
+	}
+
+	result := newAppCommandCaller().invoke(t, d, "reviewer", "approve", `{"id":"tk-1"}`)
+
+	if !result.Success {
+		t.Fatalf("the command failed: %s", protocol.Deref(result.Error))
+	}
+	if protocol.Deref(result.Payload) != `{"approved":"tk-1"}` {
+		t.Fatalf("the handler's answer did not reach the caller: %v", result.Payload)
+	}
+	log := runtime.commandLog()
+	if len(log) != 1 {
+		t.Fatalf("the sidecar ran %d commands", len(log))
+	}
+	got := log[0]
+	if got.Handler != apps.CommandHandlerKey("approve") {
+		t.Errorf("handler key is %q, want the command: prefix", got.Handler)
+	}
+	if got.App != "reviewer" || got.VersionID != version.ID {
+		t.Errorf("the dispatch names %s version %d, want reviewer version %d", got.App, got.VersionID, version.ID)
+	}
+	if string(got.Payload) != `{"id":"tk-1"}` {
+		t.Errorf("payload reached the handler as %s", got.Payload)
+	}
+
+	rows := invocationsOf(t, d, "reviewer")
+	if len(rows) != 1 {
+		t.Fatalf("invocations = %+v, want the one command", rows)
+	}
+	if rows[0].Status != appInvocationStatusOK || rows[0].Handler != apps.CommandHandlerKey("approve") {
+		t.Errorf("invocation = %+v", rows[0])
+	}
+	if rows[0].EventName != appCommandEvent || rows[0].EventSubject != "approve" {
+		t.Errorf("a command's invocation must name itself, not borrow a fact: %+v", rows[0])
+	}
+}
+
+// A command that takes no argument is a command, and "returned nothing" has to
+// survive as nothing rather than as a null the view has to know about.
+func TestAppCommandWithNoPayloadAndNoAnswerSucceeds(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "reviewer", commandManifest(appbuild.Command{Name: "refresh"}))
+	startFakeAppRuntime(t, d, nil)
+
+	result := newAppCommandCaller().invoke(t, d, "reviewer", "refresh", "")
+
+	if !result.Success {
+		t.Fatalf("the command failed: %s", protocol.Deref(result.Error))
+	}
+	if result.Payload != nil {
+		t.Fatalf("a handler that returned nothing carried %v", *result.Payload)
+	}
+}
+
+// The serving version's declaration is the contract, exactly as it is for
+// views: a rollback takes a command away with it, and the refusal says which
+// version is answering and what it does declare.
+func TestAppCommandIsRefusedByTheServingVersionsDeclaration(t *testing.T) {
+	d := newAppDaemon(t)
+	first := installApp(t, d, "reviewer", commandManifest(appbuild.Command{Name: "approve"}))
+	installApp(t, d, "reviewer", commandManifest(
+		appbuild.Command{Name: "approve"}, appbuild.Command{Name: "reject"}))
+	startFakeAppRuntime(t, d, nil)
+	caller := newAppCommandCaller()
+
+	if result := caller.invoke(t, d, "reviewer", "reject", ""); !result.Success {
+		t.Fatalf("the newly declared command failed: %s", protocol.Deref(result.Error))
+	}
+	if err := d.store.SetAppCurrentVersion("reviewer", first.ID, first.CreatedAt); err != nil {
+		t.Fatalf("roll back: %v", err)
+	}
+
+	mustFail(t, caller.invoke(t, d, "reviewer", "reject", ""), "reject", "approve", "reviewer")
+}
+
+func TestAppCommandRefusesAnAppThatIsDisabledOrMissing(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "reviewer", commandManifest(appbuild.Command{Name: "approve"}))
+	startFakeAppRuntime(t, d, nil)
+	caller := newAppCommandCaller()
+
+	mustFail(t, caller.invoke(t, d, "ghost", "approve", ""), "ghost", "attn app apply")
+
+	if resp := appSetEnabled(t, d, "reviewer", false); !resp.Ok {
+		t.Fatalf("disable reviewer: %v", protocol.Deref(resp.Error))
+	}
+	mustFail(t, caller.invoke(t, d, "reviewer", "approve", ""), "disabled", "attn app enable reviewer")
+}
+
+// A limit someone can hit is a limit they must see: the refusal names the limit,
+// its value and the ask, and says where larger data belongs.
+func TestAppCommandRefusesAPayloadOverTheLimit(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "reviewer", commandManifest(appbuild.Command{Name: "approve"}))
+	startFakeAppRuntime(t, d, nil)
+
+	huge := `{"note":"` + strings.Repeat("x", appCommandPayloadLimit) + `"}`
+	result := newAppCommandCaller().invoke(t, d, "reviewer", "approve", huge)
+
+	mustFail(t, result, "approve", "reviewer", "262144", "document")
+}
+
+func TestAppCommandRefusesAPayloadThatIsNotJSON(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "reviewer", commandManifest(appbuild.Command{Name: "approve"}))
+	startFakeAppRuntime(t, d, nil)
+
+	mustFail(t, newAppCommandCaller().invoke(t, d, "reviewer", "approve", "{not json"), "JSON")
+}
+
+// A handler that throws is the app's fault and the caller's answer — recorded,
+// reported in the handler's own words, and nothing more.
+func TestAppCommandCarriesAThrownHandlerBackToTheCaller(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "reviewer", commandManifest(appbuild.Command{Name: "approve"}))
+	runtime := startFakeAppRuntime(t, d, nil)
+	runtime.command = func(*fakeAppRuntime, appCommandRequest) (json.RawMessage, error) {
+		return nil, errTest("Error: approve needs an id")
+	}
+
+	mustFail(t, newAppCommandCaller().invoke(t, d, "reviewer", "approve", ""), "approve needs an id")
+
+	rows := invocationsOf(t, d, "reviewer")
+	if len(rows) != 1 || rows[0].Status != appInvocationStatusError {
+		t.Fatalf("invocations = %+v, want one recorded failure", rows)
+	}
+}
+
+// A handler that never returns is abandoned, and the refusal is one an agent can
+// act on: the command, the app, and the limit that was reached.
+func TestAppCommandAbandonsAHandlerThatNeverReturns(t *testing.T) {
+	d := newAppDaemon(t)
+	// The shipped tripwires are 60s and 2s; waiting them out would prove nothing
+	// extra and cost a minute.
+	d.appDispatchWait = 300 * time.Millisecond
+	d.appPingWait = 50 * time.Millisecond
+	installApp(t, d, "reviewer", commandManifest(appbuild.Command{Name: "approve"}))
+	runtime := startFakeAppRuntime(t, d, nil)
+	runtime.command = func(f *fakeAppRuntime, _ appCommandRequest) (json.RawMessage, error) {
+		f.freezeLoop()
+		select {}
+	}
+
+	result := newAppCommandCaller().invoke(t, d, "reviewer", "approve", "")
+
+	mustFail(t, result, "approve", "reviewer", "300ms")
+	// The clock that disables an app exists for a consumer pinning the durable
+	// log. A command pins nothing, so a docked tile must not be able to switch a
+	// healthy app off by clicking.
+	if status := appStatus(t, d, "reviewer"); status.AppStatusResult.Stall != nil {
+		t.Fatalf("a failed command advanced the stall clock: %+v", status.AppStatusResult.Stall)
+	}
+}
+
+// Nothing to answer is worse than an error: a request with no id could never
+// reach the caller, so it is refused where the caller can still see it.
+func TestAppCommandWithoutARequestIDIsRefusedOnTheSpot(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "reviewer", commandManifest(appbuild.Command{Name: "approve"}))
+	caller := newAppCommandCaller()
+
+	d.handleAppCommand(caller.client, &protocol.AppCommandMessage{
+		Cmd: protocol.CmdAppCommand, App: "reviewer", Command: "approve",
+	})
+
+	select {
+	case msg := <-caller.client.send:
+		var out map[string]any
+		if err := json.Unmarshal(msg.payload, &out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out["event"] != protocol.EventCommandError {
+			t.Fatalf("answered with %v, want an error event", out)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("a command with no request id was answered with silence")
+	}
+}
+
+// `attn app status` is the only way to see that a command exists without
+// invoking it, and what it shows is the serving version's declaration.
+func TestAppStatusCarriesTheServingVersionsCommands(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "reviewer", commandManifest(
+		appbuild.Command{Name: "approve", Description: "Approve the request."},
+		appbuild.Command{Name: "reject"},
+	))
+
+	resp := appStatus(t, d, "reviewer")
+	if !resp.Ok {
+		t.Fatalf("app status: %v", protocol.Deref(resp.Error))
+	}
+	commands := resp.AppStatusResult.App.Commands
+	if len(commands) != 2 {
+		t.Fatalf("commands = %+v, want both", commands)
+	}
+	if commands[0].Name != "approve" || protocol.Deref(commands[0].Description) != "Approve the request." {
+		t.Errorf("first command = %+v", commands[0])
+	}
+	if commands[1].Description != nil {
+		t.Errorf("a command with no description carried one: %+v", commands[1])
+	}
+}
+
+type errTest string
+
+func (e errTest) Error() string { return string(e) }

--- a/internal/daemon/app_commands_test.go
+++ b/internal/daemon/app_commands_test.go
@@ -190,6 +190,28 @@ func TestAppCommandRefusesAPayloadOverTheLimit(t *testing.T) {
 	mustFail(t, result, "approve", "reviewer", "262144", "document")
 }
 
+// The same limit in the other direction: what the handler answers with is
+// bounded too, or the advertised limit is only half a limit.
+func TestAppCommandRefusesAnAnswerOverTheLimit(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "reviewer", commandManifest(appbuild.Command{Name: "approve"}))
+	runtime := startFakeAppRuntime(t, d, nil)
+	runtime.command = func(*fakeAppRuntime, appCommandRequest) (json.RawMessage, error) {
+		return json.RawMessage(`{"note":"` + strings.Repeat("x", appCommandPayloadLimit) + `"}`), nil
+	}
+
+	result := newAppCommandCaller().invoke(t, d, "reviewer", "approve", "")
+
+	mustFail(t, result, "approve", "reviewer", "262144", "document")
+	if result.Payload != nil {
+		t.Fatalf("the oversized answer reached the caller anyway")
+	}
+	rows := invocationsOf(t, d, "reviewer")
+	if len(rows) != 1 || rows[0].Status != appInvocationStatusError {
+		t.Fatalf("invocations = %+v, want one recorded failure", rows)
+	}
+}
+
 func TestAppCommandRefusesAPayloadThatIsNotJSON(t *testing.T) {
 	d := newAppDaemon(t)
 	installApp(t, d, "reviewer", commandManifest(appbuild.Command{Name: "approve"}))

--- a/internal/daemon/app_commands_test.go
+++ b/internal/daemon/app_commands_test.go
@@ -103,8 +103,8 @@ func TestAppCommandRunsTheHandlerAndAnswersTheCaller(t *testing.T) {
 		t.Fatalf("the sidecar ran %d commands", len(log))
 	}
 	got := log[0]
-	if got.Handler != apps.CommandHandlerKey("approve") {
-		t.Errorf("handler key is %q, want the command: prefix", got.Handler)
+	if got.Handler != "approve" {
+		t.Errorf("the sidecar was asked for handler %q, want the command's bare name", got.Handler)
 	}
 	if got.App != "reviewer" || got.VersionID != version.ID {
 		t.Errorf("the dispatch names %s version %d, want reviewer version %d", got.App, got.VersionID, version.ID)
@@ -117,7 +117,7 @@ func TestAppCommandRunsTheHandlerAndAnswersTheCaller(t *testing.T) {
 	if len(rows) != 1 {
 		t.Fatalf("invocations = %+v, want the one command", rows)
 	}
-	if rows[0].Status != appInvocationStatusOK || rows[0].Handler != apps.CommandHandlerKey("approve") {
+	if rows[0].Status != appInvocationStatusOK || rows[0].Handler != apps.CommandLabel("approve") {
 		t.Errorf("invocation = %+v", rows[0])
 	}
 	if rows[0].EventName != appCommandEvent || rows[0].EventSubject != "approve" {

--- a/internal/daemon/app_consumers.go
+++ b/internal/daemon/app_consumers.go
@@ -123,12 +123,18 @@ type appStall struct {
 }
 
 // appDispatchPlan is everything one delivery needs, read once per event.
+//
+// handler and label are separate on purpose. The handler is a key of the
+// bundle's map for this kind — an event pattern here, a bare command name for a
+// command — and the label is what the invocation log shows, which names the
+// kind because a reader wants to know which of them ran.
 type appDispatchPlan struct {
 	app         string
 	namespace   string
 	versionID   int64
 	artifact    string
 	handler     string
+	label       string
 	collections []string
 }
 
@@ -324,7 +330,7 @@ func (d *Daemon) deliverAppEvent(ctx context.Context, name string, ev bus.Event)
 		EventSeq:     ev.Seq,
 		EventName:    ev.Name,
 		EventSubject: ev.Subject,
-		Handler:      plan.handler,
+		Handler:      plan.label,
 		Duration:     took,
 		StartedAt:    started,
 	}
@@ -395,6 +401,7 @@ func (d *Daemon) planAppDispatch(name string, ev bus.Event) (*appDispatchPlan, e
 		versionID: version.ID,
 		artifact:  version.ArtifactPath,
 		handler:   handler,
+		label:     apps.SubscriptionLabel(handler),
 	}
 	for _, collection := range manifest.Collections {
 		plan.collections = append(plan.collections, collection.Name)

--- a/internal/daemon/app_runtime.go
+++ b/internal/daemon/app_runtime.go
@@ -419,7 +419,9 @@ const appDispatchTimeout = 60 * time.Second
 //
 // Handler is resolved here rather than in the host: the daemon holds the frozen
 // declaration and the same pattern matching the bus filter uses, and a second
-// implementation of that rule in TypeScript is one free to drift.
+// implementation of that rule in TypeScript is one free to drift. It is a key of
+// the bundle's `subscriptions` map — which map to index in is what the method
+// name already says, so no key ever carries its kind.
 //
 // Artifact is an absolute path, and that is the whole of the hot-reload story:
 // versions are content-addressed, so each one has its own path, `import()`
@@ -459,7 +461,8 @@ type appDispatchResult struct {
 // depends on which half is populated is one every reader has to decode twice.
 // Everything either one needs to find and scope a handler — the artifact, the
 // key, the in-flight id, the declared collections — is identical, and so is
-// what the host does with it.
+// what the host does with it. Handler is the command's bare name, looked up in
+// the bundle's `commands` map.
 type appCommandRequest struct {
 	Dispatch    string          `json:"dispatch"`
 	App         string          `json:"app"`

--- a/internal/daemon/app_runtime.go
+++ b/internal/daemon/app_runtime.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -50,7 +51,7 @@ const (
 	// case this guards is an old binary inside a stale app bundle meeting a new
 	// daemon, where every symptom of the skew would otherwise appear later and
 	// somewhere else.
-	appRuntimeAPIVersion = 2
+	appRuntimeAPIVersion = 3
 )
 
 // appRuntimeHostOverride lets a test — and a developer running a checkout's
@@ -448,6 +449,34 @@ type appDispatchEvent struct {
 type appDispatchResult struct {
 	OK    bool   `json:"ok"`
 	Error string `json:"error,omitempty"`
+}
+
+// appCommandRequest is `app.command`, the daemon's other call into the sidecar.
+//
+// It is appDispatchRequest with the fact replaced by the caller's payload.
+// Deliberately a second method rather than one with an optional event: the two
+// carry different things and answer differently, and a shape whose meaning
+// depends on which half is populated is one every reader has to decode twice.
+// Everything either one needs to find and scope a handler — the artifact, the
+// key, the in-flight id, the declared collections — is identical, and so is
+// what the host does with it.
+type appCommandRequest struct {
+	Dispatch    string          `json:"dispatch"`
+	App         string          `json:"app"`
+	VersionID   int64           `json:"version_id"`
+	Artifact    string          `json:"artifact"`
+	Handler     string          `json:"handler"`
+	Collections []string        `json:"collections"`
+	Payload     json.RawMessage `json:"payload,omitempty"`
+}
+
+// appCommandDispatchResult is appDispatchResult plus what the handler returned.
+// A handler that returned nothing carries no payload, which is different from
+// one that returned null.
+type appCommandDispatchResult struct {
+	OK      bool            `json:"ok"`
+	Error   string          `json:"error,omitempty"`
+	Payload json.RawMessage `json:"payload,omitempty"`
 }
 
 // appDispatch is one in-flight handler run, as the daemon sees it.

--- a/internal/daemon/app_runtime.go
+++ b/internal/daemon/app_runtime.go
@@ -51,7 +51,12 @@ const (
 	// case this guards is an old binary inside a stale app bundle meeting a new
 	// daemon, where every symptom of the skew would otherwise appear later and
 	// somewhere else.
-	appRuntimeAPIVersion = 3
+	//
+	// It moves with the daemon↔host contract, which includes the shape of an
+	// app's bundle: the host loads it. Bump it here and in apphost/src/index.ts
+	// together — TestAppRuntimeAPIVersionMatchesTheHost is what fails when only
+	// one moves.
+	appRuntimeAPIVersion = 4
 )
 
 // appRuntimeHostOverride lets a test — and a developer running a checkout's

--- a/internal/daemon/app_runtime_ipc_test.go
+++ b/internal/daemon/app_runtime_ipc_test.go
@@ -187,7 +187,7 @@ func TestAppWatchStreamsInvocationsAsTheyHappen(t *testing.T) {
 			// The auditor's invocation must not reach a watcher of greeter.
 			t.Fatalf("the stream carried %+v, want greeter's own invocation", info)
 		}
-		if info.Status != appInvocationStatusOK || info.Handler != "ticket.*" {
+		if info.Status != appInvocationStatusOK || info.Handler != apps.SubscriptionLabel("ticket.*") {
 			t.Fatalf("streamed invocation = %+v", info)
 		}
 	case <-time.After(2 * time.Second):

--- a/internal/daemon/app_runtime_rpc.go
+++ b/internal/daemon/app_runtime_rpc.go
@@ -55,6 +55,14 @@ func (c *appRuntimeConnection) dispatch(ctx context.Context, req appDispatchRequ
 	return result, nil
 }
 
+func (c *appRuntimeConnection) command(ctx context.Context, req appCommandRequest) (appCommandDispatchResult, error) {
+	var result appCommandDispatchResult
+	if err := c.request(ctx, "app runtime", "app.command", req, &result); err != nil {
+		return appCommandDispatchResult{}, err
+	}
+	return result, nil
+}
+
 // appRuntimePingResult answers whether the sidecar's event loop is turning. The
 // host serves it without touching app code, so a silent ping means the loop
 // itself is blocked and no app's handler is being run.

--- a/internal/daemon/app_runtime_test.go
+++ b/internal/daemon/app_runtime_test.go
@@ -48,10 +48,16 @@ type fakeAppRuntime struct {
 	// reaches the daemon.
 	handler func(*fakeAppRuntime, appDispatchRequest) error
 
+	// command runs in place of a command handler. Nil answers every command with
+	// no payload, which is what a handler returning nothing looks like on the
+	// wire. Returning an error is a handler that threw.
+	command func(*fakeAppRuntime, appCommandRequest) (json.RawMessage, error)
+
 	writeMu sync.Mutex
 
 	mu         sync.Mutex
 	dispatches []appDispatchRequest
+	commands   []appCommandRequest
 	pending    map[string]chan jsonRPCMessage
 	nextID     int
 	// loopFrozen models a blocked event loop. A real host does everything off one
@@ -168,8 +174,12 @@ func (f *fakeAppRuntime) serve(reader *bufio.Reader) {
 			// either: a frozen loop cannot read its own socket.
 			continue
 		}
+		if msg.Method == "app.command" {
+			f.serveCommand(msg)
+			continue
+		}
 		if msg.Method != "app.dispatch" {
-			f.sendRaw(jsonRPCFailure(msg.ID, jsonRPCInvalidRequest, "the fake sidecar only serves app.dispatch and app.runtime.ping"))
+			f.sendRaw(jsonRPCFailure(msg.ID, jsonRPCInvalidRequest, "the fake sidecar only serves app.dispatch, app.command and app.runtime.ping"))
 			continue
 		}
 		var req appDispatchRequest
@@ -207,6 +217,52 @@ func (f *fakeAppRuntime) serve(reader *bufio.Reader) {
 			f.sendRaw(jsonRPCResult(id, result))
 		}(msg.ID, req)
 	}
+}
+
+// serveCommand is the command half of the loop above, with the same
+// entered/left announcements: a command runs on the one event loop every
+// dispatch runs on, so the daemon has to be able to name it when that loop
+// stops turning.
+func (f *fakeAppRuntime) serveCommand(msg jsonRPCMessage) {
+	var req appCommandRequest
+	if err := json.Unmarshal(msg.Params, &req); err != nil {
+		f.sendRaw(jsonRPCFailure(msg.ID, jsonRPCInvalidRequest, err.Error()))
+		return
+	}
+	f.mu.Lock()
+	f.commands = append(f.commands, req)
+	f.mu.Unlock()
+	f.sendRaw(jsonRPCMessage{
+		JSONRPC: "2.0",
+		Method:  appRuntimeEnteredMethod,
+		Params:  mustMarshalHandlerParams(f.t, appRuntimeHandlerParams{Dispatch: req.Dispatch, App: req.App}),
+	})
+	go func(id json.RawMessage, req appCommandRequest) {
+		result := appCommandDispatchResult{OK: true}
+		if f.command != nil {
+			payload, err := f.command(f, req)
+			if err != nil {
+				result = appCommandDispatchResult{OK: false, Error: err.Error()}
+			} else {
+				result = appCommandDispatchResult{OK: true, Payload: payload}
+			}
+		}
+		f.sendRaw(jsonRPCMessage{
+			JSONRPC: "2.0",
+			Method:  appRuntimeLeftMethod,
+			Params:  mustMarshalHandlerParams(f.t, appRuntimeHandlerParams{Dispatch: req.Dispatch, App: req.App}),
+		})
+		f.sendRaw(jsonRPCResult(id, result))
+	}(msg.ID, req)
+}
+
+// commandLog is what this sidecar was asked to run, in arrival order.
+func (f *fakeAppRuntime) commandLog() []appCommandRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]appCommandRequest, len(f.commands))
+	copy(out, f.commands)
+	return out
 }
 
 func mustMarshalHandlerParams(t *testing.T, params appRuntimeHandlerParams) json.RawMessage {

--- a/internal/daemon/app_runtime_version_test.go
+++ b/internal/daemon/app_runtime_version_test.go
@@ -1,0 +1,27 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The daemon and the host each hold the API version as their own constant, and
+// nothing else in the build compares them: the host is a compiled binary the
+// daemon meets at hello, so a version that moved on one side and not the other
+// is discovered as a refused runtime — or, worse, as a served one whose contract
+// has quietly changed. This is the witness the frontend's protocol version has
+// and this one did not.
+func TestAppRuntimeAPIVersionMatchesTheHost(t *testing.T) {
+	hostPath := filepath.Join("..", "..", "apphost", "src", "index.ts")
+	data, err := os.ReadFile(hostPath)
+	if err != nil {
+		t.Fatalf("read the app runtime host: %v", err)
+	}
+	want := fmt.Sprintf("const APP_RUNTIME_API_VERSION = %d", appRuntimeAPIVersion)
+	if !strings.Contains(string(data), want) {
+		t.Fatalf("%s must contain %q — the daemon speaks version %d", hostPath, want, appRuntimeAPIVersion)
+	}
+}

--- a/internal/daemon/app_ui.go
+++ b/internal/daemon/app_ui.go
@@ -26,12 +26,6 @@ import (
 // Design: docs/plans/2026-08-13-ext-a5-ui-host-and-app-sdk.md, "The app UI
 // registry" and "Reload".
 
-// appViewCrashHandler is the invocation handler name a caught render error is
-// recorded under. Distinct from both keys a dispatched handler is invoked by —
-// a subscription's raw event pattern and a command's `command:` — so `attn app
-// logs` says which surface failed.
-const appViewCrashHandler = "view:"
-
 // appViewCrashEvent is the event name a render crash is recorded against. A
 // crash has no fact behind it, so it names itself rather than borrowing a bus
 // fact's name and claiming a seq it does not have.
@@ -222,7 +216,7 @@ func (d *Daemon) handleAppViewCrash(_ *wsClient, msg *protocol.AppViewCrashMessa
 		VersionID:    version.ID,
 		EventName:    appViewCrashEvent,
 		EventSubject: strings.TrimSpace(msg.TileID),
-		Handler:      appViewCrashHandler + view,
+		Handler:      apps.ViewLabel(view),
 		Status:       appInvocationStatusError,
 		Error:        text,
 		StartedAt:    now,

--- a/internal/daemon/app_ui.go
+++ b/internal/daemon/app_ui.go
@@ -27,8 +27,9 @@ import (
 // registry" and "Reload".
 
 // appViewCrashHandler is the invocation handler name a caught render error is
-// recorded under. `view:` rather than the `subscribe:`/`command:` prefixes a
-// dispatched handler uses, so `attn app logs` says which surface failed.
+// recorded under. Distinct from both keys a dispatched handler is invoked by —
+// a subscription's raw event pattern and a command's `command:` — so `attn app
+// logs` says which surface failed.
 const appViewCrashHandler = "view:"
 
 // appViewCrashEvent is the event name a render crash is recorded against. A

--- a/internal/daemon/app_ui_test.go
+++ b/internal/daemon/app_ui_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/victorarias/attn/internal/appbuild"
+	"github.com/victorarias/attn/internal/apps"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/store"
 )
@@ -135,7 +136,7 @@ func TestAViewCrashIsRecordedAgainstTheVersionThatServedIt(t *testing.T) {
 		t.Fatalf("the crash is stamped with version %d, want %d", got.VersionID, version.ID)
 	}
 	// The handler name is what makes `attn app logs` say which surface failed.
-	if got.Handler != appViewCrashHandler+"approvals" {
+	if got.Handler != apps.ViewLabel("approvals") {
 		t.Fatalf("handler is %q", got.Handler)
 	}
 	if got.Status != appInvocationStatusError || !strings.Contains(got.Error, "TypeError") {

--- a/internal/daemon/apps.go
+++ b/internal/daemon/apps.go
@@ -377,6 +377,7 @@ func (d *Daemon) appSummary(row store.App, head int64) (protocol.AppSummary, err
 			// From the serving version's frozen declaration, not the manifest on
 			// disk: after a rollback those differ, and what docks is what serves.
 			summary.Views = appViewsForWire(version.Declaration, d.logf)
+			summary.Commands = appDeclaredCommands(version.Declaration, d.logf)
 		}
 	}
 	consumer, ok, err := d.store.GetBusConsumer(apps.ConsumerName(row.Name))

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -170,6 +170,7 @@ var CommandMeta = map[string]CommandMetadata{
 	// Logged: a view that crashes is worth a daemon.log line beside the
 	// invocation it records.
 	protocol.CmdAppViewCrash:              commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdAppCommand:                commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdOpenMarkdown:              commandMetadata(ScopeSession, true, true),
 	protocol.CmdOpenSentFiles:             commandMetadata(ScopeSession, true, true),
 	protocol.CmdMarkdownAnnotationsGet:    commandMetadata(ScopeSession, true, true),

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -1347,6 +1347,8 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		d.handleWorkspaceLayoutSetSplitRatio(client, msg.(*protocol.WorkspaceLayoutSetSplitRatioMessage))
 	case protocol.CmdAppViewCrash: // wire: app_view_crash
 		d.handleAppViewCrash(client, msg.(*protocol.AppViewCrashMessage))
+	case protocol.CmdAppCommand: // wire: app_command
+		d.handleAppCommand(client, msg.(*protocol.AppCommandMessage))
 	case protocol.CmdDocSubscribe: // wire: doc_subscribe
 		d.handleDocSubscribeWS(client, msg.(*protocol.DocSubscribeMessage))
 	case protocol.CmdDocUnsubscribe: // wire: doc_unsubscribe

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "243"
+const ProtocolVersion = "244"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only
@@ -154,6 +154,7 @@ const (
 	CmdAppRuntimeRestart                     = "app_runtime_restart"
 	CmdAppWatch                              = "app_watch"
 	CmdAppViewCrash                          = "app_view_crash"
+	CmdAppCommand                            = "app_command"
 	CmdGetTicket                             = "get_ticket"
 	CmdTicketChangeStatus                    = "ticket_change_status"
 	CmdTicketAddComment                      = "ticket_add_comment"
@@ -383,6 +384,7 @@ const (
 	EventTicketsUpdated                  = "tickets_updated"
 	EventGardenSeedsUpdated              = "garden_seeds_updated"
 	EventAppsUpdated                     = "apps_updated"
+	EventAppCommandResult                = "app_command_result"
 	EventDocSubscriptionDelivery         = "doc_subscription_delivery"
 	EventDocSubscriptionEnded            = "doc_subscription_ended"
 	EventTicketResult                    = "ticket_result"
@@ -849,6 +851,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdAppViewCrash:
 		var msg AppViewCrashMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAppCommand:
+		var msg AppCommandMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -267,6 +267,48 @@ type AppApplyResult struct {
 	VersionID int `json:"version_id"`
 }
 
+type AppCommandInfo struct {
+	// Description corresponds to the JSON schema field "description".
+	Description *string `json:"description,omitempty,omitzero"`
+
+	// Name corresponds to the JSON schema field "name".
+	Name string `json:"name"`
+}
+
+type AppCommandMessage struct {
+	// App corresponds to the JSON schema field "app".
+	App string `json:"app"`
+
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Command corresponds to the JSON schema field "command".
+	Command string `json:"command"`
+
+	// Payload corresponds to the JSON schema field "payload".
+	Payload *string `json:"payload,omitempty,omitzero"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+}
+
+type AppCommandResultMessage struct {
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// Payload corresponds to the JSON schema field "payload".
+	Payload *string `json:"payload,omitempty,omitzero"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+}
+
 type AppConsumerInfo struct {
 	// Cursor corresponds to the JSON schema field "cursor".
 	Cursor int `json:"cursor"`
@@ -581,6 +623,9 @@ type AppStatusResult struct {
 }
 
 type AppSummary struct {
+	// Commands corresponds to the JSON schema field "commands".
+	Commands []AppCommandInfo `json:"commands,omitempty,omitzero"`
+
 	// Consumer corresponds to the JSON schema field "consumer".
 	Consumer *AppConsumerInfo `json:"consumer,omitempty,omitzero"`
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -4596,6 +4596,18 @@ model AppSummary {
   // declaration. Empty for an app with no views, and for an app with no version
   // applied yet — a view exists only inside a built version.
   "views"?: AppViewInfo[];
+  // The commands the serving version declares, same rule as views: what an app
+  // answers is what the version now serving declared, not what its manifest
+  // says today. It is the only way to see a command exists without invoking it.
+  "commands"?: AppCommandInfo[];
+}
+
+// One declared command: something a view of this app can ask it to do.
+model AppCommandInfo {
+  "name": string;
+  // The manifest's description, when it has one. attn renders no UI from it —
+  // an app draws its own button — so this is for a reader of `attn app status`.
+  "description"?: string;
 }
 
 // One declared view: a named component the app offers attn to render, as the
@@ -4674,6 +4686,44 @@ model AppViewCrashMessage {
   // The error as the boundary caught it: message first, then the component stack
   // when React gave one.
   "error": string;
+}
+
+// A view asks its app to do something.
+//
+// The envelope is generic on purpose: attn knows the app, the command name and
+// a payload it never looks inside, and the app's handler is what gives any of
+// it meaning. That is the whole surface — there is no per-command shape in the
+// protocol, and adding a command is a manifest line plus a handler.
+//
+// `app` is composed by the host from the mount's identity and never by the
+// view, the same rule that makes a view unable to read another app's documents.
+model AppCommandMessage {
+  "cmd": "app_command";
+  "request_id": string;
+  "app": string;
+  "command": string;
+  // The argument, as JSON text. Text rather than a typed field because the
+  // daemon never interprets it: it is handed to the app's handler and its
+  // answer comes back the same way, exactly as a document body travels.
+  // Absent when the command takes none.
+  "payload"?: string;
+}
+
+// What the app's command handler answered.
+//
+// `success` false covers every way the command did not run — the app is not
+// installed, disabled, has no serving version, does not declare this command,
+// the runtime is not there, or the handler threw — and `error` is the sentence
+// a person reads in the tile. A handler that threw is a failed command, never a
+// dead socket: the distinction the runtime draws between an app's fault and its
+// own is unchanged here.
+model AppCommandResultMessage {
+  event: "app_command_result";
+  "request_id": string;
+  "success": boolean;
+  "error"?: string;
+  // The handler's return value as JSON text, when it returned one.
+  "payload"?: string;
 }
 
 model AppVersionInfo {
@@ -5835,5 +5885,6 @@ alias DaemonEvent =
   | BusStatusResultMessage
   | BusSetConsumerEnabledResultMessage
   | AppsUpdatedMessage
+  | AppCommandResultMessage
   | DocSubscriptionDeliveryMessage
   | DocSubscriptionEndedMessage;

--- a/sdk/attn-app/package.json
+++ b/sdk/attn-app/package.json
@@ -11,6 +11,10 @@
     "./jsx-runtime": "./src/jsx-runtime.ts",
     "./jsx-dev-runtime": "./src/jsx-dev-runtime.ts"
   },
+  "dependencies": {
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1"
+  },
   "peerDependencies": {
     "react": "^19.1.0"
   },

--- a/sdk/attn-app/src/components.tsx
+++ b/sdk/attn-app/src/components.tsx
@@ -1,0 +1,250 @@
+// The component slice: what a view needs to stop looking foreign.
+//
+// Tokens come for free — a view mounts inside attn's DOM, so every
+// `var(--color-*)` and `var(--font-*)` already resolves — and that is most of
+// "looks native" at zero cost. What is left is the handful of controls a view
+// would otherwise hand-roll: attn has 55 distinct button class names across 51
+// stylesheets, which is the receipt for why `Button` is component number one.
+//
+// These render class names and nothing else. The stylesheet backing them lives
+// in attn's own build (app/src/components/appViews/appSdkComponents.css), not
+// here: the SDK is a rollup entry the import map resolves to, so a CSS import in
+// this file would emit an asset no page links and every style would silently
+// vanish. app/src/components/appViews/appSdkComponents.classes.test.tsx renders
+// each component and fails on a class the stylesheet does not define.
+//
+// Two components are deliberately absent, and stay absent until a view needs
+// them: a spinner (a permanently animating element is a battery bug in a window
+// that is open all day — loading states are text) and a relative-time label (a
+// repaint loop waiting to happen; an absolute timestamp with a `title` costs
+// nothing and repaints never).
+//
+// Design: docs/plans/2026-08-13-ext-a5-ui-host-and-app-sdk.md, "The
+// design-system slice".
+
+import type { ChangeEvent, KeyboardEvent, ReactElement, ReactNode } from "react"
+import ReactMarkdown from "react-markdown"
+import remarkGfm from "remark-gfm"
+
+function classes(...names: Array<string | false | null | undefined>): string {
+  return names.filter(Boolean).join(" ")
+}
+
+/**
+ * `primary` is the one action a view wants; `secondary` is everything else;
+ * `danger` is the one that destroys something. There is no fourth: a view that
+ * needs another meaning is telling the SDK about a component it is missing.
+ */
+export type ButtonVariant = "primary" | "secondary" | "danger"
+
+export interface ButtonProps {
+  children?: ReactNode
+  variant?: ButtonVariant
+  disabled?: boolean
+  onClick?: () => void
+  /** Buttons in a view are actions, never form submissions, so this defaults to "button". */
+  type?: "button" | "submit"
+  title?: string
+  className?: string
+}
+
+export function Button({
+  children,
+  variant = "secondary",
+  disabled,
+  onClick,
+  type = "button",
+  title,
+  className,
+}: ButtonProps): ReactElement {
+  return (
+    <button
+      type={type}
+      className={classes("attn-app-button", `attn-app-button-${variant}`, className)}
+      disabled={disabled}
+      onClick={onClick}
+      title={title}
+    >
+      {children}
+    </button>
+  )
+}
+
+export interface TextInputProps {
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  disabled?: boolean
+  /** Rendered under the field, in the error colour. A refusal the user can read. */
+  error?: string
+  ariaLabel?: string
+  className?: string
+}
+
+export function TextInput({
+  value,
+  onChange,
+  placeholder,
+  disabled,
+  error,
+  ariaLabel,
+  className,
+}: TextInputProps): ReactElement {
+  return (
+    <div className={classes("attn-app-field", className)}>
+      <input
+        type="text"
+        className={classes("attn-app-input", error && "attn-app-input-invalid")}
+        value={value}
+        placeholder={placeholder}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        aria-invalid={error ? true : undefined}
+        onChange={(event: ChangeEvent<HTMLInputElement>) => onChange(event.target.value)}
+      />
+      {error && <div className="attn-app-field-error">{error}</div>}
+    </div>
+  )
+}
+
+export interface TextAreaProps extends TextInputProps {
+  /** Visible rows. The box does not grow on its own — a view that wants that says so. */
+  rows?: number
+}
+
+export function TextArea({
+  value,
+  onChange,
+  placeholder,
+  disabled,
+  error,
+  ariaLabel,
+  className,
+  rows = 3,
+}: TextAreaProps): ReactElement {
+  return (
+    <div className={classes("attn-app-field", className)}>
+      <textarea
+        className={classes("attn-app-textarea", error && "attn-app-input-invalid")}
+        value={value}
+        rows={rows}
+        placeholder={placeholder}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        aria-invalid={error ? true : undefined}
+        onChange={(event: ChangeEvent<HTMLTextAreaElement>) => onChange(event.target.value)}
+      />
+      {error && <div className="attn-app-field-error">{error}</div>}
+    </div>
+  )
+}
+
+export interface ListProps {
+  children?: ReactNode
+  className?: string
+}
+
+/** The scrolling column a view's rows live in. */
+export function List({ children, className }: ListProps): ReactElement {
+  return (
+    <div className={classes("attn-app-list", className)} role="list">
+      {children}
+    </div>
+  )
+}
+
+export interface ListRowProps {
+  /** The line the user reads first. */
+  title: ReactNode
+  /** The quieter second line: who, when, which session. */
+  meta?: ReactNode
+  /** Trailing controls, laid out at the row's end. */
+  actions?: ReactNode
+  /** A row that answers a click is focusable and reachable by keyboard. */
+  onClick?: () => void
+  selected?: boolean
+  className?: string
+}
+
+export function ListRow({
+  title,
+  meta,
+  actions,
+  onClick,
+  selected,
+  className,
+}: ListRowProps): ReactElement {
+  const interactive = !!onClick
+  return (
+    <div
+      className={classes(
+        "attn-app-list-row",
+        interactive && "attn-app-list-row-interactive",
+        selected && "attn-app-list-row-selected",
+        className,
+      )}
+      role={interactive ? "button" : "listitem"}
+      tabIndex={interactive ? 0 : undefined}
+      aria-selected={selected}
+      onClick={onClick}
+      onKeyDown={
+        interactive
+          ? (event: KeyboardEvent<HTMLDivElement>) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault()
+                onClick?.()
+              }
+            }
+          : undefined
+      }
+    >
+      <div className="attn-app-list-row-body">
+        <div className="attn-app-list-row-title">{title}</div>
+        {meta && <div className="attn-app-list-row-meta">{meta}</div>}
+      </div>
+      {actions && <div className="attn-app-list-row-actions">{actions}</div>}
+    </div>
+  )
+}
+
+export interface EmptyStateProps {
+  /** What is not there — "Nothing waiting", not "No data". */
+  title: string
+  /** Why, or what to do about it. Empty is fine; a wrong guess is not. */
+  hint?: ReactNode
+  className?: string
+}
+
+/**
+ * The state a live-query view is in most of the time. It is text, on purpose:
+ * "nothing pending" rendered wrong is what makes a working tile look broken,
+ * and a spinner that never stops is worse than a sentence.
+ */
+export function EmptyState({ title, hint, className }: EmptyStateProps): ReactElement {
+  return (
+    <div className={classes("attn-app-empty", className)}>
+      <div className="attn-app-empty-title">{title}</div>
+      {hint && <div className="attn-app-empty-hint">{hint}</div>}
+    </div>
+  )
+}
+
+export interface MarkdownProps {
+  /** The source. Agent-written content is markdown, which is why this is here. */
+  children: string
+  className?: string
+}
+
+/**
+ * Read-only markdown, with GitHub tables and task lists.
+ *
+ * No raw HTML and no scripts: what a view renders here is usually written by an
+ * agent, and an app that wants richer output composes components instead.
+ */
+export function Markdown({ children, className }: MarkdownProps): ReactElement {
+  return (
+    <div className={classes("attn-app-markdown", className)}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{children}</ReactMarkdown>
+    </div>
+  )
+}

--- a/sdk/attn-app/src/index.ts
+++ b/sdk/attn-app/src/index.ts
@@ -150,6 +150,23 @@ export interface ViewProps {
 // a view only ever calls the hook.
 export { useQuery } from "./useQuery"
 export type { LiveQueryOptions, QueryError, QueryResult } from "./useQuery"
+export { useCommand } from "./useCommand"
+export type { CommandOutcome, CommandRunner } from "./useCommand"
+
+// The component slice. Styles come from attn's own build, not from here — see
+// the header of components.tsx.
+export { Button, EmptyState, List, ListRow, Markdown, TextArea, TextInput } from "./components"
+export type {
+  ButtonProps,
+  ButtonVariant,
+  EmptyStateProps,
+  ListProps,
+  ListRowProps,
+  MarkdownProps,
+  TextAreaProps,
+  TextInputProps,
+} from "./components"
+
 export { AppViewRuntimeProvider, useAppViewRuntime } from "./runtime"
 export type {
   AppViewRuntime,

--- a/sdk/attn-app/src/runtime.ts
+++ b/sdk/attn-app/src/runtime.ts
@@ -65,6 +65,17 @@ export interface AppViewRuntime {
   readonly namespace: string
   /** Opens a live query; the returned function closes it and must be called. */
   subscribe: (subscriber: DocumentSubscriber) => () => void
+  /**
+   * Invokes one command on the app this tile belongs to, and resolves with
+   * whatever its handler returned. Which app is asked is the host's to say, for
+   * the same reason the namespace is: a view names a command, never an app.
+   *
+   * It rejects when the command does not run — the app is disabled, the serving
+   * version declares no such command, the handler threw or never returned. The
+   * rejection carries the daemon's own words, which name the app, the command
+   * and what to do about it.
+   */
+  command: (command: string, payload?: unknown) => Promise<unknown>
 }
 
 const AppViewRuntimeContext = createContext<AppViewRuntime | null>(null)

--- a/sdk/attn-app/src/useCommand.ts
+++ b/sdk/attn-app/src/useCommand.ts
@@ -49,7 +49,7 @@ export interface CommandRunner {
  * ```
  *
  * The command must appear in a `[[commands]]` block of attn-app.toml and the
- * bundle must export a handler under `command:<name>` — the generated `Handlers`
+ * bundle must export a handler under `commands` — the generated `Handlers`
  * type makes the second half a compile error at `attn app apply`.
  */
 export function useCommand(command: string): CommandRunner {

--- a/sdk/attn-app/src/useCommand.ts
+++ b/sdk/attn-app/src/useCommand.ts
@@ -1,0 +1,103 @@
+// useCommand — a view acting, as a view sees it.
+//
+// A command is the way out for the way in `useQuery` opened: the view names one
+// of the commands its manifest declares, the host addresses it to this app, and
+// the app's own handler runs in the sidecar with the same document access it has
+// on a bus event. The view is never the authority for the app's rules.
+//
+// One rule shapes the shape: **the returned runner never rejects.** A view calls
+// it straight from an onClick, and a rejected promise nobody awaited is an
+// unhandled rejection that reaches attn's console rather than the user's tile.
+// It resolves with an outcome to branch on, and mirrors the same failure into
+// `error` for the common case of just rendering it.
+//
+// Design: docs/plans/2026-08-13-ext-a5-ui-host-and-app-sdk.md, "Protocol
+// envelopes".
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useAppViewRuntime } from "./runtime"
+
+/** What one invocation did. Never a rejection — see the file header. */
+export type CommandOutcome =
+  | { ok: true; value: unknown }
+  | { ok: false; error: string }
+
+/**
+ * A command, ready to invoke. It is a function first, because that is what a
+ * view does with it; `pending` and `error` are what it renders around the call.
+ */
+export interface CommandRunner {
+  (payload?: unknown): Promise<CommandOutcome>
+  /** True from the call until the daemon answers. */
+  readonly pending: boolean
+  /**
+   * The last failure, cleared by the next call. It is a message meant to be
+   * shown: it names the app, the command and the way forward.
+   */
+  readonly error: string | null
+}
+
+/**
+ * Invoke one of this app's declared commands.
+ *
+ * ```tsx
+ * const approve = useCommand("approve")
+ * <Button variant="primary" disabled={approve.pending} onClick={() => approve({ id })}>
+ *   Approve
+ * </Button>
+ * {approve.error && <p>{approve.error}</p>}
+ * ```
+ *
+ * The command must appear in a `[[commands]]` block of attn-app.toml and the
+ * bundle must export a handler under `command:<name>` — the generated `Handlers`
+ * type makes the second half a compile error at `attn app apply`.
+ */
+export function useCommand(command: string): CommandRunner {
+  const runtime = useAppViewRuntime()
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  // A tile can be undocked while a command is in flight. Answering into an
+  // unmounted component is a warning nobody can act on, and the daemon has
+  // already recorded the invocation either way.
+  const live = useRef(true)
+  useEffect(() => {
+    live.current = true
+    return () => {
+      live.current = false
+    }
+  }, [])
+
+  const run = useCallback(
+    async (payload?: unknown): Promise<CommandOutcome> => {
+      if (!runtime) {
+        const message = `useCommand("${command}") was called outside an attn app view host, so there is no daemon to run it.`
+        setError(message)
+        return { ok: false, error: message }
+      }
+      setPending(true)
+      setError(null)
+      try {
+        const value = await runtime.command(command, payload)
+        return { ok: true, value }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        if (live.current) setError(message)
+        return { ok: false, error: message }
+      } finally {
+        if (live.current) setPending(false)
+      }
+    },
+    [runtime, command],
+  )
+
+  return useMemo(() => {
+    const runner = ((payload?: unknown) => run(payload)) as {
+      (payload?: unknown): Promise<CommandOutcome>
+      pending: boolean
+      error: string | null
+    }
+    runner.pending = pending
+    runner.error = error
+    return runner as CommandRunner
+  }, [run, pending, error])
+}


### PR DESCRIPTION
Slice 5 of the A5 plan (`docs/plans/2026-08-13-ext-a5-ui-host-and-app-sdk.md`): a
docked view can act, it looks like the rest of attn, and the scaffold teaches
all of it. Into `epic/ext-a5`, on top of slices 1–4.

## What a view can do now

**Act.** An app declares `[[commands]]` in its manifest and exports a handler for
each under the bundle's `commands` map; codegen derives that group from the
declaration, so a declared command with no handler is a compiler error at `attn
app apply`. A view calls
`useCommand("forget")` and gets a runner that never rejects — it carries
`.pending` and `.error` instead, because a click that failed is UI state, not an
exception. The view names the command; it never names an app. `AppTileHost`
binds which app is asked, the same rule the document namespace already follows,
so a view cannot invoke another app's command any more than it can read another
app's documents.

The envelope goes view → SDK → `app_command` → daemon → shared runtime →
`commands[<name>]` handler → result back to the caller that asked. What answers is
the **serving version's frozen declaration**, exactly as it is for views: a
rollback takes a command away with it, and the refusal names the version's own
commands.

**Look native.** The SDK re-exports Button, TextInput, TextArea, List/ListRow,
EmptyState and Markdown, drawn entirely with attn's tokens. The doc's list, and
nothing beyond it — a spinner and a relative-time label stay out, because a
permanent repaint loop beside GPU terminals is a battery bug no test catches.
Nothing here animates or transitions.

**Be teachable.** `attn app new` now scaffolds a working tile rather than a stub:
a live `useQuery`, a command wired to a Forget button, the components, and an
AGENTS.md that teaches views, params, reading, acting and drawing. The scaffold
applies untouched.

## Decisions worth reviewing

**Kind is structure, not a prefix on a key.** The plan drew
`"subscribe:doc.changed"` beside `"command:approve"` in one flat map. Instead a
bundle default-exports one map per kind — `subscriptions`, keyed by the raw event
pattern, and `commands`, keyed by the bare name. The manifest already separates
the kinds; the bundle mirrors that rather than re-encoding kind as a string
convention. Codegen derives a typed group per kind, so tsc enforces "every
declared command has a command-shaped handler" structurally; the sidecar indexes
the map its dispatch context names (a fact arrived → `subscriptions`, a command
envelope → `commands`) and constructs no keys at all. A collision is
inexpressible rather than proven-absent by a rule someone could later break.

Invocation **labels** are separate, and only a rendering choice for `attn app
logs`: `command:approve`, `subscribe:ticket.*`, `view:approvals`. Because they
carry no dispatch meaning, labelling every kind is free.

An app installed before this exports the flat shape and stops dispatching until
re-applied. Pre-release, with no app installed outside a dev profile, that is one
`attn app apply`.

**Failure is the app's, and costs one click.** A handler that throws comes back
in its own words, naming the app and the command; a handler that never yields is
abandoned at the daemon's 60s budget with a refusal naming the app, the command
and the limit. The frontend waits 75s so that named refusal is what the view
shows rather than a timeout of its own. Neither advances the app's stall clock —
that clock exists for a consumer pinning the durable log, and a docked tile pins
nothing, so clicking must not be able to disable a healthy app.

**One command carries at most 256KB in either direction** — the document body
limit, for the same reason. The refusal names the limit, the ask, and says a
document is where larger data belongs.

**Component styles live in `app/src`, not in the SDK.** A CSS import inside the
SDK's rollup entry would emit an asset the import map's fixed-name chunks cannot
link, and every rule would silently vanish. The components emit `attn-app-*`
classes only; `appSdkComponents.css` (imported by `AppTileHost`) defines them,
and a test renders every component in every state that changes its classes and
fails on a class with no rule — and on a rule no component emits.

Protocol 244: `app_command` / `app_command_result`, in all five lockstep spots.
As-built record added to the plan doc; `view` and `tile` added to the glossary.

## Live verification

Throwaway profile `a5s5b` (installed from this branch, preflight PASS, protocol
244 CLI/app/daemon). `attn app new tally` → `attn app apply tally` **untouched** →
docked `tally/sessions` through the real dock picker → drove the command. Re-run
in full after the handler-map reshape, since dispatch changed.

A click runs the command; the handler deletes the document and the live query
drops the row — no refetch, no reload:

![command succeeds](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/deb6a3da371277f043d0655a92e744fc2f14f95c/delegate-a5-slice5-act-e4ff9cac/a5s5b-command-ok.gif)

[Full-quality recording (mp4)](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/deb6a3da371277f043d0655a92e744fc2f14f95c/delegate-a5-slice5-act-e4ff9cac/a5s5b-command-ok.mp4)

Then the handler was broken and re-applied. The failure reaches the view in the
handler's own words, naming the app and the command — nothing silent, and the row
stays:

![command fails](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/d6b39ec263766441a627e50d47cff743cae0f076/delegate-a5-slice5-act-e4ff9cac/a5s5b-command-fails.gif)

[Full-quality recording (mp4)](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/d6b39ec263766441a627e50d47cff743cae0f076/delegate-a5-slice5-act-e4ff9cac/a5s5b-command-fails.mp4)

Also verified live on that profile: the invocation log labels every kind —
`command:forget` (ok, then error) beside `subscribe:session.state.changed` — the
app stayed **enabled** after the failure (stall clock untouched), and all three
compile gates fire at `attn app apply`, each naming what is wrong:

    Property 'commands' is missing in type '{ subscriptions: … }' but required in type 'Handlers'
    Property '"forget"' is missing in type '{}' but required in type '{ forget: … }'
    'remember' does not exist in type '{ forget: (payload: unknown, ctx: Ctx) => unknown; }'

`attn app status` lists the serving version's commands.
`scenario-tr301-local-utility-session-switch` passed on the pre-reshape build; the
reshape touches no frontend code, so ⌘T typing and switch-away/back utility focus
are unchanged.

Surfaces walked: CLI (`app new`, `apply`, `status`, `logs`), daemon+app, protocol
(all five spots), Linux (no darwin-only code added), SDK, docs (glossary, plan
as-built, changelog fragment). No new mount kind; the exit proof is slice 6.

Tests: full Go suite, 2861 frontend tests, `make check-types`, `make check-sdk`,
`pnpm run build`, plus new coverage for the command path (ten daemon tests),
manifest/codegen, the SDK components' class contract, and the host's binding.


https://claude.ai/code/session_01Da42YienvPmtwKmEt99oei
