### PR TITLE
feat(crew): retry a day's turnover with the letter already filed

### DIFF
--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -250,7 +250,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '247';
+export const PROTOCOL_VERSION = '248';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1960,6 +1960,7 @@ export enum CreateWorktreeResultMessageEvent {
 export interface CrewHandoffMessage {
     cmd:        CrewHandoffMessageCmd;
     note:       string;
+    retry?:     boolean;
     session_id: string;
     [property: string]: any;
 }
@@ -13494,6 +13495,7 @@ const typeMap: any = {
     "CrewHandoffMessage": o([
         { json: "cmd", js: "cmd", typ: r("CrewHandoffMessageCmd") },
         { json: "note", js: "note", typ: "" },
+        { json: "retry", js: "retry", typ: u(undefined, true) },
         { json: "session_id", js: "session_id", typ: "" },
     ], "any"),
     "CrewHandoffResult": o([

--- a/changelog.d/crew-handoff-retry.yaml
+++ b/changelog.d/crew-handoff-retry.yaml
@@ -1,0 +1,11 @@
+kind: added
+area: cli
+change: >
+  `attn handoff --retry` turns a crew member's day over with the letter it
+  already filed. Writing the letter and starting the next day are one motion but
+  two acts, and only the second one can fail — when it did, the letter was on
+  disk and the day was stuck: the line is append-only, so writing it again inside
+  the same minute was refused as if it were a correction. Now the retry runs the
+  turnover against the letter already there, no second file and no overwrite, and
+  the two refusals have been pulled apart: filing again after a failed turnover
+  names the retry, and a retry with nothing filed says to write a letter first.

--- a/cmd/attn/handoff.go
+++ b/cmd/attn/handoff.go
@@ -32,12 +32,18 @@ correction is a new letter.
 Filing ends the day. The moment the letter lands, attn closes this session and
 wakes the member's successor, primed by what you just wrote — one motion.
 
+Writing the letter and turning the day over are one motion but two acts, and
+only the second one can fail. When it does, the letter stays filed and this day
+keeps running: --retry runs the turnover again against the letter already on
+disk, without writing a second one.
+
 Only the session living a member's day can file one, and only on the home
 daemon. The note for whoever tends a piece of work next is the other axis:
 attn seed note <id> -m "…" --handoff.
 
 flags:
   -m <text>          the letter; - reads it from stdin
+  --retry            turn the day over with the letter already filed; no -m
   --session <id>     the session closing its day (defaults to ATTN_SESSION_ID)
   --json             print the machine result as JSON
 `)
@@ -45,6 +51,7 @@ flags:
 
 type handoffArgs struct {
 	note    string
+	retry   bool
 	session string
 	json    bool
 }
@@ -53,6 +60,7 @@ func parseHandoffArgs(args []string, envSession string) (handoffArgs, error) {
 	fs := flag.NewFlagSet("handoff", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	message := fs.String("m", "", "the letter; - reads it from stdin")
+	retry := fs.Bool("retry", false, "turn the day over with the letter already filed")
 	session := fs.String("session", "", "the session closing its day (defaults to ATTN_SESSION_ID)")
 	jsonOut := fs.Bool("json", false, "print the machine result as JSON")
 	if err := fs.Parse(args); err != nil {
@@ -61,10 +69,13 @@ func parseHandoffArgs(args []string, envSession string) (handoffArgs, error) {
 	if fs.NArg() != 0 {
 		return handoffArgs{}, fmt.Errorf("handoff takes its letter in -m, not %q", strings.Join(fs.Args(), " "))
 	}
-	if strings.TrimSpace(*message) == "" {
+	if *retry && strings.TrimSpace(*message) != "" {
+		return handoffArgs{}, errors.New("--retry turns the day over with the letter you already filed, so it takes no -m; drop one of the two")
+	}
+	if !*retry && strings.TrimSpace(*message) == "" {
 		return handoffArgs{}, errors.New(`the letter is the handoff — pass it with -m "<your letter>", or -m - to pipe it in`)
 	}
-	parsed := handoffArgs{note: *message, session: strings.TrimSpace(*session), json: *jsonOut}
+	parsed := handoffArgs{note: *message, retry: *retry, session: strings.TrimSpace(*session), json: *jsonOut}
 	if parsed.session == "" {
 		parsed.session = strings.TrimSpace(envSession)
 	}
@@ -87,7 +98,7 @@ func runHandoff(args []string) {
 		}
 		note = string(raw)
 	}
-	result, err := client.New("").CrewHandoff(parsed.session, note)
+	result, err := client.New("").CrewHandoff(parsed.session, note, parsed.retry)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "handoff: %v\n", err)
 		os.Exit(1)
@@ -96,11 +107,15 @@ func runHandoff(args []string) {
 		printJSON(result)
 		return
 	}
-	fmt.Printf("%s's letter is filed at %s.\n", result.Member, result.Path)
+	if parsed.retry {
+		fmt.Printf("%s's letter was already filed at %s.\n", result.Member, result.Path)
+	} else {
+		fmt.Printf("%s's letter is filed at %s.\n", result.Member, result.Path)
+	}
 	if napErr := strings.TrimSpace(protocol.Deref(result.NapError)); napErr != "" {
 		// The letter is on disk; only the successor is missing. Say both, and say
 		// which is which — this session is still alive and still the member.
-		fmt.Fprintf(os.Stderr, "handoff: no successor was woken: %s\nThis day is still running and %s is still bound to it.\n", napErr, result.Member)
+		fmt.Fprintf(os.Stderr, "handoff: no successor was woken: %s\nThis day is still running and %s is still bound to it. `attn handoff --retry` turns it over again with the letter above — it is filed, so do not write another.\n", napErr, result.Member)
 		os.Exit(1)
 	}
 	fmt.Printf("%s's next day is session %s, waking now. This one ends here.\n",

--- a/cmd/attn/handoff_test.go
+++ b/cmd/attn/handoff_test.go
@@ -42,6 +42,33 @@ func TestParseHandoffArgs_ThereIsNoHandoffWithoutALetter(t *testing.T) {
 	}
 }
 
+// The retry is the one call that needs no letter: it turns the day over with
+// the one already filed.
+func TestParseHandoffArgs_ARetryNeedsNoLetter(t *testing.T) {
+	parsed, err := parseHandoffArgs([]string{"--retry"}, "session-1")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !parsed.retry || parsed.note != "" {
+		t.Fatalf("parsed retry=%t note=%q, want a retry carrying no letter", parsed.retry, parsed.note)
+	}
+	if parsed.session != "session-1" {
+		t.Errorf("session = %q, want the env fallback", parsed.session)
+	}
+}
+
+// Writing a letter and turning the day over with one already written are two
+// different asks; a call that says both has not decided which it is.
+func TestParseHandoffArgs_ARetryWithALetterIsRefused(t *testing.T) {
+	_, err := parseHandoffArgs([]string{"--retry", "-m", "another one"}, "session-1")
+	if err == nil {
+		t.Fatal("a retry carrying a letter was accepted")
+	}
+	if !strings.Contains(err.Error(), "--retry") {
+		t.Errorf("the refusal %q does not name the flag that conflicts", err)
+	}
+}
+
 // A letter typed as a positional is the shell eating the quotes, not a member
 // naming something — say which flag it belongs in rather than filing a fragment.
 func TestParseHandoffArgs_APositionalIsRefusedByName(t *testing.T) {

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -546,6 +546,14 @@ binding moves from one session to the other in a single write, so the member is
 never momentarily unbound. A nap that cannot run leaves the letter filed and the
 day running: a member is never torn down with its letter unfiled.
 
+That state has its own way out. Writing the letter and turning the day over are
+one motion but two acts, and only the second can fail, so `attn handoff --retry`
+runs the turnover again against the letter already filed — no second file, no
+overwrite, append-only untouched. The registry records which letter the current
+day filed so the two refusals stay apart: filing again after a failed turnover
+names the retry, and a retry with nothing filed names the verb that writes a
+letter.
+
 Tending is not a crew privilege: workers and errand sessions tend seeds too,
 under any free-string name. Where a tender's name happens to match a registered
 member it resolves to that member's id, so the claim compares addresses rather

--- a/docs/plans/2026-08-11-the-crew-primitive.md
+++ b/docs/plans/2026-08-11-the-crew-primitive.md
@@ -244,6 +244,18 @@ sequenceDiagram
   and never rolled back — it is the member's honest closure — and everything
   after it that fails leaves the day's session running with its binding
   held. A member is never torn down with its letter unfiled.
+- **A failed nap needs a way out, and it is not a second letter.** Filing and
+  turning the day over are one motion but two acts, and only the second can
+  fail. Slice 3 left the letter filed and the day running, which is right — but
+  the only verb left refuses, because the letter's name is taken by the letter
+  the same day just wrote, and append-only is absolute. So the retry is its own
+  path: `attn handoff --retry` runs the turnover against the letter already
+  filed and writes nothing. The registry records which letter the current day
+  filed, so the two refusals never share an exit — a collision this day caused
+  names the retry, a retry with nothing filed names the verb that writes a
+  letter. Ships ahead of slice 4 because auto-sleep runs the nap unattended,
+  and an unattended failure with no way out is a member stuck awake all night.
+
 - **Where the launch directory and the awareness dirs come from.**
   Registry fields, set by `attn crew set <member> --cwd <dir>
   --awareness-dir <dir>`, never read out of the member's prose — the

--- a/internal/client/crew.go
+++ b/internal/client/crew.go
@@ -70,11 +70,14 @@ func (c *Client) CrewPrime(sessionID string) (*protocol.CrewPrimeResult, error) 
 
 // CrewHandoff files the calling session's member letter and ends its day. The
 // note is the member's own prose; the daemon names the file, refuses to
-// overwrite one, and wakes the successor.
-func (c *Client) CrewHandoff(sessionID, note string) (*protocol.CrewHandoffResult, error) {
-	resp, err := c.send(protocol.CrewHandoffMessage{
-		Cmd: protocol.CmdCrewHandoff, SessionID: sessionID, Note: note,
-	})
+// overwrite one, and wakes the successor. retry turns the day over with the
+// letter this day already filed and ignores note.
+func (c *Client) CrewHandoff(sessionID, note string, retry bool) (*protocol.CrewHandoffResult, error) {
+	msg := protocol.CrewHandoffMessage{Cmd: protocol.CmdCrewHandoff, SessionID: sessionID, Note: note}
+	if retry {
+		msg.Retry = protocol.Ptr(true)
+	}
+	resp, err := c.send(msg)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/crew/crew.go
+++ b/internal/crew/crew.go
@@ -69,6 +69,25 @@ type Member struct {
 	// non-empty value still binds is judged at read against live sessions, so a
 	// day that ended without ceremony releases on its own.
 	BindingSession string `json:"binding_session"`
+	// LetterPath and LetterSession are the letter the current day has already
+	// filed, and who filed it. They exist so a turnover that failed after the
+	// filing can be retried against the letter already on disk rather than
+	// against a second one: append-only means the letter is not writable twice,
+	// so without this the only way out of a failed nap would be to wait out the
+	// minute and file a correction. Cleared when a day starts — a fresh day has
+	// written nothing yet.
+	LetterPath    string `json:"letter_path"`
+	LetterSession string `json:"letter_session"`
+}
+
+// FiledLetterFor answers whether sessionID has already filed this member's
+// closing letter, and where it landed. A letter recorded against a different
+// session belongs to a day that has ended and says nothing about this one.
+func (m Member) FiledLetterFor(sessionID string) (string, bool) {
+	if sessionID == "" || m.LetterPath == "" || m.LetterSession != sessionID {
+		return "", false
+	}
+	return m.LetterPath, true
 }
 
 // MembersSchema declares which fields a query may name. Everything else in the

--- a/internal/crew/crew_test.go
+++ b/internal/crew/crew_test.go
@@ -199,6 +199,23 @@ func TestEncode_WritesDeclaredFieldsEvenWhenEmpty(t *testing.T) {
 	}
 }
 
+// A filed letter answers only the day that wrote it: the record outlives the
+// binding on purpose, so the read is what makes it inert once the day changes.
+func TestFiledLetterFor_AnswersOnlyTheSessionThatFiledIt(t *testing.T) {
+	member := Member{ID: "keel", LetterPath: "/homes/keel/handoffs/a.md", LetterSession: "day-1"}
+	if path, ok := member.FiledLetterFor("day-1"); !ok || path != member.LetterPath {
+		t.Fatalf("FiledLetterFor(day-1) = %q, %t; want the letter it filed", path, ok)
+	}
+	for _, session := range []string{"day-2", ""} {
+		if path, ok := member.FiledLetterFor(session); ok {
+			t.Errorf("FiledLetterFor(%q) = %q; a letter another day wrote is not this day's", session, path)
+		}
+	}
+	if _, ok := (Member{ID: "keel", LetterSession: "day-1"}).FiledLetterFor("day-1"); ok {
+		t.Error("a member with no recorded letter reported one")
+	}
+}
+
 func TestMembersSchema_IsAValidDeclaration(t *testing.T) {
 	if err := MembersSchema().Validate(); err != nil {
 		t.Fatalf("MembersSchema is not declarable: %v", err)

--- a/internal/daemon/crew.go
+++ b/internal/daemon/crew.go
@@ -147,6 +147,45 @@ func (d *Daemon) readCrewMembers() ([]crew.Member, map[string]docstore.Document,
 	return members, docs, nil
 }
 
+// updateCrewMember reads a member, lets mutate decide its new body, and writes
+// it against the revision it was read at — remaking the decision when the record
+// moves underneath, because a conflict is not a refusal. mutate returns false to
+// abandon the write without an error: nothing needed changing, which a caller
+// racing the record's own owner must be able to say. Three attempts is a
+// tripwire; two writers contending is one retry.
+func (d *Daemon) updateCrewMember(memberID string, mutate func(*crew.Member) (bool, error)) (crew.Member, error) {
+	if err := d.requireHome(crew.Surface); err != nil {
+		return crew.Member{}, err
+	}
+	schema, err := d.crewCollection()
+	if err != nil {
+		return crew.Member{}, err
+	}
+	const attempts = 3
+	for range attempts {
+		members, docs, err := d.readCrewMembers()
+		if err != nil {
+			return crew.Member{}, err
+		}
+		member, ok := crew.Resolve(memberID, members)
+		if !ok {
+			return crew.Member{}, fmt.Errorf("no crew member %q is registered", memberID)
+		}
+		write, err := mutate(&member)
+		if err != nil || !write {
+			return member, err
+		}
+		err = d.writeCrewMember(*schema, member, docs[member.ID].Rev)
+		if err == nil {
+			return member, nil
+		}
+		if !docstore.IsConflict(err) {
+			return crew.Member{}, err
+		}
+	}
+	return crew.Member{}, fmt.Errorf("the registry record for %q was rewritten under all %d attempts to update it; try again", memberID, attempts)
+}
+
 // crewBindingLive reports whether a stored binding still binds: a non-empty
 // session the daemon still knows. The read-time judgment, shared by the
 // single-holder claim, the roster read, and session decoration.

--- a/internal/daemon/crew_handoff.go
+++ b/internal/daemon/crew_handoff.go
@@ -2,8 +2,10 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"syscall"
 	"time"
@@ -47,38 +49,24 @@ const crewNapPrompt = "Your predecessor just closed their day and left you the l
 // call from the nap's rollback: a binding that has since moved on is not
 // quietly stolen back.
 func (d *Daemon) transferCrewBinding(memberID, from, to string) error {
-	if err := d.requireHome(crew.Surface); err != nil {
-		return err
-	}
-	schema, err := d.crewCollection()
+	_, err := d.updateCrewMember(memberID, func(member *crew.Member) (bool, error) {
+		if member.BindingSession != from {
+			return false, fmt.Errorf("%s's day is no longer session %s; nothing was moved", member.ID, shortSessionID(from))
+		}
+		member.BindingSession = to
+		// The filed-letter fields are deliberately left alone. They name the
+		// session that wrote the letter, and `FiledLetterFor` only answers the
+		// session they name — so they go inert the moment the day changes, and a
+		// rollback that puts the binding back finds them still true. Clearing them
+		// here would erase, on the way in, exactly what the way out needs.
+		return true, nil
+	})
 	if err != nil {
 		return err
 	}
-	const attempts = 3
-	for range attempts {
-		members, docs, err := d.readCrewMembers()
-		if err != nil {
-			return err
-		}
-		member, ok := crew.Resolve(memberID, members)
-		if !ok {
-			return fmt.Errorf("no crew member %q is registered", memberID)
-		}
-		if member.BindingSession != from {
-			return fmt.Errorf("%s's day is no longer session %s; nothing was moved", member.ID, shortSessionID(from))
-		}
-		member.BindingSession = to
-		err = d.writeCrewMember(*schema, member, docs[member.ID].Rev)
-		if err == nil {
-			d.publishFact(FactCrewBound, member.ID, nil)
-			d.logf("crew: %s's binding moved from session %s to %s", member.ID, from, to)
-			return nil
-		}
-		if !docstore.IsConflict(err) {
-			return err
-		}
-	}
-	return fmt.Errorf("the registry record for %q was rewritten under all %d attempts to move its binding; try again", memberID, attempts)
+	d.publishFact(FactCrewBound, memberID, nil)
+	d.logf("crew: %s's binding moved from session %s to %s", memberID, from, to)
+	return nil
 }
 
 // crewMemberForSession answers which member a session is living, judged the
@@ -105,7 +93,12 @@ func (d *Daemon) crewMemberForSession(sessionID string) (crew.Member, bool) {
 // crewHandoff files the letter and runs the nap. The letter is filed first and
 // is never rolled back: it is the member's honest closure, and a nap that could
 // not run is a day that did not start, not a letter that was not written.
-func (d *Daemon) crewHandoff(sessionID, note string) (*protocol.CrewHandoffResult, error) {
+//
+// retry is the way out of exactly that state. Writing the letter and turning the
+// day over are one motion but two acts, and only the second one can fail. A
+// retry runs the turnover against the letter already on disk: no second file, no
+// overwrite, append-only untouched.
+func (d *Daemon) crewHandoff(sessionID, note string, retry bool) (*protocol.CrewHandoffResult, error) {
 	if err := d.requireHome(crew.Surface); err != nil {
 		return nil, err
 	}
@@ -116,14 +109,10 @@ func (d *Daemon) crewHandoff(sessionID, note string) (*protocol.CrewHandoffResul
 	if !bound {
 		return nil, fmt.Errorf("this session is not living a crew member's day, so it has no day-line to close. A crew handoff is a member's own letter to its successor; the note you write for whoever tends a piece of work next is `attn seed note <id> -m \"…\" --handoff`")
 	}
-	if err := crew.ValidateHandoffNote(note); err != nil {
-		return nil, err
-	}
-	path, err := crew.FileHandoff(member.HomeDir, member.ID, note, time.Now())
+	path, err := d.crewLetterForHandoff(member, sessionID, note, retry)
 	if err != nil {
 		return nil, err
 	}
-	d.logf("crew: %s filed a letter at %s (%d bytes)", member.ID, path, len(note))
 
 	result := &protocol.CrewHandoffResult{Member: member.ID, Path: path}
 	newSessionID, err := d.crewNap(member, sessionID)
@@ -136,6 +125,57 @@ func (d *Daemon) crewHandoff(sessionID, note string) (*protocol.CrewHandoffResul
 	}
 	result.SessionID = protocol.Ptr(newSessionID)
 	return result, nil
+}
+
+// crewLetterForHandoff settles which letter this handoff turns the day over
+// with: the one being written now, or the one this day already filed. The two
+// paths never share an exit — each refusal names the other by its verb, because
+// "a letter is already filed under that name" is the same sentence for a retry
+// and for a correction and the caller cannot tell which it is in.
+func (d *Daemon) crewLetterForHandoff(member crew.Member, sessionID, note string, retry bool) (string, error) {
+	filed, hasFiled := member.FiledLetterFor(sessionID)
+	if retry {
+		if !hasFiled {
+			return "", fmt.Errorf("%s's day has filed no letter yet, so there is no turnover to retry — write one with `attn handoff -m \"<your letter>\"`", member.ID)
+		}
+		if _, err := os.Stat(filed); err != nil {
+			return "", fmt.Errorf("%s's filed letter is recorded at %s but is not readable there (%v); file this day's letter again with `attn handoff -m \"<your letter>\"`", member.ID, filed, err)
+		}
+		d.logf("crew: %s is retrying its turnover with the letter already filed at %s", member.ID, filed)
+		return filed, nil
+	}
+	if err := crew.ValidateHandoffNote(note); err != nil {
+		return "", err
+	}
+	path, err := crew.FileHandoff(member.HomeDir, member.ID, note, time.Now())
+	if err != nil {
+		if errors.Is(err, crew.ErrHandoffExists) && hasFiled {
+			// The one collision that is not a correction: this day wrote that letter
+			// minutes ago and the turnover behind it failed.
+			return "", fmt.Errorf("%s's letter for this minute is already filed at %s — if the turnover is what failed, `attn handoff --retry` runs it against that letter; if this is a correction, file it as its own letter a minute from now", member.ID, filed)
+		}
+		return "", err
+	}
+	d.logf("crew: %s filed a letter at %s (%d bytes)", member.ID, path, len(note))
+	d.recordCrewLetter(member.ID, sessionID, path)
+	return path, nil
+}
+
+// recordCrewLetter remembers which letter this day filed, so a failed turnover
+// has something to retry against. Best-effort by design: the letter is on disk
+// either way, and a registry write that fails must not undo a filing or fail the
+// nap that is about to run.
+func (d *Daemon) recordCrewLetter(memberID, sessionID, path string) {
+	if _, err := d.updateCrewMember(memberID, func(member *crew.Member) (bool, error) {
+		if member.BindingSession != sessionID {
+			return false, nil
+		}
+		member.LetterPath = path
+		member.LetterSession = sessionID
+		return true, nil
+	}); err != nil {
+		d.logf("crew: recording %s's filed letter at %s: %v", memberID, path, err)
+	}
 }
 
 // crewNap starts the member's next day in place of the one that just ended: a
@@ -268,7 +308,7 @@ func (d *Daemon) closeNappedSession(sessionID string) {
 // IPC handlers.
 
 func (d *Daemon) handleCrewHandoff(conn net.Conn, msg *protocol.CrewHandoffMessage) {
-	result, err := d.crewHandoff(strings.TrimSpace(msg.SessionID), msg.Note)
+	result, err := d.crewHandoff(strings.TrimSpace(msg.SessionID), msg.Note, protocol.Deref(msg.Retry))
 	if err != nil {
 		d.sendCrewError(conn, "handoff", err)
 		return

--- a/internal/daemon/crew_handoff_test.go
+++ b/internal/daemon/crew_handoff_test.go
@@ -21,6 +21,12 @@ func crewHandoffCall(t *testing.T, d *Daemon, sessionID, note string) protocol.R
 	return gardenCall(t, func(c net.Conn) { d.handleCrewHandoff(c, &msg) })
 }
 
+func crewHandoffRetryCall(t *testing.T, d *Daemon, sessionID string) protocol.Response {
+	t.Helper()
+	msg := protocol.CrewHandoffMessage{Cmd: protocol.CmdCrewHandoff, SessionID: sessionID, Retry: protocol.Ptr(true)}
+	return gardenCall(t, func(c net.Conn) { d.handleCrewHandoff(c, &msg) })
+}
+
 func spawnedSessions(t *testing.T, backend *fakeSpawnBackend) []ptybackend.SpawnOptions {
 	t.Helper()
 	backend.mu.Lock()
@@ -234,6 +240,156 @@ func TestCrewHandoff_ANapThatCannotSpawnKeepsTheLetterAndTheDay(t *testing.T) {
 	}
 	if got := protocol.Deref(memberByID(t, crewList(t, d), "alder").BindingSession); got != woken.SessionID {
 		t.Fatalf("roster binding = %q, want the day still running %q — a failed nap must give the binding back", got, woken.SessionID)
+	}
+}
+
+// The way out of a nap that failed behind a filed letter. The line is
+// append-only, so the letter cannot be written twice: a retry runs the turnover
+// again against the one already on disk, and files nothing.
+func TestCrewHandoff_ARetryTurnsTheDayOverWithTheLetterAlreadyFiled(t *testing.T) {
+	d, backend, _ := newWakeableDaemon(t)
+	woken, err := d.crewWake("alder", "")
+	if err != nil {
+		t.Fatalf("wake: %v", err)
+	}
+	backend.mu.Lock()
+	backend.spawnErr = errors.New("no room to launch")
+	backend.mu.Unlock()
+
+	first := crewHandoffCall(t, d, woken.SessionID, "The letter, written once.")
+	if !first.Ok {
+		t.Fatalf("handoff: %v", protocol.Deref(first.Error))
+	}
+	filed := first.CrewHandoffResult.Path
+	if protocol.Deref(first.CrewHandoffResult.NapError) == "" {
+		t.Fatal("the nap was supposed to fail")
+	}
+	before := handoffFiles(t, d, "alder")
+
+	backend.mu.Lock()
+	backend.spawnErr = nil
+	backend.mu.Unlock()
+
+	retried := crewHandoffRetryCall(t, d, woken.SessionID)
+	if !retried.Ok {
+		t.Fatalf("retry: %v", protocol.Deref(retried.Error))
+	}
+	result := retried.CrewHandoffResult
+	if napErr := protocol.Deref(result.NapError); napErr != "" {
+		t.Fatalf("the retried nap did not run: %s", napErr)
+	}
+	if result.Path != filed {
+		t.Errorf("the retry reports %s, want the letter already filed at %s", result.Path, filed)
+	}
+	if after := handoffFiles(t, d, "alder"); len(after) != len(before) {
+		t.Fatalf("the handoffs dir went from %v to %v; a retry writes no second letter", before, after)
+	}
+	successor := protocol.Deref(result.SessionID)
+	if successor == "" || successor == woken.SessionID {
+		t.Fatalf("the successor's session is %q; the retry must start the next day", successor)
+	}
+	if d.store.Get(woken.SessionID) != nil {
+		t.Error("the day that handed off is still running after the retry")
+	}
+	if got := protocol.Deref(memberByID(t, crewList(t, d), "alder").BindingSession); got != successor {
+		t.Fatalf("roster binding = %q, want the successor %q", got, successor)
+	}
+	// The letter the member actually wrote is what threads the new day — the
+	// retry must not have primed the successor off some other file.
+	_, block, bound := d.crewPrimeForSession(successor)
+	if !bound || !strings.Contains(block, "The letter, written once.") {
+		t.Error("the successor was not primed by the letter that was already filed")
+	}
+}
+
+// A retry and a correction share a symptom — the name this letter would take is
+// taken — and must never share an exit. When this day is the one that took it,
+// the refusal names the retry; nothing is filed either way.
+func TestCrewHandoff_AFilingCollisionAfterAFailedNapNamesTheRetry(t *testing.T) {
+	d, backend, _ := newWakeableDaemon(t)
+	woken, err := d.crewWake("alder", "")
+	if err != nil {
+		t.Fatalf("wake: %v", err)
+	}
+	backend.mu.Lock()
+	backend.spawnErr = errors.New("no room to launch")
+	backend.mu.Unlock()
+
+	first := crewHandoffCall(t, d, woken.SessionID, "The letter, written once.")
+	if !first.Ok {
+		t.Fatalf("handoff: %v", protocol.Deref(first.Error))
+	}
+	// Take the next minute's name too, so a minute rolling over between the two
+	// calls cannot let the second one through.
+	dir := filepath.Join(d.dataRoot, crew.HomesDirName, "alder", crew.HandoffsDirName)
+	next := filepath.Join(dir, crew.HandoffFileName("alder", time.Now().Add(time.Minute)))
+	if err := os.WriteFile(next, []byte("taken\n"), 0o644); err != nil {
+		t.Fatalf("take %s: %v", next, err)
+	}
+	before := handoffFiles(t, d, "alder")
+
+	second := crewHandoffCall(t, d, woken.SessionID, "The letter, written twice.")
+	if second.Ok {
+		t.Fatal("a second letter was filed over the one this day already wrote")
+	}
+	refusal := protocol.Deref(second.Error)
+	if !strings.Contains(refusal, "--retry") {
+		t.Errorf("the refusal %q does not name the retry path", refusal)
+	}
+	if !strings.Contains(refusal, first.CrewHandoffResult.Path) {
+		t.Errorf("the refusal %q does not name the letter already filed", refusal)
+	}
+	if after := handoffFiles(t, d, "alder"); len(after) != len(before) {
+		t.Fatalf("the handoffs dir went from %v to %v; a refused filing writes nothing", before, after)
+	}
+}
+
+// The other half of the pair: a retry with nothing to retry says so, and points
+// at the verb that writes a letter. A member must never be told "already filed"
+// when nothing is.
+func TestCrewHandoff_ARetryWithNoFiledLetterSaysToWriteOne(t *testing.T) {
+	d, backend, _ := newWakeableDaemon(t)
+	woken, err := d.crewWake("keel", "")
+	if err != nil {
+		t.Fatalf("wake: %v", err)
+	}
+
+	resp := crewHandoffRetryCall(t, d, woken.SessionID)
+	if resp.Ok {
+		t.Fatal("a day with no letter turned over on a retry")
+	}
+	if refusal := protocol.Deref(resp.Error); !strings.Contains(refusal, `attn handoff -m`) {
+		t.Errorf("the refusal %q does not name the verb that writes a letter", refusal)
+	}
+	if len(spawnedSessions(t, backend)) != 1 {
+		t.Error("a refused retry woke a successor")
+	}
+	if d.store.Get(woken.SessionID) == nil {
+		t.Error("a refused retry tore the day down")
+	}
+}
+
+// A letter belongs to the day that wrote it. Once the turnover succeeds, the
+// new day has written nothing — so its retry is refused rather than turning the
+// day over a second time off its predecessor's letter.
+func TestCrewHandoff_ANewDayInheritsNoLetterToRetry(t *testing.T) {
+	d, _, _ := newWakeableDaemon(t)
+	woken, err := d.crewWake("trellis", "")
+	if err != nil {
+		t.Fatalf("wake: %v", err)
+	}
+	first := crewHandoffCall(t, d, woken.SessionID, "Filed and gone.")
+	if !first.Ok {
+		t.Fatalf("handoff: %v", protocol.Deref(first.Error))
+	}
+	successor := protocol.Deref(first.CrewHandoffResult.SessionID)
+
+	resp := crewHandoffRetryCall(t, d, successor)
+	if resp.Ok {
+		t.Fatal("a fresh day turned over on its predecessor's letter")
+	}
+	if refusal := protocol.Deref(resp.Error); !strings.Contains(refusal, "filed no letter yet") {
+		t.Errorf("the refusal %q does not say this day has written nothing", refusal)
 	}
 }
 

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "247"
+const ProtocolVersion = "248"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1625,6 +1625,9 @@ type CrewHandoffMessage struct {
 	// Note corresponds to the JSON schema field "note".
 	Note string `json:"note"`
 
+	// Retry corresponds to the JSON schema field "retry".
+	Retry *bool `json:"retry,omitempty,omitzero"`
+
 	// SessionID corresponds to the JSON schema field "session_id".
 	SessionID string `json:"session_id"`
 }

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -5149,6 +5149,10 @@ model CrewHandoffMessage {
   cmd: "crew_handoff";
   session_id: string;
   note: string;
+  // Turn the day over with the letter this day already filed, instead of
+  // writing one. The way out of a turnover that failed behind a filed letter:
+  // the line is append-only, so the letter cannot be written a second time.
+  retry?: boolean;
 }
 
 // Where the letter landed, and what became of the day. A filed letter is never


### PR DESCRIPTION
## What this fixes

A crew member's handoff is one motion made of two acts: file the letter, then turn the day over. Slice 3 (#898) got the failure state right — a nap that cannot run leaves the letter filed, the day's session running, and the binding held, so a member is never torn down with its letter unfiled.

But it left no way forward. The only verb available refuses: `attn handoff -m "…"` would file a letter under a name the same day's letter already holds a minute ago, and the line is append-only, so the refusal is `a letter is already filed under that name`. That sentence is also what a member sees when it tries to file a correction. **A retry and a correction shared one exit**, and the member had to wait out the minute and write a second letter for one day.

That is fine while a human is watching. It is not fine under slice 4's auto-sleep, which runs the nap unattended — an unattended failure with no way out is a member stuck awake all night.

## What ships

`attn handoff --retry` runs the turnover again against the letter already on disk. It writes no second file and overwrites nothing; append-only stays absolute.

The registry records which letter the current day filed (`letter_path`, `letter_session`), so the two paths refuse apart and each refusal names the other's verb:

- filing again when this day already filed and the name collides → *"…if the turnover is what failed, `attn handoff --retry` runs it against that letter; if this is a correction, file it as its own letter a minute from now"*
- `--retry` with nothing filed → *"…has filed no letter yet, so there is no turnover to retry — write one with `attn handoff -m "<your letter>"`"*
- `--retry` together with `-m` → refused at parse; the call has not decided which it is
- the failed-nap message now points at the retry and says the letter is filed, so do not write another

The record answers only the session that filed it, which makes it inert the moment the day changes — so a new day inherits nothing to retry. It is deliberately **not** cleared by the binding move: the move happens before the successor spawns, and clearing on the way in would erase exactly what the way out needs when that spawn fails and the binding rolls back.

Filing a genuine correction past the minute is unchanged and still sanctioned by the plan (*"a correction is a new letter, not an edit"*) — the turnover then runs with the newest letter, which is also what primes the successor.

## Surfaces walked

- **CLI** — `attn handoff --retry`, help text, and the mutually-exclusive parse.
- **Daemon** — `crew_handoff.go`; `transferCrewBinding` moved onto a new shared `updateCrewMember` read-modify-write helper rather than carrying its own retry loop.
- **Protocol** — `crew_handoff.retry`, regenerated, 247 → 248 in all three lockstep spots. (#900 took 247 while this branch was open, so the bump moved.)
- **Docs** — glossary handoff/nap section; a ruling in the crew plan.
- **Not touched** — no app surface. The visible turnover (pane replaced, sidebar shows the member on its new day) is slice 3's and is unchanged; this PR adds a CLI verb and two refusals.
- **Linux** — no platform-specific code.

## Verification

Live on a throwaway profile `crewretry` (fresh data dir, real `claude` member session, app installed from this branch — preflight `PASS`, `protocol.app_daemon: installed app and daemon use protocol 248`, re-run after the version moved).

A real failed nap was produced by removing the member's launch directory behind it, so the successor's worker genuinely could not start:

```
$ attn handoff --session <day-1> -m "Dear next retryist, …"
retryist's letter is filed at …/handoffs/2026-08-14T19-55Z-retryist.md.
handoff: no successor was woken: wake retryist's successor: worker did not become ready: …
This day is still running and retryist is still bound to it. `attn handoff --retry` turns it
over again with the letter above — it is filed, so do not write another.
```

With the next minute's name also taken, so the collision is deterministic:

```
$ attn handoff --session <day-1> -m "a fourth one"
handoff: daemon error: crew handoff: retryist's letter for this minute is already filed at
…/2026-08-14T19-53Z-retryist.md — if the turnover is what failed, `attn handoff --retry` runs
it against that letter; if this is a correction, file it as its own letter a minute from now
```

Directory restored, then the retry — four letters before, four after:

```
$ attn handoff --session <day-1> --retry
retryist's letter was already filed at …/2026-08-14T19-53Z-retryist.md.
retryist's next day is session a5ee5e48, waking now. This one ends here.

$ attn crew list
MEMBER        STATE     SESSION     HOME
retryist      awake     a5ee5e48    /Users/victor/.attn-crewretry/crew/retryist
```

And the fresh day inherits nothing:

```
$ attn handoff --session <day-2> --retry
handoff: daemon error: crew handoff: retryist's day has filed no letter yet, so there is no
turnover to retry — write one with `attn handoff -m "<your letter>"`
```

Automated: four new daemon tests (retry turns over with no second file and primes off it; the collision names the retry; a retry with nothing filed names `-m`; a new day inherits no letter), plus CLI parse tests and a `FiledLetterFor` unit test. Mutation-checked — no-oping the letter record fails the two tests that depend on it. `go test ./internal/daemon ./internal/crew ./cmd/attn ./internal/protocol` green.

No recording: this PR adds no app surface.

Profile `crewretry` is cleaned after merge.

https://claude.ai/code/session_01TJYbmUtMPGhMoDcp1Vawtu
