### PR TITLE
feat(annotations): streamline markdown quick labels

### DIFF
--- a/app/src/annotations/QuickLabelPicker.tsx
+++ b/app/src/annotations/QuickLabelPicker.tsx
@@ -2,6 +2,7 @@ import {
   useEffect,
   Fragment,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   type CSSProperties,
@@ -14,7 +15,7 @@ import { LABEL_COLOR_MAP, type QuickLabel } from './quickLabels';
 export interface FloatingQuickLabelPickerProps {
   mode?: 'floating';
   className: string;
-  labels: readonly QuickLabel[];
+  groups: readonly (readonly QuickLabel[])[];
   anchorEl: HTMLElement;
   cursorHint?: { x: number; y: number } | null;
   onSelect: (label: QuickLabel) => void;
@@ -71,7 +72,7 @@ function computePosition(
 
 function FloatingQuickLabelPicker({
   className,
-  labels,
+  groups,
   anchorEl,
   cursorHint,
   onSelect,
@@ -80,6 +81,16 @@ function FloatingQuickLabelPicker({
   const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
   const [height, setHeight] = useState(0);
   const ref = useRef<HTMLDivElement>(null);
+  const { labels, indexedGroups } = useMemo(() => {
+    const flattened = groups.flat();
+    let nextIndex = 0;
+    return {
+      labels: flattened,
+      indexedGroups: groups.map((group) =>
+        group.map((label) => ({ label, index: nextIndex++ })),
+      ),
+    };
+  }, [groups]);
 
   useEffect(() => {
     const update = () => setPosition(computePosition(anchorEl, cursorHint, height));
@@ -139,33 +150,38 @@ function FloatingQuickLabelPicker({
       style={{ top: position.top, left: position.left, width: PICKER_WIDTH }}
       onMouseDown={(event) => event.stopPropagation()}
     >
-      {labels.map((label, index) => {
-        const color = LABEL_COLOR_MAP[label.color];
-        return (
-          <button
-            key={label.id}
-            type="button"
-            className="md-quick-label-row"
-            onClick={() => onSelect(label)}
-            title={label.tip}
-          >
-            <span
-              className="md-ql-chip"
-              style={color
-                ? ({
-                    background: color.bg,
-                    '--md-ql-text': color.text,
-                    '--md-ql-text-dark': color.darkText,
-                  } as CSSProperties)
-                : undefined}
-            >
-              {label.emoji}
-            </span>
-            <span className="md-quick-label-text">{label.text}</span>
-            {index < 10 && <span className="md-quick-label-num">{(index + 1) % 10}</span>}
-          </button>
-        );
-      })}
+      {indexedGroups.map((group, groupIndex) => (
+        <Fragment key={group[0].label.id}>
+          {groupIndex > 0 ? <span className="md-quick-label-divider" role="separator" /> : null}
+          {group.map(({ label, index }) => {
+            const color = LABEL_COLOR_MAP[label.color];
+            return (
+              <button
+                key={label.id}
+                type="button"
+                className="md-quick-label-row"
+                onClick={() => onSelect(label)}
+                title={label.tip}
+              >
+                <span
+                  className="md-ql-chip"
+                  style={color
+                    ? ({
+                        background: color.bg,
+                        '--md-ql-text': color.text,
+                        '--md-ql-text-dark': color.darkText,
+                      } as CSSProperties)
+                    : undefined}
+                >
+                  {label.emoji}
+                </span>
+                <span className="md-quick-label-text">{label.text}</span>
+                {index < 10 && <span className="md-quick-label-num">{(index + 1) % 10}</span>}
+              </button>
+            );
+          })}
+        </Fragment>
+      ))}
     </div>,
     document.body,
   );

--- a/app/src/annotations/QuickLabelPicker.tsx
+++ b/app/src/annotations/QuickLabelPicker.tsx
@@ -152,7 +152,7 @@ function FloatingQuickLabelPicker({
     >
       {indexedGroups.map((group, groupIndex) => (
         <Fragment key={group[0].label.id}>
-          {groupIndex > 0 ? <span className="md-quick-label-divider" role="separator" /> : null}
+          {groupIndex > 0 ? <hr className="md-quick-label-divider" /> : null}
           {group.map(({ label, index }) => {
             const color = LABEL_COLOR_MAP[label.color];
             return (

--- a/app/src/annotations/quickLabels.test.ts
+++ b/app/src/annotations/quickLabels.test.ts
@@ -18,6 +18,11 @@ describe('the shared label set', () => {
 
   it('flattens the groups in row order, with no repeated identity', () => {
     expect(QUICK_LABELS).toEqual(QUICK_LABEL_GROUPS.flat());
+    expect(QUICK_LABELS).toHaveLength(12);
+    expect(QUICK_LABEL_GROUPS).toHaveLength(5);
+    expect(QUICK_LABEL_GROUPS[3]).toEqual([
+      { id: 'cut-this', emoji: '🪓', text: 'Cut this', color: 'amber' },
+    ]);
     expect(new Set(QUICK_LABELS.map((label) => label.emoji)).size).toBe(QUICK_LABELS.length);
     expect(new Set(QUICK_LABELS.map((label) => label.id)).size).toBe(QUICK_LABELS.length);
   });
@@ -33,6 +38,8 @@ describe('label lookups', () => {
   it('resolve a mark back to the label it was made with', () => {
     expect(labelByEmoji('💯')?.id).toBe('exactly-this');
     expect(labelByEmoji('👍')?.id).toBe('i-agree');
+    expect(labelByEmoji('🪓')?.id).toBe('cut-this');
+    expect(labelByEmoji('✂️')).toBeUndefined();
     expect(labelById('verify-this')?.text).toBe('Verify this');
     expect(labelByEmoji('🦄')).toBeUndefined();
     expect(labelById('never-existed')).toBeUndefined();

--- a/app/src/annotations/quickLabels.ts
+++ b/app/src/annotations/quickLabels.ts
@@ -26,8 +26,7 @@ export const LABEL_COLOR_MAP: Record<string, { bg: string; text: string; darkTex
   amber: { bg: 'rgba(180,83,9,0.15)', text: '#b45309', darkText: '#fbbf24' },
 };
 
-// The label row. A group is what the terminal picker draws a divider between;
-// the Markdown reader draws one flat list.
+// The label row. A group is what both pickers draw a divider between.
 export const QUICK_LABEL_GROUPS: QuickLabel[][] = [
   [
     { id: 'i-agree', emoji: '👍', text: 'I agree', color: 'green' },
@@ -69,8 +68,7 @@ export const QUICK_LABEL_GROUPS: QuickLabel[][] = [
     },
   ],
   [
-    { id: 'cut-this', emoji: '✂️', text: 'Cut this', color: 'amber' },
-    { id: 'simplify-this', emoji: '🪓', text: 'Simplify this', color: 'purple' },
+    { id: 'cut-this', emoji: '🪓', text: 'Cut this', color: 'amber' },
   ],
   [
     { id: 'your-call', emoji: '🪙', text: 'Your call', color: 'green' },

--- a/app/src/components/MarkdownReader/MarkdownReader.css
+++ b/app/src/components/MarkdownReader/MarkdownReader.css
@@ -985,10 +985,6 @@
   color: #f59e0b;
 }
 
-.md-toolbar-btn--copied {
-  color: var(--md-success, #3fb950);
-}
-
 .md-toolbar-icon {
   width: 16px;
   height: 16px;
@@ -1182,6 +1178,12 @@
 
 .md-quick-label-row:hover {
   background: var(--color-bg-button, #252528);
+}
+
+.md-quick-label-divider {
+  height: 1px;
+  margin: 3px 6px;
+  background: var(--color-border, #2a2a2d);
 }
 
 .md-quick-label-text {

--- a/app/src/components/MarkdownReader/MarkdownReader.css
+++ b/app/src/components/MarkdownReader/MarkdownReader.css
@@ -1181,6 +1181,7 @@
 }
 
 .md-quick-label-divider {
+  border: 0;
   height: 1px;
   margin: 3px 6px;
   background: var(--color-border, #2a2a2d);

--- a/app/src/components/MarkdownReader/annotations/AnnotationLayer.tsx
+++ b/app/src/components/MarkdownReader/annotations/AnnotationLayer.tsx
@@ -37,7 +37,7 @@ type PopoverState =
 
 interface HoverBlock {
   blockId: string;
-  /** The .md-codeblock wrapper (toolbar anchor + copy text source). */
+  /** The .md-codeblock wrapper used as the toolbar anchor. */
   element: HTMLElement;
 }
 
@@ -281,15 +281,12 @@ export function AnnotationLayer({ api, rootRef, path }: AnnotationLayerProps) {
   const showSelectionToolbar = pending !== null && popover === null;
   const showHoverToolbar = !showSelectionToolbar && popover === null && hoverBlock !== null;
 
-  const hoverCopyText = hoverBlock?.element.querySelector('pre')?.textContent ?? '';
-
   return (
     <>
       {showSelectionToolbar && pending && (
         <SelectionToolbar
           getAnchorRect={getPendingRect}
           positionMode={pending.isCodeBlock ? 'top-right' : 'center-above'}
-          copyText={pending.selectionText}
           onDelete={handleDelete}
           onRequestComment={handleRequestComment}
           onQuickLabel={handleQuickLabel}
@@ -302,7 +299,6 @@ export function AnnotationLayer({ api, rootRef, path }: AnnotationLayerProps) {
         <SelectionToolbar
           getAnchorRect={getHoverRect}
           positionMode="top-right"
-          copyText={hoverCopyText}
           onDelete={handleDelete}
           onRequestComment={handleRequestComment}
           onQuickLabel={handleQuickLabel}

--- a/app/src/components/MarkdownReader/annotations/AnnotationLayer.tsx
+++ b/app/src/components/MarkdownReader/annotations/AnnotationLayer.tsx
@@ -16,7 +16,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { RefObject } from 'react';
-import { resolveDomRange } from '../anchoring';
+import { resolveDomRange } from '../anchoring/domRange';
 import { AnnotationPopover } from './AnnotationPopover';
 import { AnnotationSidebar } from './AnnotationSidebar';
 import { SelectionToolbar } from './SelectionToolbar';

--- a/app/src/components/MarkdownReader/annotations/QuickLabelPicker.test.tsx
+++ b/app/src/components/MarkdownReader/annotations/QuickLabelPicker.test.tsx
@@ -1,7 +1,7 @@
 /**
  * QuickLabelPicker — cursor-hint positioning with viewport clamping (E14),
  * one-tick-deferred outside dismiss (E15), digit/Alt+digit selection and
- * Escape (E16), and the full label row set.
+ * Escape (E16), and grouped label rendering.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -10,7 +10,7 @@ import {
   QuickLabelPicker,
   type FloatingQuickLabelPickerProps,
 } from '../../../annotations/QuickLabelPicker';
-import { QUICK_LABELS } from './quickLabels';
+import { QUICK_LABEL_PICKER_GROUPS, QUICK_LABEL_PICKER_LABELS } from './quickLabels';
 
 function makeAnchor(rect: Partial<DOMRect> = {}): HTMLElement {
   const el = document.createElement('button');
@@ -24,7 +24,7 @@ function renderPicker(overrides: Partial<FloatingQuickLabelPickerProps> = {}) {
   const anchorEl = overrides.anchorEl ?? makeAnchor();
   const props: FloatingQuickLabelPickerProps = {
     className: 'md-quick-label-picker',
-    labels: QUICK_LABELS,
+    groups: QUICK_LABEL_PICKER_GROUPS,
     cursorHint: { x: 300, y: 110 },
     onSelect: vi.fn(),
     onDismiss: vi.fn(),
@@ -56,16 +56,18 @@ afterEach(() => {
 });
 
 describe('QuickLabelPicker', () => {
-  it('renders the whole label set, numbering the ten that have a shortcut', () => {
-    // Past the tenth there is no digit to press, and a badge there would name
-    // a key that applies a different label.
+  it('renders the filtered groups with dividers and nine digit shortcuts', () => {
     renderPicker();
     const rows = document.querySelectorAll('.md-quick-label-row');
-    expect(rows).toHaveLength(QUICK_LABELS.length);
-    expect(rows[0].textContent).toContain(QUICK_LABELS[0].text);
+    expect(rows).toHaveLength(9);
+    expect(document.querySelectorAll('.md-quick-label-divider')).toHaveLength(4);
+    expect(Array.from(rows, (row) => row.querySelector('.md-ql-chip')?.textContent)).toEqual([
+      '💯', '😕', '🔍', '🧾', '🔬', '🔄', '🪓', '🪙', '🙋',
+    ]);
+    expect(rows[0].textContent).toContain(QUICK_LABEL_PICKER_LABELS[0].text);
     expect(rows[0].querySelector('.md-quick-label-num')!.textContent).toBe('1');
-    expect(rows[9].querySelector('.md-quick-label-num')!.textContent).toBe('0');
-    expect(rows[10]?.querySelector('.md-quick-label-num')).toBeNull();
+    expect(rows[8].querySelector('.md-quick-label-num')!.textContent).toBe('9');
+    expect(document.querySelectorAll('.md-quick-label-num')).toHaveLength(9);
   });
 
   it('positions at the cursor hint (x − 28) below the anchor (E14)', () => {
@@ -124,22 +126,22 @@ describe('QuickLabelPicker', () => {
     outside.remove();
   });
 
-  it('bare digits and Alt+digits select labels; 0 is the tenth (E16)', () => {
+  it('bare digits and Alt+digits select the flattened group order; 0 does nothing (E16)', () => {
     const { props } = renderPicker();
     act(() => {
       window.dispatchEvent(new KeyboardEvent('keydown', { code: 'Digit1', key: '1', bubbles: true }));
     });
-    expect(props.onSelect).toHaveBeenLastCalledWith(QUICK_LABELS[0]);
+    expect(props.onSelect).toHaveBeenLastCalledWith(QUICK_LABEL_PICKER_LABELS[0]);
     act(() => {
       window.dispatchEvent(
         new KeyboardEvent('keydown', { code: 'Digit3', key: '3', altKey: true, bubbles: true }),
       );
     });
-    expect(props.onSelect).toHaveBeenLastCalledWith(QUICK_LABELS[2]);
+    expect(props.onSelect).toHaveBeenLastCalledWith(QUICK_LABEL_PICKER_LABELS[2]);
     act(() => {
       window.dispatchEvent(new KeyboardEvent('keydown', { code: 'Digit0', key: '0', bubbles: true }));
     });
-    expect(props.onSelect).toHaveBeenLastCalledWith(QUICK_LABELS[9]);
+    expect(props.onSelect).toHaveBeenCalledTimes(2);
   });
 
   it('ctrl/meta digits are left alone (app shortcuts)', () => {
@@ -162,7 +164,7 @@ describe('QuickLabelPicker', () => {
 
   it('clicking a row selects its label', () => {
     const { props } = renderPicker();
-    fireEvent.click(screen.getByText(QUICK_LABELS[4].text));
-    expect(props.onSelect).toHaveBeenCalledWith(QUICK_LABELS[4]);
+    fireEvent.click(screen.getByText(QUICK_LABEL_PICKER_LABELS[4].text));
+    expect(props.onSelect).toHaveBeenCalledWith(QUICK_LABEL_PICKER_LABELS[4]);
   });
 });

--- a/app/src/components/MarkdownReader/annotations/SelectionToolbar.test.tsx
+++ b/app/src/components/MarkdownReader/annotations/SelectionToolbar.test.tsx
@@ -1,17 +1,17 @@
 /**
  * SelectionToolbar — the interaction contract:
  * - positioning modes (center-above / top-right) and scroll-out close (E5);
- * - Delete / 👍 / Cancel buttons (E6, E7 wiring);
- * - Alt+1..Alt+0 quick labels (E8);
+ * - Delete / promoted labels / Cancel buttons (E6, E7 wiring);
+ * - Alt+1..Alt+9 picker labels (E8);
  * - the full type-to-comment guard set, one assertion per guard (E9);
  * - keyboard suppression while the picker is open (E16);
  * - outside-pointerdown dismiss.
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { SelectionToolbar, type SelectionToolbarProps } from './SelectionToolbar';
-import { QUICK_LABELS, THUMBS_UP_LABEL } from './quickLabels';
+import { PROMOTED_LABELS, QUICK_LABEL_PICKER_LABELS } from './quickLabels';
 
 function fakeRect(overrides: Partial<DOMRect> = {}): DOMRect {
   const base = { top: 200, bottom: 220, left: 100, right: 300, width: 200, height: 20, x: 100, y: 200 };
@@ -22,7 +22,6 @@ function renderToolbar(overrides: Partial<SelectionToolbarProps> = {}) {
   const props: SelectionToolbarProps = {
     getAnchorRect: () => fakeRect(),
     positionMode: 'center-above',
-    copyText: 'selected words',
     onDelete: vi.fn(),
     onRequestComment: vi.fn(),
     onQuickLabel: vi.fn(),
@@ -82,12 +81,26 @@ describe('SelectionToolbar', () => {
     expect(props.onRequestComment).not.toHaveBeenCalled();
   });
 
-  it('the one-click agreement button applies a label from the shared set (E7)', () => {
+  it('renders exactly the three promoted label buttons and no Copy action (E7)', () => {
     const { props } = renderToolbar();
-    fireEvent.click(screen.getByTitle(THUMBS_UP_LABEL.text));
-    expect(props.onQuickLabel).toHaveBeenCalledWith(THUMBS_UP_LABEL);
-    expect(THUMBS_UP_LABEL.emoji).toBe('👍');
-    expect(QUICK_LABELS).toContain(THUMBS_UP_LABEL);
+    const toolbar = document.querySelector<HTMLElement>('.md-selection-toolbar')!;
+
+    expect(within(toolbar).queryByTitle('Copy')).toBeNull();
+    expect(within(toolbar).getAllByRole('button').map((button) => button.title)).toEqual([
+      'Delete',
+      'Comment',
+      'Quick label',
+      'I agree',
+      'This is wrong',
+      'Clarify this',
+      'Cancel',
+    ]);
+
+    for (const label of PROMOTED_LABELS) {
+      fireEvent.click(within(toolbar).getByTitle(label.text));
+      expect(props.onQuickLabel).toHaveBeenLastCalledWith(label);
+    }
+    expect(PROMOTED_LABELS.map((label) => label.emoji)).toEqual(['👍', '❌', '❓']);
   });
 
   it('Cancel button closes', () => {
@@ -96,15 +109,14 @@ describe('SelectionToolbar', () => {
     expect(props.onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('Alt+1..Alt+9 and Alt+0 apply quick labels 1..10 (E8)', () => {
+  it('Alt+1..Alt+9 apply the filtered picker labels and Alt+0 does nothing (E8)', () => {
     const { props } = renderToolbar();
     pressKey({ code: 'Digit1', key: '1', altKey: true });
-    expect(props.onQuickLabel).toHaveBeenLastCalledWith(QUICK_LABELS[0]);
+    expect(props.onQuickLabel).toHaveBeenLastCalledWith(QUICK_LABEL_PICKER_LABELS[0]);
     pressKey({ code: 'Digit9', key: '9', altKey: true });
-    expect(props.onQuickLabel).toHaveBeenLastCalledWith(QUICK_LABELS[8]);
+    expect(props.onQuickLabel).toHaveBeenLastCalledWith(QUICK_LABEL_PICKER_LABELS[8]);
     pressKey({ code: 'Digit0', key: '0', altKey: true });
-    expect(props.onQuickLabel).toHaveBeenLastCalledWith(QUICK_LABELS[9]);
-    expect(props.onQuickLabel).toHaveBeenCalledTimes(3);
+    expect(props.onQuickLabel).toHaveBeenCalledTimes(2);
     expect(props.onRequestComment).not.toHaveBeenCalled();
   });
 
@@ -141,7 +153,7 @@ describe('SelectionToolbar', () => {
       expect(props.onRequestComment).not.toHaveBeenCalled();
       // ...but digits now select labels via the picker.
       pressKey({ code: 'Digit2', key: '2' });
-      expect(props.onQuickLabel).toHaveBeenCalledWith(QUICK_LABELS[1]);
+      expect(props.onQuickLabel).toHaveBeenCalledWith(QUICK_LABEL_PICKER_LABELS[1]);
     });
 
     it('guard 4: Escape closes the toolbar', () => {

--- a/app/src/components/MarkdownReader/annotations/SelectionToolbar.tsx
+++ b/app/src/components/MarkdownReader/annotations/SelectionToolbar.tsx
@@ -3,8 +3,8 @@
  * hovered code block). Ported from plannotator's AnnotationToolbar minus
  * math/images/keyboard-copy.
  *
- * Buttons: Copy, Delete (redline — creates instantly, no popover), Comment,
- * ⚡ quick-label picker toggle, a fixed one-click agreement button, Cancel.
+ * Buttons: Delete (redline — creates instantly, no popover), Comment,
+ * ⚡ quick-label picker toggle, three promoted quick labels, Cancel.
  *
  * Positioning: `center-above` for prose (centered over the selection rect),
  * `top-right` for code blocks (right-aligned above the block); recomputed on
@@ -31,7 +31,12 @@ import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useEscapeStack } from '../../../hooks/useEscapeStack';
 import { QuickLabelPicker } from '../../../annotations/QuickLabelPicker';
-import { QUICK_LABELS, THUMBS_UP_LABEL, type QuickLabel } from './quickLabels';
+import {
+  PROMOTED_LABELS,
+  QUICK_LABEL_PICKER_GROUPS,
+  QUICK_LABEL_PICKER_LABELS,
+  type QuickLabel,
+} from './quickLabels';
 
 export type ToolbarPositionMode = 'center-above' | 'top-right';
 
@@ -52,8 +57,6 @@ export interface SelectionToolbarProps {
   /** Live anchor rect — re-read on every scroll/resize tick. */
   getAnchorRect: () => DOMRect | null;
   positionMode: ToolbarPositionMode;
-  /** Text the Copy button places on the clipboard. */
-  copyText: string;
   onDelete: () => void;
   onRequestComment: (initialChar?: string) => void;
   onQuickLabel: (label: QuickLabel) => void;
@@ -70,7 +73,6 @@ export interface SelectionToolbarProps {
 export function SelectionToolbar({
   getAnchorRect,
   positionMode,
-  copyText,
   onDelete,
   onRequestComment,
   onQuickLabel,
@@ -83,29 +85,12 @@ export function SelectionToolbar({
   const [position, setPosition] = useState<{ top: number; left?: number; right?: number } | null>(
     null,
   );
-  const [copied, setCopied] = useState(false);
   const [showQuickLabels, setShowQuickLabels] = useState(false);
   const [pickerHint, setPickerHint] = useState<{ x: number; y: number } | null>(null);
   const toolbarRef = useRef<HTMLDivElement>(null);
   const zapButtonRef = useRef<HTMLButtonElement>(null);
   const showQuickLabelsRef = useRef(showQuickLabels);
   showQuickLabelsRef.current = showQuickLabels;
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(copyText);
-    } catch {
-      const textarea = document.createElement('textarea');
-      textarea.value = copyText;
-      textarea.style.cssText = 'position:fixed;opacity:0';
-      document.body.appendChild(textarea);
-      textarea.select();
-      document.execCommand('copy');
-      textarea.remove();
-    }
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
-  };
 
   // Position on mount + capture-phase scroll + resize; scroll-out close.
   useEffect(() => {
@@ -152,8 +137,8 @@ export function SelectionToolbar({
         e.preventDefault();
         const digit = parseInt(e.code.slice(5), 10);
         const index = digit === 0 ? 9 : digit - 1;
-        if (index < QUICK_LABELS.length) {
-          onQuickLabel(QUICK_LABELS[index]);
+        if (index < QUICK_LABEL_PICKER_LABELS.length) {
+          onQuickLabel(QUICK_LABEL_PICKER_LABELS[index]);
         }
         return;
       }
@@ -215,15 +200,6 @@ export function SelectionToolbar({
     >
       <button
         type="button"
-        className={`md-toolbar-btn ${copied ? 'md-toolbar-btn--copied' : ''}`.trim()}
-        title={copied ? 'Copied!' : 'Copy'}
-        onClick={handleCopy}
-      >
-        {copied ? <CheckIcon /> : <CopyIcon />}
-      </button>
-      <span className="md-toolbar-divider" />
-      <button
-        type="button"
         className="md-toolbar-btn md-toolbar-btn--delete"
         title="Delete"
         onClick={onDelete}
@@ -250,18 +226,21 @@ export function SelectionToolbar({
       >
         <ZapIcon />
       </button>
-      <button
-        type="button"
-        className="md-toolbar-btn"
-        title={THUMBS_UP_LABEL.text}
-        onClick={() => onQuickLabel(THUMBS_UP_LABEL)}
-      >
-        <span className="md-toolbar-emoji">{THUMBS_UP_LABEL.emoji}</span>
-      </button>
+      {PROMOTED_LABELS.map((label) => (
+        <button
+          key={label.id}
+          type="button"
+          className="md-toolbar-btn"
+          title={label.text}
+          onClick={() => onQuickLabel(label)}
+        >
+          <span className="md-toolbar-emoji">{label.emoji}</span>
+        </button>
+      ))}
       {showQuickLabels && zapButtonRef.current && (
         <QuickLabelPicker
           className="md-quick-label-picker"
-          labels={QUICK_LABELS}
+          groups={QUICK_LABEL_PICKER_GROUPS}
           anchorEl={zapButtonRef.current}
           cursorHint={pickerHint}
           onSelect={(label) => {
@@ -281,18 +260,6 @@ export function SelectionToolbar({
 }
 
 // ---- icons (donor SVGs, stroke=currentColor) --------------------------------
-
-const CopyIcon = () => (
-  <svg className="md-toolbar-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-  </svg>
-);
-
-const CheckIcon = () => (
-  <svg className="md-toolbar-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-  </svg>
-);
 
 const TrashIcon = () => (
   <svg className="md-toolbar-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/app/src/components/MarkdownReader/annotations/quickLabels.ts
+++ b/app/src/components/MarkdownReader/annotations/quickLabels.ts
@@ -28,9 +28,14 @@ export const PROMOTED_LABELS: readonly QuickLabel[] = PROMOTED_LABEL_IDS.map(req
 
 const promotedLabelIds = new Set<string>(PROMOTED_LABEL_IDS);
 
-export const QUICK_LABEL_PICKER_GROUPS: readonly (readonly QuickLabel[])[] = QUICK_LABEL_GROUPS
-  .map((group) => group.filter((label) => !promotedLabelIds.has(label.id)))
-  .filter((group) => group.length > 0);
+const pickerGroups: QuickLabel[][] = [];
+for (const group of QUICK_LABEL_GROUPS) {
+  const pickerGroup = group.filter((label) => !promotedLabelIds.has(label.id));
+  if (pickerGroup.length > 0) {
+    pickerGroups.push(pickerGroup);
+  }
+}
+export const QUICK_LABEL_PICKER_GROUPS: readonly (readonly QuickLabel[])[] = pickerGroups;
 
 export const QUICK_LABEL_PICKER_LABELS: readonly QuickLabel[] = QUICK_LABEL_PICKER_GROUPS.flat();
 

--- a/app/src/components/MarkdownReader/annotations/quickLabels.ts
+++ b/app/src/components/MarkdownReader/annotations/quickLabels.ts
@@ -2,23 +2,37 @@
 // Markdown reader needs. A document mark stores `quickLabelId` and the tip it
 // was made with, never the label's text baked into the comment.
 
-import { QUICK_LABELS, labelById, type QuickLabel } from '../../../annotations/quickLabels';
+import {
+  QUICK_LABEL_GROUPS,
+  QUICK_LABELS,
+  labelById,
+  type QuickLabel,
+} from '../../../annotations/quickLabels';
 
 export { LABEL_COLOR_MAP, QUICK_LABELS, type QuickLabel } from '../../../annotations/quickLabels';
 
-// What the toolbar's fixed 👍 button applies.
-const AGREEMENT_LABEL_ID = 'i-agree';
+const PROMOTED_LABEL_IDS = ['i-agree', 'this-is-wrong', 'clarify-this'] as const;
 
-export const THUMBS_UP_LABEL: QuickLabel = (() => {
-  const label = QUICK_LABELS.find((candidate) => candidate.id === AGREEMENT_LABEL_ID);
+function requireQuickLabel(id: string): QuickLabel {
+  const label = labelById(id);
   if (!label) {
     throw new Error(
-      `The one-click agreement button points at quick label "${AGREEMENT_LABEL_ID}", which the shared set no longer offers. `
+      `A promoted toolbar button points at quick label "${id}", which the shared set no longer offers. `
       + `Point it at one of: ${QUICK_LABELS.map((candidate) => candidate.id).join(', ')}.`,
     );
   }
   return label;
-})();
+}
+
+export const PROMOTED_LABELS: readonly QuickLabel[] = PROMOTED_LABEL_IDS.map(requireQuickLabel);
+
+const promotedLabelIds = new Set<string>(PROMOTED_LABEL_IDS);
+
+export const QUICK_LABEL_PICKER_GROUPS: readonly (readonly QuickLabel[])[] = QUICK_LABEL_GROUPS
+  .map((group) => group.filter((label) => !promotedLabelIds.has(label.id)))
+  .filter((group) => group.length > 0);
+
+export const QUICK_LABEL_PICKER_LABELS: readonly QuickLabel[] = QUICK_LABEL_PICKER_GROUPS.flat();
 
 export function quickLabelById(id: string): QuickLabel | undefined {
   return labelById(id);

--- a/changelog.d/delegate-annot-toolbar-quick-labels.yaml
+++ b/changelog.d/delegate-annot-toolbar-quick-labels.yaml
@@ -1,0 +1,6 @@
+kind: changed
+area: annotations
+change: >
+  Markdown selection actions now put agreement, disagreement, and clarification
+  labels directly in the toolbar, group the remaining quick labels in the picker,
+  and use the axe icon for Cut this. The redundant Copy action was removed.


### PR DESCRIPTION
## What changed

Markdown annotations now keep the three promoted verdicts directly in the selection toolbar:

- removed the redundant Copy action
- added one-click 👍 I agree, ❌ This is wrong, and ❓ Clarify this actions
- grouped the remaining quick labels in the ⚡ picker and kept its digits aligned with Alt+digit
- replaced the old Cut/Simplify pair with a single 🪓 Cut this label shared by markdown and terminal annotations

The floating picker now contains nine non-promoted labels in five groups. The terminal picker keeps its existing chip layout and picks up only the shared label-set change.

## Live verification

Verified in the isolated packaged profile `annot-e18c`:

- markdown toolbar order is Delete, Comment, ⚡, 👍, ❌, ❓, Cancel, with no Copy
- ❌ and ❓ apply their labels in one click
- the ⚡ picker shows the nine grouped labels; digit 7 applies 🪓 Cut this
- the terminal annotation popup still renders grouped chips, with 🪓 Cut this and no ✂️

![clip2](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/dbcce425e6aae7db8ae687321a928e34bc79e9c9/delegate-annot-toolbar-e18ca85e/clip2.gif)

[Full-quality recording (mp4)](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/dbcce425e6aae7db8ae687321a928e34bc79e9c9/delegate-annot-toolbar-e18ca85e/clip2.mp4)
