### PR TITLE
fix(sessions): keep a crew member's name off the auto-titler

### DIFF
--- a/changelog.d/crew-member-keeps-its-name.yaml
+++ b/changelog.d/crew-member-keeps-its-name.yaml
@@ -1,0 +1,9 @@
+kind: fixed
+area: sessions
+change: >
+  A crew member no longer loses its name. A member launches in its own
+  home, so the auto-titler's "nobody has named this session" check —
+  label equals the directory basename — could not tell an unnamed
+  session apart from one named trellis, and replaced the member's name
+  with a title generated from the waking conversation at the first turn
+  end. A session a member is bound to is never auto-titled.

--- a/internal/daemon/crew.go
+++ b/internal/daemon/crew.go
@@ -316,6 +316,28 @@ func (d *Daemon) crewMembersBySession() map[string]string {
 	return out
 }
 
+// crewMemberBoundTo names the member a session is living as, or "" when it is
+// nobody. Read the roster rather than the session record: CrewMember is a
+// broadcast decoration, so it is nil on everything d.store.Get returns.
+func (d *Daemon) crewMemberBoundTo(sessionID string) string {
+	if d.store == nil || strings.TrimSpace(sessionID) == "" {
+		return ""
+	}
+	members, _, err := d.readCrewMembers()
+	if err != nil {
+		if !docstore.IsUndeclaredCollection(err) {
+			d.logf("crew: reading roster for session %s: %v", sessionID, err)
+		}
+		return ""
+	}
+	for _, member := range members {
+		if member.BindingSession == sessionID && d.crewBindingLive(member) {
+			return member.ID
+		}
+	}
+	return ""
+}
+
 // decorateCrewMember marks the session living a member's current day. Mirrors
 // decorateChiefOfStaffWithSessionID: set only when bound, cleared otherwise so
 // it round-trips as an omitted field.
