### PR TITLE
refactor(annotations): consolidate shared annotation seams

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -455,10 +455,9 @@ this is where daemon traffic lands:
   per-domain event bodies lifted out of the switch, reached from its `default`.
   Grep a wire name (`fs_write_result`) to find the module that owns it. Adding a
   domain means a new module plus one line in that `default` chain.
-- `hooks/daemonMarkdownAnnotationEvents.ts` uses a *second* correlation scheme —
-  keyed `<op>:<workspaceId>:<path>`, last-writer-wins, `request_id`-checked — so
-  annotation drafts supersede rather than queue. Do not route it through
-  `daemonPendingRequests`.
+- Markdown annotations use `daemonPendingRequests.ts`'s keyed correlation with
+  `<op>:<workspaceId>:<path>` keys, last-writer-wins superseding, and
+  `request_id` checks. `daemonMarkdownAnnotationEvents.ts` only decodes results.
 - `store/daemonSessions.ts`: Zustand store for session/PR state.
 - `pty/`: transport, attach planning, binary frame decode, runtime lifecycle.
 - Tests are topic-suffixed: `Source.concern.test.tsx`. Keep that — the suffix

--- a/app/scripts/real-app-harness/scenario-terminal-annotations.mjs
+++ b/app/scripts/real-app-harness/scenario-terminal-annotations.mjs
@@ -44,9 +44,9 @@ const TURN_START_TIMEOUT_MS = 90_000;
 const ANCHOR_TIMEOUT_MS = 30_000;
 const SETTLED_STATES = new Set(['idle', 'waiting_input', 'pending_approval']);
 
-// The label clicked in the popup. Its aria-label is the button's accessible
-// name in QUICK_LABELS; its emoji is what the filed annotation carries.
-const LABEL = { name: 'Show the receipt', emoji: '🧾' };
+// The label clicked in the popup. The UI renders its emoji, while the daemon
+// stores its stable id.
+const LABEL = { name: 'Show the receipt', id: 'show-the-receipt', emoji: '🧾' };
 // The note drafted beside the marks, and what proves it left the composer.
 const NOTE = 'Prefer the smallest change that covers this.';
 const FIRST_MESSAGE = 'A retry wrapper protects idempotent operations from duplicate network effects.';
@@ -407,6 +407,10 @@ async function main() {
       );
       const [annotation] = stored.annotations;
       runner.assert(annotation.quote === quote, `Daemon quote ${JSON.stringify(annotation.quote)} != UI quote ${JSON.stringify(quote)}`);
