### PR TITLE
docs(garden): the garden-era epic design and the ticket-retirement path

### DIFF
--- a/changelog.d/garden-era-epic-plan.yaml
+++ b/changelog.d/garden-era-epic-plan.yaml
@@ -1,0 +1,14 @@
+kind: internal
+area: docs
+change: >
+  The garden-era epic design: slice 6 (a plot read and reviewed as a
+  rendered, annotated document) plus ticket retirement, on one epic
+  branch proven by living on it. Encodes the 2026-08-14 rulings —
+  read-only panel drills with the tile as the one annotated reader,
+  attn://seed/<id> as the house URI and draft key with typed fields
+  wherever the daemon acts, live re-anchor on body edits, the
+  split-button submit that flips to a log note on an untended seed,
+  artifacts as typed attach entries in the seed's log, ticket verbs
+  kept as permanent signposts, and backlog todos bulk-converting while
+  in-flight delegations drain on their tickets. The retirement path is
+  also recorded at the garden slices plan's "Tickets retire" entry.

--- a/docs/plans/2026-08-06-the-garden-vertical-slices.md
+++ b/docs/plans/2026-08-06-the-garden-vertical-slices.md
@@ -563,9 +563,12 @@ Acceptance:
   slice 6, and the path is: a delegation binds a seed — the brief is the
   seed's body, the delegate session its tender; status reports become
   log notes; steering goes over agent-msg. The `attn ticket` verbs
-  become loud signposts to their garden equivalents for a window rather
-  than vanishing. Open tickets convert to seeds; done tickets stay
-  readable, never migrated. Victor proves it by living on the epic
+  become loud signposts to their garden equivalents, kept indefinitely
+  — their audience is agents on stale guidance, and a signpost is what
+  lets them self-correct. Unbound backlog todos bulk-convert to seeds
+  at cutover; in-flight delegations finish on their tickets; done
+  tickets stay readable, never migrated. Victor proves it by living on
+  the epic
   branch for days without touching tickets before it merges. The
   landmine to design around: delegation reporting IS tickets today
   (briefs, status reports, artifacts all land there), so the garden must

--- a/docs/plans/2026-08-06-the-garden-vertical-slices.md
+++ b/docs/plans/2026-08-06-the-garden-vertical-slices.md
@@ -555,10 +555,24 @@ Acceptance:
   has repeated and earned its packet.
 - **Gates as turns** — `gate` seeds opening turns when unblocked; the
   schema field exists from slice 1.
-- **Tickets retire** (decided 2026-08-06; supersedes "tickets as views").
-  There will be no era of two capture systems: the garden takes over as
-  soon as it is usable — slice 5 (capture + dispatch) is the bar — and
-  tickets are then removed, not kept as a parallel board.
+- **Tickets retire** (decided 2026-08-06; supersedes "tickets as views";
+  path ruled 2026-08-14). There will be no era of two capture systems:
+  the garden takes over as soon as it is usable — slice 5 (capture +
+  dispatch) is the bar — and tickets are then removed, not kept as a
+  parallel board. The retirement rides the garden-era epic alongside
+  slice 6, and the path is: a delegation binds a seed — the brief is the
+  seed's body, the delegate session its tender; status reports become
+  log notes; steering goes over agent-msg. The `attn ticket` verbs
+  become loud signposts to their garden equivalents for a window rather
+  than vanishing. Open tickets convert to seeds; done tickets stay
+  readable, never migrated. Victor proves it by living on the epic
+  branch for days without touching tickets before it merges. The
+  landmine to design around: delegation reporting IS tickets today
+  (briefs, status reports, artifacts all land there), so the garden must
+  carry that weight before tickets die. The outpost leg stays gated on
+  the uplink per
+  [the arc plan](2026-08-10-home-garden-crew-arc.md) — retiring outpost
+  tickets while outposts are fenced would strand outpost delegations.
 - **Laurels attach to seeds** — the recognition arc; seed ids are the
   attachment points, nothing in this plan blocks it.
 - **Ready nudges** — waking a tender when its blocker falls (doorbell path).