@@ -337,8 +359,8 @@ func (d *Daemon) decorateCrewMember(session *protocol.Session, membersBySession 
 // through untouched: the registry never becomes a requirement to tend.
 func (d *Daemon) resolveTenderMember(memberName, sessionID string) string {
 	memberName = strings.TrimSpace(memberName)
-	if memberName == "" && sessionID == "" {
-		return ""
+	if memberName == "" {
+		return d.crewMemberBoundTo(sessionID)
 	}
 	members, _, err := d.readCrewMembers()
 	if err != nil {
@@ -347,18 +369,10 @@ func (d *Daemon) resolveTenderMember(memberName, sessionID string) string {
 		}
 		return memberName
 	}
-	if memberName != "" {
-		if member, ok := crew.Resolve(memberName, members); ok {
-			return member.ID
-		}
-		return memberName
+	if member, ok := crew.Resolve(memberName, members); ok {
+		return member.ID
 	}
-	for _, member := range members {
-		if member.BindingSession == sessionID && sessionID != "" && d.crewBindingLive(member) {
-			return member.ID
-		}
-	}
-	return ""
+	return memberName
 }
 
 // IPC handlers.

--- a/internal/daemon/session_title.go
+++ b/internal/daemon/session_title.go
@@ -47,7 +47,7 @@ func (d *Daemon) maybeGenerateSessionTitle(sessionID, transcriptPath string) {
 	if session == nil {
 		return
 	}
-	if session.Label != defaultSessionLabel(session.Directory, session.ID) {
+	if !d.sessionMayBeAutoTitled(session) {
 		return
 	}
 
@@ -109,12 +109,25 @@ func (d *Daemon) maybeGenerateSessionTitle(sessionID, transcriptPath string) {
 	// Re-fetch and re-check: the label may have been renamed (by the user or a
 	// concurrent caller) while the LLM run was in flight.
 	session = d.store.Get(sessionID)
-	if session == nil || session.Label != defaultSessionLabel(session.Directory, session.ID) {
+	if session == nil || !d.sessionMayBeAutoTitled(session) {
 		return
 	}
 	d.store.UpdateSessionLabel(sessionID, title)
 	session.Label = title
 	d.publishFact(FactSessionRenamed, sessionID, nil)
+}
+
+// sessionMayBeAutoTitled reports whether nobody has named this session yet.
+// Two ways a session is already named: a crew member is bound to it — the
+// member's name IS its identity — or its label was moved off the cwd basename
+// the launch gave it. The member check cannot be folded into the label one: a
+// member launches in its own home, so its name and its default label are the
+// same string.
+func (d *Daemon) sessionMayBeAutoTitled(session *protocol.Session) bool {
+	if session.Label != defaultSessionLabel(session.Directory, session.ID) {
+		return false
+	}
+	return d.crewMemberBoundTo(session.ID) == ""
 }
 
 // execSessionTitle dispatches the title generation run per the session's own

--- a/internal/daemon/session_title_test.go
+++ b/internal/daemon/session_title_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/victorarias/attn/internal/crew"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/transcript"
 )
@@ -327,5 +328,58 @@ func TestMaybeGenerateSessionTitle_ConcurrentAttemptRunsExecOnce(t *testing.T) {
 	got := d.store.Get("sess-1")
 	if got == nil || got.Label != "Fix login flow" {
 		t.Fatalf("session label = %+v, want %q", got, "Fix login flow")
+	}
+}
+
+// A member's name is its identity, not a placeholder. A member launches in its
+// own home, so its label and its cwd basename are the same string and the
+// default-label check alone cannot tell "nobody named this" from "this is
+// trellis" — the auto-titler used to overwrite a live member's name at its
+// first Stop.
+func TestMaybeGenerateSessionTitle_CrewMemberNeverTitled(t *testing.T) {
+	d := newCrewDaemon(t)
+	home := filepath.Join(d.dataRoot, crew.HomesDirName, "trellis")
+	seedSessionTitleSession(t, d, "sess-trellis", home, "")
+	if _, err := d.claimCrewBinding("trellis", "sess-trellis"); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	transcriptPath := writeSessionTitleTranscript(t)
+
+	calls := 0
+	d.sessionTitleExec = func(ctx context.Context, session *protocol.Session, slice transcript.ConversationSlice) (string, error) {
+		calls++
+		return "Fix login flow", nil
+	}
+
+	d.maybeGenerateSessionTitle("sess-trellis", transcriptPath)
+
+	if calls != 0 {
+		t.Fatalf("exec calls = %d, want 0 (a bound member is named by definition)", calls)
+	}
+	if got := d.store.Get("sess-trellis"); got == nil || got.Label != "trellis" {
+		t.Fatalf("session label = %+v, want %q", got, "trellis")
+	}
+}
+
+// The binding can be claimed while the LLM run is in flight — a member woken
+// into a session that was already talking. The post-run re-check must see it.
+func TestMaybeGenerateSessionTitle_CrewBindingRace(t *testing.T) {
+	d := newCrewDaemon(t)
+	directory := t.TempDir()
+	seedSessionTitleSession(t, d, "sess-1", directory, "")
+	transcriptPath := writeSessionTitleTranscript(t)
+
+	d.sessionTitleExec = func(ctx context.Context, session *protocol.Session, slice transcript.ConversationSlice) (string, error) {
+		if _, err := d.claimCrewBinding("trellis", "sess-1"); err != nil {
+			t.Errorf("claim: %v", err)
+		}
+		return "llm title", nil
+	}
+
+	d.maybeGenerateSessionTitle("sess-1", transcriptPath)
+
+	wantLabel := defaultSessionLabel(directory, "sess-1")
+	if got := d.store.Get("sess-1"); got == nil || got.Label != wantLabel {
+		t.Fatalf("session label = %+v, want unchanged %q (a session that became a member must not be titled)", got, wantLabel)
 	}
 }


### PR DESCRIPTION
## A crew member never loses its name

Wake `trellis` and, at the first Stop hook, the auto-titler replaces the
member's name with a title generated from the waking conversation. Victor
watched it happen to a live session.

## Why the guard could not tell

`maybeGenerateSessionTitle` asks "has anybody named this session yet?" by
comparing the label against `defaultSessionLabel`, which is
`filepath.Base(cwd)`. That is a proxy, and for a crew member the proxy
collides with the answer: a member launches in its own home
(`~/.attn/crew/trellis`), so the cwd basename is `trellis` — exactly the
label the wake sets. "Nobody named this" and "this is trellis" produce the
same string, so the guard let the rename through.

Ordinary delegations were never affected: a delegation's label
(`annot-terminal`) differs from its worktree basename
(`attn--delegate-annot-terminal-…`).

## The fix

`sessionMayBeAutoTitled` now asks the real question — is a crew member
bound to this session — after the default-label check, which stays because
it is correct for everyone else. A bound session is named by definition.

The binding is read off the roster (`crewMemberBoundTo`, new in
`crew.go`), not off `session.CrewMember`: that field is a broadcast
decoration applied to a clone in `sessionForBroadcast`, so it is `nil` on
every record `d.store.Get` returns. A guard written against it would have
silently never fired.

The same helper replaces the hand-rolled binding scan that
`resolveTenderMember` carried, and drops a roster read from its
name-given path.

Both guard sites are updated: the entry check, and the post-run re-check
that already existed for a rename landing while the LLM call is in flight.
A wake claiming a binding during that window is now caught by the same
re-check.

## Every other surface that can rename a session

| Surface | Reaches a member? | Verdict |
| --- | --- | --- |
| `maybeGenerateSessionTitle` (Stop hook, `daemon.go:3167`) | yes | fixed here; the only auto-title entry point in the tree |
| `handleRenameSession` (`rename.go`) | yes, from the app's rename | left alone — a deliberate user rename is not a placeholder being overwritten. No CLI, plugin, or SDK path reaches it; `rename_session` is sent only from `useDaemonSocket.ts` |
| `delegate.go:704` (adoption relabels to the delegation name) | no | a wake spawns through `handleSpawnSession` directly, never through the delegation machinery |
| worker-recovery relabel (`daemon.go:1606`) | yes, for a session attn has no row for | correct as-is — it re-derives `filepath.Base(cwd)`, which for a member is its own name |

`defaultSessionLabel` has exactly two callers, both in
`maybeGenerateSessionTitle`, so no other code carries the same collision.

## Verification

- Two regression tests, both confirmed red against the pre-fix guard:
  `TestMaybeGenerateSessionTitle_CrewMemberNeverTitled` (bound member,
  label equal to its home's basename → exec never runs) and
  `TestMaybeGenerateSessionTitle_CrewBindingRace` (binding claimed while
  the LLM call is in flight → label unchanged).
- Existing session-title tests unchanged and green.
- `make test-quick` green; `go vet ./internal/daemon` clean.
- Live A/B on a throwaway `mname` profile, same member, same wake, same
  daemon — only the guard differs.

  **Guard removed** (`sessionMayBeAutoTitled` forced to `true` past the
  label check), wake `trellis`, first turn ends:

  ```
  00:07:09 a103ef09  trellis             claude   trellis  working
  00:07:17 a103ef09  Session handoff a…  claude   trellis  waiting_input
  $ attn agent peek a103ef09
  session a103ef09-… (claude) — Session handoff and orientation
  crew member: this session is trellis today
  ```

  **Guard restored**, `make install-daemon PROFILE=mname`, wake again:

  ```
  00:08:06 3b00e11b  trellis             claude   trellis  working
  00:08:14 3b00e11b  trellis             claude   trellis  waiting_input
  $ attn agent peek 3b00e11b
  session 3b00e11b-… (claude) — trellis
  crew member: this session is trellis today
  ```

  The first leg is also the receipt that auto-titling was live in this
  daemon, so the second leg's unchanged name is the guard and not an
  inert titler.

No screen recording: the visible change is a sidebar label that does not
change, and the two-daemon A/B above says more than a clip of a name
staying put. Happy to record one if you want it.

No protocol change: the guard reads state the daemon already has.