+      runner.assert(
+        annotation.quick_label_id === LABEL.id,
+        `Stored quick label = ${JSON.stringify(annotation.quick_label_id)}, want ${LABEL.id}`,
+      );
       runner.assert(
         typeof annotation.message_key === 'string' && annotation.message_key.length > 0,
         `Stored annotation has no message key: ${JSON.stringify(annotation)}`,

--- a/app/src/annotations/QuickLabelPicker.tsx
+++ b/app/src/annotations/QuickLabelPicker.tsx
@@ -104,7 +104,9 @@ function FloatingQuickLabelPicker({
       }
     };
     window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
   }, [labels, onSelect]);
 
   useEffect(() => {

--- a/app/src/annotations/QuickLabelPicker.tsx
+++ b/app/src/annotations/QuickLabelPicker.tsx
@@ -37,6 +37,16 @@ const PICKER_WIDTH = 192;
 const GAP = 6;
 const VIEWPORT_PADDING = 12;
 
+function addDeferredPointerDownListener(listener: (event: PointerEvent) => void): () => void {
+  const timer = window.setTimeout(() => {
+    document.addEventListener('pointerdown', listener, true);
+  }, 0);
+  return () => {
+    window.clearTimeout(timer);
+    document.removeEventListener('pointerdown', listener, true);
+  };
+}
+
 function computePosition(
   anchorEl: HTMLElement,
   cursorHint: { x: number; y: number } | null | undefined,
@@ -115,13 +125,7 @@ function FloatingQuickLabelPicker({
         onDismiss();
       }
     };
-    const timer = setTimeout(() => {
-      document.addEventListener('pointerdown', handlePointerDown, true);
-    }, 0);
-    return () => {
-      clearTimeout(timer);
-      document.removeEventListener('pointerdown', handlePointerDown, true);
-    };
+    return addDeferredPointerDownListener(handlePointerDown);
   }, [onDismiss]);
 
   if (!position) {

--- a/app/src/annotations/QuickLabelPicker.tsx
+++ b/app/src/annotations/QuickLabelPicker.tsx
@@ -1,39 +1,48 @@
-/**
- * Floating quick-label list at the last mouseup position, clamped to the
- * viewport; falls back to the anchor element with no cursor hint.
- *
- * Interaction contract: bare digits 1..9,0 and Alt+digit apply label N (0 =
- * 10th); Escape dismisses; outside pointerdown dismisses, but that listener
- * installs one tick late so the click that OPENED the picker never dismisses.
- */
-
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import {
+  useEffect,
+  Fragment,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from 'react';
 import { createPortal } from 'react-dom';
-import { useEscapeStack } from '../../../hooks/useEscapeStack';
-import { LABEL_COLOR_MAP, QUICK_LABELS, type QuickLabel } from './quickLabels';
+import { useEscapeStack } from '../hooks/useEscapeStack';
+import { LABEL_COLOR_MAP, type QuickLabel } from './quickLabels';
 
-export interface QuickLabelPickerProps {
+export interface FloatingQuickLabelPickerProps {
+  mode?: 'floating';
+  className: string;
+  labels: readonly QuickLabel[];
   anchorEl: HTMLElement;
-  /** Mouse coordinates at the last mouseup — picker appears here. */
   cursorHint?: { x: number; y: number } | null;
   onSelect: (label: QuickLabel) => void;
   onDismiss: () => void;
 }
 
+interface ChipQuickLabelPickerProps {
+  mode: 'chips';
+  className: string;
+  groups: readonly (readonly QuickLabel[])[];
+  isSelected: (label: QuickLabel) => boolean;
+  onSelect: (label: QuickLabel) => void;
+  onHint: (hint: string | null) => void;
+  children?: ReactNode;
+}
+
+export type QuickLabelPickerProps = FloatingQuickLabelPickerProps | ChipQuickLabelPickerProps;
+
 const PICKER_WIDTH = 192;
 const GAP = 6;
 const VIEWPORT_PADDING = 12;
 
-// `height` is measured, 0 before first layout: the list is as tall as the
-// label set makes it, and a guessed constant hangs off-screen once one is added.
 function computePosition(
   anchorEl: HTMLElement,
   cursorHint: { x: number; y: number } | null | undefined,
   height: number,
 ): { top: number; left: number } {
   const rect = anchorEl.getBoundingClientRect();
-
-  // Vertical: below the anchor, above when it does not fit, else viewport-clamped.
   const below = rect.bottom + GAP;
   const above = rect.top - GAP - height;
   const lowestTop = window.innerHeight - VIEWPORT_PADDING - height;
@@ -42,22 +51,26 @@ function computePosition(
     top = above >= VIEWPORT_PADDING ? above : Math.max(VIEWPORT_PADDING, lowestTop);
   }
 
-  // Horizontal: cursor x puts the first row under the pointer; else anchor edge.
   let left = cursorHint ? cursorHint.x - 28 : rect.right - PICKER_WIDTH / 2;
   left = Math.max(
     VIEWPORT_PADDING,
     Math.min(left, window.innerWidth - PICKER_WIDTH - VIEWPORT_PADDING),
   );
-
   return { top, left };
 }
 
-export function QuickLabelPicker({ anchorEl, cursorHint, onSelect, onDismiss }: QuickLabelPickerProps) {
+function FloatingQuickLabelPicker({
+  className,
+  labels,
+  anchorEl,
+  cursorHint,
+  onSelect,
+  onDismiss,
+}: FloatingQuickLabelPickerProps) {
   const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
   const [height, setHeight] = useState(0);
   const ref = useRef<HTMLDivElement>(null);
 
-  // First pass places with height 0; the layout effect corrects before paint.
   useEffect(() => {
     const update = () => setPosition(computePosition(anchorEl, cursorHint, height));
     update();
@@ -76,29 +89,27 @@ export function QuickLabelPicker({ anchorEl, cursorHint, onSelect, onDismiss }: 
     }
   });
 
-  // Mounts after the toolbar, so the stack closes the picker first.
   useEscapeStack(onDismiss, true);
 
   useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      const isDigit = (e.code >= 'Digit1' && e.code <= 'Digit9') || e.code === 'Digit0';
-      if (isDigit && !e.ctrlKey && !e.metaKey) {
-        e.preventDefault();
-        const digit = parseInt(e.code.slice(5), 10);
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const isDigit = (event.code >= 'Digit1' && event.code <= 'Digit9') || event.code === 'Digit0';
+      if (isDigit && !event.ctrlKey && !event.metaKey) {
+        event.preventDefault();
+        const digit = parseInt(event.code.slice(5), 10);
         const index = digit === 0 ? 9 : digit - 1;
-        if (index < QUICK_LABELS.length) {
-          onSelect(QUICK_LABELS[index]);
+        if (index < labels.length) {
+          onSelect(labels[index]);
         }
       }
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [onDismiss, onSelect]);
+  }, [labels, onSelect]);
 
-  // Deferred one tick so the opening click misses the capture-phase listener.
   useEffect(() => {
-    const handlePointerDown = (e: PointerEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
+    const handlePointerDown = (event: PointerEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
         onDismiss();
       }
     };
@@ -118,11 +129,11 @@ export function QuickLabelPicker({ anchorEl, cursorHint, onSelect, onDismiss }: 
   return createPortal(
     <div
       ref={ref}
-      className="md-quick-label-picker"
+      className={className}
       style={{ top: position.top, left: position.left, width: PICKER_WIDTH }}
-      onMouseDown={(e) => e.stopPropagation()}
+      onMouseDown={(event) => event.stopPropagation()}
     >
-      {QUICK_LABELS.map((label, index) => {
+      {labels.map((label, index) => {
         const color = LABEL_COLOR_MAP[label.color];
         return (
           <button
@@ -134,20 +145,17 @@ export function QuickLabelPicker({ anchorEl, cursorHint, onSelect, onDismiss }: 
           >
             <span
               className="md-ql-chip"
-              style={
-                color
-                  ? ({
-                      background: color.bg,
-                      '--md-ql-text': color.text,
-                      '--md-ql-text-dark': color.darkText,
-                    } as React.CSSProperties)
-                  : undefined
-              }
+              style={color
+                ? ({
+                    background: color.bg,
+                    '--md-ql-text': color.text,
+                    '--md-ql-text-dark': color.darkText,
+                  } as CSSProperties)
+                : undefined}
             >
               {label.emoji}
             </span>
             <span className="md-quick-label-text">{label.text}</span>
-            {/* Past ten, a badge would promise a shortcut for another label. */}
             {index < 10 && <span className="md-quick-label-num">{(index + 1) % 10}</span>}
           </button>
         );
@@ -155,4 +163,47 @@ export function QuickLabelPicker({ anchorEl, cursorHint, onSelect, onDismiss }: 
     </div>,
     document.body,
   );
+}
+
+function ChipQuickLabelPicker({
+  className,
+  groups,
+  isSelected,
+  onSelect,
+  onHint,
+  children,
+}: ChipQuickLabelPickerProps) {
+  return (
+    <div className={className}>
+      {groups.map((group, groupIndex) => (
+        <Fragment key={group[0].id}>
+          {groupIndex > 0 ? <span className="anno-popup-divider" /> : null}
+          {group.map((label) => (
+            <button
+              key={label.id}
+              type="button"
+              className={`anno-popup-label${isSelected(label) ? ' anno-popup-label--on' : ''}`}
+              title={label.text}
+              aria-label={label.text}
+              onClick={() => onSelect(label)}
+              onMouseEnter={() => onHint(label.text)}
+              onMouseLeave={() => onHint(null)}
+              onFocus={() => onHint(label.text)}
+              onBlur={() => onHint(null)}
+            >
+              {label.emoji}
+            </button>
+          ))}
+        </Fragment>
+      ))}
+      {children}
+    </div>
+  );
+}
+
+export function QuickLabelPicker(props: QuickLabelPickerProps) {
+  if (props.mode === 'chips') {
+    return <ChipQuickLabelPicker {...props} />;
+  }
+  return <FloatingQuickLabelPicker {...props} />;
 }

--- a/app/src/annotations/useAnnotationSend.test.tsx
+++ b/app/src/annotations/useAnnotationSend.test.tsx
@@ -1,0 +1,86 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAnnotationSend, type AnnotationSendResult } from './useAnnotationSend';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('useAnnotationSend', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('guards re-entry, reports sending and sent, then expires sent', async () => {
+    const pending = deferred<AnnotationSendResult>();
+    const send = vi.fn(() => pending.promise);
+    const { result } = renderHook(() => useAnnotationSend({
+      send,
+      shortcutId: 'terminal.sendAnnotations',
+      enabled: true,
+      sentClearMs: 2200,
+    }));
+
+    act(() => {
+      result.current.send();
+      result.current.send();
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(result.current.outcome).toEqual({ kind: 'sending' });
+
+    await act(async () => pending.resolve({ kind: 'sent' }));
+    expect(result.current.outcome).toEqual({ kind: 'sent' });
+    act(() => vi.advanceTimersByTime(2199));
+    expect(result.current.outcome).toEqual({ kind: 'sent' });
+    act(() => vi.advanceTimersByTime(1));
+    expect(result.current.outcome).toBeNull();
+  });
+
+  it('keeps skipped distinct and persistent', async () => {
+    const { result } = renderHook(() => useAnnotationSend({
+      send: async () => ({ kind: 'skipped' as const }),
+      shortcutId: 'terminal.sendAnnotations',
+      enabled: true,
+      sentClearMs: 2200,
+    }));
+
+    act(() => result.current.send());
+    await act(async () => {});
+    expect(result.current.outcome).toEqual({ kind: 'skipped' });
+    act(() => vi.runAllTimers());
+    expect(result.current.outcome).toEqual({ kind: 'skipped' });
+  });
+
+  it('turns a rejected send into a persistent error', async () => {
+    const { result } = renderHook(() => useAnnotationSend({
+      send: async () => { throw new Error('delivery failed'); },
+      shortcutId: 'terminal.sendAnnotations',
+      enabled: true,
+      sentClearMs: 2200,
+    }));
+
+    act(() => result.current.send());
+    await act(async () => {});
+    expect(result.current.outcome).toEqual({ kind: 'error', message: 'delivery failed' });
+    act(() => vi.runAllTimers());
+    expect(result.current.outcome).toEqual({ kind: 'error', message: 'delivery failed' });
+  });
+
+  it('preserves delivered-with-clear-warning as a persistent outcome', async () => {
+    const { result } = renderHook(() => useAnnotationSend({
+      send: async () => ({ kind: 'warning' as const, message: 'draft clear failed' }),
+      shortcutId: 'markdown.sendAnnotations',
+      enabled: true,
+      sentClearMs: 4000,
+    }));
+
+    act(() => result.current.send());
+    await act(async () => {});
+    expect(result.current.outcome).toEqual({ kind: 'warning', message: 'draft clear failed' });
+    act(() => vi.runAllTimers());
+    expect(result.current.outcome).toEqual({ kind: 'warning', message: 'draft clear failed' });
+  });
+});

--- a/app/src/annotations/useAnnotationSend.ts
+++ b/app/src/annotations/useAnnotationSend.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useShortcut } from '../shortcuts/useShortcut';
 import type { ShortcutId } from '../shortcuts/registry';
 
@@ -28,9 +28,12 @@ export function useAnnotationSend<T extends AnnotationSendResult>({
   sentClearMs,
 }: UseAnnotationSendOptions<T>) {
   const sendRef = useRef(send);
-  sendRef.current = send;
   const sendingRef = useRef(false);
   const [outcome, setOutcome] = useState<AnnotationSendOutcome<T>>(null);
+
+  useLayoutEffect(() => {
+    sendRef.current = send;
+  }, [send]);
 
   const sendNow = useCallback(() => {
     if (sendingRef.current) {

--- a/app/src/annotations/useAnnotationSend.ts
+++ b/app/src/annotations/useAnnotationSend.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useShortcut } from '../shortcuts/useShortcut';
+import type { ShortcutId } from '../shortcuts/registry';
+
+export type AnnotationSendResult =
+  | { kind: 'sent' }
+  | { kind: 'skipped' }
+  | { kind: 'warning'; message: string }
+  | { kind: 'error'; message: string };
+
+export type AnnotationSendOutcome<T extends AnnotationSendResult> =
+  | { kind: 'sending' }
+  | T
+  | { kind: 'error'; message: string }
+  | null;
+
+interface UseAnnotationSendOptions<T extends AnnotationSendResult> {
+  send: () => T | null | Promise<T | null>;
+  shortcutId: ShortcutId;
+  enabled: boolean;
+  sentClearMs: number;
+}
+
+export function useAnnotationSend<T extends AnnotationSendResult>({
+  send,
+  shortcutId,
+  enabled,
+  sentClearMs,
+}: UseAnnotationSendOptions<T>) {
+  const sendRef = useRef(send);
+  sendRef.current = send;
+  const sendingRef = useRef(false);
+  const [outcome, setOutcome] = useState<AnnotationSendOutcome<T>>(null);
+
+  const sendNow = useCallback(() => {
+    if (sendingRef.current) {
+      return;
+    }
+    sendingRef.current = true;
+
+    let result: T | null | Promise<T | null>;
+    try {
+      result = sendRef.current();
+    } catch (error) {
+      sendingRef.current = false;
+      setOutcome({
+        kind: 'error',
+        message: error instanceof Error ? error.message : 'Send failed',
+      });
+      return;
+    }
+
+    if (result === null) {
+      sendingRef.current = false;
+      return;
+    }
+    if (!(result instanceof Promise)) {
+      sendingRef.current = false;
+      setOutcome(result);
+      return;
+    }
+
+    setOutcome({ kind: 'sending' });
+    void result
+      .then((next) => {
+        if (next !== null) {
+          setOutcome(next);
+        }
+      })
+      .catch((error: unknown) => {
+        setOutcome({
+          kind: 'error',
+          message: error instanceof Error ? error.message : 'Send failed',
+        });
+      })
+      .finally(() => {
+        sendingRef.current = false;
+      });
+  }, []);
+
+  useShortcut(shortcutId, sendNow, enabled);
+
+  useEffect(() => {
+    if (outcome?.kind !== 'sent') {
+      return;
+    }
+    const timer = window.setTimeout(() => setOutcome(null), sentClearMs);
+    return () => window.clearTimeout(timer);
+  }, [outcome, sentClearMs]);
+
+  const clearOutcome = useCallback(() => setOutcome(null), []);
+  return { outcome, send: sendNow, clearOutcome };
+}

--- a/app/src/components/MarkdownReader/annotations/QuickLabelPicker.test.tsx
+++ b/app/src/components/MarkdownReader/annotations/QuickLabelPicker.test.tsx
@@ -6,7 +6,10 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { QuickLabelPicker, type QuickLabelPickerProps } from './QuickLabelPicker';
+import {
+  QuickLabelPicker,
+  type FloatingQuickLabelPickerProps,
+} from '../../../annotations/QuickLabelPicker';
 import { QUICK_LABELS } from './quickLabels';
 
 function makeAnchor(rect: Partial<DOMRect> = {}): HTMLElement {
@@ -17,9 +20,11 @@ function makeAnchor(rect: Partial<DOMRect> = {}): HTMLElement {
   return el;
 }
 
-function renderPicker(overrides: Partial<QuickLabelPickerProps> = {}) {
+function renderPicker(overrides: Partial<FloatingQuickLabelPickerProps> = {}) {
   const anchorEl = overrides.anchorEl ?? makeAnchor();
-  const props: QuickLabelPickerProps = {
+  const props: FloatingQuickLabelPickerProps = {
+    className: 'md-quick-label-picker',
+    labels: QUICK_LABELS,
     cursorHint: { x: 300, y: 110 },
     onSelect: vi.fn(),
     onDismiss: vi.fn(),

--- a/app/src/components/MarkdownReader/annotations/SelectionToolbar.tsx
+++ b/app/src/components/MarkdownReader/annotations/SelectionToolbar.tsx
@@ -30,7 +30,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useEscapeStack } from '../../../hooks/useEscapeStack';
-import { QuickLabelPicker } from './QuickLabelPicker';
+import { QuickLabelPicker } from '../../../annotations/QuickLabelPicker';
 import { QUICK_LABELS, THUMBS_UP_LABEL, type QuickLabel } from './quickLabels';
 
 export type ToolbarPositionMode = 'center-above' | 'top-right';
@@ -260,6 +260,8 @@ export function SelectionToolbar({
       </button>
       {showQuickLabels && zapButtonRef.current && (
         <QuickLabelPicker
+          className="md-quick-label-picker"
+          labels={QUICK_LABELS}
           anchorEl={zapButtonRef.current}
           cursorHint={pickerHint}
           onSelect={(label) => {

--- a/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.tsx
+++ b/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.tsx
@@ -15,7 +15,7 @@ import { BrowserTileBody } from './BrowserTileBody';
 import { MarkdownReader } from '../MarkdownReader';
 import type { MarkdownAnnotationsSendHandle } from '../MarkdownReader';
 import { getMarkdownAnnotationsTransport } from '../MarkdownReader/annotations/transport';
-import { useShortcut } from '../../shortcuts';
+import { useAnnotationSend } from '../../annotations/useAnnotationSend';
 import { useNotebookSurfaceContext } from '../../contexts/NotebookSurfaceContext';
 import { NotebookTile } from '../notebook/NotebookTile';
 import type { NotebookSurfaceHandle } from '../NotebookSurface';
@@ -80,9 +80,7 @@ interface WorkspaceDockTileProps {
     `skipped`/`warning`/`error` persist until the next action. `warning`
     covers delivered-but-draft-clear-failed: the payload reached the session
     but the daemon still holds the draft, so local state is kept to match. */
-type SendStatus =
-  | { kind: 'idle' }
-  | { kind: 'sending' }
+type MarkdownSendResult =
   | { kind: 'sent' }
   | { kind: 'skipped' }
   | { kind: 'warning'; message: string }
@@ -136,18 +134,10 @@ export function WorkspaceDockTile({
   const isMarkdown = tile.tileKind === 'markdown';
   const annotationsSendRef = useRef<MarkdownAnnotationsSendHandle | null>(null);
   const [annotationCount, setAnnotationCount] = useState(0);
-  const [sendStatus, setSendStatus] = useState<SendStatus>({ kind: 'idle' });
-  // Focus-within on the tile root gates the ⌘Enter shortcut's REGISTRATION
-  // (see useShortcut below): when focus sits in a terminal pane the shortcut
+  // Focus-within on the tile root gates the ⌘Enter shortcut's registration:
+  // when focus sits in a terminal pane the shortcut
   // must not exist at all, so the key falls through to the PTY untouched.
   const [hasFocusWithin, setHasFocusWithin] = useState(false);
-  const sendingRef = useRef(false);
-  const sentClearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  useEffect(() => () => {
-    if (sentClearTimerRef.current) {
-      clearTimeout(sentClearTimerRef.current);
-    }
-  }, []);
 
   // The Send target: the tile's persisted session binding, but only while that
   // session is still in the workspace — otherwise the picker shows a disabled
@@ -176,87 +166,60 @@ export function WorkspaceDockTile({
       : '';
   const transportAvailable = getMarkdownAnnotationsTransport() !== null;
 
-  const setSendResult = useCallback((status: SendStatus) => {
-    if (sentClearTimerRef.current) {
-      clearTimeout(sentClearTimerRef.current);
-      sentClearTimerRef.current = null;
-    }
-    setSendStatus(status);
-    if (status.kind === 'sent') {
-      sentClearTimerRef.current = setTimeout(() => {
-        sentClearTimerRef.current = null;
-        setSendStatus((prev) => (prev.kind === 'sent' ? { kind: 'idle' } : prev));
-      }, SEND_SENT_CLEAR_MS);
-    }
-  }, []);
-
-  const sendNow = useCallback(() => {
+  const performAnnotationSend = useCallback((): MarkdownSendResult | null | Promise<MarkdownSendResult> => {
     const handle = annotationsSendRef.current;
     const transport = getMarkdownAnnotationsTransport();
-    if (sendingRef.current || annotationCount === 0 || !targetSessionId || !handle || !transport || !path) {
-      return;
+    if (annotationCount === 0 || !targetSessionId || !handle || !transport || !path) {
+      return null;
     }
     if (!handle.isHydrated()) {
       // The daemon draft has not been loaded (hydrate in flight or failed):
       // local edits are unsaved, so the daemon would format a STALE stored
       // draft — not what the sidebar shows. Refuse rather than mis-deliver.
-      setSendResult({ kind: 'error', message: NOT_HYDRATED_MESSAGE });
-      return;
+      return { kind: 'error', message: NOT_HYDRATED_MESSAGE };
     }
-    sendingRef.current = true;
-    setSendResult({ kind: 'sending' });
-    void (async () => {
-      try {
-        // Flush the 500ms save debounce first so the daemon formats a draft
-        // that includes the last keystroke's edit.
-        await handle.flushPendingSave();
-        const result = await transport.submitMarkdownAnnotations(
-          path,
-          targetSessionId,
-          handle.getOrphanedIds(),
-        );
-        if (result.status === 'delivered' && result.error) {
-          // Delivered, but the daemon FAILED to clear its draft afterwards
-          // (spec B.7): keep local state — it still matches the surviving
-          // daemon draft — and surface the qualified outcome instead of a
-          // clean "Sent ✓" over a silently emptied list.
-          setSendResult({ kind: 'warning', message: result.error });
-        } else if (result.status === 'delivered') {
-          // Daemon already tombstone-cleared; mirror locally without a second
-          // clear and seed the generation counter from the new floor.
-          handle.applyDeliveredClear(result.generation ?? 0);
-          setSendResult({ kind: 'sent' });
-        } else if (result.status === 'skipped_pending_approval') {
-          setSendResult({ kind: 'skipped' }); // annotations kept for retry
-        } else {
-          setSendResult({ kind: 'error', message: result.error || 'Send failed' });
-        }
-      } catch (error) {
-        setSendResult({
-          kind: 'error',
-          message: error instanceof Error ? error.message : 'Send failed',
-        });
-      } finally {
-        sendingRef.current = false;
+    return (async () => {
+      // Flush the 500ms save debounce first so the daemon formats a draft
+      // that includes the last keystroke's edit.
+      await handle.flushPendingSave();
+      const result = await transport.submitMarkdownAnnotations(
+        path,
+        targetSessionId,
+        handle.getOrphanedIds(),
+      );
+      if (result.status === 'delivered' && result.error) {
+        // The daemon delivered the payload but kept its draft; local state
+        // stays with that surviving source of truth.
+        return { kind: 'warning', message: result.error };
       }
+      if (result.status === 'delivered') {
+        handle.applyDeliveredClear(result.generation ?? 0);
+        return { kind: 'sent' };
+      }
+      if (result.status === 'skipped_pending_approval') {
+        return { kind: 'skipped' };
+      }
+      return { kind: 'error', message: result.error || 'Send failed' };
     })();
-  }, [annotationCount, path, setSendResult, targetSessionId]);
+  }, [annotationCount, path, targetSessionId]);
 
-  // ⌘Enter — registration-gated (not handler-gated): the dispatcher consumes
-  // the event whenever a matching handler is registered, so an always-on
-  // no-op handler would eat the terminal's ⌘Enter. The def's
-  // `editableTarget: 'native'` additionally keeps it out of textareas (the
-  // annotation popover's own ⌘Enter submits the comment there).
-  useShortcut(
-    'markdown.sendAnnotations',
-    sendNow,
-    isMarkdown
+  const sendEnabled = isMarkdown
       && visible
       && hasFocusWithin
       && annotationCount > 0
       && !!targetSessionId
-      && transportAvailable,
-  );
+      && transportAvailable;
+  const {
+    outcome: sendOutcome,
+    send: sendNow,
+    clearOutcome: clearSendOutcome,
+  } = useAnnotationSend<MarkdownSendResult>({
+    send: performAnnotationSend,
+    shortcutId: 'markdown.sendAnnotations',
+    enabled: sendEnabled,
+    sentClearMs: SEND_SENT_CLEAR_MS,
+  });
+  const sendStatus = sendOutcome ?? { kind: 'idle' as const };
 
   const handleTileFocus = useCallback(() => {
     setHasFocusWithin(true);
@@ -493,7 +456,7 @@ export function WorkspaceDockTile({
                 // AND Send target); the daemon echo confirms it later. On a
                 // failed retarget request, roll back to the persisted binding.
                 setPendingTargetSessionId(sessionId);
-                setSendResult({ kind: 'idle' });
+                clearSendOutcome();
                 void Promise.resolve(onRetargetTile?.(sessionId)).catch((error) => {
                   console.warn('[WorkspaceDockTile] Failed to retarget tile session:', error);
                   setPendingTargetSessionId((prev) => (prev === sessionId ? null : prev));

--- a/app/src/components/TerminalAnnotations/AnnotatedTerminal.annotate.test.tsx
+++ b/app/src/components/TerminalAnnotations/AnnotatedTerminal.annotate.test.tsx
@@ -362,7 +362,7 @@ describe('AnnotatedTerminal', () => {
     // One click is the whole gesture: the popup closes and the panel takes over.
     expect(screen.queryByTestId('annotation-popup')).toBeNull();
     expect(screen.getByTestId('annotation-panel')).toBeTruthy();
-    expect(stored()[0]?.emoji).toBe('🔍');
+    expect(stored()[0]?.quickLabelId).toBe('verify-this');
     expect(stored()[0]?.quote).toBe(TURN_1.slice(0, 26));
   });
 
@@ -431,7 +431,7 @@ describe('AnnotatedTerminal', () => {
     fireEvent.click(screen.getByLabelText('Show the receipt'));
 
     expect(stored()).toHaveLength(1);
-    expect(stored()[0].emoji).toBe('🧾');
+    expect(stored()[0].quickLabelId).toBe('show-the-receipt');
   });
 
   it('reopens a comment straight into its editor, prefilled', async () => {
@@ -1035,8 +1035,8 @@ describe('AnnotatedTerminal sending', () => {
     await waitFor(() => expect(screen.getByTestId('annotation-send-note')).toBeTruthy());
     expect(stored()).toHaveLength(1);
     expect(stored()[0].id).toBe(id);
-    expect(stored()[0].emoji).toBe('🧾');
-    await waitFor(() => expect(daemon.annotations.map((entry) => entry.emoji)).toEqual(['🧾']));
+    expect(stored()[0].quickLabelId).toBe('show-the-receipt');
+    await waitFor(() => expect(daemon.annotations.map((entry) => entry.quickLabelId)).toEqual(['show-the-receipt']));
     expect(daemon.calls.clearAnnotations).toBe(0);
   });
 
@@ -1064,7 +1064,7 @@ describe('AnnotatedTerminal sending', () => {
     });
 
     await waitFor(() => expect(stored().map((entry) => entry.id)).toEqual([editedId]));
-    expect(stored()[0].emoji).toBe('❌');
+    expect(stored()[0].quickLabelId).toBe('this-is-wrong');
   });
 
   it('tombstones the daemon draft only once the send is delivered', async () => {
@@ -1101,7 +1101,7 @@ describe('AnnotatedTerminal persistence', () => {
     anchor('turn-1', 0, 26);
     fireEvent.click(screen.getByLabelText('Verify this'));
     await waitFor(() => expect(daemon.annotations).toHaveLength(1));
-    expect(daemon.annotations[0].emoji).toBe('🔍');
+    expect(daemon.annotations[0].quickLabelId).toBe('verify-this');
     expect(daemon.annotations[0].quote).toBe(TURN_1.slice(0, 26));
 
     fireEvent.click(screen.getByLabelText('Remove annotation'));
@@ -1116,7 +1116,7 @@ describe('AnnotatedTerminal persistence', () => {
       start: 4,
       end: 10,
       quote: TURN_1.slice(4, 10),
-      emoji: '❓',
+      quickLabelId: 'clarify-this',
       comment: 'why this?',
     }];
     daemon.generation = 7;
@@ -1144,7 +1144,7 @@ describe('AnnotatedTerminal persistence', () => {
     renderTerminal({ api: daemon });
 
     await waitFor(() => expect(stored()).toHaveLength(1));
-    expect(stored()[0].emoji).toBe('🔍');
+    expect(stored()[0].quickLabelId).toBe('verify-this');
     expect(stored()[0].quote).toBe(TURN_1.slice(0, 26));
   });
 
@@ -1161,7 +1161,7 @@ describe('AnnotatedTerminal persistence', () => {
       start: 31,
       end: 55,
       quote: TURN_1.slice(31, 55),
-      emoji: '🧾',
+      quickLabelId: 'show-the-receipt',
       comment: '',
     }];
 
@@ -1196,7 +1196,7 @@ describe('AnnotatedTerminal persistence', () => {
       start: 0,
       end: 26,
       quote: TURN_1.slice(0, 26),
-      emoji: '🔍',
+      quickLabelId: 'verify-this',
       comment: '',
     }], '', daemon.tombstone);
     expect(late.stale).toBe(true);

--- a/app/src/components/TerminalAnnotations/AnnotatedTerminal.tsx
+++ b/app/src/components/TerminalAnnotations/AnnotatedTerminal.tsx
@@ -19,9 +19,10 @@ import {
   type MessageAnchor,
   type TerminalAnnotation,
 } from '../../utils/terminalAnnotations';
-import { QUICK_LABEL_GROUPS, buildAnnotationPayload, labelByEmoji } from './quickLabels';
+import { QUICK_LABEL_GROUPS, buildAnnotationPayload, labelById } from './quickLabels';
+import { QuickLabelPicker } from '../../annotations/QuickLabelPicker';
 import { clampToViewport, placePopup, type PlaceOptions, type Placement } from './placement';
-import { useShortcut } from '../../shortcuts/useShortcut';
+import { useAnnotationSend } from '../../annotations/useAnnotationSend';
 import { formatShortcut } from '../../shortcuts/formatShortcut';
 import './TerminalAnnotations.css';
 
@@ -88,10 +89,8 @@ interface Notice {
   seq: number;
 }
 
-// The footer's whole vocabulary. `sending` exists because the delivery is a
-// round trip with a pause in it, and an idle-looking button gets pressed twice.
-type SendOutcome =
-  | { kind: 'sending' }
+// The terminal-specific results carried by the shared send state machine.
+type TerminalSendResult =
   // Annotated mid-flight, so not part of the send. Reported, not assumed zero:
   // a panel that does not empty otherwise reads as a failure.
   | { kind: 'sent'; count: number; kept: number }
@@ -117,10 +116,6 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
     // Mutating the store is invisible to React; this drives the repaint.
     const [version, setVersion] = useState(0);
     const [composer, setComposer] = useState<Composer | null>(null);
-    // What the last send did, shown in the panel's footer. Null between sends.
-    const [outcome, setOutcome] = useState<SendOutcome | null>(null);
-    // Guards the round trip: the send is reachable from the button and ⌘Enter.
-    const sendingRef = useRef(false);
     // What a gesture that resolved to nothing has to say, and where. Null
     // otherwise: it answers a question the pointer just asked.
     const [notice, setNotice] = useState<Notice | null>(null);
@@ -302,7 +297,7 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
       const current = composer;
       if (current) {
         const annotation = store.list().find((entry) => entry.id === current.annotationId);
-        if (annotation && !annotation.emoji && !annotation.comment) {
+        if (annotation && !annotation.quickLabelId && !annotation.comment) {
           store.remove(current.annotationId);
           persist();
           bump();
@@ -468,10 +463,10 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
       ? annotations.find((entry) => entry.id === composer.annotationId) ?? null
       : null;
 
-    const applyLabel = (emoji: string) => {
+    const applyLabel = (quickLabelId: string) => {
       if (!composed) return;
-      const next = composed.emoji === emoji ? '' : emoji;
-      store.update(composed.id, { emoji: next });
+      const next = composed.quickLabelId === quickLabelId ? '' : quickLabelId;
+      store.update(composed.id, { quickLabelId: next });
       // Toggling the only label off leaves an annotation that says nothing.
       if (!next && !composed.comment) store.remove(composed.id);
       persist();
@@ -482,7 +477,7 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
     const saveComment = () => {
       if (!composed) return;
       store.update(composed.id, { comment: draft.trim() });
-      if (!draft.trim() && !composed.emoji) store.remove(composed.id);
+      if (!draft.trim() && !composed.quickLabelId) store.remove(composed.id);
       persist();
       bump();
       closeComposer();
@@ -520,15 +515,15 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
 
     // Delivers the set and submits it. The marks are spent only on `delivered`:
     // clearing undelivered work is the one failure the user cannot undo.
-    const send = () => {
-      if (annotations.length === 0 || !annotationApi || sendingRef.current) return;
+    const performSend = (): Promise<TerminalSendResult | null> | null => {
+      if (annotations.length === 0 || !annotationApi) return null;
       // Land any note still waiting on its typing pause before composing.
       flushNoteSave();
       // A comment being typed when the send fires is part of what was meant.
       if (composed && composer?.writing) {
         const comment = draft.trim();
         store.update(composed.id, { comment });
-        if (!comment && !composed.emoji) store.remove(composed.id);
+        if (!comment && !composed.quickLabelId) store.remove(composed.id);
       }
       // Re-read after that commit; the render's list predates it. Copied, not
       // referenced: `list()` hands back the store's own array, and this is held
@@ -538,25 +533,22 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
       bump();
       if (sending.length === 0) {
         persist();
-        return;
+        return null;
       }
       // Snapshotted for the same reason: the box stays typable across the trip.
       const sendingNote = note.trim();
       const payload = buildAnnotationPayload(sending.map((entry) => ({
         quote: entry.quote,
-        emoji: entry.emoji,
+        quickLabelId: entry.quickLabelId,
         comment: entry.comment,
         start: entry.start,
       })), sendingNote);
-      sendingRef.current = true;
-      setOutcome({ kind: 'sending' });
-      void annotationApi.submitAnnotations(sessionId, payload)
+      return annotationApi.submitAnnotations(sessionId, payload)
         .then((result) => {
           if (result.status !== 'delivered') {
-            setOutcome(result.status === 'skipped_pending_approval'
+            return result.status === 'skipped_pending_approval'
               ? { kind: 'skipped' }
-              : { kind: 'error', message: 'The session did not take the feedback. Nothing was sent.' });
-            return;
+              : { kind: 'error', message: 'The session did not take the feedback. Nothing was sent.' };
           }
           // The surface stays live across the round trip, so an entry is spent
           // only if it still reads exactly as when composed.
@@ -564,57 +556,38 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
           sending.forEach((entry) => {
             const now = current.get(entry.id);
             if (!now) return;
-            if (now.emoji !== entry.emoji || now.comment !== entry.comment) return;
+            if (now.quickLabelId !== entry.quickLabelId || now.comment !== entry.comment) return;
             store.remove(entry.id);
           });
           // Same rule for the note: typed over mid-flight, it belongs to the next.
           if (sendingNote && noteRef.current.trim() === sendingNote) writeNote('');
           const kept = store.list().length;
-          setOutcome({ kind: 'sent', count: sending.length, kept });
           bump();
           // Either way the generation is raised, refusing a save already in
           // flight. A tombstone only when nothing survived — including a note
           // typed over mid-flight, since the clear zeroes the note column.
           if (kept > 0 || noteRef.current.trim()) {
             persist();
-            return;
+            return { kind: 'sent', count: sending.length, kept };
           }
           generationRef.current += 1;
-          return annotationApi.clearAnnotations(sessionId, generationRef.current)
+          void annotationApi.clearAnnotations(sessionId, generationRef.current)
             .then((cleared) => {
               generationRef.current = Math.max(generationRef.current, cleared.generation);
             })
             .catch(() => {
               // The feedback is in the session either way; the next save re-adds it.
             });
-        })
-        .catch((error: unknown) => {
-          setOutcome({
-            kind: 'error',
-            message: error instanceof Error ? error.message : 'Send failed',
-          });
-        })
-        .finally(() => {
-          sendingRef.current = false;
+          return { kind: 'sent', count: sending.length, kept };
         });
     };
 
-    // Registration-gated, not handler-gated: the dispatcher consumes ⌘Enter
-    // whenever a handler is registered, so an always-on no-op would swallow the
-    // terminal's. `editableTarget: 'native'` keeps it out of the comment box.
-    useShortcut(
-      'terminal.sendAnnotations',
-      send,
-      enabled && paneActive && annotations.length > 0,
-    );
-
-    // The confirmation lives in the panel's footer and expires on its own. A
-    // refusal does not: it is why the marks are still there.
-    useEffect(() => {
-      if (outcome?.kind !== 'sent') return;
-      const timer = window.setTimeout(() => setOutcome(null), 2200);
-      return () => window.clearTimeout(timer);
-    }, [outcome]);
+    const { outcome, send } = useAnnotationSend<TerminalSendResult>({
+      send: performSend,
+      shortcutId: 'terminal.sendAnnotations',
+      enabled: enabled && paneActive && annotations.length > 0,
+      sentClearMs: 2200,
+    });
 
     // Same measure-then-fit as the popup: the pointer is routinely near an edge.
     useLayoutEffect(() => {
@@ -728,25 +701,14 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
               : { left: composer.clientX, top: composer.clientY }}
             onMouseDown={(event) => event.preventDefault()}
           >
-            <div className="anno-popup-labels">
-              {QUICK_LABEL_GROUPS.map((group, groupIndex) => (
-                <React.Fragment key={group[0].id}>
-                  {groupIndex > 0 ? <span className="anno-popup-divider" /> : null}
-                  {group.map((label) => (
-                    <button
-                      key={label.id}
-                      type="button"
-                      className={`anno-popup-label${composed.emoji === label.emoji ? ' anno-popup-label--on' : ''}`}
-                      title={label.text}
-                      aria-label={label.text}
-                      onClick={() => applyLabel(label.emoji)}
-                      {...hintProps(label.text)}
-                    >
-                      {label.emoji}
-                    </button>
-                  ))}
-                </React.Fragment>
-              ))}
+            <QuickLabelPicker
+              mode="chips"
+              className="anno-popup-labels"
+              groups={QUICK_LABEL_GROUPS}
+              isSelected={(label) => composed.quickLabelId === label.id}
+              onSelect={(label) => applyLabel(label.id)}
+              onHint={setHint}
+            >
               <span className="anno-popup-divider" />
               <button
                 type="button"
@@ -771,12 +733,12 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
               >
                 🗑
               </button>
-            </div>
+            </QuickLabelPicker>
             {/* Hovering names what a chip does; at rest the line names the mark
                 this annotation already carries, so reopening one says what it
                 says without a click. */}
             <div className="anno-popup-hint" data-testid="annotation-popup-hint">
-              {hint ?? labelByEmoji(composed.emoji)?.text ?? 'Pick a label, or write a comment'}
+              {hint ?? labelById(composed.quickLabelId)?.text ?? 'Pick a label, or write a comment'}
             </div>
             {composer.writing ? (
               <div className="anno-popup-compose">
@@ -849,7 +811,7 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
                     onClick={(event) => reopenFromCard(annotation, event)}
                   >
                     <span className="anno-card-chip">
-                      {annotation.emoji || '💬'}
+                      {labelById(annotation.quickLabelId)?.emoji || '💬'}
                     </span>
                     <span className="anno-card-quote">{annotation.quote}</span>
                     {annotation.comment ? (

--- a/app/src/components/TerminalAnnotations/quickLabels.payload.test.ts
+++ b/app/src/components/TerminalAnnotations/quickLabels.payload.test.ts
@@ -20,7 +20,7 @@ describe('buildAnnotationPayload', () => {
     // The agent cannot see the highlight. The quote is the only thing that
     // tells it which part of its own answer the feedback lands on.
     const payload = buildAnnotationPayload([
-      { start: 40, emoji: '🧾', comment: '', quote: 'ship it without tests' },
+      { start: 40, quickLabelId: 'show-the-receipt', comment: '', quote: 'ship it without tests' },
     ]);
 
     expect(payload).toContain('> ship it without tests');
@@ -33,7 +33,7 @@ describe('buildAnnotationPayload', () => {
     const verify = QUICK_LABELS.find((label) => label.id === 'verify-this')!;
 
     const payload = buildAnnotationPayload([
-      { start: 0, emoji: verify.emoji, comment: '', quote: 'the parser already handles this' },
+      { start: 0, quickLabelId: verify.id, comment: '', quote: 'the parser already handles this' },
     ]);
 
     expect(payload).toContain(verify.tip!);
@@ -41,8 +41,8 @@ describe('buildAnnotationPayload', () => {
 
   it('orders items by position in the message, not by when they were made', () => {
     const payload = buildAnnotationPayload([
-      { start: 900, emoji: '❓', comment: '', quote: 'the last claim' },
-      { start: 10, emoji: '❓', comment: '', quote: 'the first claim' },
+      { start: 900, quickLabelId: 'clarify-this', comment: '', quote: 'the last claim' },
+      { start: 10, quickLabelId: 'clarify-this', comment: '', quote: 'the first claim' },
     ]);
 
     expect(payload.indexOf('the first claim')).toBeLessThan(payload.indexOf('the last claim'));
@@ -51,7 +51,7 @@ describe('buildAnnotationPayload', () => {
 
   it('carries a bare comment with no label', () => {
     const payload = buildAnnotationPayload([
-      { start: 0, emoji: '', comment: 'this contradicts the paragraph above', quote: 'always safe' },
+      { start: 0, quickLabelId: '', comment: 'this contradicts the paragraph above', quote: 'always safe' },
     ]);
 
     expect(payload).toContain('💬 Comment');
@@ -60,7 +60,7 @@ describe('buildAnnotationPayload', () => {
 
   it('sends agreement as the label alone', () => {
     const payload = buildAnnotationPayload([
-      { start: 0, emoji: '💯', comment: '', quote: 'the retry only fires on idempotent verbs' },
+      { start: 0, quickLabelId: 'exactly-this', comment: '', quote: 'the retry only fires on idempotent verbs' },
     ]);
 
     expect(payload).toContain('💯 Exactly this');
@@ -72,7 +72,7 @@ describe('buildAnnotationPayload', () => {
     // own last message. Telling it to "address each annotation" on top of that
     // is an instruction the annotations already are.
     const payload = buildAnnotationPayload([
-      { start: 0, emoji: '❓', comment: '', quote: 'always safe' },
+      { start: 0, quickLabelId: 'clarify-this', comment: '', quote: 'always safe' },
     ]);
 
     expect(payload.split('\n')[0]).toBe('Feedback on your last message.');
@@ -84,8 +84,8 @@ describe('buildAnnotationPayload', () => {
 
   describe('with a note', () => {
     const MARKS = [
-      { start: 40, emoji: '🧾', comment: '', quote: 'the retry wrapper' },
-      { start: 4, emoji: '❓', comment: 'which parser?', quote: 'the parser' },
+      { start: 40, quickLabelId: 'show-the-receipt', comment: '', quote: 'the retry wrapper' },
+      { start: 4, quickLabelId: 'clarify-this', comment: 'which parser?', quote: 'the parser' },
     ];
 
     it('puts the note ahead of the marks it qualifies', () => {

--- a/app/src/components/TerminalAnnotations/quickLabels.ts
+++ b/app/src/components/TerminalAnnotations/quickLabels.ts
@@ -7,15 +7,15 @@
 export {
   QUICK_LABEL_GROUPS,
   QUICK_LABELS,
-  labelByEmoji,
+  labelById,
   type QuickLabel,
 } from '../../annotations/quickLabels';
 
-import { labelByEmoji } from '../../annotations/quickLabels';
+import { labelById } from '../../annotations/quickLabels';
 
 export interface PayloadAnnotation {
   quote: string;
-  emoji: string;
+  quickLabelId: string;
   comment: string;
   // Offset of the annotation's start in the message, used only to order the
   // payload the way the user reads the message.
@@ -44,10 +44,10 @@ export function buildAnnotationPayload(
   const trimmedNote = note.trim();
   if (trimmedNote) lines.push(trimmedNote, '');
   ordered.forEach((annotation, index) => {
-    const label = annotation.emoji ? labelByEmoji(annotation.emoji) : undefined;
+    const label = annotation.quickLabelId ? labelById(annotation.quickLabelId) : undefined;
     const heading = label
       ? `${label.emoji} ${label.text}`
-      : `${annotation.emoji || '💬'} Comment`;
+      : '💬 Comment';
     lines.push(`## ${index + 1}. ${heading}`, '');
     lines.push(`> ${annotation.quote.split('\n').join('\n> ')}`, '');
     if (label?.tip) lines.push(label.tip);

--- a/app/src/hooks/daemonMarkdownAnnotationEvents.ts
+++ b/app/src/hooks/daemonMarkdownAnnotationEvents.ts
@@ -1,24 +1,6 @@
-/**
- * Markdown-annotation daemon events (`markdown_annotations_*_result`).
- *
- * These do NOT use the shared `<kind>:<requestId>` correlation in
- * daemonPendingRequests.ts. Annotation commands are per-document and
- * last-writer-wins: the waiter is keyed `<op>:<workspaceId>:<path>` so a newer
- * request supersedes an older one for the same document, and the event's
- * `request_id` is checked against the stored one to drop a late result whose
- * request was already replaced. Two correlation schemes in one hook was a large
- * part of why the events were hard to follow; naming this one is the point of
- * the module.
- */
+/** Markdown-annotation daemon event decoding (`markdown_annotations_*_result`). */
 
-/** The waiter an annotation command parks, keyed by `markdownAnnotationKey`. */
-export interface PendingMarkdownAnnotation {
-  requestId: string;
-  resolve: (value: unknown) => void;
-  reject: (error: Error) => void;
-}
-
-export type PendingMarkdownAnnotations = Map<string, PendingMarkdownAnnotation>;
+import { takeKeyedRequest, type PendingKeyedRequests } from './daemonPendingRequests';
 
 /** `<op>:<workspaceId>:<path>` — one in-flight request per document per op. */
 export function markdownAnnotationKey(op: string, workspaceId: string, path: string): string {
@@ -45,7 +27,7 @@ type MarkdownAnnotationEvent = {
  */
 export function handleMarkdownAnnotationDaemonEvent(
   event: MarkdownAnnotationEvent,
-  pending: PendingMarkdownAnnotations,
+  pending: PendingKeyedRequests,
 ): boolean {
   switch (event.event) {
     case 'markdown_annotations_get_result':
@@ -58,11 +40,10 @@ export function handleMarkdownAnnotationDaemonEvent(
             ? 'save'
             : 'clear';
       const key = markdownAnnotationKey(op, String(event.workspace_id ?? ''), String(event.path));
-      const waiter = pending.get(key);
-      if (!waiter || waiter.requestId !== event.request_id) {
+      const waiter = takeKeyedRequest(pending, key, event.request_id);
+      if (!waiter) {
         return true; // superseded or timed out — drop the late result
       }
-      pending.delete(key);
       if (op === 'save' && !event.success && event.stale) {
         // Stale generation (tombstone / newer writer) is a protocol outcome the
         // client handles, not an error.
@@ -89,11 +70,10 @@ export function handleMarkdownAnnotationDaemonEvent(
       // pending entry with workspaceId '' so mirror that here (the daemon echoes
       // workspace_id '' or omits it).
       const key = markdownAnnotationKey('submit', String(event.workspace_id ?? ''), String(event.path));
-      const waiter = pending.get(key);
-      if (!waiter || waiter.requestId !== event.request_id) {
+      const waiter = takeKeyedRequest(pending, key, event.request_id);
+      if (!waiter) {
         return true; // superseded or timed out — drop the late result
       }
-      pending.delete(key);
       if (event.success || event.status === 'skipped_pending_approval') {
         // skipped_pending_approval resolves (success:false) so the UI can
         // message it distinctly from a hard failure; a delivered result may

--- a/app/src/hooks/daemonPendingRequests.ts
+++ b/app/src/hooks/daemonPendingRequests.ts
@@ -16,9 +16,55 @@ export interface PendingRequest {
 
 export type PendingRequests = Map<string, PendingRequest>;
 
+export interface PendingKeyedRequest extends PendingRequest {
+  requestId: string;
+}
+
+export type PendingKeyedRequests = Map<string, PendingKeyedRequest>;
+
 /** `<kind>:<requestId>` — the correlation key both sides of a command agree on. */
 export function pendingRequestKey(kind: string, requestId: string): string {
   return `${kind}:${requestId}`;
+}
+
+/** Park one last-writer-wins request and reject the waiter it supersedes. */
+export function sendKeyedRequest<T>(
+  pending: PendingKeyedRequests,
+  key: string,
+  requestId: string,
+  send: () => void,
+  timeoutMessage: string,
+  timeoutMs: number,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    pending.get(key)?.reject(new Error('Superseded by a newer request'));
+    pending.set(key, {
+      requestId,
+      resolve: resolve as (value: unknown) => void,
+      reject,
+    });
+    send();
+    setTimeout(() => {
+      if (pending.get(key)?.requestId === requestId) {
+        pending.delete(key);
+        reject(new Error(timeoutMessage));
+      }
+    }, timeoutMs);
+  });
+}
+
+/** Take the waiter only when the result still answers its request id. */
+export function takeKeyedRequest(
+  pending: PendingKeyedRequests,
+  key: string,
+  requestId: unknown,
+): PendingRequest | undefined {
+  const waiter = pending.get(key);
+  if (!waiter || waiter.requestId !== requestId) {
+    return undefined;
+  }
+  pending.delete(key);
+  return waiter;
 }
 
 /** The fields every `*_result` event carries, whatever else it adds. */

--- a/app/src/hooks/daemonSessionAnnotationEvents.ts
+++ b/app/src/hooks/daemonSessionAnnotationEvents.ts
@@ -14,6 +14,7 @@
 
 import type { PendingRequests } from './daemonPendingRequests';
 import { settlePendingRequest } from './daemonPendingRequests';
+import { labelByEmoji } from '../annotations/quickLabels';
 
 /** The event shapes this module reads, loosely typed off the wire union. */
 type SessionAnnotationEvent = {
@@ -58,7 +59,7 @@ export interface DaemonSessionAnnotation {
   start: number;
   end: number;
   quote: string;
-  emoji: string;
+  quickLabelId: string;
   comment: string;
 }
 
@@ -80,7 +81,9 @@ function toAnnotations(raw: unknown): DaemonSessionAnnotation[] {
       start: Number(record?.start ?? 0),
       end: Number(record?.end ?? 0),
       quote: String(record?.quote ?? ''),
-      emoji: String(record?.emoji ?? ''),
+      quickLabelId: typeof record?.quick_label_id === 'string'
+        ? record.quick_label_id
+        : labelByEmoji(String(record?.emoji ?? ''))?.id ?? '',
       comment: String(record?.comment ?? ''),
     };
     // An entry with no id could never be addressed by a later save, so it is
@@ -96,7 +99,7 @@ export function annotationToWire(annotation: DaemonSessionAnnotation): Record<st
     start: annotation.start,
     end: annotation.end,
     quote: annotation.quote,
-    emoji: annotation.emoji,
+    quick_label_id: annotation.quickLabelId,
     comment: annotation.comment,
   };
 }

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -3274,7 +3274,7 @@ describe('useDaemonSocket notebook and annotation events', () => {
     unmount();
   });
 
-  it('resolves session_annotations_get with the stored list and its generation', async () => {
+  it('decodes an emoji-only old-format session annotation to its quick-label id', async () => {
     const { result, unmount, ws } = await renderAndOpen();
 
     const promise = result.current.sendSessionAnnotationsGet('session-1');
@@ -3308,7 +3308,7 @@ describe('useDaemonSocket notebook and annotation events', () => {
         start: 4,
         end: 10,
         quote: 'parser',
-        emoji: '❓',
+        quickLabelId: 'clarify-this',
         comment: 'why this?',
       }],
       // A get that carried no note reads as an empty one: the panel's box has
@@ -3354,7 +3354,7 @@ describe('useDaemonSocket notebook and annotation events', () => {
       start: 4,
       end: 10,
       quote: 'parser',
-      emoji: '❓',
+      quickLabelId: 'clarify-this',
       comment: 'why this?',
     }], 'and land the retry wrapper as is', 3);
     await Promise.resolve();
@@ -3370,7 +3370,7 @@ describe('useDaemonSocket notebook and annotation events', () => {
         start: 4,
         end: 10,
         quote: 'parser',
-        emoji: '❓',
+        quick_label_id: 'clarify-this',
         comment: 'why this?',
       }],
     });

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -80,9 +80,14 @@ import {
 import {
   handleMarkdownAnnotationDaemonEvent,
   markdownAnnotationKey,
-  type PendingMarkdownAnnotations,
 } from './daemonMarkdownAnnotationEvents';
-import { pendingRequestKey, settlePendingRequest, type PendingRequests } from './daemonPendingRequests';
+import {
+  pendingRequestKey,
+  sendKeyedRequest as sendLastWriterWinsRequest,
+  settlePendingRequest,
+  type PendingKeyedRequests,
+  type PendingRequests,
+} from './daemonPendingRequests';
 import { BUILD_PROFILE, daemonProfileMatches, fetchDaemonHealthProfile, profileMismatchMessage } from '../utils/buildProfile';
 import { controlBrowserHost, serializeBrowserControlResultMessage } from '../browser/host';
 import { useWorkflowRunsStore } from '../store/workflowRuns';
@@ -1008,9 +1013,8 @@ export function useDaemonSocket({
   // Keyed `<kind>:<requestId>` — see daemonPendingRequests.ts for the format and
   // the settle helper the extracted event modules use.
   const pendingActionsRef = useRef<PendingRequests>(new Map());
-  // Markdown-annotation drafts use their own last-writer-wins correlation —
-  // see daemonMarkdownAnnotationEvents.ts, not daemonPendingRequests.ts.
-  const mdAnnotationsPendingRef = useRef<PendingMarkdownAnnotations>(new Map());
+  // Markdown-annotation drafts use shared last-writer-wins correlation.
+  const mdAnnotationsPendingRef = useRef<PendingKeyedRequests>(new Map());
   // Completed transcript messages invalidate only their own terminal. Keeping
   // listeners here avoids a global React tick and releases the session entry as
   // soon as its last pane unmounts.
@@ -3933,45 +3937,35 @@ export function useDaemonSocket({
     });
   }, []);
 
-  // Markdown annotation drafts (request/result pattern; save/clear can fail —
-  // stale-generation rejection — so no fire-and-forget). Pending entries are
-  // keyed `<op>:<path>` in a dedicated map: a newer request for the same
-  // path+op supersedes the in-flight one (rejects it), and results are
-  // matched by request_id so a late result for a superseded request can
-  // never settle its successor.
+  // Markdown annotation drafts use last-writer-wins request correlation keyed
+  // by operation, workspace, and path.
   const sendMarkdownAnnotationsCommand = useCallback(<T,>(
     op: 'get' | 'save' | 'clear' | 'submit',
     path: string,
     workspaceId: string,
     extra: Record<string, unknown>,
   ): Promise<T> => {
-    return new Promise<T>((resolve, reject) => {
-      const ws = wsRef.current;
-      if (!ws || ws.readyState !== WebSocket.OPEN) {
-        reject(new Error('WebSocket not connected'));
-        return;
-      }
-      // workspace-scoped: the same path open in two workspaces (possibly on
-      // two different endpoints) must not supersede each other's requests.
-      const key = markdownAnnotationKey(op, workspaceId, path);
-      const requestId = crypto.randomUUID();
-      mdAnnotationsPendingRef.current.get(key)?.reject(new Error('Superseded by a newer request'));
-      mdAnnotationsPendingRef.current.set(key, { requestId, resolve: resolve as (value: unknown) => void, reject });
-      ws.send(JSON.stringify({
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error('WebSocket not connected'));
+    }
+    // Workspace scope keeps identical paths on different endpoints independent.
+    const key = markdownAnnotationKey(op, workspaceId, path);
+    const requestId = crypto.randomUUID();
+    return sendLastWriterWinsRequest<T>(
+      mdAnnotationsPendingRef.current,
+      key,
+      requestId,
+      () => ws.send(JSON.stringify({
         cmd: `markdown_annotations_${op}`,
         path,
         workspace_id: workspaceId,
         request_id: requestId,
         ...extra,
-      }));
-      setTimeout(() => {
-        const pending = mdAnnotationsPendingRef.current.get(key);
-        if (pending?.requestId === requestId) {
-          mdAnnotationsPendingRef.current.delete(key);
-          reject(new Error('Timeout'));
-        }
-      }, 10000);
-    });
+      })),
+      'Timeout',
+      10000,
+    );
   }, []);
 
   // workspace_id is the requesting tile's owning workspace: on a hub it routes

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -250,7 +250,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '246';
+export const PROTOCOL_VERSION = '247';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -6262,13 +6262,14 @@ export interface Session {
 }
 
 export interface SessionAnnotation {
-    comment:     string;
-    emoji:       string;
-    end:         number;
-    id:          string;
-    message_key: string;
-    quote:       string;
-    start:       number;
+    comment:         string;
+    emoji?:          string;
+    end:             number;
+    id:              string;
+    message_key:     string;
+    quick_label_id?: string;
+    quote:           string;
+    start:           number;
     [property: string]: any;
 }
 
@@ -6322,13 +6323,14 @@ export interface SessionAnnotationsGetResultMessage {
 }
 
 export interface SessionAnnotationsGetResultMessageAnnotation {
-    comment:     string;
-    emoji:       string;
-    end:         number;
-    id:          string;
-    message_key: string;
-    quote:       string;
-    start:       number;
+    comment:         string;
+    emoji?:          string;
+    end:             number;
+    id:              string;
+    message_key:     string;
+    quick_label_id?: string;
+    quote:           string;
+    start:           number;
     [property: string]: any;
 }
 
@@ -16187,10 +16189,11 @@ const typeMap: any = {
     ], "any"),
     "SessionAnnotation": o([
         { json: "comment", js: "comment", typ: "" },
-        { json: "emoji", js: "emoji", typ: "" },
+        { json: "emoji", js: "emoji", typ: u(undefined, "") },
         { json: "end", js: "end", typ: 0 },
         { json: "id", js: "id", typ: "" },
         { json: "message_key", js: "message_key", typ: "" },
+        { json: "quick_label_id", js: "quick_label_id", typ: u(undefined, "") },
         { json: "quote", js: "quote", typ: "" },
         { json: "start", js: "start", typ: 0 },
     ], "any"),
@@ -16225,10 +16228,11 @@ const typeMap: any = {
     ], "any"),
     "SessionAnnotationsGetResultMessageAnnotation": o([
         { json: "comment", js: "comment", typ: "" },
-        { json: "emoji", js: "emoji", typ: "" },
+        { json: "emoji", js: "emoji", typ: u(undefined, "") },
         { json: "end", js: "end", typ: 0 },
         { json: "id", js: "id", typ: "" },
         { json: "message_key", js: "message_key", typ: "" },
+        { json: "quick_label_id", js: "quick_label_id", typ: u(undefined, "") },
         { json: "quote", js: "quote", typ: "" },
         { json: "start", js: "start", typ: 0 },
     ], "any"),

--- a/app/src/utils/terminalAnnotations.gate.test.ts
+++ b/app/src/utils/terminalAnnotations.gate.test.ts
@@ -61,7 +61,7 @@ function storeWithAnchor(markdown = MESSAGE, phrase = ANCHOR) {
   store.setMessages([{ key: 'turn-1', markdown }]);
   const start = markdown.indexOf(phrase);
   expect(start).toBeGreaterThanOrEqual(0);
-  const annotation = store.add('turn-1', start, start + phrase.length, '❓', 'why this?');
+  const annotation = store.add('turn-1', start, start + phrase.length, 'clarify-this', 'why this?');
   expect(annotation).not.toBeNull();
   return { store, annotation: annotation! };
 }
@@ -187,7 +187,7 @@ describe('annotationAt', () => {
   it('gives an overlap to the annotation drawn on top', () => {
     const { store, annotation } = storeWithAnchor();
     const start = MESSAGE.indexOf(ANCHOR);
-    const later = store.add('turn-1', start, start + ANCHOR.length, '🧪', '');
+    const later = store.add('turn-1', start, start + ANCHOR.length, 'test-label', '');
     const grid = new FakeGrid(render(MESSAGE, 62));
     const wash = store.project(grid)[0].rows[0];
 
@@ -307,7 +307,7 @@ describe('the annotatable window', () => {
 
   it('gives every annotation its own id', () => {
     const { store } = storeWithAnchor();
-    const second = store.add('turn-1', 0, 6, '🧪', '');
+    const second = store.add('turn-1', 0, 6, 'test-label', '');
 
     expect(second!.id).not.toBe(store.list()[0].id);
   });

--- a/app/src/utils/terminalAnnotations.ts
+++ b/app/src/utils/terminalAnnotations.ts
@@ -46,7 +46,7 @@ export interface TerminalAnnotation {
   // The markdown the offsets covered when made; kept so the panel still lists
   // an annotation whose message fell out of the window.
   quote: string;
-  emoji: string;
+  quickLabelId: string;
   comment: string;
 }
 
@@ -134,7 +134,7 @@ export class TerminalAnnotationStore {
     this.annotations = annotations.map((annotation) => ({ ...annotation }));
   }
 
-  add(messageKey: string, start: number, end: number, emoji = '', comment = ''): TerminalAnnotation | null {
+  add(messageKey: string, start: number, end: number, quickLabelId = '', comment = ''): TerminalAnnotation | null {
     const markdown = this.markdownByKey.get(messageKey);
     if (markdown === undefined) return null;
     if (start < 0 || end > markdown.length || start >= end) return null;
@@ -144,17 +144,17 @@ export class TerminalAnnotationStore {
       start,
       end,
       quote: markdown.slice(start, end),
-      emoji,
+      quickLabelId,
       comment,
     };
     this.annotations.push(annotation);
     return annotation;
   }
 
-  update(id: string, patch: { emoji?: string; comment?: string }): TerminalAnnotation | null {
+  update(id: string, patch: { quickLabelId?: string; comment?: string }): TerminalAnnotation | null {
     const annotation = this.annotations.find((entry) => entry.id === id);
     if (!annotation) return null;
-    if (patch.emoji !== undefined) annotation.emoji = patch.emoji;
+    if (patch.quickLabelId !== undefined) annotation.quickLabelId = patch.quickLabelId;
     if (patch.comment !== undefined) annotation.comment = patch.comment;
     return annotation;
   }

--- a/changelog.d/annotation-shared-seams.yaml
+++ b/changelog.d/annotation-shared-seams.yaml
@@ -1,0 +1,7 @@
+kind: internal
+area: annotations
+change: >
+  Terminal and Markdown annotations now share draft handlers, request
+  correlation, quick-label picking, and send-outcome orchestration while
+  keeping their domain-specific anchoring, rendering, payload, and clearing
+  behavior separate.

--- a/docs/plans/2026-08-14-annotation-shared-seams.md
+++ b/docs/plans/2026-08-14-annotation-shared-seams.md
@@ -1,0 +1,48 @@
+# Plan: Consolidate annotation shared seams
+
+## Goal
+
+Share exactly five mechanics between terminal and markdown annotations without changing user-visible behavior, anchoring, rendering, payload formatting, clear ownership, or the two draft models beyond terminal label storage. The Task 3 amendment permits only the label field's protocol shape and version bump.
+
+## Architecture Map
+
+```text
+Daemon draft commands
+  session adapter  \
+                    -> annotationDraftHandler -> generic draft store accessors
+  markdown adapter /
+
+Frontend annotation flows
+  daemon socket -> shared pending-request correlation -> domain event decoder
+  composer      -> shared QuickLabelPicker
+                -> shared useAnnotationSend -> existing domain send function
+```
+
+Persisted terminal draft entries change only from `emoji` to `quickLabelId`; the session draft decoder translates old emoji-only entries while all new writes use IDs. Protocol 246 makes the new field optional beside the optional legacy field.
+
+## Boundaries
+
+- Daemon adapters own typed protocol result construction; the shared handler owns trim, validation, JSON encoding, stale-save mapping, storage, and reply sequencing.
+- `daemonPendingRequests.ts` owns plain and keyed correlation; markdown event decoding only interprets result events.
+- Each annotation stack keeps its anchor, highlight renderer, submit payload formatter, clear-on-send owner, and domain-specific draft fields.
+- The shared picker accepts styling from its caller so both composers keep their current appearance.
+- The shared send hook owns re-entrancy, outcome state, sent expiry, and shortcut registration; callers keep domain eligibility and messages.
+
+## Implementation Steps
+
+- [x] Task 1: validate and finish the shared daemon draft handler, shared submit statuses, and byte-level adapter tests.
+- [x] Task 2: move markdown last-writer-wins correlation into `daemonPendingRequests.ts`.
+- [x] Task 3: store terminal labels by `quickLabelId` and decode persisted emoji-only entries.
+- [x] Task 4: move and reuse `QuickLabelPicker` with caller-provided styling.
+- [x] Task 5: extract `useAnnotationSend` and cover states plus re-entrancy.
+- [x] Add the internal annotations changelog fragment.
+- [x] Run daemon/store tests, frontend tests, and `make build-app`.
+- [x] Install and preflight a named profile; verify and record both send flows; publish evidence; clean the profile.
+- [ ] Rebase onto main, open a ready PR, address figgyster/CI, merge, and update the ticket.
+
+## Decisions
+
+- Preserve request/result JSON bytes in Task 1 tests; this catches omitted fields and zero-value serialization changes that typed assertions can miss.
+- Keep the old terminal label compatibility at the wire decoder only. No migration or write fallback is added.
+- Keep each composer’s sent-expiry duration as a hook argument rather than normalizing behavior.
+- The Task 3 amendment authorizes optional `quick_label_id`, optional legacy `emoji`, regenerated bindings, and one protocol-version bump.

--- a/docs/plans/2026-08-14-annotation-shared-seams.md
+++ b/docs/plans/2026-08-14-annotation-shared-seams.md
@@ -18,7 +18,7 @@ Frontend annotation flows
                 -> shared useAnnotationSend -> existing domain send function
 ```
 
-Persisted terminal draft entries change only from `emoji` to `quickLabelId`; the session draft decoder translates old emoji-only entries while all new writes use IDs. Protocol 246 makes the new field optional beside the optional legacy field.
+Persisted terminal draft entries change only from `emoji` to `quickLabelId`; the session draft decoder translates old emoji-only entries while all new writes use IDs. Protocol 247 makes the new field optional beside the optional legacy field.
 
 ## Boundaries
 

--- a/internal/daemon/ws_annotation_drafts.go
+++ b/internal/daemon/ws_annotation_drafts.go
@@ -1,0 +1,196 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// Submit statuses on the wire (plain strings in the protocol).
+const (
+	annotationSubmitStatusDelivered = "delivered"
+	annotationSubmitStatusSkipped   = "skipped_pending_approval"
+	annotationSubmitStatusError     = "error"
+)
+
+type annotationDraft struct {
+	annotations string
+	note        string
+	generation  int
+}
+
+type annotationDraftAccessors struct {
+	get   func(string) (annotationDraft, error)
+	save  func(string, string, string, int, time.Time) error
+	clear func(string, int, time.Time) error
+}
+
+type annotationDraftResult[T any] struct {
+	key         string
+	annotations []T
+	note        *string
+	generation  int
+	success     bool
+	stale       *bool
+	err         *string
+}
+
+type annotationDraftHandler[T any] struct {
+	daemon    *Daemon
+	accessors annotationDraftAccessors
+	keyField  string
+	send      func(annotationDraftResult[T])
+}
+
+func newAnnotationDraftHandler[T, R any](
+	d *Daemon,
+	client *wsClient,
+	accessors annotationDraftAccessors,
+	keyField string,
+	buildResult func(annotationDraftResult[T]) R,
+) annotationDraftHandler[T] {
+	return annotationDraftHandler[T]{
+		daemon:    d,
+		accessors: accessors,
+		keyField:  keyField,
+		send: func(result annotationDraftResult[T]) {
+			d.sendToClient(client, buildResult(result))
+		},
+	}
+}
+
+func (h annotationDraftHandler[T]) get(operation, rawKey string, decode func(string) ([]T, error)) {
+	result := annotationDraftResult[T]{
+		key:         strings.TrimSpace(rawKey),
+		annotations: []T{},
+	}
+	if result.key == "" {
+		result.err = protocol.Ptr(fmt.Sprintf("%s: %s is required", operation, h.keyField))
+		h.send(result)
+		return
+	}
+	draft, err := h.accessors.get(result.key)
+	if err != nil {
+		h.daemon.logf("%s: %s: %v", operation, result.key, err)
+		result.err = protocol.Ptr(err.Error())
+		h.send(result)
+		return
+	}
+	annotations, err := decode(draft.annotations)
+	if err != nil {
+		h.daemon.logf("%s: %s: corrupt stored draft: %v", operation, result.key, err)
+		result.err = protocol.Ptr("stored annotation draft is corrupt: " + err.Error())
+		h.send(result)
+		return
+	}
+	result.success = true
+	result.annotations = annotations
+	if draft.note != "" {
+		result.note = protocol.Ptr(draft.note)
+	}
+	result.generation = draft.generation
+	h.send(result)
+}
+
+func (h annotationDraftHandler[T]) save(operation, rawKey string, annotations []T, note string, generation int) {
+	result := annotationDraftResult[T]{
+		key:        strings.TrimSpace(rawKey),
+		generation: generation,
+	}
+	if result.key == "" {
+		result.err = protocol.Ptr(fmt.Sprintf("%s: %s is required", operation, h.keyField))
+		h.send(result)
+		return
+	}
+	annotationsJSON, err := json.Marshal(annotations)
+	if err != nil {
+		result.err = protocol.Ptr(operation + ": encoding annotations: " + err.Error())
+		h.send(result)
+		return
+	}
+	err = h.accessors.save(result.key, string(annotationsJSON), note, generation, time.Now())
+	if errors.Is(err, store.ErrStaleAnnotationSave) {
+		h.daemon.logf("%s: %s: stale save at generation %d rejected", operation, result.key, generation)
+		result.stale = protocol.Ptr(true)
+		h.send(result)
+		return
+	}
+	if err != nil {
+		h.daemon.logf("%s: %s: %v", operation, result.key, err)
+		result.err = protocol.Ptr(err.Error())
+		h.send(result)
+		return
+	}
+	result.success = true
+	h.send(result)
+}
+
+func (h annotationDraftHandler[T]) clear(operation, rawKey string, generation int) {
+	result := annotationDraftResult[T]{
+		key:        strings.TrimSpace(rawKey),
+		generation: generation,
+	}
+	if result.key == "" {
+		result.err = protocol.Ptr(fmt.Sprintf("%s: %s is required", operation, h.keyField))
+		h.send(result)
+		return
+	}
+	if err := h.accessors.clear(result.key, generation, time.Now()); err != nil {
+		h.daemon.logf("%s: %s: %v", operation, result.key, err)
+		result.err = protocol.Ptr(err.Error())
+		h.send(result)
+		return
+	}
+	draft, err := h.accessors.get(result.key)
+	if err != nil {
+		h.daemon.logf("%s: %s: reading floor: %v", operation, result.key, err)
+		result.err = protocol.Ptr(err.Error())
+		h.send(result)
+		return
+	}
+	result.success = true
+	result.generation = draft.generation
+	h.send(result)
+}
+
+func sessionAnnotationDraftAccessors(s *store.Store) annotationDraftAccessors {
+	return annotationDraftAccessors{
+		get: func(key string) (annotationDraft, error) {
+			draft, err := s.GetSessionAnnotationDraft(key)
+			if err != nil {
+				return annotationDraft{}, err
+			}
+			return annotationDraft{
+				annotations: draft.Annotations,
+				note:        draft.Note,
+				generation:  draft.Generation,
+			}, nil
+		},
+		save:  s.SaveSessionAnnotationDraft,
+		clear: s.ClearSessionAnnotationDraft,
+	}
+}
+
+func markdownAnnotationDraftAccessors(s *store.Store) annotationDraftAccessors {
+	return annotationDraftAccessors{
+		get: func(key string) (annotationDraft, error) {
+			draft, err := s.GetMarkdownAnnotationDraft(key)
+			if err != nil {
+				return annotationDraft{}, err
+			}
+			return annotationDraft{
+				annotations: draft.Annotations,
+				generation:  draft.Generation,
+			}, nil
+		},
+		save: func(key, annotations, _ string, generation int, now time.Time) error {
+			return s.SaveMarkdownAnnotationDraft(key, annotations, generation, now)
+		},
+		clear: s.ClearMarkdownAnnotationDraft,
+	}
+}

--- a/internal/daemon/ws_annotation_drafts_test.go
+++ b/internal/daemon/ws_annotation_drafts_test.go
@@ -1,0 +1,136 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+func annotationDraftResultBytes(t *testing.T, invoke func(*wsClient)) []byte {
+	t.Helper()
+	client := &wsClient{send: make(chan outboundMessage, 1)}
+	invoke(client)
+	select {
+	case message := <-client.send:
+		return message.payload
+	default:
+		t.Fatal("no annotation draft result was sent")
+		return nil
+	}
+}
+
+func assertAnnotationDraftResultBytes(t *testing.T, want string, invoke func(*wsClient)) {
+	t.Helper()
+	if got := string(annotationDraftResultBytes(t, invoke)); got != want {
+		t.Fatalf("result bytes:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestSessionAnnotationDraftAdapterPreservesResultBytes(t *testing.T) {
+	d := annotationDaemon(t)
+
+	t.Run("save", func(t *testing.T) {
+		assertAnnotationDraftResultBytes(t,
+			`{"event":"session_annotations_save_result","generation":1,"request_id":"session-save","session_id":"session-1","success":true}`,
+			func(client *wsClient) {
+				d.handleSessionAnnotationsSave(client, &protocol.SessionAnnotationsSaveMessage{
+					SessionID: "  session-1  ", RequestID: "session-save", Generation: 1,
+				})
+			})
+	})
+
+	t.Run("stale save", func(t *testing.T) {
+		assertAnnotationDraftResultBytes(t,
+			`{"event":"session_annotations_save_result","generation":1,"request_id":"session-stale","session_id":"session-1","stale":true,"success":false}`,
+			func(client *wsClient) {
+				d.handleSessionAnnotationsSave(client, &protocol.SessionAnnotationsSaveMessage{
+					SessionID: "session-1", RequestID: "session-stale", Generation: 1,
+				})
+			})
+	})
+
+	t.Run("get", func(t *testing.T) {
+		assertAnnotationDraftResultBytes(t,
+			`{"annotations":[],"event":"session_annotations_get_result","generation":1,"request_id":"session-get","session_id":"session-1","success":true}`,
+			func(client *wsClient) {
+				d.handleSessionAnnotationsGet(client, &protocol.SessionAnnotationsGetMessage{
+					SessionID: "session-1", RequestID: "session-get",
+				})
+			})
+	})
+
+	t.Run("clear", func(t *testing.T) {
+		assertAnnotationDraftResultBytes(t,
+			`{"event":"session_annotations_clear_result","generation":2,"request_id":"session-clear","session_id":"session-1","success":true}`,
+			func(client *wsClient) {
+				d.handleSessionAnnotationsClear(client, &protocol.SessionAnnotationsClearMessage{
+					SessionID: "session-1", RequestID: "session-clear", Generation: 2,
+				})
+			})
+	})
+
+	t.Run("empty key", func(t *testing.T) {
+		assertAnnotationDraftResultBytes(t,
+			`{"annotations":[],"error":"session_annotations_get: session_id is required","event":"session_annotations_get_result","generation":0,"request_id":"session-empty","session_id":"","success":false}`,
+			func(client *wsClient) {
+				d.handleSessionAnnotationsGet(client, &protocol.SessionAnnotationsGetMessage{
+					SessionID: "   ", RequestID: "session-empty",
+				})
+			})
+	})
+}
+
+func TestMarkdownAnnotationDraftAdapterPreservesResultBytes(t *testing.T) {
+	d := newMarkdownAnnotationsDaemon(t)
+	const workspaceID = "workspace-1"
+
+	t.Run("save", func(t *testing.T) {
+		assertAnnotationDraftResultBytes(t,
+			`{"event":"markdown_annotations_save_result","generation":1,"path":"/tmp/plan.md","request_id":"markdown-save","success":true,"workspace_id":"workspace-1"}`,
+			func(client *wsClient) {
+				d.handleMarkdownAnnotationsSave(client, &protocol.MarkdownAnnotationsSaveMessage{
+					Path: "  /tmp/plan.md  ", RequestID: "markdown-save", WorkspaceID: workspaceID, Generation: 1,
+				})
+			})
+	})
+
+	t.Run("stale save", func(t *testing.T) {
+		assertAnnotationDraftResultBytes(t,
+			`{"event":"markdown_annotations_save_result","generation":1,"path":"/tmp/plan.md","request_id":"markdown-stale","stale":true,"success":false,"workspace_id":"workspace-1"}`,
+			func(client *wsClient) {
+				d.handleMarkdownAnnotationsSave(client, &protocol.MarkdownAnnotationsSaveMessage{
+					Path: "/tmp/plan.md", RequestID: "markdown-stale", WorkspaceID: workspaceID, Generation: 1,
+				})
+			})
+	})
+
+	t.Run("get", func(t *testing.T) {
+		assertAnnotationDraftResultBytes(t,
+			`{"annotations":[],"event":"markdown_annotations_get_result","generation":1,"path":"/tmp/plan.md","request_id":"markdown-get","success":true,"workspace_id":"workspace-1"}`,
+			func(client *wsClient) {
+				d.handleMarkdownAnnotationsGet(client, &protocol.MarkdownAnnotationsGetMessage{
+					Path: "/tmp/plan.md", RequestID: "markdown-get", WorkspaceID: workspaceID,
+				})
+			})
+	})
+
+	t.Run("clear", func(t *testing.T) {
+		assertAnnotationDraftResultBytes(t,
+			`{"event":"markdown_annotations_clear_result","generation":2,"path":"/tmp/plan.md","request_id":"markdown-clear","success":true,"workspace_id":"workspace-1"}`,
+			func(client *wsClient) {
+				d.handleMarkdownAnnotationsClear(client, &protocol.MarkdownAnnotationsClearMessage{
+					Path: "/tmp/plan.md", RequestID: "markdown-clear", WorkspaceID: workspaceID, Generation: 2,
+				})
+			})
+	})
+
+	t.Run("empty key", func(t *testing.T) {
+		assertAnnotationDraftResultBytes(t,
+			`{"annotations":[],"error":"markdown_annotations_get: path is required","event":"markdown_annotations_get_result","generation":0,"path":"","request_id":"markdown-empty","success":false,"workspace_id":"workspace-1"}`,
+			func(client *wsClient) {
+				d.handleMarkdownAnnotationsGet(client, &protocol.MarkdownAnnotationsGetMessage{
+					Path: "   ", RequestID: "markdown-empty", WorkspaceID: workspaceID,
+				})
+			})
+	})
+}

--- a/internal/daemon/ws_markdown_annotations.go
+++ b/internal/daemon/ws_markdown_annotations.go
@@ -2,12 +2,9 @@ package daemon
 
 import (
 	"encoding/json"
-	"errors"
 	"strings"
-	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
-	"github.com/victorarias/attn/internal/store"
 )
 
 // Markdown annotation drafts are keyed by absolute file path on the daemon
@@ -33,37 +30,20 @@ import (
 // generation is the current floor — max(stored generation, tombstone) — so a
 // re-mounting client seeds its counter past any tombstone.
 func (d *Daemon) handleMarkdownAnnotationsGet(client *wsClient, msg *protocol.MarkdownAnnotationsGetMessage) {
-	path := strings.TrimSpace(msg.Path)
-	result := protocol.MarkdownAnnotationsGetResultMessage{
-		Event:       protocol.EventMarkdownAnnotationsGetResult,
-		RequestID:   msg.RequestID,
-		Path:        path,
-		WorkspaceID: msg.WorkspaceID,
-		Annotations: []protocol.MarkdownAnnotation{},
-	}
-	if path == "" {
-		result.Error = protocol.Ptr("markdown_annotations_get: path is required")
-		d.sendToClient(client, result)
-		return
-	}
-	draft, err := d.store.GetMarkdownAnnotationDraft(path)
-	if err != nil {
-		d.logf("markdown_annotations_get: %s: %v", path, err)
-		result.Error = protocol.Ptr(err.Error())
-		d.sendToClient(client, result)
-		return
-	}
-	annotations, err := decodeMarkdownAnnotations(draft.Annotations)
-	if err != nil {
-		d.logf("markdown_annotations_get: %s: corrupt stored draft: %v", path, err)
-		result.Error = protocol.Ptr("stored annotation draft is corrupt: " + err.Error())
-		d.sendToClient(client, result)
-		return
-	}
-	result.Success = true
-	result.Annotations = annotations
-	result.Generation = draft.Generation
-	d.sendToClient(client, result)
+	handler := newAnnotationDraftHandler(d, client, markdownAnnotationDraftAccessors(d.store), "path",
+		func(result annotationDraftResult[protocol.MarkdownAnnotation]) protocol.MarkdownAnnotationsGetResultMessage {
+			return protocol.MarkdownAnnotationsGetResultMessage{
+				Event:       protocol.EventMarkdownAnnotationsGetResult,
+				RequestID:   msg.RequestID,
+				Path:        result.key,
+				WorkspaceID: msg.WorkspaceID,
+				Annotations: result.annotations,
+				Generation:  result.generation,
+				Success:     result.success,
+				Error:       result.err,
+			}
+		})
+	handler.get("markdown_annotations_get", msg.Path, decodeMarkdownAnnotations)
 }
 
 // handleMarkdownAnnotationsSave persists the full annotation list for a path.
@@ -71,40 +51,20 @@ func (d *Daemon) handleMarkdownAnnotationsGet(client *wsClient, msg *protocol.Ma
 // as stale=true, success=false — benign; the client drops its pending list
 // and re-hydrates.
 func (d *Daemon) handleMarkdownAnnotationsSave(client *wsClient, msg *protocol.MarkdownAnnotationsSaveMessage) {
-	path := strings.TrimSpace(msg.Path)
-	result := protocol.MarkdownAnnotationsSaveResultMessage{
-		Event:       protocol.EventMarkdownAnnotationsSaveResult,
-		RequestID:   msg.RequestID,
-		Path:        path,
-		WorkspaceID: msg.WorkspaceID,
-		Generation:  msg.Generation,
-	}
-	if path == "" {
-		result.Error = protocol.Ptr("markdown_annotations_save: path is required")
-		d.sendToClient(client, result)
-		return
-	}
-	annotationsJSON, err := json.Marshal(msg.Annotations)
-	if err != nil {
-		result.Error = protocol.Ptr("markdown_annotations_save: encoding annotations: " + err.Error())
-		d.sendToClient(client, result)
-		return
-	}
-	err = d.store.SaveMarkdownAnnotationDraft(path, string(annotationsJSON), msg.Generation, time.Now())
-	if errors.Is(err, store.ErrStaleMarkdownAnnotationSave) {
-		d.logf("markdown_annotations_save: %s: stale save at generation %d rejected", path, msg.Generation)
-		result.Stale = protocol.Ptr(true)
-		d.sendToClient(client, result)
-		return
-	}
-	if err != nil {
-		d.logf("markdown_annotations_save: %s: %v", path, err)
-		result.Error = protocol.Ptr(err.Error())
-		d.sendToClient(client, result)
-		return
-	}
-	result.Success = true
-	d.sendToClient(client, result)
+	handler := newAnnotationDraftHandler(d, client, markdownAnnotationDraftAccessors(d.store), "path",
+		func(result annotationDraftResult[protocol.MarkdownAnnotation]) protocol.MarkdownAnnotationsSaveResultMessage {
+			return protocol.MarkdownAnnotationsSaveResultMessage{
+				Event:       protocol.EventMarkdownAnnotationsSaveResult,
+				RequestID:   msg.RequestID,
+				Path:        result.key,
+				WorkspaceID: msg.WorkspaceID,
+				Generation:  result.generation,
+				Success:     result.success,
+				Stale:       result.stale,
+				Error:       result.err,
+			}
+		})
+	handler.save("markdown_annotations_save", msg.Path, msg.Annotations, "", msg.Generation)
 }
 
 // handleMarkdownAnnotationsClear tombstones the draft for a path at the given
@@ -112,35 +72,19 @@ func (d *Daemon) handleMarkdownAnnotationsSave(client *wsClient, msg *protocol.M
 // generation floor. Today only the sidebar "clear all" calls it; PR6's
 // clear-on-send reuses the same primitive.
 func (d *Daemon) handleMarkdownAnnotationsClear(client *wsClient, msg *protocol.MarkdownAnnotationsClearMessage) {
-	path := strings.TrimSpace(msg.Path)
-	result := protocol.MarkdownAnnotationsClearResultMessage{
-		Event:       protocol.EventMarkdownAnnotationsClearResult,
-		RequestID:   msg.RequestID,
-		Path:        path,
-		WorkspaceID: msg.WorkspaceID,
-		Generation:  msg.Generation,
-	}
-	if path == "" {
-		result.Error = protocol.Ptr("markdown_annotations_clear: path is required")
-		d.sendToClient(client, result)
-		return
-	}
-	if err := d.store.ClearMarkdownAnnotationDraft(path, msg.Generation, time.Now()); err != nil {
-		d.logf("markdown_annotations_clear: %s: %v", path, err)
-		result.Error = protocol.Ptr(err.Error())
-		d.sendToClient(client, result)
-		return
-	}
-	draft, err := d.store.GetMarkdownAnnotationDraft(path)
-	if err != nil {
-		d.logf("markdown_annotations_clear: %s: reading floor: %v", path, err)
-		result.Error = protocol.Ptr(err.Error())
-		d.sendToClient(client, result)
-		return
-	}
-	result.Success = true
-	result.Generation = draft.Generation
-	d.sendToClient(client, result)
+	handler := newAnnotationDraftHandler(d, client, markdownAnnotationDraftAccessors(d.store), "path",
+		func(result annotationDraftResult[protocol.MarkdownAnnotation]) protocol.MarkdownAnnotationsClearResultMessage {
+			return protocol.MarkdownAnnotationsClearResultMessage{
+				Event:       protocol.EventMarkdownAnnotationsClearResult,
+				RequestID:   msg.RequestID,
+				Path:        result.key,
+				WorkspaceID: msg.WorkspaceID,
+				Generation:  result.generation,
+				Success:     result.success,
+				Error:       result.err,
+			}
+		})
+	handler.clear("markdown_annotations_clear", msg.Path, msg.Generation)
 }
 
 // decodeMarkdownAnnotations unmarshals a stored draft blob into protocol

--- a/internal/daemon/ws_markdown_annotations_submit.go
+++ b/internal/daemon/ws_markdown_annotations_submit.go
@@ -8,13 +8,6 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 )
 
-// Submit statuses on the wire (plain strings in the protocol).
-const (
-	markdownSubmitStatusDelivered = "delivered"
-	markdownSubmitStatusSkipped   = "skipped_pending_approval"
-	markdownSubmitStatusError     = "error"
-)
-
 // handleMarkdownAnnotationsSubmit formats the persisted annotation draft for
 // a path into the feedback payload and delivers it into the target session's
 // PTY via typeDoorbell (bracketed paste, then Enter, both under doorbellMu).
@@ -36,7 +29,7 @@ func (d *Daemon) handleMarkdownAnnotationsSubmit(client *wsClient, msg *protocol
 		RequestID:       msg.RequestID,
 		Path:            path,
 		TargetSessionID: target,
-		Status:          markdownSubmitStatusError,
+		Status:          annotationSubmitStatusError,
 	}
 	fail := func(errText string) {
 		result.Error = protocol.Ptr(errText)
@@ -74,7 +67,7 @@ func (d *Daemon) handleMarkdownAnnotationsSubmit(client *wsClient, msg *protocol
 	// UX pre-check; typeDoorbell re-checks the state under doorbellMu — that
 	// in-lock check is the fence, this one just avoids formatting for nothing.
 	if !isNudgeDeliveryAllowed(string(session.State)) {
-		result.Status = markdownSubmitStatusSkipped
+		result.Status = annotationSubmitStatusSkipped
 		d.sendToClient(client, result)
 		return
 	}
@@ -85,7 +78,7 @@ func (d *Daemon) handleMarkdownAnnotationsSubmit(client *wsClient, msg *protocol
 	payload := formatMarkdownAnnotationPayload(path, annotations, orphaned)
 	if err := d.typeDoorbell(target, payload); err != nil {
 		if errors.Is(err, errDoorbellBlockedByApproval) {
-			result.Status = markdownSubmitStatusSkipped
+			result.Status = annotationSubmitStatusSkipped
 			d.sendToClient(client, result)
 			return
 		}
@@ -99,7 +92,7 @@ func (d *Daemon) handleMarkdownAnnotationsSubmit(client *wsClient, msg *protocol
 	// still reports delivered — never risk a re-delivery — but carries an
 	// error so the UI can re-hydrate instead of assuming an empty draft.
 	result.Success = true
-	result.Status = markdownSubmitStatusDelivered
+	result.Status = annotationSubmitStatusDelivered
 	if err := d.store.ClearMarkdownAnnotationDraft(path, draft.Generation, time.Now()); err != nil {
 		d.logf("markdown_annotations_submit: %s: delivered but clearing drafts failed: %v", path, err)
 		result.Error = protocol.Ptr("delivered; failed to clear drafts: " + err.Error())

--- a/internal/daemon/ws_markdown_annotations_submit_test.go
+++ b/internal/daemon/ws_markdown_annotations_submit_test.go
@@ -82,7 +82,7 @@ func TestMarkdownAnnotationsSubmitDelivered(t *testing.T) {
 
 	res := sendSubmit(t, d, "target", nil)
 
-	if !res.Success || res.Status != markdownSubmitStatusDelivered || res.Error != nil {
+	if !res.Success || res.Status != annotationSubmitStatusDelivered || res.Error != nil {
 		t.Fatalf("result = %+v, want delivered", res)
 	}
 	if res.Generation == nil || *res.Generation != 5 {
@@ -138,7 +138,7 @@ func TestMarkdownAnnotationsSubmitSkippedPendingApproval(t *testing.T) {
 
 	res := sendSubmit(t, d, "target", nil)
 
-	if res.Success || res.Status != markdownSubmitStatusSkipped || res.Error != nil {
+	if res.Success || res.Status != annotationSubmitStatusSkipped || res.Error != nil {
 		t.Fatalf("result = %+v, want skipped_pending_approval", res)
 	}
 	mu.Lock()
@@ -158,7 +158,7 @@ func TestMarkdownAnnotationsSubmitUnknownSession(t *testing.T) {
 
 	res := sendSubmit(t, d, "nope", nil)
 
-	if res.Success || res.Status != markdownSubmitStatusError ||
+	if res.Success || res.Status != annotationSubmitStatusError ||
 		res.Error == nil || !strings.Contains(*res.Error, "session not found: nope") {
 		t.Fatalf("result = %+v, want session-not-found error", res)
 	}
@@ -177,7 +177,7 @@ func TestMarkdownAnnotationsSubmitEmptyDraft(t *testing.T) {
 
 	res := sendSubmit(t, d, "target", nil)
 
-	if res.Success || res.Status != markdownSubmitStatusError ||
+	if res.Success || res.Status != annotationSubmitStatusError ||
 		res.Error == nil || *res.Error != "no annotations to send" {
 		t.Fatalf("result = %+v, want no-annotations error", res)
 	}
@@ -197,7 +197,7 @@ func TestMarkdownAnnotationsSubmitDeliveryFailure(t *testing.T) {
 
 	res := sendSubmit(t, d, "target", nil)
 
-	if res.Success || res.Status != markdownSubmitStatusError ||
+	if res.Success || res.Status != annotationSubmitStatusError ||
 		res.Error == nil || !strings.Contains(*res.Error, "pty write exploded") {
 		t.Fatalf("result = %+v, want delivery error", res)
 	}
@@ -222,7 +222,7 @@ func TestMarkdownAnnotationsSubmitClearFailureStillDelivered(t *testing.T) {
 
 	res := sendSubmit(t, d, "target", nil)
 
-	if !res.Success || res.Status != markdownSubmitStatusDelivered {
+	if !res.Success || res.Status != annotationSubmitStatusDelivered {
 		t.Fatalf("result = %+v, want delivered despite clear failure", res)
 	}
 	if res.Error == nil || !strings.Contains(*res.Error, "delivered; failed to clear drafts") {

--- a/internal/daemon/ws_session_annotations.go
+++ b/internal/daemon/ws_session_annotations.go
@@ -4,10 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
-	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
-	"github.com/victorarias/attn/internal/store"
 )
 
 // Terminal annotations persist per session: whole-list saves under a monotonic
@@ -19,119 +17,58 @@ import (
 // handleSessionAnnotationsGet replies with a session's persisted annotations.
 // generation is the floor, so a re-mounting client seeds past an earlier clear.
 func (d *Daemon) handleSessionAnnotationsGet(client *wsClient, msg *protocol.SessionAnnotationsGetMessage) {
-	sessionID := strings.TrimSpace(msg.SessionID)
-	result := protocol.SessionAnnotationsGetResultMessage{
-		Event:       protocol.EventSessionAnnotationsGetResult,
-		RequestID:   msg.RequestID,
-		SessionID:   sessionID,
-		Annotations: []protocol.SessionAnnotation{},
-	}
-	if sessionID == "" {
-		result.Error = protocol.Ptr("session_annotations_get: session_id is required")
-		d.sendToClient(client, result)
-		return
-	}
-	draft, err := d.store.GetSessionAnnotationDraft(sessionID)
-	if err != nil {
-		d.logf("session_annotations_get: %s: %v", sessionID, err)
-		result.Error = protocol.Ptr(err.Error())
-		d.sendToClient(client, result)
-		return
-	}
-	annotations, err := decodeSessionAnnotations(draft.Annotations)
-	if err != nil {
-		d.logf("session_annotations_get: %s: corrupt stored draft: %v", sessionID, err)
-		result.Error = protocol.Ptr("stored annotation draft is corrupt: " + err.Error())
-		d.sendToClient(client, result)
-		return
-	}
-	result.Success = true
-	result.Annotations = annotations
-	if draft.Note != "" {
-		result.Note = protocol.Ptr(draft.Note)
-	}
-	result.Generation = draft.Generation
-	d.sendToClient(client, result)
+	handler := newAnnotationDraftHandler(d, client, sessionAnnotationDraftAccessors(d.store), "session_id",
+		func(result annotationDraftResult[protocol.SessionAnnotation]) protocol.SessionAnnotationsGetResultMessage {
+			return protocol.SessionAnnotationsGetResultMessage{
+				Event:       protocol.EventSessionAnnotationsGetResult,
+				RequestID:   msg.RequestID,
+				SessionID:   result.key,
+				Annotations: result.annotations,
+				Note:        result.note,
+				Generation:  result.generation,
+				Success:     result.success,
+				Error:       result.err,
+			}
+		})
+	handler.get("session_annotations_get", msg.SessionID, decodeSessionAnnotations)
 }
 
 // handleSessionAnnotationsSave persists the full annotation list for a session.
 func (d *Daemon) handleSessionAnnotationsSave(client *wsClient, msg *protocol.SessionAnnotationsSaveMessage) {
-	sessionID := strings.TrimSpace(msg.SessionID)
-	result := protocol.SessionAnnotationsSaveResultMessage{
-		Event:      protocol.EventSessionAnnotationsSaveResult,
-		RequestID:  msg.RequestID,
-		SessionID:  sessionID,
-		Generation: msg.Generation,
-	}
-	if sessionID == "" {
-		result.Error = protocol.Ptr("session_annotations_save: session_id is required")
-		d.sendToClient(client, result)
-		return
-	}
 	annotations := msg.Annotations
 	if annotations == nil {
 		annotations = []protocol.SessionAnnotation{}
 	}
-	annotationsJSON, err := json.Marshal(annotations)
-	if err != nil {
-		result.Error = protocol.Ptr("session_annotations_save: encoding annotations: " + err.Error())
-		d.sendToClient(client, result)
-		return
-	}
-	err = d.store.SaveSessionAnnotationDraft(
-		sessionID,
-		string(annotationsJSON),
-		protocol.Deref(msg.Note),
-		msg.Generation,
-		time.Now(),
-	)
-	if errors.Is(err, store.ErrStaleAnnotationSave) {
-		d.logf("session_annotations_save: %s: stale save at generation %d rejected", sessionID, msg.Generation)
-		result.Stale = protocol.Ptr(true)
-		d.sendToClient(client, result)
-		return
-	}
-	if err != nil {
-		d.logf("session_annotations_save: %s: %v", sessionID, err)
-		result.Error = protocol.Ptr(err.Error())
-		d.sendToClient(client, result)
-		return
-	}
-	result.Success = true
-	d.sendToClient(client, result)
+	handler := newAnnotationDraftHandler(d, client, sessionAnnotationDraftAccessors(d.store), "session_id",
+		func(result annotationDraftResult[protocol.SessionAnnotation]) protocol.SessionAnnotationsSaveResultMessage {
+			return protocol.SessionAnnotationsSaveResultMessage{
+				Event:      protocol.EventSessionAnnotationsSaveResult,
+				RequestID:  msg.RequestID,
+				SessionID:  result.key,
+				Generation: result.generation,
+				Success:    result.success,
+				Stale:      result.stale,
+				Error:      result.err,
+			}
+		})
+	handler.save("session_annotations_save", msg.SessionID, annotations, protocol.Deref(msg.Note), msg.Generation)
 }
 
 // handleSessionAnnotationsClear tombstones a session's annotations and replies
 // with the new generation floor.
 func (d *Daemon) handleSessionAnnotationsClear(client *wsClient, msg *protocol.SessionAnnotationsClearMessage) {
-	sessionID := strings.TrimSpace(msg.SessionID)
-	result := protocol.SessionAnnotationsClearResultMessage{
-		Event:      protocol.EventSessionAnnotationsClearResult,
-		RequestID:  msg.RequestID,
-		SessionID:  sessionID,
-		Generation: msg.Generation,
-	}
-	if sessionID == "" {
-		result.Error = protocol.Ptr("session_annotations_clear: session_id is required")
-		d.sendToClient(client, result)
-		return
-	}
-	if err := d.store.ClearSessionAnnotationDraft(sessionID, msg.Generation, time.Now()); err != nil {
-		d.logf("session_annotations_clear: %s: %v", sessionID, err)
-		result.Error = protocol.Ptr(err.Error())
-		d.sendToClient(client, result)
-		return
-	}
-	draft, err := d.store.GetSessionAnnotationDraft(sessionID)
-	if err != nil {
-		d.logf("session_annotations_clear: %s: reading floor: %v", sessionID, err)
-		result.Error = protocol.Ptr(err.Error())
-		d.sendToClient(client, result)
-		return
-	}
-	result.Success = true
-	result.Generation = draft.Generation
-	d.sendToClient(client, result)
+	handler := newAnnotationDraftHandler(d, client, sessionAnnotationDraftAccessors(d.store), "session_id",
+		func(result annotationDraftResult[protocol.SessionAnnotation]) protocol.SessionAnnotationsClearResultMessage {
+			return protocol.SessionAnnotationsClearResultMessage{
+				Event:      protocol.EventSessionAnnotationsClearResult,
+				RequestID:  msg.RequestID,
+				SessionID:  result.key,
+				Generation: result.generation,
+				Success:    result.success,
+				Error:      result.err,
+			}
+		})
+	handler.clear("session_annotations_clear", msg.SessionID, msg.Generation)
 }
 
 // handleSessionAnnotationsSubmit delivers composed annotation feedback through
@@ -148,7 +85,7 @@ func (d *Daemon) handleSessionAnnotationsSubmit(client *wsClient, msg *protocol.
 		Event:     protocol.EventSessionAnnotationsSubmitResult,
 		RequestID: msg.RequestID,
 		SessionID: sessionID,
-		Status:    markdownSubmitStatusError,
+		Status:    annotationSubmitStatusError,
 	}
 	fail := func(errText string) {
 		result.Error = protocol.Ptr(errText)
@@ -168,7 +105,7 @@ func (d *Daemon) handleSessionAnnotationsSubmit(client *wsClient, msg *protocol.
 	}
 	if err := d.typeDoorbell(sessionID, msg.Text); err != nil {
 		if errors.Is(err, errDoorbellBlockedByApproval) {
-			result.Status = markdownSubmitStatusSkipped
+			result.Status = annotationSubmitStatusSkipped
 			d.sendToClient(client, result)
 			return
 		}
@@ -177,7 +114,7 @@ func (d *Daemon) handleSessionAnnotationsSubmit(client *wsClient, msg *protocol.
 		return
 	}
 	result.Success = true
-	result.Status = markdownSubmitStatusDelivered
+	result.Status = annotationSubmitStatusDelivered
 	d.sendToClient(client, result)
 }
 

--- a/internal/daemon/ws_session_annotations_submit_test.go
+++ b/internal/daemon/ws_session_annotations_submit_test.go
@@ -40,7 +40,7 @@ func TestSessionAnnotationsSubmitDelivers(t *testing.T) {
 
 	res := sendAnnotationSubmit(t, d, "session-1", submitAnnotationText)
 
-	if !res.Success || res.Status != markdownSubmitStatusDelivered || res.Error != nil {
+	if !res.Success || res.Status != annotationSubmitStatusDelivered || res.Error != nil {
 		t.Fatalf("result = %+v, want delivered", res)
 	}
 	wantPaste := bracketedPasteStart + submitAnnotationText + bracketedPasteEnd
@@ -64,7 +64,7 @@ func TestSessionAnnotationsSubmitSkipsPendingApproval(t *testing.T) {
 
 	res := sendAnnotationSubmit(t, d, "session-1", submitAnnotationText)
 
-	if res.Success || res.Status != markdownSubmitStatusSkipped || res.Error != nil {
+	if res.Success || res.Status != annotationSubmitStatusSkipped || res.Error != nil {
 		t.Fatalf("result = %+v, want skipped_pending_approval", res)
 	}
 	mu.Lock()
@@ -82,7 +82,7 @@ func TestSessionAnnotationsSubmitUnknownSession(t *testing.T) {
 
 	res := sendAnnotationSubmit(t, d, "nope", submitAnnotationText)
 
-	if res.Success || res.Status != markdownSubmitStatusError ||
+	if res.Success || res.Status != annotationSubmitStatusError ||
 		res.Error == nil || !strings.Contains(*res.Error, "unknown session nope") {
 		t.Fatalf("result = %+v, want unknown-session error", res)
 	}
@@ -104,7 +104,7 @@ func TestSessionAnnotationsSubmitRejectsEmptyText(t *testing.T) {
 
 	res := sendAnnotationSubmit(t, d, "session-1", "   \n ")
 
-	if res.Success || res.Status != markdownSubmitStatusError ||
+	if res.Success || res.Status != annotationSubmitStatusError ||
 		res.Error == nil || !strings.Contains(*res.Error, "text is required") {
 		t.Fatalf("result = %+v, want text-required error", res)
 	}
@@ -124,7 +124,7 @@ func TestSessionAnnotationsSubmitDeliveryFailure(t *testing.T) {
 
 	res := sendAnnotationSubmit(t, d, "session-1", submitAnnotationText)
 
-	if res.Success || res.Status != markdownSubmitStatusError || res.Error == nil {
+	if res.Success || res.Status != annotationSubmitStatusError || res.Error == nil {
 		t.Fatalf("result = %+v, want delivery error", res)
 	}
 }

--- a/internal/daemon/ws_session_annotations_test.go
+++ b/internal/daemon/ws_session_annotations_test.go
@@ -57,13 +57,13 @@ func annotationsClear(t *testing.T, d *Daemon, sessionID string, generation int)
 
 func annotation(id, messageKey, quote string) protocol.SessionAnnotation {
 	return protocol.SessionAnnotation{
-		ID:         id,
-		MessageKey: messageKey,
-		Start:      0,
-		End:        len(quote),
-		Quote:      quote,
-		Emoji:      "🔄",
-		Comment:    "",
+		ID:           id,
+		MessageKey:   messageKey,
+		Start:        0,
+		End:          len(quote),
+		Quote:        quote,
+		QuickLabelID: protocol.Ptr("consider-alternatives"),
+		Comment:      "",
 	}
 }
 

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "246"
+const ProtocolVersion = "247"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -6073,7 +6073,7 @@ type SessionAnnotation struct {
 	Comment string `json:"comment"`
 
 	// Emoji corresponds to the JSON schema field "emoji".
-	Emoji string `json:"emoji"`
+	Emoji *string `json:"emoji,omitempty,omitzero"`
 
 	// End corresponds to the JSON schema field "end".
 	End int `json:"end"`
@@ -6083,6 +6083,9 @@ type SessionAnnotation struct {
 
 	// MessageKey corresponds to the JSON schema field "message_key".
 	MessageKey string `json:"message_key"`
+
+	// QuickLabelID corresponds to the JSON schema field "quick_label_id".
+	QuickLabelID *string `json:"quick_label_id,omitempty,omitzero"`
 
 	// Quote corresponds to the JSON schema field "quote".
 	Quote string `json:"quote"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -2633,7 +2633,9 @@ model SessionAnnotation {
   // The markdown the offsets covered when the annotation was made. Kept so the
   // panel can list it, and the draft can be submitted, without the message.
   quote: string;
-  emoji: string;
+  quick_label_id?: string;
+  // Read compatibility for drafts written before labels stored their stable id.
+  emoji?: string;
   comment: string;
 }
 


### PR DESCRIPTION
## TL;DR

Terminal and markdown annotations now share the five mechanics they had independently reimplemented: draft command handling, keyed request correlation, quick-label identity, the quick-label picker, and send-outcome orchestration. Their anchoring, highlighting, payload formatting, and clear-on-send ownership remain separate, so the user-visible flows stay unchanged.

## Why

The two annotation stacks had accumulated five near-identical seams with subtly different ownership. That duplication made fixes easy to land on one path and miss on the other. This refactor gives each shared mechanism one home while keeping the genuinely different domain behavior at each caller.

The resulting ownership is:

```text
daemon draft commands
  terminal adapter  \
                     -> generic draft handler -> generic draft store
  markdown adapter  /

frontend composers
  daemon socket -> shared plain/keyed request correlation
  terminal + markdown -> shared picker -> shared send-outcome hook
```

## What changed

1. A generic daemon draft handler now owns key trimming, validation, JSON encoding, stale-save mapping, store calls, and reply sequencing. The terminal and markdown handlers only build their typed protocol results. Submit handlers are unchanged apart from moving their three shared status constants.
2. `daemonPendingRequests.ts` now owns markdown's `<op>:<workspaceId>:<path>` last-writer-wins correlation, including superseding and request-id-checked timeouts. The markdown event module only decodes results.
3. Terminal drafts now persist `quick_label_id` instead of an emoji. Protocol 247 makes `quick_label_id` and the legacy `emoji` field optional; the read boundary maps old emoji-only drafts to stable label IDs, while every new write emits only the ID.
4. One quick-label picker renders both the markdown floating menu and terminal chip row, with each caller supplying its existing styling and label adapter.
5. One send hook owns the re-entrancy guard, sending/sent/skipped/error outcome lifecycle, sent expiry, and registration-gated ⌘Enter shortcut. Each composer keeps its existing eligibility rules, messages, timeout, delivery reconciliation, and warning state.

The terminal annotation packaged-app scenario also checks that the daemon stores the stable quick-label ID, so the live persistence path covers the protocol amendment rather than only the rendered emoji.

## Review path

1. Start with `internal/daemon/ws_annotation_drafts.go` and its byte-exact adapter tests to verify the daemon boundary.
2. Follow `daemonPendingRequests.ts` into `daemonMarkdownAnnotationEvents.ts` and `useDaemonSocket.ts` for keyed correlation.
3. Review `daemonSessionAnnotationEvents.ts` with the protocol schema to verify the legacy read/new-write split.
4. Finish with `QuickLabelPicker.tsx` and `useAnnotationSend.ts`, then their two composer call sites, to verify styling and domain behavior stayed at the edges.

## Manual verification

An isolated `annotseams` profile passed its bundled preflight on the pre-rebase build. After main claimed protocol 246, the rebased head was installed again as `annotseams247`; its bundled preflight confirmed app, CLI, and daemon all negotiate protocol 247.

The terminal flow annotated a live Codex response, chose a label, added a comment and note, survived an app relaunch and a later turn, then submitted through the real ⌘Enter path. The daemon stored `show-the-receipt`, the draft tombstone advanced, and the target session took a new turn on the delivered feedback.

![terminal annotation creation and persistence](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/a97242f71b352522fd9fc184df8be468eebdff30/refactor-annotation-seams/recording-01.gif)

[Full-quality terminal recording, part 1](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/a97242f71b352522fd9fc184df8be468eebdff30/refactor-annotation-seams/recording-01.mp4)

![terminal annotation comment and send](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/a97242f71b352522fd9fc184df8be468eebdff30/refactor-annotation-seams/recording-02.gif)

[Full-quality terminal recording, part 2](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/a97242f71b352522fd9fc184df8be468eebdff30/refactor-annotation-seams/recording-02.mp4)

The markdown flow opened a document tile beside a shell target, created a quick-label and a comment annotation, exercised the target dropdown, and submitted through ⌘Enter. The tile cleared to zero and the target composer contained both formatted feedback entries.

![markdown annotation creation and target selection](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/a97242f71b352522fd9fc184df8be468eebdff30/refactor-annotation-seams/markdown-annotations.gif)

[Full-quality markdown recording, part 1](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/a97242f71b352522fd9fc184df8be468eebdff30/refactor-annotation-seams/markdown-annotations.mp4)

![markdown annotation delivery in the target composer](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/a97242f71b352522fd9fc184df8be468eebdff30/refactor-annotation-seams/markdown-annotations-final.gif)

[Full-quality markdown recording, part 2](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/a97242f71b352522fd9fc184df8be468eebdff30/refactor-annotation-seams/markdown-annotations-final.mp4)

The throwaway profile was cleaned afterward; its daemon stopped, one worker was reaped, and its app bundle and data directory were removed.

## Out of scope

This does not consolidate anchoring, highlight rendering, terminal/markdown payload formatting, clear-on-send ownership, or any other draft fields. Those remain intentionally different between the two annotation stacks.
