### PR TITLE
docs(apps): slice 3 owns the TrimBusEvents retention floor

### DIFF
--- a/changelog.d/slice3-owns-retention-floor.yaml
+++ b/changelog.d/slice3-owns-retention-floor.yaml
@@ -1,0 +1,6 @@
+kind: internal
+area: apps
+change: >
+  The reconcile design doc's slice plan now assigns the TrimBusEvents
+  retention-floor change to slice 3, beside the fence cleanup it already
+  owned, so the retention policy lands as code in one slice.

--- a/docs/plans/2026-08-14-ext-app-reconcile-handler.md
+++ b/docs/plans/2026-08-14-ext-app-reconcile-handler.md
@@ -475,7 +475,11 @@ proof.
    the end of this doc as code, both halves of one promise: keep the facts —
    `TrimBusEvents` floors at the minimum cursor across installed app
    consumers, enabled or disabled, with "disabled must not pin" narrowed to
-   rows no install serves — and deliver the facts: slice 1's as-built cleanup
+   rows no install serves, replacing the shipped test that pins the old
+   contract (`TestTrimBusEventsIgnoresDisabledConsumers`) with its witness: a
+   disabled installed app's rows survive a trim that would have deleted them,
+   while orphaned rows still trim — and deliver the facts: slice 1's as-built
+   cleanup
    (delete the `re_enabled` insert and enum value, re-fence `version_changed`
    to cursor and `gap` to `earliest - 1`) with the three witnesses named in
    slice 1's note. The per-lane cap stays out until its number has a receipt

--- a/docs/plans/2026-08-14-ext-app-reconcile-handler.md
+++ b/docs/plans/2026-08-14-ext-app-reconcile-handler.md
@@ -471,7 +471,15 @@ proof.
 3. **Failure, interruption, and operator surfaces.** Start/settle reconcile
    invocation rows, startup interruption repair, timeout-driven generation
    recycle, app status, command refusal, auto-disable, notifications, and the
-   loud missing-handler paths. Protocol changes follow `main.tsp` generation
+   loud missing-handler paths. This slice also lands the retention policy from
+   the end of this doc as code, both halves of one promise: keep the facts —
+   `TrimBusEvents` floors at the minimum cursor across installed app
+   consumers, enabled or disabled, with "disabled must not pin" narrowed to
+   rows no install serves — and deliver the facts: slice 1's as-built cleanup
+   (delete the `re_enabled` insert and enum value, re-fence `version_changed`
+   to cursor and `gap` to `earliest - 1`) with the three witnesses named in
+   slice 1's note. The per-lane cap stays out until its number has a receipt
+   from measured lane growth. Protocol changes follow `main.tsp` generation
    and increment `ProtocolVersion`; generated Go and TypeScript are never
    edited by hand. Verification tier: full non-production app plus packaged-app
    harness. Prove an infinite loop loses its generation and another app resumes.


### PR DESCRIPTION
One assignment the reconcile design doc left implicit after #909: the `TrimBusEvents` floor change — the code that makes installed apps pin retention whether enabled or disabled — now lives in slice 3's bullet, beside the fence cleanup that slice already owned. The two are halves of one promise (keep the facts, deliver the facts) and land together. The per-lane cap remains excluded until its number has a measured receipt, per the doc's retention section.

Victor ruled the assignment on ticket app-reconcile, 2026-08-15.

https://claude.ai/code/session_01FEGuaBJNKQmpxHbG1LJSyP