### PR TITLE
feat(apps): fence facts behind durable reconciliation

### DIFF
--- a/changelog.d/app-reconcile-durable-fence.yaml
+++ b/changelog.d/app-reconcile-durable-fence.yaml
@@ -1,0 +1,13 @@
+kind: fixed
+area: apps
+change: >
+  App reconciliation is now durable at the event-bus boundary: a version move,
+  re-enable, or retained-history gap records the current bus-head fence, and an
+  app receives no later fact until that owed rebuild completes. Requests that
+  arrive during a rebuild remain owed for the next run, and a daemon restart
+  loses neither the request nor its cursor boundary.
+symptom: >
+  An app that rebuilt a document collection from events could silently keep
+  stale rows after being re-enabled, falling behind retention, or changing
+  versions, because the bus resumed delivery without first rebuilding from
+  current state.

--- a/docs/plans/2026-08-14-ext-app-reconcile-handler.md
+++ b/docs/plans/2026-08-14-ext-app-reconcile-handler.md
@@ -1,0 +1,481 @@
+# App reconcile handler
+
+Designed 2026-08-14 and approved by Victor. This follows
+[A4's app registry and runtime](2026-08-06-ext-a4-app-registry-and-runtime.md),
+[A1's durable consumer contract](2026-08-01-ext-a1-event-bus.md), and
+[A5's manifest and SDK shape](2026-08-13-ext-a5-ui-host-and-app-sdk.md).
+
+## Problem
+
+An app's collections are a materialized view over current state. A fact wakes
+the app, but the collection is what survives. Three real paths can leave that
+view stale:
+
+1. A disabled app is re-enabled after retention passed its cursor.
+2. An enabled consumer resumes below the oldest surviving fact.
+3. A different app version derives different collection contents from the
+   same current state.
+
+The bus currently repairs the first two by logging the gap and moving the
+consumer directly to head (`internal/bus/bus.go`, `reconcileGap`). The app is
+not called. A version move re-points the consumer and its declarations
+(`internal/daemon/app_apply.go`, `internal/daemon/app_consumers.go`) but never
+rebuilds existing documents. In both cases the runtime proceeds as though the
+view were current.
+
+Views are not affected. Every live-query delivery is a complete window; a
+later window supersedes anything a view missed. This design is only for
+headless app handlers and the collections they maintain.
+
+## Gate answers
+
+### 1. Trigger once from a durable request, not from a synthetic fact
+
+Recommendation: each condition writes a durable reconcile request. The
+consumer lane coalesces every request already pending for the app into one
+invocation. Reasons are a set, so a version move while disabled followed by
+re-enable invokes once with both `version_changed` and `re_enabled`.
+
+```text
+version move / re-enable / resume below retention
+  persist app_reconcile_request(reason, version, through_seq, detail)
+  wake the app's ordinary bus consumer
+    coalesce pending requests
+    run version's reconcile handler
+    mark claimed requests complete
+    advance cursor through through_seq
+    deliver later facts in seq order
+```
+
+The three detectors are:
+
+- **Resume with a gap.** `internal/bus.Bus` already reads `earliest`, `head`,
+  and the consumer cursor before it advances. Durable registration gains a
+  pre-drain hook. For an app consumer, the hook inserts a `gap` request carrying
+  `{cursor, earliest, through_seq: head, missed}` before anything moves. A
+  non-app consumer keeps A1's current log-and-resume behavior.
+- **Enable after disable.** `handleAppSetEnabled` already reads the consumer
+  record before setting its bit (`internal/daemon/apps.go`). A transition from
+  `enabled=false` to `true` inserts `re_enabled` in the same store transaction
+  as the bit flip. Enabling an already-enabled app is a no-op and creates no
+  request.
+- **Version change.** A pointer move to a different version inserts
+  `version_changed` in the same transaction as the pointer move, carrying the
+  previous and target version ids. Initial installation has no previous
+  version and does not reconcile. Re-applying the already-serving content
+  moves no pointer and creates no request, matching
+  `publishAppVersionChanged` in `internal/daemon/app_apply.go`. Rollback is a
+  version change and does reconcile.
+
+`through_seq` is the bus head read inside the triggering transaction. It is the
+fence the rebuilt view supersedes. A gap uses the head already read by the bus.
+Facts published after that fence wait in the log and are delivered after the
+reconcile succeeds.
+
+`app.version.changed` and `app.enabled.changed` remain domain facts for other
+consumers and the UI. They are not the orchestration mechanism: consuming an
+app's own fact would put the trigger behind the cursor whose movement it must
+control.
+
+Requests that arrive before a run starts coalesce. A request that arrives
+after a run has claimed its fence cannot join that run honestly; it remains
+owed and causes one more reconcile before fact delivery resumes.
+
+### 2. Declare the handler; pass reasons and a current-state snapshot
+
+Recommendation: the manifest declares support explicitly:
+
+```toml
+reconcile = true
+```
+
+The bundle follows A5's structured exports: one map per handler kind, with
+reconcile as its own sibling export. Kind is structure, never a prefix encoded
+into a flat handler key:
+
+```ts
+export const subscriptions = {
+  "ticket.*": onTicket,
+} satisfies Subscriptions
+
+export const commands = {
+  refresh: onRefresh,
+} satisfies Commands
+
+export const reconcile: ReconcileHandler<AppCollections> =
+  async (reason, ctx) => { /* converge collections */ }
+```
+
+Apply still never evaluates app code. The manifest tells the daemon that the
+capability exists; codegen plus `tsc` proves the function is present. This
+extends the same declaration-to-generated-group shape A5 uses for
+subscriptions and commands. The sidecar selects `subscriptions` for a fact,
+`commands` for a command envelope, and `reconcile` for this lifecycle call;
+collisions between kinds are inexpressible.
+
+The SDK contract is:
+
+```ts
+type ReconcileCause = "gap" | "re_enabled" | "version_changed"
+
+type ReconcileReason = {
+  causes: readonly ReconcileCause[]
+  version: number
+  throughSeq: number
+  gap?: {
+    cursor: number
+    earliest: number
+    missed: number
+  }
+  previousVersions: readonly number[]
+}
+
+type ReconcileHandler<Collections> = (
+  reason: ReconcileReason,
+  ctx: AppContext<Collections>,
+) => void | Promise<void>
+```
+
+Causes are sorted in the order above, not in arrival order. `version` is the
+version whose handler is running. `previousVersions` contains the distinct
+versions named by coalesced pointer moves, in request order. A retry receives
+the same claimed reason. A later trigger produces a later invocation.
+
+The current A4 context exposes only the app's declared document collections
+(`apphost/src/dispatch.ts`, `internal/daemon/app_runtime_rpc.go`). That can
+store a projection but cannot rebuild one from attn's current state. Add one
+read-only surface to `AppContext`, available to ordinary event handlers too:
+
+```ts
+type AppContext<Collections> = {
+  app: string
+  version: number
+  collections: Collections
+  current: {
+    snapshot(): Promise<CurrentStateSnapshot>
+  }
+}
+```
+
+`CurrentStateSnapshot` reuses the daemon's existing initial-state projection
+instead of inventing a second meaning of "current". Its exact fields are:
+
+```ts
+type CurrentStateSnapshot = {
+  asOfSeq: number
+  sessions: Session[]
+  endpoints: EndpointInfo[]
+  workspaces: Workspace[]
+  prs: PR[]
+  repos: RepoState[]
+  authors: AuthorState[]
+  githubHosts: string[]
+  tickets: TicketRow[]
+  seeds: Seed[]
+  crew: CrewMember[]
+  apps: AppSummary[]
+}
+```
+
+These are the state-bearing domain fields assembled for `InitialStateMessage`
+in `internal/daemon/websocket.go`; A5 adds `apps` to that projection. Protocol
+identity, warnings, client-only metadata, and the untyped `settings` map are
+not app state and are not included. In particular, `settings` is the daemon's
+entire settings table plus derived client capability flags, not a bounded app
+read contract. An app that needs configuration gets a purpose-built typed
+reader later. The builder reads local and relayed domain state exactly as
+Initial State does. The snapshot call captures `asOfSeq` first, then builds the
+projection; every mutation committed at or below that position is therefore
+already visible, while a later mutation still has a fact above the fence.
+
+The complete reconcile-time surface is deliberately small:
+
+- `ctx.current.snapshot()` reads attn's current state.
+- `ctx.collections.<declared>` provides the existing `get`, `put`, `delete`,
+  `query`, and `count` operations in the app's own namespace.
+- The bundle retains the ordinary Bun Web and Node APIs. An app whose truth is
+  an external service may read it directly.
+
+There is no bus replay, raw database access, arbitrary namespace read, live
+query, or cursor mutation in this contract. A state domain not present in the
+snapshot must first gain an ordinary typed current-state read; a reconcile
+handler must not pretend an old fact payload is current truth.
+
+### 3. Run in the shared sidecar, with the existing dispatch tripwires
+
+Recommendation: reconcile is an ordinary version-stamped dispatch on the
+single-threaded event loop in the one shared Bun sidecar
+(`apphost/src/index.ts`). It uses the existing 60-second dispatch timeout and
+2-second liveness ping from
+`internal/daemon/app_runtime.go` and `internal/daemon/app_consumers.go`.
+
+The receipt is A4's live measurement: a warm document-writing handler took
+0–1ms, cold process start plus import and first write took 41–77ms, and an
+answered sidecar ping took 344–416us. Sixty seconds is four to five orders of
+magnitude beyond an ordinary SDK round trip; the two-second ping is roughly
+5,000 times its measured healthy cost. A reconcile large enough to need more
+than that checkpoints progress in its own collection and remains idempotent
+across attempts. The failure names `timeout=60s` and the operation it
+abandoned.
+
+The exit proof records the full seeded rebuild duration. If a healthy rebuild
+approaches this tripwire, the implementation changes the timeout from that
+receipt before merging; it does not add an unmeasured second budget.
+
+A timeout must interrupt the work, not merely stop waiting for it. After the
+ping attributes the dispatch, the daemon terminates that sidecar generation
+and lets the existing supervisor start a new one. This covers both shapes:
+
+- a yielding promise that never settles is removed with the old process;
+- a non-yielding loop cannot prevent the daemon's Go timer from firing, and
+  cannot starve other apps after the generation is terminated.
+
+Other in-flight apps receive runtime failures and retry from their unchanged
+cursors. The worst broken reconcile can hold the shared sidecar is the existing
+dispatch timeout plus its liveness attribution; it cannot park the process in a
+permanent frozen state. The stop must be generation-fenced through
+`internal/supervise`, never a process-name kill.
+
+### 4. Keep reconcile owed until success; make every attempt visible
+
+Recommendation: the request is the durable statement that reconciliation is
+owed. It is complete only when the handler returns successfully and the
+consumer cursor is advanced through the claimed fence in the same transaction.
+
+The runtime writes an invocation row with `status=running` before dispatch and
+settles it to `ok`, `error`, `runtime_error`, or `interrupted`. A row still
+running when the daemon starts is marked interrupted. Its reconcile request is
+unchanged, so the next enabled drain runs it again.
+
+A throw or timeout follows the existing app failure policy:
+
+- keep the request and cursor in place;
+- record the attempt under handler `reconcile`, stamped with the serving
+  version and the structured reasons;
+- retry with A1's capped exponential backoff;
+- after A4's existing 15-minute stall window on the same claimed request,
+  auto-disable the app and write the existing durable notification.
+
+There is no fixed attempt count. It retries at least once and as many times as
+fit before success or the existing stall clock disables it. Re-enabling clears
+the stall clock but not the owed request.
+
+A daemon stop or sidecar restart is interruption, not app failure. It records
+`interrupted` when the daemon can, otherwise startup closes the leftover
+`running` row. It does not advance the app's failure clock. A sidecar transport
+failure records `runtime_error`; the supervisor's existing park and notification
+remain the loud terminal state for a broken runtime.
+
+The user-facing surfaces are the same three levels as handler failure:
+
+- every attempt is in the invocation log and `attn app dev` stream;
+- `attn app status <name>` shows `reconcile owed`, its reasons and fence, the
+  current attempt, and the last error;
+- a durable notification is written when auto-disable makes the failure need
+  user action.
+
+This is intentionally not an immediate notification on every throw. Ordinary
+handler failures are visible while retrying and notify when attn stops trying;
+reconcile follows the same posture.
+
+### 5. Reconcile is a fence in the app's fact-delivery lane
+
+Recommendation: an app receives no fact while any reconcile request is owed or
+running. The bus's pre-drain hook runs after the enabled bit and log bounds are
+read, but before the first `Since(cursor)` call.
+
+On success, one transaction marks the claimed requests complete and advances
+the consumer to `max(cursor, through_seq)`. Facts at or below the fence are not
+replayed: the current-state rebuild supersedes them. Facts appended during the
+run have a greater seq and remain in the log. They are delivered in order after
+the hook finds no later reconcile request.
+
+This gives every trigger the same sequence:
+
+```text
+old in-flight handler settles
+  reconcile current version through fence N
+    trigger during run? reconcile again through its later fence
+  deliver N+1, N+2, ...
+```
+
+A snapshot may include a mutation above the claimed fence. Its later fact is
+still delivered. That is an allowed duplicate observation under the bus's
+existing at-least-once contract; it is never a missed mutation.
+
+A5 commands are not bus deliveries. While reconcile is owed or running, the
+daemon refuses a command for that app with a named `reconcile_owed` result and
+the current reasons. Letting commands mutate the same collections halfway
+through a rebuild would make the fence meaningless. Views remain mounted and
+may observe intermediate document writes; a reconcile that needs atomic visual
+replacement writes a generation marker in its collection and switches that
+marker last.
+
+### 6. The handler converges; the runtime serializes and redelivers
+
+Recommendation: the app contract states this plainly:
+
+- A reconcile handler is idempotent. Running it twice with the same reason, or
+  after a partially completed attempt, must converge to the same collection
+  contents.
+- It removes rows that no longer exist in current truth as well as adding and
+  updating rows that do. A rebuild that only upserts is incomplete.
+- An ordinary event handler remains tolerant of redelivery. It may receive a
+  fact already reflected in the snapshot used by reconcile.
+
+The runtime guarantees:
+
+- at most one reconcile runs for an app at a time;
+- no fact handler or app command for that app runs across its reconcile fence;
+- the serving version and claimed reason are fixed for one attempt;
+- the request and cursor advance survive or fail together;
+- interruption and failure never complete the request or advance the cursor;
+- a callback through `ctx` is accepted only while that dispatch is in flight,
+  matching today's `lookupAppDispatch` fence.
+
+Different apps still run concurrently on the sidecar's event loop. A handler
+that yields does not hold them up; a handler that does not yield loses its
+sidecar generation at the timeout.
+
+### 7. No handler means no silent resume
+
+Recommendation: a subscribed app without `reconcile = true` must never cross a
+trigger while still enabled.
+
+- **Version change:** refuse apply or rollback before the pointer moves. The
+  error names the current and requested versions and says to declare and
+  implement `reconcile`. Initial install is allowed because there is no old
+  derived state.
+- **Re-enable:** refuse the enable and leave the consumer disabled. The CLI
+  caller is already present, so the named refusal is the loud surface.
+- **Gap discovered while enabled:** leave the cursor in place, disable the app,
+  record a `missing_reconcile` invocation, and write a durable notification.
+  Retrying code that does not exist cannot heal and would only pin retention.
+
+An A5 view-only app keeps the sentinel consumer row used for uniform lifecycle
+handling, but its filter matches nothing. It cannot miss a subscribed fact, so
+reconcile obligations are inert for it.
+
+Silently keeping the old A1 skip-to-head behavior was rejected. So was running
+an optional no-op reconcile: both certify stale collections as current.
+
+### 8. Existing apps are grandfathered, not silently declared safe
+
+Recommendation: the migration creates no reconcile request merely because attn
+was upgraded. Existing installed versions continue to run under their frozen
+declarations, and their cursors do not move.
+
+`attn app status` reports `reconcile: unsupported` for a subscribed version
+whose frozen declaration predates the field. The next trigger follows the loud
+rules above: a version move or enable is refused, and a discovered gap disables
+and notifies. Re-applying byte-identical content is allowed because it moves no
+pointer and triggers nothing.
+
+The scaffold declares and implements reconcile from this stage forward. Its
+example rebuilds from `ctx.current.snapshot()`, deletes stale documents, and
+upserts the desired set. The generated SDK and scaffold guidance say that
+reconcile is idempotent and may be interrupted.
+
+## Persistent shape and ownership
+
+Two small records keep trigger history separate from attempts:
+
+```text
+app_reconcile_requests
+  id                  monotonic claim boundary
+  app_name
+  reason              gap | re_enabled | version_changed
+  version_id          target version when requested
+  through_seq         bus-head fence
+  previous_version_id nullable
+  cursor              gap only
+  earliest            gap only
+  missed              gap only
+  created_at
+
+app_reconcile_progress
+  app_name             primary key
+  completed_request_id highest request completed for this app
+  updated_at
+```
+
+The consumer lane selects requests above `completed_request_id`, captures the
+largest id, and folds their reasons. Completion advances only through that
+captured id. A request inserted during the run therefore remains pending
+without a `running` state machine. A unique trigger key makes retrying the bus's
+gap hook idempotent.
+
+`app_invocations` remains the attempt log. Its event fields become optional for
+non-event invocations, and its shape gains an invocation kind plus reconcile
+reason/fence. Invocation labels are rendering, not dispatch keys: logs may say
+`subscription:ticket.*`, `command:refresh`, or `reconcile`, while the sidecar
+dispatches through the structured exports above. This joins A5's command and
+render-error invocation work instead of encoding a fake `app.reconcile` bus
+fact.
+
+The store owns atomic trigger writes and completion-plus-cursor advance.
+`internal/bus` owns only when its pre-drain hook runs and the fallback behavior
+for consumers without one. `internal/daemon` owns app policy, dispatch,
+auto-disable, status, and notification. `apphost` only loads the named version,
+builds the SDK context, and invokes the reconcile export.
+
+Removing an app deletes its reconcile requests and progress with the registry
+and consumer. Version history, invocation history, and `app/<name>` documents
+keep A4's existing retention rules.
+
+## Delivery
+
+This changes daemon lifecycle, persistence, the app-runtime RPC, the SDK, and
+user-visible status. Every slice after the store seam needs a running
+non-production app; the final slice carries the stale-before/fixed-after live
+proof.
+
+1. **Durable trigger and lane fence.** Add the reconcile request/progress
+   migration and store transactions; extend `internal/bus` registration with
+   the pre-drain hook; write the three trigger paths and completion-plus-cursor
+   transaction. Unit and integration tests cover coalescing, a trigger during a
+   run, restart before completion, cursor fencing, and non-app gap parity.
+   Verification tier: full non-production app/daemon install because this
+   changes a live durable consumer's background loop, plus direct inspection of
+   cursor and request rows; no new app code runs yet.
+2. **Manifest, SDK, and sidecar dispatch.** Add `reconcile = true`, the typed
+   reconcile export beside A5's subscription and command maps,
+   `ReconcileReason`, `ctx.current.snapshot()`, the shared Initial State domain
+   projection builder, and the reconcile sidecar dispatch. Extend the version
+   hash through the frozen declaration as today. Verification tier:
+   full non-production app install because the daemon/runtime RPC and packaged
+   sidecar change; Linux host build and tests apply because `apphost` and
+   `internal/**` run on remotes.
+3. **Failure, interruption, and operator surfaces.** Start/settle reconcile
+   invocation rows, startup interruption repair, timeout-driven generation
+   recycle, app status, command refusal, auto-disable, notifications, and the
+   loud missing-handler paths. Protocol changes follow `main.tsp` generation
+   and increment `ProtocolVersion`; generated Go and TypeScript are never
+   edited by hand. Verification tier: full non-production app plus packaged-app
+   harness. Prove an infinite loop loses its generation and another app resumes.
+4. **Scaffold and exit proof.** Teach the handler in `attn app new` and the SDK
+   docs. First demonstrate today's stale state. Then show disable, trim, enable
+   rebuilding the collection with one coalesced invocation; force an enabled
+   gap; apply a version deriving a new field; interrupt a reconcile by restarting
+   the dev daemon; and show each case converges before later facts run. Record
+   the visible status and notification paths. Verification tier: full packaged
+   app on a throwaway profile, with a Linux remote dispatch witness.
+
+Every slice adds focused tests. The bus timing tests run under `synctest`; no
+sleeps or polling. The live proof uses a seeded realistic app collection rather
+than an empty database.
+
+## Open questions
+
+None. Victor approved the two review calls on 2026-08-14:
+
+- expose the state-bearing Initial State domain projection as one snapshot and
+  no raw store or settings API; typed domain readers may be added later without
+  breaking it;
+- refuse a subscribed legacy version's pointer move before it happens rather
+  than install a version attn already knows it cannot serve safely.
+
+Victor also required A5's structured export shape: subscription and command
+maps are separate, and reconcile is its own sibling export. Retry, ordering,
+interruption, missing-handler behavior, and the sidecar timeout therefore have
+no implementation-time product choice left.

--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -105,8 +105,8 @@ type Gap struct {
 	Missed   int64
 }
 
-// PreDrain runs after the consumer registration and log bounds are read, but
-// before any event is selected. It may durably move the cursor; the bus re-reads
+// PreDrain runs after the consumer registration and log bounds are read, before
+// each event batch is selected. It may durably move the cursor; the bus re-reads
 // the registration after it returns.
 type PreDrain func(ctx context.Context, consumer Consumer, gap *Gap) error
 
@@ -777,48 +777,57 @@ func (b *Bus) deliver(d *durable) {
 
 // drain reads forward from the consumer's cursor until the log is exhausted.
 func (b *Bus) drain(d *durable) error {
-	// The enabled bit is the kill switch and lives only in the database; re-read
-	// it, never cache it for the process lifetime.
-	rec, ok, err := b.store.GetConsumer(d.name)
-	if err != nil {
-		return fmt.Errorf("reading registration: %w", err)
-	}
-	if !ok {
-		return fmt.Errorf("registration for %s disappeared", d.name)
-	}
-	d.setPosition(rec.Cursor, rec.Enabled)
-	if !rec.Enabled {
-		return nil
-	}
-
-	earliest, head, err := b.store.Bounds()
-	if err != nil {
-		return fmt.Errorf("reading log bounds: %w", err)
-	}
-	var gap *Gap
-	if earliest != 0 && d.position() < earliest-1 {
-		gap = &Gap{
-			Cursor: d.position(), Earliest: earliest, Head: head,
-			Missed: earliest - 1 - d.position(),
-		}
-	}
-	if d.preDrain != nil {
-		if err := d.preDrain(d.ctx, rec, gap); err != nil {
-			return fmt.Errorf("before draining: %w", err)
-		}
-		rec, ok, err = b.store.GetConsumer(d.name)
+	prepare := func() (bool, error) {
+		// The enabled bit is the kill switch and lives only in the database;
+		// re-read it, never cache it for the process lifetime.
+		rec, ok, err := b.store.GetConsumer(d.name)
 		if err != nil {
-			return fmt.Errorf("reading registration after pre-drain: %w", err)
+			return false, fmt.Errorf("reading registration: %w", err)
 		}
 		if !ok {
-			return fmt.Errorf("registration for %s disappeared during pre-drain", d.name)
+			return false, fmt.Errorf("registration for %s disappeared", d.name)
 		}
 		d.setPosition(rec.Cursor, rec.Enabled)
 		if !rec.Enabled {
-			return nil
+			return false, nil
 		}
-	} else if gap != nil {
-		if err := b.reconcileGap(d, *gap); err != nil {
+
+		earliest, head, err := b.store.Bounds()
+		if err != nil {
+			return false, fmt.Errorf("reading log bounds: %w", err)
+		}
+		var gap *Gap
+		if earliest != 0 && d.position() < earliest-1 {
+			gap = &Gap{
+				Cursor: d.position(), Earliest: earliest, Head: head,
+				Missed: earliest - 1 - d.position(),
+			}
+		}
+		if d.preDrain == nil {
+			if gap != nil {
+				if err := b.reconcileGap(d, *gap); err != nil {
+					return false, err
+				}
+			}
+			return true, nil
+		}
+		if err := d.preDrain(d.ctx, rec, gap); err != nil {
+			return false, fmt.Errorf("before draining: %w", err)
+		}
+		rec, ok, err = b.store.GetConsumer(d.name)
+		if err != nil {
+			return false, fmt.Errorf("reading registration after pre-drain: %w", err)
+		}
+		if !ok {
+			return false, fmt.Errorf("registration for %s disappeared during pre-drain", d.name)
+		}
+		d.setPosition(rec.Cursor, rec.Enabled)
+		return rec.Enabled, nil
+	}
+
+	if d.preDrain == nil {
+		ready, err := prepare()
+		if err != nil || !ready {
 			return err
 		}
 	}
@@ -845,6 +854,12 @@ func (b *Bus) drain(d *durable) error {
 	for {
 		if d.ctx.Err() != nil {
 			return nil
+		}
+		if d.preDrain != nil {
+			ready, err := prepare()
+			if err != nil || !ready {
+				return err
+			}
 		}
 		events, err := b.store.Since(d.position(), b.batchSize)
 		if err != nil {

--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -97,6 +97,19 @@ type Store interface {
 // redelivers the event; handlers must tolerate redelivery.
 type Handler func(ctx context.Context, ev Event) error
 
+// Gap describes the history missing below a durable consumer's cursor.
+type Gap struct {
+	Cursor   int64
+	Earliest int64
+	Head     int64
+	Missed   int64
+}
+
+// PreDrain runs after the consumer registration and log bounds are read, but
+// before any event is selected. It may durably move the cursor; the bus re-reads
+// the registration after it returns.
+type PreDrain func(ctx context.Context, consumer Consumer, gap *Gap) error
+
 // Options configures a Bus; zero durations fall back to the package defaults.
 type Options struct {
 	Store        Store
@@ -166,8 +179,9 @@ type Bus struct {
 }
 
 type durable struct {
-	name    string
-	handler Handler
+	name     string
+	handler  Handler
+	preDrain PreDrain
 
 	wake chan struct{}
 
@@ -390,6 +404,19 @@ func (b *Bus) wakeDurables() {
 // must neither rewind a consumer nor resurrect a killed one. A registration
 // that fails to persist leaves nothing behind, so the caller can retry.
 func (b *Bus) Register(name string, filter Filter, h Handler) error {
+	return b.register(name, filter, nil, h)
+}
+
+// RegisterWithPreDrain adds a durable consumer whose owner must settle work at
+// the cursor boundary before ordinary fact delivery begins.
+func (b *Bus) RegisterWithPreDrain(name string, filter Filter, pre PreDrain, h Handler) error {
+	if pre == nil {
+		return fmt.Errorf("bus: consumer %s needs a pre-drain hook", name)
+	}
+	return b.register(name, filter, pre, h)
+}
+
+func (b *Bus) register(name string, filter Filter, pre PreDrain, h Handler) error {
 	if strings.TrimSpace(name) == "" {
 		return errors.New("bus: consumer name is required")
 	}
@@ -412,7 +439,7 @@ func (b *Bus) Register(name string, filter Filter, h Handler) error {
 	if _, retiring := b.retiring[name]; retiring {
 		return fmt.Errorf("bus: consumer %s is being unregistered; retry once it is gone", name)
 	}
-	d := b.newDurable(name, filter, h)
+	d := b.newDurable(name, filter, pre, h)
 
 	// Before Start, the registration is all there is to do: Start persists every
 	// consumer and launches its loop. The same is true for a bus with no store,
@@ -573,17 +600,18 @@ func (b *Bus) Registered(name string) bool {
 
 // newDurable builds a consumer and its cancel scope. Callers that also touch the
 // consumer set hold b.mu; the bus context it reads is fixed at construction.
-func (b *Bus) newDurable(name string, filter Filter, h Handler) *durable {
+func (b *Bus) newDurable(name string, filter Filter, pre PreDrain, h Handler) *durable {
 	ctx, cancel := context.WithCancel(b.ctx)
 	return &durable{
-		name:    name,
-		filter:  filter,
-		handler: h,
-		wake:    make(chan struct{}, 1),
-		ctx:     ctx,
-		cancel:  cancel,
-		done:    make(chan struct{}),
-		enabled: true,
+		name:     name,
+		filter:   filter,
+		handler:  h,
+		preDrain: pre,
+		wake:     make(chan struct{}, 1),
+		ctx:      ctx,
+		cancel:   cancel,
+		done:     make(chan struct{}),
+		enabled:  true,
 	}
 }
 
@@ -763,8 +791,36 @@ func (b *Bus) drain(d *durable) error {
 		return nil
 	}
 
-	if err := b.reconcileGap(d); err != nil {
-		return err
+	earliest, head, err := b.store.Bounds()
+	if err != nil {
+		return fmt.Errorf("reading log bounds: %w", err)
+	}
+	var gap *Gap
+	if earliest != 0 && d.position() < earliest-1 {
+		gap = &Gap{
+			Cursor: d.position(), Earliest: earliest, Head: head,
+			Missed: earliest - 1 - d.position(),
+		}
+	}
+	if d.preDrain != nil {
+		if err := d.preDrain(d.ctx, rec, gap); err != nil {
+			return fmt.Errorf("before draining: %w", err)
+		}
+		rec, ok, err = b.store.GetConsumer(d.name)
+		if err != nil {
+			return fmt.Errorf("reading registration after pre-drain: %w", err)
+		}
+		if !ok {
+			return fmt.Errorf("registration for %s disappeared during pre-drain", d.name)
+		}
+		d.setPosition(rec.Cursor, rec.Enabled)
+		if !rec.Enabled {
+			return nil
+		}
+	} else if gap != nil {
+		if err := b.reconcileGap(d, *gap); err != nil {
+			return err
+		}
 	}
 
 	// A lagging consumer never leaves the loop below, so the kill switch is
@@ -848,18 +904,10 @@ func (b *Bus) drain(d *durable) error {
 
 // reconcileGap handles a cursor below the oldest surviving event (retention
 // trimmed past it while disabled or dead): resume at head, with a logged gap.
-func (b *Bus) reconcileGap(d *durable) error {
-	earliest, head, err := b.store.Bounds()
-	if err != nil {
-		return fmt.Errorf("reading log bounds: %w", err)
-	}
-	if earliest == 0 || d.position() >= earliest-1 {
-		return nil
-	}
-	missed := earliest - 1 - d.position()
+func (b *Bus) reconcileGap(d *durable, gap Gap) error {
 	b.log("bus: consumer %s resumed at head %d; %d event(s) were trimmed before its cursor %d",
-		d.name, head, missed, d.position())
-	return b.advance(d, head)
+		d.name, gap.Head, gap.Missed, gap.Cursor)
+	return b.advance(d, gap.Head)
 }
 
 func (b *Bus) advance(d *durable, seq int64) error {

--- a/internal/bus/bus_test.go
+++ b/internal/bus/bus_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -688,6 +689,72 @@ func TestConsumerBelowTheTrimPointResumesAtHead(t *testing.T) {
 	names, _ := rec.snapshot()
 	if names[0] != "e.happened" {
 		t.Fatalf("after resuming at head, delivered %v", names)
+	}
+}
+
+func TestPreDrainOwnsGapRepairAndKeepsLaterFactsBehindItsFence(t *testing.T) {
+	s := newMemStore()
+	for _, name := range []string{"one", "two", "three", "four"} {
+		if _, err := s.Append(Event{Name: name}, time.Now()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	s.dropEventsBelow(4)
+	s.consumers["app:projection"] = Consumer{Name: "app:projection", Cursor: 1, Filter: "*", Enabled: true}
+
+	b := testBus(t, s)
+	rec := newRecorder()
+	var got *Gap
+	d := b.newDurable("app:projection", All, func(_ context.Context, consumer Consumer, gap *Gap) error {
+		if consumer.Cursor != 1 || gap == nil {
+			t.Fatalf("pre-drain consumer/gap = %+v / %+v", consumer, gap)
+		}
+		copy := *gap
+		got = &copy
+		if err := s.SetCursor(consumer.Name, gap.Head, time.Now()); err != nil {
+			return err
+		}
+		_, err := s.Append(Event{Name: "after-fence"}, time.Now())
+		return err
+	}, rec.handle)
+	t.Cleanup(d.cancel)
+	if err := b.drain(d); err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.Cursor != 1 || got.Earliest != 4 || got.Head != 4 || got.Missed != 2 {
+		t.Fatalf("gap = %+v", got)
+	}
+	names, seqs := rec.snapshot()
+	if len(names) != 1 || names[0] != "after-fence" || seqs[0] != 5 {
+		t.Fatalf("delivered names/seqs = %v / %v", names, seqs)
+	}
+	c, _, _ := s.GetConsumer("app:projection")
+	if c.Cursor != 5 {
+		t.Fatalf("cursor = %d, want later fact 5", c.Cursor)
+	}
+}
+
+func TestPreDrainFailureMovesNeitherGapNorFactCursor(t *testing.T) {
+	s := newMemStore()
+	for _, name := range []string{"one", "two", "three"} {
+		if _, err := s.Append(Event{Name: name}, time.Now()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	s.dropEventsBelow(3)
+	s.consumers["app:projection"] = Consumer{Name: "app:projection", Cursor: 0, Filter: "*", Enabled: true}
+	b := testBus(t, s)
+	rec := newRecorder()
+	d := b.newDurable("app:projection", All, func(context.Context, Consumer, *Gap) error {
+		return errors.New("reconcile still owed")
+	}, rec.handle)
+	t.Cleanup(d.cancel)
+	if err := b.drain(d); err == nil || !strings.Contains(err.Error(), "reconcile still owed") {
+		t.Fatalf("drain error = %v", err)
+	}
+	c, _, _ := s.GetConsumer("app:projection")
+	if c.Cursor != 0 || rec.count() != 0 {
+		t.Fatalf("failed pre-drain moved cursor/delivered: cursor=%d delivered=%d", c.Cursor, rec.count())
 	}
 }
 

--- a/internal/bus/bus_test.go
+++ b/internal/bus/bus_test.go
@@ -705,7 +705,15 @@ func TestPreDrainOwnsGapRepairAndKeepsLaterFactsBehindItsFence(t *testing.T) {
 	b := testBus(t, s)
 	rec := newRecorder()
 	var got *Gap
+	checks := 0
 	d := b.newDurable("app:projection", All, func(_ context.Context, consumer Consumer, gap *Gap) error {
+		checks++
+		if checks == 2 {
+			if consumer.Cursor != 5 || gap != nil {
+				t.Fatalf("second pre-drain consumer/gap = %+v / %+v", consumer, gap)
+			}
+			return nil
+		}
 		if consumer.Cursor != 1 || gap == nil {
 			t.Fatalf("pre-drain consumer/gap = %+v / %+v", consumer, gap)
 		}
@@ -721,8 +729,8 @@ func TestPreDrainOwnsGapRepairAndKeepsLaterFactsBehindItsFence(t *testing.T) {
 	if err := b.drain(d); err != nil {
 		t.Fatal(err)
 	}
-	if got == nil || got.Cursor != 1 || got.Earliest != 4 || got.Head != 4 || got.Missed != 2 {
-		t.Fatalf("gap = %+v", got)
+	if checks != 2 || got == nil || got.Cursor != 1 || got.Earliest != 4 || got.Head != 4 || got.Missed != 2 {
+		t.Fatalf("checks/gap = %d / %+v", checks, got)
 	}
 	names, seqs := rec.snapshot()
 	if len(names) != 1 || names[0] != "after-fence" || seqs[0] != 5 {
@@ -755,6 +763,56 @@ func TestPreDrainFailureMovesNeitherGapNorFactCursor(t *testing.T) {
 	c, _, _ := s.GetConsumer("app:projection")
 	if c.Cursor != 0 || rec.count() != 0 {
 		t.Fatalf("failed pre-drain moved cursor/delivered: cursor=%d delivered=%d", c.Cursor, rec.count())
+	}
+}
+
+func TestPreDrainRechecksObligationsBetweenBatches(t *testing.T) {
+	s := newMemStore()
+	if _, err := s.Append(Event{Name: "before-trigger"}, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	s.consumers["app:projection"] = Consumer{Name: "app:projection", Filter: "*", Enabled: true}
+	b := testBus(t, s)
+	b.batchSize = 1
+
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	owed := false
+	checks := 0
+	d := b.newDurable("app:projection", All, func(context.Context, Consumer, *Gap) error {
+		checks++
+		if owed {
+			return errors.New("reconcile still owed")
+		}
+		return nil
+	}, func(ctx context.Context, ev Event) error {
+		close(firstStarted)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-releaseFirst:
+			return nil
+		}
+	})
+	t.Cleanup(d.cancel)
+
+	drained := make(chan error, 1)
+	go func() { drained <- b.drain(d) }()
+	<-firstStarted
+	owed = true
+	for _, name := range []string{"after-trigger-one", "after-trigger-two"} {
+		if _, err := s.Append(Event{Name: name}, time.Now()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	close(releaseFirst)
+
+	if err := <-drained; err == nil || !strings.Contains(err.Error(), "reconcile still owed") {
+		t.Fatalf("drain error = %v", err)
+	}
+	consumer, _, _ := s.GetConsumer("app:projection")
+	if checks != 2 || consumer.Cursor != 1 {
+		t.Fatalf("pre-drain checks/cursor = %d/%d, want 2/1", checks, consumer.Cursor)
 	}
 }
 

--- a/internal/bus/lifecycle_test.go
+++ b/internal/bus/lifecycle_test.go
@@ -312,7 +312,7 @@ func TestRetiredConsumerDropsLateResults(t *testing.T) {
 	s := newMemStore()
 	b := testBus(t, s)
 
-	d := b.newDurable("app:gone", All, func(context.Context, Event) error { return nil })
+	d := b.newDurable("app:gone", All, nil, func(context.Context, Event) error { return nil })
 	t.Cleanup(d.cancel)
 	d.retire()
 

--- a/internal/daemon/app_consumers.go
+++ b/internal/daemon/app_consumers.go
@@ -186,10 +186,49 @@ func (d *Daemon) registerAppConsumer(name string) error {
 		}
 		return nil
 	}
-	if err := d.eventBus.Register(consumer, filter, d.appEventHandler(name)); err != nil {
+	if err := d.eventBus.RegisterWithPreDrain(consumer, filter, d.appPreDrain(name), d.appEventHandler(name)); err != nil {
 		return fmt.Errorf("registering the bus consumer for app %q: %w", name, err)
 	}
 	return nil
+}
+
+func (d *Daemon) appPreDrain(name string) bus.PreDrain {
+	return func(_ context.Context, consumer bus.Consumer, gap *bus.Gap) error {
+		manifest, _, err := d.appDeclaration(name)
+		if err != nil {
+			return err
+		}
+		if len(manifest.EventPatterns()) == 0 {
+			claim, err := d.store.AppReconcilePending(name)
+			if err != nil {
+				return err
+			}
+			if len(claim.Requests) != 0 {
+				if err := d.store.CompleteAppReconcile(name, claim.ThroughRequestID, claim.ThroughSeq, d.appNow()); err != nil {
+					return err
+				}
+			}
+			if gap != nil && gap.Head > claim.ThroughSeq {
+				if err := d.store.AdvanceBusConsumerCursor(consumer.Name, gap.Head, d.appNow()); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		if gap != nil {
+			if _, err := d.store.RequestAppReconcileGap(name, gap.Cursor, gap.Earliest, gap.Head, d.appNow()); err != nil {
+				return fmt.Errorf("recording the gap reconciliation for app %q: %w", name, err)
+			}
+		}
+		claim, err := d.store.AppReconcilePending(name)
+		if err != nil {
+			return fmt.Errorf("reading reconciliation owed by app %q: %w", name, err)
+		}
+		if len(claim.Requests) == 0 {
+			return nil
+		}
+		return fmt.Errorf("app %q reconciliation is owed through bus seq %d; its handler has not completed", name, claim.ThroughSeq)
+	}
 }
 
 // appFilter reads an app's declared subscriptions off its current version.

--- a/internal/daemon/app_reconcile_test.go
+++ b/internal/daemon/app_reconcile_test.go
@@ -1,0 +1,73 @@
+package daemon
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/apps"
+	"github.com/victorarias/attn/internal/bus"
+	"github.com/victorarias/attn/internal/store"
+)
+
+func TestAppPreDrainRecordsOneGapAndFencesFactsUntilCompletion(t *testing.T) {
+	d := newDaemonForTest(t)
+	seedApp(t, d, "approval-gate", true)
+	gap := &bus.Gap{Cursor: 1, Earliest: 4, Head: 6, Missed: 2}
+	hook := d.appPreDrain("approval-gate")
+	for attempt := 0; attempt < 2; attempt++ {
+		err := hook(context.Background(), bus.Consumer{Name: apps.ConsumerName("approval-gate")}, gap)
+		if err == nil || !strings.Contains(err.Error(), "reconciliation is owed") {
+			t.Fatalf("attempt %d error = %v", attempt+1, err)
+		}
+	}
+	claim, err := d.store.AppReconcilePending("approval-gate")
+	if err != nil || len(claim.Requests) != 1 {
+		t.Fatalf("pending = %+v, %v", claim, err)
+	}
+	request := claim.Requests[0]
+	if request.Reason != store.AppReconcileGap || request.Cursor != 1 || request.Earliest != 4 || request.Missed != 2 || request.ThroughSeq != 6 {
+		t.Fatalf("gap request = %+v", request)
+	}
+	if err := d.store.CompleteAppReconcile("approval-gate", claim.ThroughRequestID, claim.ThroughSeq, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if err := hook(context.Background(), bus.Consumer{Name: apps.ConsumerName("approval-gate")}, nil); err != nil {
+		t.Fatalf("pre-drain after completion: %v", err)
+	}
+	consumer, ok, err := d.store.GetBusConsumer(apps.ConsumerName("approval-gate"))
+	if err != nil || !ok || consumer.Cursor != 6 {
+		t.Fatalf("consumer after completion = %+v, found=%t, err=%v", consumer, ok, err)
+	}
+}
+
+func TestAppPreDrainKeepsNoSubscriptionAppsOnGapParity(t *testing.T) {
+	d := newDaemonForTest(t)
+	now := time.Now()
+	if _, _, err := d.store.CommitAppVersion(store.AppVersion{
+		AppName: "clock", ContentHash: "sha256:clock-1",
+		Declaration: `{"name":"clock"}`, ArtifactPath: "bundle.js",
+	}, now); err != nil {
+		t.Fatal(err)
+	}
+	seedAppConsumer(t, d, "clock", true, 1)
+	if _, _, err := d.store.CommitAppVersion(store.AppVersion{
+		AppName: "clock", ContentHash: "sha256:clock-2",
+		Declaration: `{"name":"clock"}`, ArtifactPath: "bundle-2.js",
+	}, now); err != nil {
+		t.Fatal(err)
+	}
+	hook := d.appPreDrain("clock")
+	if err := hook(context.Background(), bus.Consumer{Name: apps.ConsumerName("clock")},
+		&bus.Gap{Cursor: 1, Earliest: 4, Head: 6, Missed: 2}); err != nil {
+		t.Fatal(err)
+	}
+	if claim, err := d.store.AppReconcilePending("clock"); err != nil || len(claim.Requests) != 0 {
+		t.Fatalf("no-subscription app left reconciliation owed: %+v, %v", claim, err)
+	}
+	consumer, _, err := d.store.GetBusConsumer(apps.ConsumerName("clock"))
+	if err != nil || consumer.Cursor != 6 {
+		t.Fatalf("consumer = %+v, %v; want ordinary gap resume at 6", consumer, err)
+	}
+}

--- a/internal/daemon/apps.go
+++ b/internal/daemon/apps.go
@@ -241,7 +241,7 @@ func (d *Daemon) handleAppSetEnabled(conn net.Conn, msg *protocol.AppSetEnabledM
 	// Between the read above and this write the consumer may have been
 	// unregistered — `attn app remove` running beside this one. Reporting success
 	// then would answer for a consumer that is gone and publish a fact about it.
-	flipped, err := d.store.SetBusConsumerEnabled(consumer, msg.Enabled, time.Now())
+	flipped, changed, err := d.store.SetAppBusConsumerEnabled(name, msg.Enabled, time.Now())
 	if err != nil {
 		d.sendError(conn, fmt.Sprintf("%s app %q: %v", verb, name, err))
 		return
@@ -252,16 +252,18 @@ func (d *Daemon) handleAppSetEnabled(conn net.Conn, msg *protocol.AppSetEnabledM
 				"`attn app status %s` shows what is left.", name, consumer, verb, name))
 		return
 	}
-	if msg.Enabled {
+	if msg.Enabled && changed {
 		// Enabling is the way back from an auto-disable, so it clears both streaks
 		// that cause one. Without this the app would be disabled again on its very
 		// next failure, against a clock it never got to restart.
 		d.clearAppStall(name)
 		d.clearAppCrashes(name)
 	}
-	d.publishFact(FactAppEnabledChanged, name, appEnabledChanged{
-		Name: name, Consumer: consumer, Enabled: msg.Enabled,
-	})
+	if changed {
+		d.publishFact(FactAppEnabledChanged, name, appEnabledChanged{
+			Name: name, Consumer: consumer, Enabled: msg.Enabled,
+		})
+	}
 	d.sendDocResponse(conn, protocol.Response{
 		Ok: true,
 		AppSetEnabledResult: &protocol.AppSetEnabledResult{

--- a/internal/daemon/apps_test.go
+++ b/internal/daemon/apps_test.go
@@ -221,6 +221,37 @@ func TestAppEnableDisableFlipsTheConsumerBitAndPublishes(t *testing.T) {
 	}
 }
 
+func TestAppReEnableRecordsOneReconcileAtTheCurrentBusHead(t *testing.T) {
+	d := newDaemonForTest(t)
+	seedApp(t, d, "approval-gate", true)
+	if _, err := d.store.AppendBusEvent(store.BusEvent{Name: "ticket.created"}, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if resp := appSetEnabled(t, d, "approval-gate", false); !resp.Ok {
+		t.Fatalf("disable: %v", protocol.Deref(resp.Error))
+	}
+	if resp := appSetEnabled(t, d, "approval-gate", true); !resp.Ok {
+		t.Fatalf("enable: %v", protocol.Deref(resp.Error))
+	}
+	claim, err := d.store.AppReconcilePending("approval-gate")
+	if err != nil || len(claim.Requests) != 1 {
+		t.Fatalf("pending = %+v, %v", claim, err)
+	}
+	if got := claim.Requests[0]; got.Reason != store.AppReconcileReEnabled || got.ThroughSeq != 2 {
+		t.Fatalf("request = %+v, want re-enabled through the pre-existing fact and disable fact", got)
+	}
+	if resp := appSetEnabled(t, d, "approval-gate", true); !resp.Ok {
+		t.Fatalf("no-op enable: %v", protocol.Deref(resp.Error))
+	}
+	again, err := d.store.AppReconcilePending("approval-gate")
+	if err != nil || len(again.Requests) != 1 {
+		t.Fatalf("no-op enable added a request: %+v, %v", again, err)
+	}
+	if facts := appFacts(t, d, FactAppEnabledChanged); len(facts) != 2 {
+		t.Fatalf("enabled facts = %d, want only the disable and real re-enable", len(facts))
+	}
+}
+
 func TestAppRemoveKeepsHistoryAndDocuments(t *testing.T) {
 	d := newDaemonForTest(t)
 	version := seedApp(t, d, "approval-gate", true)

--- a/internal/store/app_reconcile.go
+++ b/internal/store/app_reconcile.go
@@ -1,0 +1,192 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+const (
+	AppReconcileGap           = "gap"
+	AppReconcileReEnabled     = "re_enabled"
+	AppReconcileVersionChange = "version_changed"
+)
+
+// AppReconcileRequest is one durable reason an app must rebuild its derived
+// collections before it receives another fact.
+type AppReconcileRequest struct {
+	ID                int64
+	AppName           string
+	Reason            string
+	VersionID         int64
+	ThroughSeq        int64
+	PreviousVersionID int64
+	Cursor            int64
+	Earliest          int64
+	Missed            int64
+	CreatedAt         time.Time
+}
+
+// AppReconcileClaim is the immutable boundary one reconcile attempt may
+// complete. Requests written after ThroughRequestID remain owed.
+type AppReconcileClaim struct {
+	Requests         []AppReconcileRequest
+	ThroughRequestID int64
+	ThroughSeq       int64
+}
+
+type reconcileQueryer interface {
+	Query(query string, args ...any) (*sql.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
+}
+
+// AppReconcilePending returns every request above the app's completed boundary.
+func (s *Store) AppReconcilePending(name string) (AppReconcileClaim, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.db == nil {
+		return AppReconcileClaim{}, nil
+	}
+	return appReconcilePending(s.db, name)
+}
+
+func appReconcilePending(q reconcileQueryer, name string) (AppReconcileClaim, error) {
+	rows, err := q.Query(`
+		SELECT id, app_name, reason, version_id, through_seq,
+		       previous_version_id, cursor, earliest, missed, created_at
+		FROM app_reconcile_requests
+		WHERE app_name = ? AND id > COALESCE((
+			SELECT completed_request_id FROM app_reconcile_progress WHERE app_name = ?
+		), 0)
+		ORDER BY id ASC
+	`, name, name)
+	if err != nil {
+		return AppReconcileClaim{}, err
+	}
+	defer rows.Close()
+	var claim AppReconcileClaim
+	for rows.Next() {
+		var (
+			r                             AppReconcileRequest
+			previous, cursor, low, missed sql.NullInt64
+			created                       string
+		)
+		if err := rows.Scan(&r.ID, &r.AppName, &r.Reason, &r.VersionID, &r.ThroughSeq,
+			&previous, &cursor, &low, &missed, &created); err != nil {
+			return AppReconcileClaim{}, err
+		}
+		r.PreviousVersionID = previous.Int64
+		r.Cursor = cursor.Int64
+		r.Earliest = low.Int64
+		r.Missed = missed.Int64
+		r.CreatedAt = parseStoreTime(created)
+		claim.Requests = append(claim.Requests, r)
+		claim.ThroughRequestID = r.ID
+		if r.ThroughSeq > claim.ThroughSeq {
+			claim.ThroughSeq = r.ThroughSeq
+		}
+	}
+	return claim, rows.Err()
+}
+
+// RequestAppReconcileGap records a retention gap. Retrying the same pre-drain
+// hook is idempotent; a different cursor or surviving window is a new trigger.
+func (s *Store) RequestAppReconcileGap(name string, cursor, earliest, throughSeq int64, now time.Time) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return false, nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	var versionID int64
+	if err := tx.QueryRow(`SELECT current_version_id FROM apps WHERE name = ?`, name).Scan(&versionID); err != nil {
+		return false, err
+	}
+	res, err := tx.Exec(`
+		INSERT OR IGNORE INTO app_reconcile_requests
+			(app_name, reason, version_id, through_seq, cursor, earliest, missed, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, name, AppReconcileGap, versionID, throughSeq, cursor, earliest,
+		earliest-1-cursor, now.UTC().Format(sortableTimeFormat))
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return n > 0, tx.Commit()
+}
+
+// CompleteAppReconcile advances the completed request boundary and the app's
+// bus cursor together. A trigger written after the claim stays pending.
+func (s *Store) CompleteAppReconcile(name string, throughRequestID, throughSeq int64, now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	var exists int
+	if err := tx.QueryRow(`
+		SELECT COUNT(*) FROM app_reconcile_requests WHERE app_name = ? AND id = ?
+	`, name, throughRequestID).Scan(&exists); err != nil {
+		return err
+	}
+	if exists == 0 {
+		return fmt.Errorf("store: app %q has no reconcile request %d to complete", name, throughRequestID)
+	}
+	stamp := now.UTC().Format(sortableTimeFormat)
+	if _, err := tx.Exec(`
+		INSERT INTO app_reconcile_progress (app_name, completed_request_id, updated_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(app_name) DO UPDATE SET
+			completed_request_id = MAX(completed_request_id, excluded.completed_request_id),
+			updated_at = excluded.updated_at
+	`, name, throughRequestID, stamp); err != nil {
+		return err
+	}
+	res, err := tx.Exec(`
+		UPDATE bus_consumers
+		SET cursor = MAX(cursor, ?), updated_at = ?
+		WHERE name = ?
+	`, throughSeq, stamp, "app:"+name)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return fmt.Errorf("store: app %q has no bus consumer whose cursor can cross reconcile fence %d", name, throughSeq)
+	}
+	return tx.Commit()
+}
+
+func appendAppReconcileRequest(tx *sql.Tx, name, reason string, versionID, throughSeq, previousVersionID int64, now time.Time) error {
+	var previous any
+	if previousVersionID != 0 {
+		previous = previousVersionID
+	}
+	_, err := tx.Exec(`
+		INSERT INTO app_reconcile_requests
+			(app_name, reason, version_id, through_seq, previous_version_id, created_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, name, reason, versionID, throughSeq, previous, now.UTC().Format(sortableTimeFormat))
+	return err
+}
+
+func busHeadWith(q reconcileQueryer) (int64, error) {
+	var head sql.NullInt64
+	err := q.QueryRow(`SELECT MAX(seq) FROM bus_events`).Scan(&head)
+	return head.Int64, err
+}

--- a/internal/store/app_reconcile_test.go
+++ b/internal/store/app_reconcile_test.go
@@ -1,0 +1,176 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func seedReconcileApp(t *testing.T, s *Store, now time.Time) AppVersion {
+	t.Helper()
+	v, _, err := s.CommitAppVersion(AppVersion{
+		AppName: "approval-gate", ContentHash: "sha256:first",
+		Declaration: `{"name":"approval-gate"}`, ArtifactPath: "bundle.js",
+	}, now)
+	if err != nil {
+		t.Fatalf("seed app: %v", err)
+	}
+	if err := s.SaveBusConsumer(BusConsumer{
+		Name: "app:approval-gate", Filter: "ticket.*", Enabled: true,
+	}, now); err != nil {
+		t.Fatalf("seed consumer: %v", err)
+	}
+	return v
+}
+
+func TestAppReconcileTriggersCoalesceAtOneClaimBoundary(t *testing.T) {
+	s := New()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	first := seedReconcileApp(t, s, now)
+	if _, err := s.AppendBusEvent(BusEvent{Name: "ticket.created"}, now); err != nil {
+		t.Fatal(err)
+	}
+	if exists, changed, err := s.SetAppBusConsumerEnabled("approval-gate", false, now); err != nil || !exists || !changed {
+		t.Fatalf("disable = exists:%t changed:%t err:%v", exists, changed, err)
+	}
+	if exists, changed, err := s.SetAppBusConsumerEnabled("approval-gate", true, now); err != nil || !exists || !changed {
+		t.Fatalf("enable = exists:%t changed:%t err:%v", exists, changed, err)
+	}
+	second, _, err := s.CommitAppVersion(AppVersion{
+		AppName: "approval-gate", ContentHash: "sha256:second",
+		Declaration: `{"name":"approval-gate"}`, ArtifactPath: "bundle-2.js",
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inserted, err := s.RequestAppReconcileGap("approval-gate", 0, 3, 4, now)
+	if err != nil || !inserted {
+		t.Fatalf("gap insert = %t, %v", inserted, err)
+	}
+	inserted, err = s.RequestAppReconcileGap("approval-gate", 0, 3, 4, now)
+	if err != nil || inserted {
+		t.Fatalf("duplicate gap insert = %t, %v", inserted, err)
+	}
+
+	claim, err := s.AppReconcilePending("approval-gate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(claim.Requests) != 3 {
+		t.Fatalf("pending = %+v, want re-enable, version, and one gap", claim.Requests)
+	}
+	if claim.Requests[0].Reason != AppReconcileReEnabled || claim.Requests[1].Reason != AppReconcileVersionChange || claim.Requests[2].Reason != AppReconcileGap {
+		t.Fatalf("reason order = %+v", claim.Requests)
+	}
+	if claim.Requests[1].PreviousVersionID != first.ID || claim.Requests[1].VersionID != second.ID {
+		t.Fatalf("version request = %+v", claim.Requests[1])
+	}
+	if claim.ThroughSeq != 4 || claim.ThroughRequestID != claim.Requests[2].ID {
+		t.Fatalf("claim boundary = %+v", claim)
+	}
+}
+
+func TestAppReconcileTriggerDuringRunRemainsOwedAndCompletionFencesCursor(t *testing.T) {
+	s := New()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	seedReconcileApp(t, s, now)
+	if _, _, err := s.SetAppBusConsumerEnabled("approval-gate", false, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := s.SetAppBusConsumerEnabled("approval-gate", true, now); err != nil {
+		t.Fatal(err)
+	}
+	first, err := s.AppReconcilePending("approval-gate")
+	if err != nil || len(first.Requests) != 1 {
+		t.Fatalf("first claim = %+v, %v", first, err)
+	}
+	if _, err := s.AppendBusEvent(BusEvent{Name: "ticket.updated"}, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.RequestAppReconcileGap("approval-gate", 0, 2, 1, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetBusConsumerCursor("app:approval-gate", 9, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CompleteAppReconcile("approval-gate", first.ThroughRequestID, first.ThroughSeq, now); err != nil {
+		t.Fatal(err)
+	}
+	consumer, _, err := s.GetBusConsumer("app:approval-gate")
+	if err != nil || consumer.Cursor != 9 {
+		t.Fatalf("completion rewound cursor: %+v, %v", consumer, err)
+	}
+	later, err := s.AppReconcilePending("approval-gate")
+	if err != nil || len(later.Requests) != 1 || later.Requests[0].Reason != AppReconcileGap {
+		t.Fatalf("later claim = %+v, %v", later, err)
+	}
+}
+
+func TestAppReconcileRequestSurvivesRestartUntilCompletion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "reconcile.db")
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	s, err := NewWithDB(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedReconcileApp(t, s, now)
+	if _, _, err := s.SetAppBusConsumerEnabled("approval-gate", false, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := s.SetAppBusConsumerEnabled("approval-gate", true, now); err != nil {
+		t.Fatal(err)
+	}
+	before, err := s.AppReconcilePending("approval-gate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	s, err = NewWithDB(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	after, err := s.AppReconcilePending("approval-gate")
+	if err != nil || after.ThroughRequestID != before.ThroughRequestID || len(after.Requests) != 1 {
+		t.Fatalf("after restart = %+v, %v; before = %+v", after, err, before)
+	}
+	if err := s.CompleteAppReconcile("approval-gate", after.ThroughRequestID, after.ThroughSeq, now); err != nil {
+		t.Fatal(err)
+	}
+	if pending, err := s.AppReconcilePending("approval-gate"); err != nil || len(pending.Requests) != 0 {
+		t.Fatalf("pending after completion = %+v, %v", pending, err)
+	}
+}
+
+func TestAppReconcileNoOpEnableAndInitialInstallCreateNoRequest(t *testing.T) {
+	s := New()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	seedReconcileApp(t, s, now)
+	if exists, changed, err := s.SetAppBusConsumerEnabled("approval-gate", true, now); err != nil || !exists || changed {
+		t.Fatalf("no-op enable = exists:%t changed:%t err:%v", exists, changed, err)
+	}
+	if pending, err := s.AppReconcilePending("approval-gate"); err != nil || len(pending.Requests) != 0 {
+		t.Fatalf("pending = %+v, %v", pending, err)
+	}
+}
+
+func TestAppReconcileReEnableBeforeFirstVersionCreatesNoRequest(t *testing.T) {
+	s := New()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	if err := s.SaveApp("view-only", now); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveBusConsumer(BusConsumer{
+		Name: "app:view-only", Filter: "app.subscribes.to.nothing", Enabled: false,
+	}, now); err != nil {
+		t.Fatal(err)
+	}
+	if exists, changed, err := s.SetAppBusConsumerEnabled("view-only", true, now); err != nil || !exists || !changed {
+		t.Fatalf("enable = exists:%t changed:%t err:%v", exists, changed, err)
+	}
+	if pending, err := s.AppReconcilePending("view-only"); err != nil || len(pending.Requests) != 0 {
+		t.Fatalf("pending = %+v, %v", pending, err)
+	}
+}

--- a/internal/store/apps.go
+++ b/internal/store/apps.go
@@ -64,35 +64,35 @@ const appColumnsSQL = `
 // Landing on the version already current is not a move — re-applying
 // byte-identical content does exactly that — so it pushes nothing and leaves the
 // chain, and the way back, alone.
-func pushServingStep(tx *sql.Tx, name string, versionID int64, stamp string) error {
+func pushServingStep(tx *sql.Tx, name string, versionID int64, stamp string) (int64, bool, error) {
 	var current, cursor sql.NullInt64
 	err := tx.QueryRow(`SELECT current_version_id, serving_step_id FROM apps WHERE name = ?`, name).
 		Scan(&current, &cursor)
 	if err == sql.ErrNoRows {
-		return fmt.Errorf("store: no app named %q", name)
+		return 0, false, fmt.Errorf("store: no app named %q", name)
 	}
 	if err != nil {
-		return err
+		return 0, false, err
 	}
 	if current.Valid && current.Int64 == versionID {
 		_, err = tx.Exec(`UPDATE apps SET updated_at = ? WHERE name = ?`, stamp, name)
-		return err
+		return current.Int64, false, err
 	}
 	res, err := tx.Exec(`
 		INSERT INTO app_serving_steps (app_name, version_id, parent_id, created_at)
 		VALUES (?, ?, ?, ?)
 	`, name, versionID, cursor, stamp)
 	if err != nil {
-		return err
+		return 0, false, err
 	}
 	step, err := res.LastInsertId()
 	if err != nil {
-		return err
+		return 0, false, err
 	}
 	_, err = tx.Exec(`
 		UPDATE apps SET current_version_id = ?, serving_step_id = ?, updated_at = ? WHERE name = ?
 	`, versionID, step, stamp, name)
-	return err
+	return current.Int64, true, err
 }
 
 // AppVersion is an immutable record of one built artifact. ContentHash is the
@@ -208,12 +208,26 @@ func (s *Store) DeleteApp(name string) (bool, error) {
 	if s.db == nil {
 		return false, nil
 	}
-	res, err := s.db.Exec(`DELETE FROM apps WHERE name = ?`, name)
+	tx, err := s.db.Begin()
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.Exec(`DELETE FROM app_reconcile_requests WHERE app_name = ?`, name); err != nil {
+		return false, err
+	}
+	if _, err := tx.Exec(`DELETE FROM app_reconcile_progress WHERE app_name = ?`, name); err != nil {
+		return false, err
+	}
+	res, err := tx.Exec(`DELETE FROM apps WHERE name = ?`, name)
 	if err != nil {
 		return false, err
 	}
 	n, err := res.RowsAffected()
-	return n > 0, err
+	if err != nil {
+		return false, err
+	}
+	return n > 0, tx.Commit()
 }
 
 // CommitAppVersion records a built version and points the app at it, in one
@@ -281,8 +295,18 @@ func (s *Store) CommitAppVersion(v AppVersion, now time.Time) (AppVersion, bool,
 		return AppVersion{}, false, err
 	}
 
-	if err := pushServingStep(tx, v.AppName, v.ID, stamp); err != nil {
+	previous, moved, err := pushServingStep(tx, v.AppName, v.ID, stamp)
+	if err != nil {
 		return AppVersion{}, false, err
+	}
+	if moved && previous != 0 {
+		head, err := busHeadWith(tx)
+		if err != nil {
+			return AppVersion{}, false, err
+		}
+		if err := appendAppReconcileRequest(tx, v.AppName, AppReconcileVersionChange, v.ID, head, previous, now); err != nil {
+			return AppVersion{}, false, err
+		}
 	}
 	if err := tx.Commit(); err != nil {
 		return AppVersion{}, false, err
@@ -317,8 +341,18 @@ func (s *Store) SetAppCurrentVersion(name string, versionID int64, now time.Time
 		return err
 	}
 	defer func() { _ = tx.Rollback() }()
-	if err := pushServingStep(tx, name, versionID, now.UTC().Format(sortableTimeFormat)); err != nil {
+	previous, moved, err := pushServingStep(tx, name, versionID, now.UTC().Format(sortableTimeFormat))
+	if err != nil {
 		return err
+	}
+	if moved && previous != 0 {
+		head, err := busHeadWith(tx)
+		if err != nil {
+			return err
+		}
+		if err := appendAppReconcileRequest(tx, name, AppReconcileVersionChange, versionID, head, previous, now); err != nil {
+			return err
+		}
 	}
 	return tx.Commit()
 }
@@ -339,13 +373,13 @@ func (s *Store) StepAppVersionBack(name string, target int64, now time.Time) err
 	if s.db == nil {
 		return nil
 	}
-	var stepID, versionID int64
+	var stepID, versionID, previous int64
 	err := s.db.QueryRow(`
-		SELECT p.id, p.version_id FROM apps a
+		SELECT p.id, p.version_id, c.version_id FROM apps a
 			JOIN app_serving_steps c ON c.id = a.serving_step_id
 			JOIN app_serving_steps p ON p.id = c.parent_id
 		WHERE a.name = ?
-	`, name).Scan(&stepID, &versionID)
+	`, name).Scan(&stepID, &versionID, &previous)
 	switch {
 	case err == sql.ErrNoRows:
 		return fmt.Errorf("store: app %q has nothing below it in its serving history", name)
@@ -354,10 +388,27 @@ func (s *Store) StepAppVersionBack(name string, target int64, now time.Time) err
 	case versionID != target:
 		return fmt.Errorf("store: app %q now has version %d one step back, not the %d this rollback resolved; nothing moved", name, versionID, target)
 	}
-	_, err = s.db.Exec(`
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	_, err = tx.Exec(`
 		UPDATE apps SET current_version_id = ?, serving_step_id = ?, updated_at = ? WHERE name = ?
 	`, versionID, stepID, now.UTC().Format(sortableTimeFormat), name)
-	return err
+	if err != nil {
+		return err
+	}
+	if previous != 0 {
+		head, err := busHeadWith(tx)
+		if err != nil {
+			return err
+		}
+		if err := appendAppReconcileRequest(tx, name, AppReconcileVersionChange, versionID, head, previous, now); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
 }
 
 // ListAppServingHistory returns the versions on an app's serving history,

--- a/internal/store/bus.go
+++ b/internal/store/bus.go
@@ -172,6 +172,21 @@ func (s *Store) SetBusConsumerCursor(name string, cursor int64, now time.Time) e
 	return err
 }
 
+// AdvanceBusConsumerCursor moves a cursor forward without allowing an older
+// fence observed by another transaction to rewind it.
+func (s *Store) AdvanceBusConsumerCursor(name string, cursor int64, now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil
+	}
+	_, err := s.db.Exec(`
+		UPDATE bus_consumers SET cursor = MAX(cursor, ?), updated_at = ? WHERE name = ?
+	`, cursor, formatTicketTime(now), name)
+	return err
+}
+
 // SetBusConsumerEnabled flips the kill switch for a consumer, and reports
 // whether there was a row to flip.
 //
@@ -199,6 +214,57 @@ func (s *Store) SetBusConsumerEnabled(name string, enabled bool, now time.Time) 
 	}
 	n, err := res.RowsAffected()
 	return n > 0, err
+}
+
+// SetAppBusConsumerEnabled flips an app consumer and records a false-to-true
+// reconciliation trigger in the same transaction. changed distinguishes a real
+// transition from an idempotent request.
+func (s *Store) SetAppBusConsumerEnabled(appName string, enabled bool, now time.Time) (exists, changed bool, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return false, false, nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return false, false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	consumerName := "app:" + appName
+	var current int
+	if err := tx.QueryRow(`SELECT enabled FROM bus_consumers WHERE name = ?`, consumerName).Scan(&current); err != nil {
+		if err == sql.ErrNoRows {
+			return false, false, nil
+		}
+		return false, false, err
+	}
+	want := 0
+	if enabled {
+		want = 1
+	}
+	if current == want {
+		return true, false, tx.Commit()
+	}
+	stamp := now.UTC().Format(sortableTimeFormat)
+	if _, err := tx.Exec(`UPDATE bus_consumers SET enabled = ?, updated_at = ? WHERE name = ?`, want, stamp, consumerName); err != nil {
+		return false, false, err
+	}
+	if enabled {
+		var versionID sql.NullInt64
+		if err := tx.QueryRow(`SELECT current_version_id FROM apps WHERE name = ?`, appName).Scan(&versionID); err != nil {
+			return false, false, err
+		}
+		if versionID.Valid {
+			head, err := busHeadWith(tx)
+			if err != nil {
+				return false, false, err
+			}
+			if err := appendAppReconcileRequest(tx, appName, AppReconcileReEnabled, versionID.Int64, head, 0, now); err != nil {
+				return false, false, err
+			}
+		}
+	}
+	return true, true, tx.Commit()
 }
 
 // DeleteBusConsumer removes a registration. Deleting a row that is not there is

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -1109,6 +1109,28 @@ CREATE INDEX IF NOT EXISTS idx_app_invocations_started ON app_invocations(starte
 	// held it — an app on version B with A behind it becomes the two-step chain
 	// A → B, which walks exactly as it did before.
 	{105, "walk an app's serving history as a chain", ``},
+	{106, "record app reconciliation owed across cursor fences", `CREATE TABLE IF NOT EXISTS app_reconcile_requests (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    app_name            TEXT NOT NULL,
+    reason              TEXT NOT NULL,
+    version_id          INTEGER NOT NULL,
+    through_seq         INTEGER NOT NULL,
+    previous_version_id INTEGER,
+    cursor              INTEGER,
+    earliest            INTEGER,
+    missed              INTEGER,
+    created_at          TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_app_reconcile_requests_pending
+    ON app_reconcile_requests(app_name, id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_app_reconcile_requests_gap
+    ON app_reconcile_requests(app_name, cursor, earliest, through_seq)
+    WHERE reason = 'gap';
+CREATE TABLE IF NOT EXISTS app_reconcile_progress (
+    app_name             TEXT PRIMARY KEY,
+    completed_request_id INTEGER NOT NULL,
+    updated_at           TEXT NOT NULL
+);`},
 }
 
 // migration99SQL is everything migration 99 does after its guarded ALTER.


### PR DESCRIPTION
## TL;DR

Adds the durable trigger and cursor fence for app reconciliation. Version changes, re-enables, and retained-log gaps now become persisted obligations, and an app cannot consume later facts until its outstanding obligation completes.

## Why

An app can miss facts while disabled, while its code changes, or when bus retention advances past its cursor. Resuming normal delivery without first repairing derived state lets the app silently build on an incomplete view of the world.

This is slice 1 of the approved [app reconcile handler design](https://github.com/victorarias/attn/blob/main/docs/plans/2026-08-14-ext-app-reconcile-handler.md). It establishes the durable ordering boundary before the SDK and runtime handler arrive in slice 2.

## What changed

- Migration 106 adds durable reconcile requests and per-app completion progress. Gap requests are idempotent, while version changes and disabled-to-enabled transitions are recorded in the same transaction as the state change that creates them.
- App bus consumers now run a pre-drain hook before every fact batch. The hook owns retained-log gaps for apps, catches obligations committed during a backlog drain, re-reads the cursor after a successful repair, and leaves both the cursor and later facts untouched when reconciliation fails.
- Completing an obligation advances reconcile progress and the consumer cursor atomically, with a `MAX` fence so an older completion cannot move a cursor backward.
- Existing non-app consumers retain their skip-to-head gap behavior.
- View-only apps keep A5's sentinel consumer row. Because its filter matches nothing, reconcile obligations are inert and the pre-drain path completes any accumulated lifecycle request without reshaping the consumer lifecycle.

The runtime reconcile export and handler dispatch are intentionally not in this slice. Until slice 2 lands, a subscribed app with an outstanding obligation remains stalled at the fence instead of consuming newer facts.

## Review path

1. `internal/store/app_reconcile.go` and migration 106 define the request/progress contract and atomic completion fence.
2. `internal/store/apps.go` and `internal/store/bus.go` show where version and enable triggers join their originating transaction.
3. `internal/bus/bus.go` places pre-drain between enabled-state inspection and normal fact reads.
4. `internal/daemon/app_consumers.go` applies app-specific gap ownership and the view-only no-op rule.

## Manual verification

Installed the full app into an isolated non-production profile and ran the bundled preflight successfully at protocol 244.

For a fresh subscribed app, initial apply created no obligation. A disable/enable transition then persisted a `re_enabled` request through bus sequence 25 while the app consumer remained fenced at cursor 24; the bus subsequently reached sequence 26 without the obligation being skipped. Direct SQLite inspection confirmed migration 106 and the request/cursor rows.

In a separate restart scenario, version and re-enable requests survived daemon restart with the subscribed cursor still fenced. Switching the serving declaration to view-only exercised the sentinel path: its pending lifecycle requests completed and its cursor caught up because the filter can never have missed a matching fact. The isolated profiles and scaffold sources were removed afterward.

## Out of scope

The manifest export, SDK context, sidecar dispatch, supervisor deadline, operator command, and end-to-end exit proof are the next three delivery slices from the approved design.
