### PR TITLE
feat(annotations): group terminal quick labels

### DIFF
--- a/app/scripts/real-app-harness/scenario-terminal-annotations.mjs
+++ b/app/scripts/real-app-harness/scenario-terminal-annotations.mjs
@@ -353,7 +353,8 @@ async function main() {
         `The annotation editor only opened after the held tool stopped: ${JSON.stringify(observer.getSession(sessionId))}`,
       );
 
-      await client.request('dom_click', { selector: `[aria-label="${LABEL.name}"]` });
+      await client.request('dom_click', { selector: '[aria-label="More labels"]' });
+      await client.request('dom_click', { selector: `[data-quick-label-id="${LABEL.id}"]` });
       const filed = await pollFor(
         async () => {
           const state = await client.request('get_annotation_state', {});

--- a/app/src/annotations/QuickLabelPicker.css
+++ b/app/src/annotations/QuickLabelPicker.css
@@ -1,0 +1,86 @@
+.md-ql-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 1px 7px;
+  border-radius: 999px;
+  /* Per-chip colors arrive as inline custom props from LABEL_COLOR_MAP. */
+  color: var(--md-ql-text-dark, var(--color-text-primary, #e8e8e8));
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme]) .md-ql-chip {
+    color: var(--md-ql-text, var(--color-text-primary, #18181b));
+  }
+}
+
+:root[data-theme='light'] .md-ql-chip {
+  color: var(--md-ql-text, var(--color-text-primary, #18181b));
+}
+
+.md-quick-label-picker {
+  position: fixed;
+  z-index: 10021;
+  display: flex;
+  flex-direction: column;
+  padding: 4px;
+  border-radius: 8px;
+  background: var(--color-bg-elevated, #1a1a1d);
+  border: 1px solid var(--color-border, #2a2a2d);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+  animation: md-qlp-in 0.12s ease-out;
+}
+
+@keyframes md-qlp-in {
+  from {
+    opacity: 0;
+    margin-top: -4px;
+  }
+  to {
+    opacity: 1;
+    margin-top: 0;
+  }
+}
+
+.md-quick-label-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 4px 6px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-text-primary, #e8e8e8);
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.md-quick-label-row:hover {
+  background: var(--color-bg-button, #252528);
+}
+
+.md-quick-label-divider {
+  border: 0;
+  height: 1px;
+  margin: 3px 6px;
+  background: var(--color-border, #2a2a2d);
+}
+
+.md-quick-label-text {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.md-quick-label-num {
+  font-size: 10px;
+  color: var(--color-text-muted, #888);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+}

--- a/app/src/annotations/QuickLabelPicker.tsx
+++ b/app/src/annotations/QuickLabelPicker.tsx
@@ -11,6 +11,7 @@ import {
 import { createPortal } from 'react-dom';
 import { useEscapeStack } from '../hooks/useEscapeStack';
 import { LABEL_COLOR_MAP, type QuickLabel } from './quickLabels';
+import './QuickLabelPicker.css';
 
 export interface FloatingQuickLabelPickerProps {
   mode?: 'floating';
@@ -20,6 +21,7 @@ export interface FloatingQuickLabelPickerProps {
   cursorHint?: { x: number; y: number } | null;
   onSelect: (label: QuickLabel) => void;
   onDismiss: () => void;
+  onHint?: (hint: string | null) => void;
 }
 
 interface ChipQuickLabelPickerProps {
@@ -77,6 +79,7 @@ function FloatingQuickLabelPicker({
   cursorHint,
   onSelect,
   onDismiss,
+  onHint,
 }: FloatingQuickLabelPickerProps) {
   const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
   const [height, setHeight] = useState(0);
@@ -160,8 +163,13 @@ function FloatingQuickLabelPicker({
                 key={label.id}
                 type="button"
                 className="md-quick-label-row"
+                data-quick-label-id={label.id}
                 onClick={() => onSelect(label)}
                 title={label.tip}
+                onMouseEnter={() => onHint?.(label.text)}
+                onMouseLeave={() => onHint?.(null)}
+                onFocus={() => onHint?.(label.text)}
+                onBlur={() => onHint?.(null)}
               >
                 <span
                   className="md-ql-chip"

--- a/app/src/annotations/quickLabels.test.ts
+++ b/app/src/annotations/quickLabels.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   LABEL_COLOR_MAP,
+  PROMOTED_LABELS,
+  QUICK_LABEL_PICKER_GROUPS,
+  QUICK_LABEL_PICKER_LABELS,
   QUICK_LABELS,
   QUICK_LABEL_GROUPS,
   labelById,
@@ -31,6 +34,20 @@ describe('the shared label set', () => {
     for (const label of QUICK_LABELS) {
       expect(LABEL_COLOR_MAP[label.color], label.id).toBeDefined();
     }
+  });
+
+  it('offers the same promoted trio and filtered picker groups to both surfaces', async () => {
+    const markdown = await import('../components/MarkdownReader/annotations/quickLabels');
+
+    expect(PROMOTED_LABELS.map((label) => label.id)).toEqual([
+      'i-agree',
+      'this-is-wrong',
+      'clarify-this',
+    ]);
+    expect(QUICK_LABEL_PICKER_LABELS).toEqual(QUICK_LABEL_PICKER_GROUPS.flat());
+    expect(QUICK_LABEL_PICKER_LABELS).toHaveLength(9);
+    expect(markdown.PROMOTED_LABELS).toBe(PROMOTED_LABELS);
+    expect(markdown.QUICK_LABEL_PICKER_GROUPS).toBe(QUICK_LABEL_PICKER_GROUPS);
   });
 });
 

--- a/app/src/annotations/quickLabels.ts
+++ b/app/src/annotations/quickLabels.ts
@@ -79,6 +79,34 @@ export const QUICK_LABEL_GROUPS: QuickLabel[][] = [
 // Every label, in row order.
 export const QUICK_LABELS: QuickLabel[] = QUICK_LABEL_GROUPS.flat();
 
+const PROMOTED_LABEL_IDS = ['i-agree', 'this-is-wrong', 'clarify-this'] as const;
+
+function requireQuickLabel(id: string): QuickLabel {
+  const label = labelById(id);
+  if (!label) {
+    throw new Error(
+      `A promoted toolbar button points at quick label "${id}", which the shared set no longer offers. `
+      + `Point it at one of: ${QUICK_LABELS.map((candidate) => candidate.id).join(', ')}.`,
+    );
+  }
+  return label;
+}
+
+export const PROMOTED_LABELS: readonly QuickLabel[] = PROMOTED_LABEL_IDS.map(requireQuickLabel);
+
+const promotedLabelIds = new Set<string>(PROMOTED_LABEL_IDS);
+
+const pickerGroups: QuickLabel[][] = [];
+for (const group of QUICK_LABEL_GROUPS) {
+  const pickerGroup = group.filter((label) => !promotedLabelIds.has(label.id));
+  if (pickerGroup.length > 0) {
+    pickerGroups.push(pickerGroup);
+  }
+}
+export const QUICK_LABEL_PICKER_GROUPS: readonly (readonly QuickLabel[])[] = pickerGroups;
+
+export const QUICK_LABEL_PICKER_LABELS: readonly QuickLabel[] = QUICK_LABEL_PICKER_GROUPS.flat();
+
 export function labelByEmoji(emoji: string): QuickLabel | undefined {
   return QUICK_LABELS.find((label) => label.emoji === emoji);
 }

--- a/app/src/components/MarkdownReader/MarkdownReader.css
+++ b/app/src/components/MarkdownReader/MarkdownReader.css
@@ -880,32 +880,6 @@
   overflow-wrap: anywhere;
 }
 
-/* ---- Quick-label chip (toolbar picker rows + sidebar badges) ---- */
-
-.md-ql-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 11px;
-  font-weight: 600;
-  padding: 1px 7px;
-  border-radius: 999px;
-  /* Per-chip colors arrive as inline custom props from LABEL_COLOR_MAP. */
-  color: var(--md-ql-text-dark, var(--color-text-primary, #e8e8e8));
-  text-transform: none;
-  letter-spacing: normal;
-}
-
-@media (prefers-color-scheme: light) {
-  :root:not([data-theme]) .md-ql-chip {
-    color: var(--md-ql-text, var(--color-text-primary, #18181b));
-  }
-}
-
-:root[data-theme='light'] .md-ql-chip {
-  color: var(--md-ql-text, var(--color-text-primary, #18181b));
-}
-
 /* ---- Selection toolbar (body portal) ---- */
 
 .md-selection-toolbar {
@@ -1133,69 +1107,4 @@
 .md-popover-submit:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-}
-
-/* ---- Quick-label picker (body portal) ---- */
-
-.md-quick-label-picker {
-  position: fixed;
-  z-index: 10021;
-  display: flex;
-  flex-direction: column;
-  padding: 4px;
-  border-radius: 8px;
-  background: var(--color-bg-elevated, #1a1a1d);
-  border: 1px solid var(--color-border, #2a2a2d);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
-  animation: md-qlp-in 0.12s ease-out;
-}
-
-@keyframes md-qlp-in {
-  from {
-    opacity: 0;
-    margin-top: -4px;
-  }
-  to {
-    opacity: 1;
-    margin-top: 0;
-  }
-}
-
-.md-quick-label-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  width: 100%;
-  padding: 4px 6px;
-  border: none;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--color-text-primary, #e8e8e8);
-  font-size: 12px;
-  text-align: left;
-  cursor: pointer;
-}
-
-.md-quick-label-row:hover {
-  background: var(--color-bg-button, #252528);
-}
-
-.md-quick-label-divider {
-  border: 0;
-  height: 1px;
-  margin: 3px 6px;
-  background: var(--color-border, #2a2a2d);
-}
-
-.md-quick-label-text {
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.md-quick-label-num {
-  font-size: 10px;
-  color: var(--color-text-muted, #888);
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
 }

--- a/app/src/components/MarkdownReader/annotations/QuickLabelPicker.test.tsx
+++ b/app/src/components/MarkdownReader/annotations/QuickLabelPicker.test.tsx
@@ -64,6 +64,9 @@ describe('QuickLabelPicker', () => {
     expect(Array.from(rows, (row) => row.querySelector('.md-ql-chip')?.textContent)).toEqual([
       '💯', '😕', '🔍', '🧾', '🔬', '🔄', '🪓', '🪙', '🙋',
     ]);
+    expect(Array.from(rows, (row) => row.getAttribute('data-quick-label-id'))).toEqual(
+      QUICK_LABEL_PICKER_LABELS.map((label) => label.id),
+    );
     expect(rows[0].textContent).toContain(QUICK_LABEL_PICKER_LABELS[0].text);
     expect(rows[0].querySelector('.md-quick-label-num')!.textContent).toBe('1');
     expect(rows[8].querySelector('.md-quick-label-num')!.textContent).toBe('9');

--- a/app/src/components/MarkdownReader/annotations/quickLabels.ts
+++ b/app/src/components/MarkdownReader/annotations/quickLabels.ts
@@ -2,42 +2,16 @@
 // Markdown reader needs. A document mark stores `quickLabelId` and the tip it
 // was made with, never the label's text baked into the comment.
 
-import {
-  QUICK_LABEL_GROUPS,
+import { labelById, type QuickLabel } from '../../../annotations/quickLabels';
+
+export {
+  LABEL_COLOR_MAP,
+  PROMOTED_LABELS,
+  QUICK_LABEL_PICKER_GROUPS,
+  QUICK_LABEL_PICKER_LABELS,
   QUICK_LABELS,
-  labelById,
   type QuickLabel,
 } from '../../../annotations/quickLabels';
-
-export { LABEL_COLOR_MAP, QUICK_LABELS, type QuickLabel } from '../../../annotations/quickLabels';
-
-const PROMOTED_LABEL_IDS = ['i-agree', 'this-is-wrong', 'clarify-this'] as const;
-
-function requireQuickLabel(id: string): QuickLabel {
-  const label = labelById(id);
-  if (!label) {
-    throw new Error(
-      `A promoted toolbar button points at quick label "${id}", which the shared set no longer offers. `
-      + `Point it at one of: ${QUICK_LABELS.map((candidate) => candidate.id).join(', ')}.`,
-    );
-  }
-  return label;
-}
-
-export const PROMOTED_LABELS: readonly QuickLabel[] = PROMOTED_LABEL_IDS.map(requireQuickLabel);
-
-const promotedLabelIds = new Set<string>(PROMOTED_LABEL_IDS);
-
-const pickerGroups: QuickLabel[][] = [];
-for (const group of QUICK_LABEL_GROUPS) {
-  const pickerGroup = group.filter((label) => !promotedLabelIds.has(label.id));
-  if (pickerGroup.length > 0) {
-    pickerGroups.push(pickerGroup);
-  }
-}
-export const QUICK_LABEL_PICKER_GROUPS: readonly (readonly QuickLabel[])[] = pickerGroups;
-
-export const QUICK_LABEL_PICKER_LABELS: readonly QuickLabel[] = QUICK_LABEL_PICKER_GROUPS.flat();
 
 export function quickLabelById(id: string): QuickLabel | undefined {
   return labelById(id);

--- a/app/src/components/TerminalAnnotations/AnnotatedTerminal.annotate.test.tsx
+++ b/app/src/components/TerminalAnnotations/AnnotatedTerminal.annotate.test.tsx
@@ -225,6 +225,25 @@ function stored() {
   return terminal.annotations?.list() ?? [];
 }
 
+function openLabelPicker() {
+  fireEvent.click(screen.getByLabelText('More labels'));
+  return document.querySelector<HTMLElement>('.md-quick-label-picker')!;
+}
+
+function pickLabel(text: string) {
+  const promoted = screen.queryByLabelText(text);
+  if (promoted) {
+    fireEvent.click(promoted);
+    return;
+  }
+  if (!document.querySelector('.md-quick-label-picker')) openLabelPicker();
+  const picker = document.querySelector('.md-quick-label-picker')!;
+  const row = Array.from(picker.querySelectorAll<HTMLElement>('.md-quick-label-row'))
+    .find((candidate) => candidate.querySelector('.md-quick-label-text')?.textContent === text);
+  expect(row, `grouped quick label "${text}"`).toBeDefined();
+  fireEvent.click(row!);
+}
+
 /** The panel row for the nth annotation, and its two controls. */
 function card(index = 0) {
   const cards = document.querySelectorAll('.anno-card');
@@ -301,7 +320,7 @@ describe('AnnotatedTerminal', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 4, 10);
-    fireEvent.click(screen.getByLabelText('Show the receipt'));
+    pickLabel('Show the receipt');
     expect(stored()).toHaveLength(1);
 
     act(() => daemon.notifyMessagesChanged());
@@ -318,7 +337,7 @@ describe('AnnotatedTerminal', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 4, 10);
-    fireEvent.click(screen.getByLabelText('Show the receipt'));
+    pickLabel('Show the receipt');
     const before = stored()[0];
 
     daemon.messages = [
@@ -340,7 +359,7 @@ describe('AnnotatedTerminal', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 4, 10);
-    fireEvent.click(screen.getByLabelText('Show the receipt'));
+    pickLabel('Show the receipt');
 
     daemon.messages = [{ key: 'turn-2', markdown: TURN_2 }];
     act(() => daemon.notifyMessagesChanged());
@@ -357,13 +376,93 @@ describe('AnnotatedTerminal', () => {
     anchor('turn-1', 0, 26);
     expect(screen.getByTestId('annotation-popup')).toBeTruthy();
 
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
 
     // One click is the whole gesture: the popup closes and the panel takes over.
     expect(screen.queryByTestId('annotation-popup')).toBeNull();
     expect(screen.getByTestId('annotation-panel')).toBeTruthy();
     expect(stored()[0]?.quickLabelId).toBe('verify-this');
     expect(stored()[0]?.quote).toBe(TURN_1.slice(0, 26));
+  });
+
+  it('renders the promoted trio and keeps their selected-state toggle behavior', async () => {
+    renderTerminal();
+    await windowReady('turn-1');
+
+    anchor('turn-1', 0, 26);
+    const popup = screen.getByTestId('annotation-popup');
+    expect(Array.from(popup.querySelectorAll('.anno-popup-label'), (button) => button.getAttribute('aria-label')))
+      .toEqual([
+        'I agree',
+        'This is wrong',
+        'Clarify this',
+        'More labels',
+        'Write a comment',
+        'Remove this annotation',
+      ]);
+
+    pickLabel('I agree');
+    expect(stored()[0]?.quickLabelId).toBe('i-agree');
+
+    activate(stored()[0].id);
+    expect(screen.getByLabelText('I agree').classList.contains('anno-popup-label--on')).toBe(true);
+    pickLabel('I agree');
+    expect(stored()).toHaveLength(0);
+  });
+
+  it('shows a selected grouped label on the trigger', async () => {
+    renderTerminal();
+    await windowReady('turn-1');
+
+    anchor('turn-1', 0, 26);
+    pickLabel('Verify this');
+    activate(stored()[0].id);
+
+    const trigger = screen.getByLabelText('More labels');
+    expect(trigger.textContent).toBe('🔍');
+    expect(trigger.classList.contains('anno-popup-label--on')).toBe(true);
+  });
+
+  it('closes only the grouped picker on Escape', async () => {
+    renderTerminal();
+    await windowReady('turn-1');
+
+    anchor('turn-1', 0, 26);
+    openLabelPicker();
+    expect(document.querySelector('.md-quick-label-picker')).not.toBeNull();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(document.querySelector('.md-quick-label-picker')).toBeNull();
+    expect(screen.getByTestId('annotation-popup')).toBeTruthy();
+    expect(stored()).toHaveLength(1);
+  });
+
+  it('toggles the grouped picker from its trigger', async () => {
+    renderTerminal();
+    await windowReady('turn-1');
+
+    anchor('turn-1', 0, 26);
+    openLabelPicker();
+    expect(document.querySelector('.md-quick-label-picker')).not.toBeNull();
+
+    fireEvent.click(screen.getByLabelText('More labels'));
+
+    expect(document.querySelector('.md-quick-label-picker')).toBeNull();
+    expect(screen.getByTestId('annotation-popup')).toBeTruthy();
+  });
+
+  it('applies the grouped picker digit shortcut and closes both layers', async () => {
+    renderTerminal();
+    await windowReady('turn-1');
+
+    anchor('turn-1', 0, 26);
+    openLabelPicker();
+    fireEvent.keyDown(window, { code: 'Digit3', key: '3' });
+
+    expect(stored()[0]?.quickLabelId).toBe('verify-this');
+    expect(document.querySelector('.md-quick-label-picker')).toBeNull();
+    expect(screen.queryByTestId('annotation-popup')).toBeNull();
   });
 
   it('discards a highlight dismissed without a label or a comment', async () => {
@@ -401,9 +500,9 @@ describe('AnnotatedTerminal', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
     anchor('turn-1', 31, 55);
-    fireEvent.click(screen.getByLabelText('Show the receipt'));
+    pickLabel('Show the receipt');
 
     fireEvent.click(screen.getByText('Send all'));
 
@@ -423,12 +522,12 @@ describe('AnnotatedTerminal', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
 
     activate(stored()[0].id);
     expect(screen.getByTestId('annotation-popup')).toBeTruthy();
 
-    fireEvent.click(screen.getByLabelText('Show the receipt'));
+    pickLabel('Show the receipt');
 
     expect(stored()).toHaveLength(1);
     expect(stored()[0].quickLabelId).toBe('show-the-receipt');
@@ -461,7 +560,7 @@ describe('AnnotatedTerminal', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
     activate(stored()[0].id);
 
     fireEvent.click(screen.getByLabelText('Remove this annotation'));
@@ -477,10 +576,10 @@ describe('AnnotatedTerminal', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
     activate(stored()[0].id);
 
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
 
     expect(stored()).toHaveLength(0);
   });
@@ -494,7 +593,7 @@ describe('AnnotatedTerminal', () => {
     anchor('turn-1', 0, 26);
     expect(stored()).toHaveLength(1);
 
-    fireEvent.mouseDown(screen.getByTestId('terminal'));
+    fireEvent.pointerDown(screen.getByTestId('terminal'));
 
     expect(screen.queryByTestId('annotation-popup')).toBeNull();
     expect(stored()).toHaveLength(0);
@@ -505,7 +604,7 @@ describe('AnnotatedTerminal', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 0, 26);
-    fireEvent.mouseDown(screen.getByLabelText('Verify this'));
+    fireEvent.pointerDown(screen.getByLabelText('This is wrong'));
 
     expect(screen.getByTestId('annotation-popup')).toBeTruthy();
   });
@@ -515,7 +614,7 @@ describe('AnnotatedTerminal', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
     const panel = screen.getByTestId('annotation-panel');
     // Pinned to its corner until moved, so the default costs no state.
     expect(panel.style.left).toBe('');
@@ -539,7 +638,7 @@ describe('AnnotatedTerminal', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
     fireEvent.click(screen.getByLabelText('Remove annotation'));
 
     expect(stored()).toHaveLength(0);
@@ -577,7 +676,7 @@ describe('AnnotatedTerminal', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
 
     fireEvent.click(card().open);
 
@@ -653,9 +752,9 @@ describe('AnnotatedTerminal', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
     anchor('turn-1', 31, 55);
-    fireEvent.click(screen.getByLabelText('Show the receipt'));
+    pickLabel('Show the receipt');
 
     fireEvent.click(card(0).open);
     terminalFocusCalls = 0;
@@ -669,7 +768,7 @@ describe('AnnotatedTerminal', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
 
     fireEvent.keyDown(window, { key: 'Enter', metaKey: true });
 
@@ -703,7 +802,7 @@ describe('AnnotatedTerminal', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
 
     fireEvent.keyDown(window, { key: 'Enter', metaKey: true });
 
@@ -733,19 +832,20 @@ describe('AnnotatedTerminal', () => {
   });
 });
 
-// Fourteen emoji-only chips is a row nobody can read. The line under it is what
-// makes the row learnable without hovering each one and waiting for a tooltip.
+// The line under the controls names both the promoted chips and the deliberate
+// marks in the picker without waiting for a native tooltip.
 describe('AnnotatedTerminal label hint', () => {
   function hint(): string {
     return screen.getByTestId('annotation-popup-hint').textContent ?? '';
   }
 
-  it('names a chip while the pointer is on it', async () => {
+  it('names a grouped picker row while the pointer is on it', async () => {
     renderTerminal();
     await windowReady('turn-1');
     anchor('turn-1', 0, 26);
 
-    fireEvent.mouseEnter(screen.getByLabelText('Show the receipt'));
+    openLabelPicker();
+    fireEvent.mouseEnter(screen.getByText('Show the receipt').closest('button')!);
 
     expect(hint()).toBe('Show the receipt');
   });
@@ -756,7 +856,7 @@ describe('AnnotatedTerminal label hint', () => {
     renderTerminal();
     await windowReady('turn-1');
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Show the receipt'));
+    pickLabel('Show the receipt');
     // Marking closes the popup, so this is the reopen a user does from the grid.
     activate(stored()[0].id);
 
@@ -803,7 +903,7 @@ describe('AnnotatedTerminal note', () => {
     const { daemon } = renderTerminal();
     await windowReady('turn-1');
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
 
     writeNote('Split this into two PRs.');
 
@@ -818,7 +918,7 @@ describe('AnnotatedTerminal note', () => {
     const first = renderTerminal({ api: daemon });
     await windowReady('turn-1');
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
     writeNote('Split this into two PRs.');
     await waitFor(() => expect(daemon.note).toBe('Split this into two PRs.'));
     first.unmount();
@@ -832,7 +932,7 @@ describe('AnnotatedTerminal note', () => {
     const { daemon } = renderTerminal({ paneActive: true });
     await windowReady('turn-1');
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
     writeNote('Split this into two PRs.');
 
     // From inside the box: the last sentence is typed there, and reaching for
@@ -848,7 +948,7 @@ describe('AnnotatedTerminal note', () => {
     const { daemon } = renderTerminal({ paneActive: true });
     await windowReady('turn-1');
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
     writeNote('Split this into two PRs.');
     await waitFor(() => expect(daemon.note).toBe('Split this into two PRs.'));
 
@@ -868,7 +968,7 @@ describe('AnnotatedTerminal note', () => {
     daemon.releaseSubmit = () => {};
     await windowReady('turn-1');
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
     writeNote('Split this into two PRs.');
     await waitFor(() => expect(daemon.note).toBe('Split this into two PRs.'));
 
@@ -895,7 +995,7 @@ describe('AnnotatedTerminal note', () => {
     daemon.nextSubmitStatus = 'skipped_pending_approval';
     await windowReady('turn-1');
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
     writeNote('Split this into two PRs.');
 
     fireEvent.click(screen.getByText('Send all'));
@@ -919,7 +1019,7 @@ describe('AnnotatedTerminal sending', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
     fireEvent.click(screen.getByText('Send all'));
 
     await waitFor(() => expect(screen.getByTestId('annotation-send-note')).toBeTruthy());
@@ -936,7 +1036,7 @@ describe('AnnotatedTerminal sending', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
     fireEvent.click(screen.getByText('Send all'));
 
     await waitFor(() => expect(screen.getByTestId('annotation-send-note')).toBeTruthy());
@@ -956,7 +1056,7 @@ describe('AnnotatedTerminal sending', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
     fireEvent.click(screen.getByText('Send all'));
 
     await waitFor(() => expect(screen.getByText('Sending…')).toBeTruthy());
@@ -981,14 +1081,14 @@ describe('AnnotatedTerminal sending', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
     const sentId = stored()[0].id;
 
     fireEvent.click(screen.getByText('Send all'));
     await waitFor(() => expect(daemon.submitted).toHaveLength(1));
     // Mid-flight, the user marks something else.
     anchor('turn-1', 31, 55);
-    fireEvent.click(screen.getByLabelText('Show the receipt'));
+    pickLabel('Show the receipt');
     const keptId = stored().find((entry) => entry.id !== sentId)!.id;
 
     await act(async () => {
@@ -1017,7 +1117,7 @@ describe('AnnotatedTerminal sending', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
     const id = stored()[0].id;
 
     fireEvent.click(screen.getByText('Send all'));
@@ -1026,7 +1126,7 @@ describe('AnnotatedTerminal sending', () => {
 
     // Mid-flight, the user changes their mind about the label.
     activate(id);
-    fireEvent.click(screen.getByLabelText('Show the receipt'));
+    pickLabel('Show the receipt');
 
     await act(async () => {
       daemon.releaseSubmit?.();
@@ -1048,10 +1148,10 @@ describe('AnnotatedTerminal sending', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
     const editedId = stored()[0].id;
     anchor('turn-1', 31, 55);
-    fireEvent.click(screen.getByLabelText('Show the receipt'));
+    pickLabel('Show the receipt');
 
     fireEvent.click(screen.getByText('Send all'));
     await waitFor(() => expect(daemon.submitted).toHaveLength(1));
@@ -1073,7 +1173,7 @@ describe('AnnotatedTerminal sending', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
     await waitFor(() => expect(daemon.annotations).toHaveLength(1));
 
     fireEvent.click(screen.getByText('Send all'));
@@ -1099,7 +1199,7 @@ describe('AnnotatedTerminal persistence', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
     await waitFor(() => expect(daemon.annotations).toHaveLength(1));
     expect(daemon.annotations[0].quickLabelId).toBe('verify-this');
     expect(daemon.annotations[0].quote).toBe(TURN_1.slice(0, 26));
@@ -1136,7 +1236,7 @@ describe('AnnotatedTerminal persistence', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
     await waitFor(() => expect(daemon.annotations).toHaveLength(1));
 
     first.unmount();
@@ -1166,7 +1266,7 @@ describe('AnnotatedTerminal persistence', () => {
     }];
 
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
 
     await waitFor(() => expect(stored().map((entry) => entry.id)).toEqual(['theirs-1']));
 
@@ -1183,7 +1283,7 @@ describe('AnnotatedTerminal persistence', () => {
     await windowReady('turn-1');
 
     anchor('turn-1', 0, 26);
-    fireEvent.click(screen.getByLabelText('Verify this'));
+    pickLabel('Verify this');
     await waitFor(() => expect(daemon.annotations).toHaveLength(1));
 
     fireEvent.click(screen.getByText('Send all'));

--- a/app/src/components/TerminalAnnotations/AnnotatedTerminal.tsx
+++ b/app/src/components/TerminalAnnotations/AnnotatedTerminal.tsx
@@ -19,10 +19,16 @@ import {
   type MessageAnchor,
   type TerminalAnnotation,
 } from '../../utils/terminalAnnotations';
-import { QUICK_LABEL_GROUPS, buildAnnotationPayload, labelById } from './quickLabels';
+import { buildAnnotationPayload, labelById } from './quickLabels';
+import {
+  PROMOTED_LABELS,
+  QUICK_LABEL_PICKER_GROUPS,
+  QUICK_LABEL_PICKER_LABELS,
+} from '../../annotations/quickLabels';
 import { QuickLabelPicker } from '../../annotations/QuickLabelPicker';
 import { clampToViewport, placePopup, type PlaceOptions, type Placement } from './placement';
 import { useAnnotationSend } from '../../annotations/useAnnotationSend';
+import { useEscapeStack } from '../../hooks/useEscapeStack';
 import { formatShortcut } from '../../shortcuts/formatShortcut';
 import './TerminalAnnotations.css';
 
@@ -133,6 +139,8 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
     // native tooltip arrives a second late. Always drawn, so naming a chip
     // cannot change the popup's height and move it out from under the pointer.
     const [hint, setHint] = useState<string | null>(null);
+    const [labelPickerOpen, setLabelPickerOpen] = useState(false);
+    const labelPickerTriggerRef = useRef<HTMLButtonElement>(null);
     const hintProps = useCallback((text: string) => ({
       onMouseEnter: () => setHint(text),
       onMouseLeave: () => setHint((current) => (current === text ? null : current)),
@@ -286,6 +294,8 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
     // elsewhere deliberately: that press owns where focus goes.
     const closeComposer = useCallback((restoreFocus = true) => {
       setComposer(null);
+      setLabelPickerOpen(false);
+      setHint(null);
       setPopupAt(null);
       setDraft('');
       if (restoreFocus) terminalRef.current?.focus();
@@ -305,6 +315,8 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
       }
       closeComposer(restoreFocus);
     }, [bump, closeComposer, composer, persist, store]);
+
+    useEscapeStack(dismissComposer, Boolean(composer));
 
     const handleAnchor = useCallback(
       (anchor: MessageAnchor, at: { clientX: number; clientY: number }) => {
@@ -361,30 +373,19 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
       [store],
     );
 
-    useEffect(() => {
-      if (!composer) return;
-      const onKey = (event: KeyboardEvent) => {
-        if (event.key === 'Escape') {
-          event.stopPropagation();
-          dismissComposer();
-        }
-      };
-      window.addEventListener('keydown', onKey, true);
-      return () => window.removeEventListener('keydown', onKey, true);
-    }, [composer, dismissComposer]);
-
     // A press elsewhere closes the popup; capture phase, so the terminal's own
-    // mousedown still runs and the click can start the next selection.
+    // pointerdown still runs and the click can start the next selection.
     useEffect(() => {
       if (!composer) return;
-      const onDown = (event: MouseEvent) => {
+      const onDown = (event: PointerEvent) => {
+        if (labelPickerOpen) return;
         if (popupRef.current?.contains(event.target as Node)) return;
         // The press decides where focus lands, including one in the panel.
         dismissComposer(false);
       };
-      window.addEventListener('mousedown', onDown, true);
-      return () => window.removeEventListener('mousedown', onDown, true);
-    }, [composer, dismissComposer]);
+      window.addEventListener('pointerdown', onDown, true);
+      return () => window.removeEventListener('pointerdown', onDown, true);
+    }, [composer, dismissComposer, labelPickerOpen]);
 
     // What placement respects beyond the window: the popup's pane and the panel
     // it must not cover, both read at placement time since both move.
@@ -462,6 +463,9 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
     const composed = composer
       ? annotations.find((entry) => entry.id === composer.annotationId) ?? null
       : null;
+    const selectedPickerLabel = composed
+      ? QUICK_LABEL_PICKER_LABELS.find((label) => label.id === composed.quickLabelId)
+      : undefined;
 
     const applyLabel = (quickLabelId: string) => {
       if (!composed) return;
@@ -704,11 +708,23 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
             <QuickLabelPicker
               mode="chips"
               className="anno-popup-labels"
-              groups={QUICK_LABEL_GROUPS}
+              groups={[PROMOTED_LABELS]}
               isSelected={(label) => composed.quickLabelId === label.id}
               onSelect={(label) => applyLabel(label.id)}
               onHint={setHint}
             >
+              <button
+                ref={labelPickerTriggerRef}
+                type="button"
+                className={`anno-popup-label${selectedPickerLabel ? ' anno-popup-label--on' : ''}`}
+                title="More labels"
+                aria-label="More labels"
+                aria-expanded={labelPickerOpen}
+                onClick={() => setLabelPickerOpen(!labelPickerOpen)}
+                {...hintProps('More labels')}
+              >
+                {selectedPickerLabel?.emoji ?? '⚡'}
+              </button>
               <span className="anno-popup-divider" />
               <button
                 type="button"
@@ -734,6 +750,23 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
                 🗑
               </button>
             </QuickLabelPicker>
+            {labelPickerOpen && labelPickerTriggerRef.current ? (
+              <QuickLabelPicker
+                className="md-quick-label-picker"
+                groups={QUICK_LABEL_PICKER_GROUPS}
+                anchorEl={labelPickerTriggerRef.current}
+                onSelect={(label) => {
+                  setLabelPickerOpen(false);
+                  setHint(null);
+                  applyLabel(label.id);
+                }}
+                onDismiss={() => {
+                  setLabelPickerOpen(false);
+                  setHint(null);
+                }}
+                onHint={setHint}
+              />
+            ) : null}
             {/* Hovering names what a chip does; at rest the line names the mark
                 this annotation already carries, so reopening one says what it
                 says without a click. */}

--- a/app/src/components/TerminalAnnotations/TerminalAnnotations.css
+++ b/app/src/components/TerminalAnnotations/TerminalAnnotations.css
@@ -24,10 +24,8 @@
   border: 1px solid var(--color-border);
   background: var(--color-bg-elevated);
   box-shadow: 0 8px 28px rgba(0, 0, 0, 0.36);
-  /* The chip row on one line is ~490px, which is wider than a pane in a
-     three-way split — and a popup that cannot fit its pane falls back to the
-     window, where it lands on the sidebar. Two shorter rows keep it inside the
-     pane it belongs to, which is worth more than a single row of glyphs. */
+  /* The comment editor is the widest popup state; the grouped label picker is
+     portalled separately and does not change this placement footprint. */
   max-width: 320px;
 }
 

--- a/changelog.d/delegate-annot-terminal-grouped-labels.yaml
+++ b/changelog.d/delegate-annot-terminal-grouped-labels.yaml
@@ -1,0 +1,6 @@
+kind: changed
+area: annotations
+change: >
+  Terminal annotations now keep I agree, This is wrong, and Clarify this as
+  one-click marks, with the other nine labeled choices in the same grouped
+  picker used for markdown annotations.


### PR DESCRIPTION
## TL;DR

Terminal annotations now use the same quick-label contract as markdown annotations: 👍, ❌, and ❓ stay one click away, while the other nine labels live in the grouped ⚡ picker with their text and digit shortcuts.

## Why

The two annotation surfaces had different muscle memory. Markdown promoted the three reflex labels and grouped the deliberate labels, while the terminal popup still rendered all twelve as an emoji-only row.

## What changed

- Moved the promoted-label list and filtered picker groups into the shared annotation module, keeping the missing-label guard. The markdown adapter now re-exports those definitions.
- Moved the floating picker's structural styles to `app/src/annotations/QuickLabelPicker.css`, imported by `QuickLabelPicker`, so terminal rendering does not depend on `MarkdownReader.css`.
- Reworked the terminal popup to render the promoted trio, then a ⚡ trigger for the shared grouped picker. A selected grouped label remains visible as the trigger's emoji and selected state.
- Kept terminal annotation semantics intact: the existing `applyLabel` toggle path, hints, comment flow, trash action, anchoring, and payloads are unchanged.
- Put the terminal popup on the shared Escape stack so Escape closes the later-mounted picker first and leaves the popup open.
- Updated unit and packaged-app coverage for the new trigger path.

## Verification

- `pnpm --dir app test` — 254 files passed; 2,839 tests passed, 15 skipped.
- `make build-app` — passed.
- Exact-head named-profile install: `make install PROFILE=annotpop-4a9`.
- Bundled preflight passed on protocol 249 at `db3a5a3302a016fdfcfc87ba01c47b52db98b46e`.
- Live terminal flow: promoted select/toggle, grouped selection by click and digit, selected trigger emoji, nested Escape, comment via 💬, removal via 🗑, and Cmd+Enter delivery into the target Codex session.
- Live markdown flow: selected text, applied 👍, and sent the annotation to the same target session; the surface remained equivalent after the shared-definition/style move.

## Evidence

![terminal grouped quick labels](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/82de53402c13abb9a4f2df3306d8787888e6047a/delegate-annot-terminal-4a927c57/clip-head.gif)

[Full-quality recording (mp4)](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/82de53402c13abb9a4f2df3306d8787888e6047a/delegate-annot-terminal-4a927c57/clip-head.mp4)

## Surfaces checked

- Frontend terminal popup and shared quick-label picker: changed and covered.
- Markdown annotations: definitions/styles moved, rendered behavior verified unchanged.
- Protocol, daemon, CLI, Linux daemon, plugins, and SDK: not affected.
- Changelog: fragment included.