--- a/docs/plans/2026-08-14-garden-era-epic.md
+++ b/docs/plans/2026-08-14-garden-era-epic.md
@@ -1,0 +1,142 @@
+# Plan: the garden-era epic
+
+Written 2026-08-14 from the rulings of that day's alignment round. This
+doc encodes decisions already made; the forks below are closed, and each
+carries its ruling date. The epic is the end of the two-capture-system
+era: slice 6 of [the garden slices plan](2026-08-06-the-garden-vertical-slices.md)
+plus ticket retirement, on one epic branch Victor lives on before it
+merges.
+
+## Goal
+
+A plot is read and reviewed the way markdown plans are today — rendered,
+annotated, feedback flowing to the tending agent — and tickets retire on
+the same branch, because the garden now does everything delegations used
+tickets for. The proof is lived, not tested: Victor runs days of real
+work from the epic branch without touching `attn ticket`, then the epic
+merges to main (his explicit OK — an epic merge is on the wait list).
+
+## Why now
+
+- Garden slice 5 shipped (#892): plots, capture, dispatch — the
+  2026-08-06 "usable" bar for retirement. Messaging (peek + msg) is
+  live. Both retirement preconditions hold.
+- The annot-seams refactor (#900) tidied exactly the files slice 6
+  builds on: one daemon draft handler, shared correlation in
+  `daemonPendingRequests.ts`, shared `QuickLabelPicker` and
+  `useAnnotationSend`. Slice 6 touches only the markdown annotation
+  stack; nothing else moves.
+
+## The shape
+
+Ruling A (2026-08-14): the panel drills read-only; the tile is the
+annotated reader; `attn open` makes a tile.
+
+```text
+GardenPanel                       # read-only
+  seed row -> drill-down          # rendered body + log, no annotations
+           -> "open as tile"      # hands off to the reader
+
+workspace tile                    # the one annotated reading surface
+  attn open <seed-id>             # same verb that docks a markdown file
+    -> tile whose document source is the seed
+       MarkdownReader             # body renders as the plan page
+         annotations/             # existing stack, second source
+       log ledger beneath         # children + notes, updates live
+```
+
+One annotation stack, two document sources. The reader learns "a seed"
+beside "a file"; anchoring, highlight rendering, and payload formatting
+stay exactly where the annot-seams audit ruled them.
+
+## The house URI
+
+Ruling B (2026-08-14): `attn://seed/<id>` is the house URI — document
+identity for tiles and the annotation draft key. The draft keying
+generalizes from `<op>:<workspaceId>:<path>`
+(`app/src/hooks/daemonMarkdownAnnotationEvents.ts`) to `<op>:<uri>`,
+where a file document's URI form carries workspace and path and a seed's
+is `attn://seed/<id>`.
+
+Wherever the daemon *acts* — submit routing, draft persistence, log
+writes — the message carries typed source/destination fields (seed id,
+session id), never recovered by parsing the URI string. The URI is
+identity and keying; typed fields are authority.
+
+## Live re-anchor
+
+Ruling C (2026-08-14): a seed's body is a living document — the tender
+edits it while Victor reads. On a body edit event the open reader
+re-anchors its annotations live: no reload, no scroll jump, no orphaned
+highlight. (The anchoring machinery already exists under
+`MarkdownReader/anchoring/`; what is new is driving it from a body-edit
+event instead of a file reload.)
+
+## Submit
+
+Ruling D (2026-08-14): the annotation composer on a seed gets a
+split-button submit. Primary sends to the tender's session (the existing
+annotation→agent path); the caret menu carries "Note on seed" (a log
+note, so feedback on unattended work is never lost). On an untended seed
+the note action flips to primary — there is nobody to send to, and the
+button says so by its shape.
+
+## Ticket retirement
+
+The path is encoded at the ["Tickets retire" entry](2026-08-06-the-garden-vertical-slices.md)
+(ruled 2026-08-14). In epic terms:
+
+- A delegation binds a seed: the brief is the seed's body, the delegate
+  session its tender. Status reports become log notes; steering goes
+  over agent-msg.
+- `attn ticket` verbs become loud signposts to their garden equivalents
+  for a window, not silent removals.
+- Open tickets convert to seeds; done tickets stay readable forever,
+  never migrated.
+- The outpost leg stays gated on the uplink per
+  [the arc plan](2026-08-10-home-garden-crew-arc.md).
+
+**The landmine this epic must design around:** delegation reporting IS
+tickets today — briefs, status reports, artifacts, and the dispatch
+skill's contract all land on the ticket. The garden takes that weight
+*before* the ticket verbs go signpost, or the first delegation on the
+epic branch has nowhere to report. That ordering is the epic's internal
+sequencing rule.
+
+## Implementation steps
+
+- [ ] Open `epic/garden-era` from main once #900 (annot-seams) merges.
+- [ ] Seed document source in the reader + `attn open <seed-id>` +
+      panel read-only drill (ruling A).
+- [ ] `attn://seed/<id>` URI, draft-key generalization, typed
+      daemon fields (ruling B).
+- [ ] Live re-anchor on body edits (ruling C).
+- [ ] Split-button submit with the untended flip (ruling D).
+- [ ] Delegation reporting on seeds: bind at dispatch, log-note status,
+      agent-msg steering — the weight transfer.
+- [ ] Ticket verbs → signposts; open-ticket conversion; done tickets
+      readable.
+- [ ] Victor lives on the branch for days without tickets.
+- [ ] Epic merge to main on his explicit OK.
+
+## Decisions
+
+- Panel stays read-only; one annotated surface, the tile (A). Two
+  annotation-capable surfaces would mean two draft owners for one seed.
+- URI for identity, typed fields for authority (B) — the daemon never
+  parses meaning out of a string a client composed.
+- Retirement rides this epic rather than waiting for a separate pass —
+  living without tickets is the only honest test of the garden carrying
+  the weight, and a lived epic branch is the cheapest place to run it.
+
+## Open questions
+
+- Where ticket *artifacts* (attached plans, references) land after
+  retirement — a seed's log can carry links, but the attach-plan
+  lifecycle (`docs/plans/2026-07-18-canonical-plan-artifact-lifecycle.md`)
+  names the Notebook and repository as homes; the seed's role there is
+  undesigned.
+- The signpost window's length — a window, not forever; when it closes
+  is a call for Victor during the lived period.
+- Exact conversion UX for open tickets (bulk vs. per-ticket) — decide
+  when converting the real board, with the real tickets in front of us.

--- a/docs/plans/2026-08-14-garden-era-epic.md
+++ b/docs/plans/2026-08-14-garden-era-epic.md
@@ -89,13 +89,26 @@ The path is encoded at the ["Tickets retire" entry](2026-08-06-the-garden-vertic
 - A delegation binds a seed: the brief is the seed's body, the delegate
   session its tender. Status reports become log notes; steering goes
   over agent-msg.
-- `attn ticket` verbs become loud signposts to their garden equivalents
-  — each prints where the capability went and exits nonzero. The
-  signposts stay indefinitely (ruled 2026-08-14): their audience is
-  mostly agents running on stale memories and guidance, a signpost is
-  what lets them self-correct, and a few inert lines of code cost
-  nothing. No removal is scheduled; a later cleanup may delete them
-  once long silent.
+- The `attn ticket` *write* verbs become loud signposts to their garden
+  equivalents — each prints where the capability went and exits
+  nonzero. The signposts stay indefinitely (ruled 2026-08-14): their
+  audience is mostly agents running on stale memories and guidance, a
+  signpost is what lets them self-correct, and a few inert lines of
+  code cost nothing. No removal is scheduled; a later cleanup may
+  delete them once long silent.
+- The *read* verbs are the explicit exception, not signposts: "done
+  tickets stay readable forever" is a mechanism, and this is it.
+  `attn ticket show` and `attn ticket list` keep reading the archived
+  store — a done ticket has no garden equivalent to point at, so a
+  stale agent reading one gets the ticket, never a signpost aimed at
+  nothing.
+- The signposts live at the CLI; the daemon keeps serving the read
+  path. That makes the signpost step itself wire-neutral. The app's
+  ticket surfaces are replaced by garden surfaces inside the epic —
+  that is where the wire moves, and that step's checklist carries the
+  ProtocolVersion bump in all its lockstep spots. Removing the then
+  orphaned daemon ticket-write commands is a later cleanup with its
+  own bump, not part of the signpost step.
 - Conversion (ruled 2026-08-14): unbound backlog todos bulk-convert to
   seeds at cutover — they are inert, nothing reports to them. In-flight
   delegations finish on their tickets; new dispatches start on seeds.
@@ -146,8 +159,10 @@ events.
 - [ ] Delegation reporting on seeds: bind at dispatch, log-note status,
       typed `attach`/`detach` with the artifact projection, agent-msg
       steering — the weight transfer.
-- [ ] Ticket verbs → permanent signposts; bulk-convert backlog todos;
-      done tickets readable.
+- [ ] App ticket surfaces → garden surfaces; this step moves the wire
+      and carries the ProtocolVersion bump in every lockstep spot.
+- [ ] Ticket write verbs → permanent CLI signposts; read verbs keep
+      the archived store; bulk-convert backlog todos.
 - [ ] Victor lives on the branch for days without tickets.
 - [ ] Epic merge to main on his explicit OK.
 

--- a/docs/plans/2026-08-14-garden-era-epic.md
+++ b/docs/plans/2026-08-14-garden-era-epic.md
@@ -90,9 +90,18 @@ The path is encoded at the ["Tickets retire" entry](2026-08-06-the-garden-vertic
   session its tender. Status reports become log notes; steering goes
   over agent-msg.
 - `attn ticket` verbs become loud signposts to their garden equivalents
-  for a window, not silent removals.
-- Open tickets convert to seeds; done tickets stay readable forever,
-  never migrated.
+  — each prints where the capability went and exits nonzero. The
+  signposts stay indefinitely (ruled 2026-08-14): their audience is
+  mostly agents running on stale memories and guidance, a signpost is
+  what lets them self-correct, and a few inert lines of code cost
+  nothing. No removal is scheduled; a later cleanup may delete them
+  once long silent.
+- Conversion (ruled 2026-08-14): unbound backlog todos bulk-convert to
+  seeds at cutover — they are inert, nothing reports to them. In-flight
+  delegations finish on their tickets; new dispatches start on seeds.
+  The board drains itself within days, and "done tickets stay readable"
+  covers the tail.
+- Done tickets stay readable forever, never migrated.
 - The outpost leg stays gated on the uplink per
   [the arc plan](2026-08-10-home-garden-crew-arc.md).
 
@@ -102,6 +111,28 @@ skill's contract all land on the ticket. The garden takes that weight
 *before* the ticket verbs go signpost, or the first delegation on the
 epic branch has nowhere to report. That ordering is the epic's internal
 sequencing rule.
+
+### Artifacts
+
+Ruled 2026-08-14: artifacts are part of the seed, and the association
+is a typed `attach` entry in its log. Storage does not move — the
+canonical-artifact lifecycle
+([2026-07-18](2026-07-18-canonical-plan-artifact-lifecycle.md)) keeps
+deciding *where documents live* (committed plans in git behind a
+reference, untracked staging files promoted into the Notebook); the
+seed records only the association, the way tickets already model an
+attach as an activity event with the artifact list derived from those
+events.
+
+- An `attach` log note carries a typed reference — notebook doc id,
+  repository path + repo, or plain URL — never a string the daemon
+  parses meaning from.
+- The seed's "current artifacts" is a projection over the log (attach
+  minus detach), rendered as a small set in the panel drill and the
+  tile, not buried in the timeline.
+- `detach` is the way out.
+- At ticket conversion, a ticket's main attached plan becomes the
+  seed's body; its other artifacts become `attach` entries.
 
 ## Implementation steps
 
@@ -113,9 +144,10 @@ sequencing rule.
 - [ ] Live re-anchor on body edits (ruling C).
 - [ ] Split-button submit with the untended flip (ruling D).
 - [ ] Delegation reporting on seeds: bind at dispatch, log-note status,
-      agent-msg steering — the weight transfer.
-- [ ] Ticket verbs → signposts; open-ticket conversion; done tickets
-      readable.
+      typed `attach`/`detach` with the artifact projection, agent-msg
+      steering — the weight transfer.
+- [ ] Ticket verbs → permanent signposts; bulk-convert backlog todos;
+      done tickets readable.
 - [ ] Victor lives on the branch for days without tickets.
 - [ ] Epic merge to main on his explicit OK.
 
@@ -128,15 +160,8 @@ sequencing rule.
 - Retirement rides this epic rather than waiting for a separate pass —
   living without tickets is the only honest test of the garden carrying
   the weight, and a lived epic branch is the cheapest place to run it.
-
-## Open questions
-
-- Where ticket *artifacts* (attached plans, references) land after
-  retirement — a seed's log can carry links, but the attach-plan
-  lifecycle (`docs/plans/2026-07-18-canonical-plan-artifact-lifecycle.md`)
-  names the Notebook and repository as homes; the seed's role there is
-  undesigned.
-- The signpost window's length — a window, not forever; when it closes
-  is a call for Victor during the lived period.
-- Exact conversion UX for open tickets (bulk vs. per-ticket) — decide
-  when converting the real board, with the real tickets in front of us.
+- Artifacts associate through the log, not a schema field or child
+  seeds (rejected: child seeds conflate documents with units of work;
+  a dedicated attachments collection duplicates what the log plus a
+  projection already express). Storage stays with the canonical
+  lifecycle; the seed holds associations only.


### PR DESCRIPTION
Encodes the 2026-08-14 direction rulings for the garden-era epic — the work that ends the two-capture-system era. Two documents move:

**New: `docs/plans/2026-08-14-garden-era-epic.md`.** The epic is slice 6 of the garden slices plan (a plot read and reviewed as a rendered, annotated document) plus ticket retirement, on one epic branch proven by living on it for days without tickets before it merges. The doc encodes the ruled forks:

- The panel drills read-only; the workspace tile is the one annotated reading surface; `attn open <seed-id>` docks one.
- `attn://seed/<id>` is the house URI — document identity and annotation draft key. Wherever the daemon acts, messages carry typed source/destination fields; the URI is never parsed for meaning.
- A seed's body is a living document: the open reader re-anchors annotations live on body edits.
- The annotation composer on a seed gets a split-button submit — send-to-tender primary, "Note on seed" in the caret menu, flipping to note-primary on an untended seed.
- Artifacts are part of the seed: a typed `attach` entry in its log (notebook doc id, repository path, or URL), with the current set derived as a projection and `detach` as the way out. Storage stays with the canonical artifact lifecycle.
- Ticket verbs become permanent signposts to their garden equivalents; unbound backlog todos bulk-convert at cutover while in-flight delegations finish on their tickets; done tickets stay readable forever.

It also names the landmine the epic must sequence around: delegation reporting IS tickets today, so the garden takes that weight before the ticket verbs go signpost.

**Updated: the "Tickets retire" entry in `docs/plans/2026-08-06-the-garden-vertical-slices.md`** now carries the ruled retirement path instead of only the 2026-08-06 decision that retirement would happen.

Docs only; no code changes.

https://claude.ai/code/session_012Bu5dMFLdBfrEo4WmQkF53