### PR TITLE
feat(crew): write a member's name as a name, everywhere you read one

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -7,6 +7,7 @@ import { openPath, openUrl } from '@tauri-apps/plugin-opener';
 import { Sidebar, type SidebarHeaderAction, type DockItem, WorkflowIcon, EditorIcon, PRsIcon, NotebookIcon } from './components/Sidebar';
 import { Dashboard } from './components/Dashboard';
 import { activityStaleMs } from './utils/activitySettings';
+import { crewDisplayName } from './utils/crewName';
 import { AttentionDrawer } from './components/AttentionDrawer';
 import { LocationPicker } from './components/LocationPicker';
 
@@ -3468,7 +3469,7 @@ function AppContent({
   const handleWakeCrewMember = useCallback((member: string) => {
     sendCrewWake(member)
       .then((result) => handleSelectSession(result.sessionId))
-      .catch((error) => showError(error instanceof Error ? error.message : `Failed to wake ${member}`));
+      .catch((error) => showError(error instanceof Error ? error.message : `Failed to wake ${crewDisplayName(member)}`));
   }, [sendCrewWake, handleSelectSession, showError]);
 
   // The daemon-facing ticket actions the pane-header ticket overlay wires into

--- a/app/src/components/GardenPanel.lifecycle.test.tsx
+++ b/app/src/components/GardenPanel.lifecycle.test.tsx
@@ -39,7 +39,7 @@ describe('GardenPanel lifecycle', () => {
     render(<GardenPanel isOpen onClose={vi.fn()} seedsTotal={1} seeds={[growing]} />);
 
     expect(screen.getByText('growing')).toBeInTheDocument();
-    expect(screen.getByText('tended by trellis')).toBeInTheDocument();
+    expect(screen.getByText('tended by Trellis')).toBeInTheDocument();
   });
 
   // A session id is not a pretty name, but "somebody holds this" is the fact the
@@ -87,7 +87,7 @@ describe('GardenPanel lifecycle', () => {
       />,
     );
     expect(screen.getByText('growing')).toBeInTheDocument();
-    expect(screen.getByText('tended by trellis')).toBeInTheDocument();
+    expect(screen.getByText('tended by Trellis')).toBeInTheDocument();
 
     rerender(
       <GardenPanel

--- a/app/src/components/GardenPanel.tsx
+++ b/app/src/components/GardenPanel.tsx
@@ -12,6 +12,7 @@
 // garden, so navigation costs no round trip.
 import { useMemo, useState } from 'react';
 import type { Seed } from '../hooks/useDaemonSocket';
+import { crewDisplayName } from '../utils/crewName';
 import './GardenPanel.css';
 
 interface GardenPanelProps {
@@ -112,7 +113,7 @@ function relationsOf(index: GardenIndex, id: string): Relation[] {
 // session id is not pretty, but "somebody holds this" is the fact the panel owes
 // the reader — showing nothing would read as unclaimed.
 function tenderOf(seed: Seed): string {
-  return seed.tender_member || seed.tender_session || '';
+  return seed.tender_member ? crewDisplayName(seed.tender_member) : seed.tender_session || '';
 }
 
 // crownOf is the crown a seed is part of, or '' when it stands on its own.
@@ -282,7 +283,7 @@ export function GardenPanel({ isOpen, onClose, seeds, seedsTotal }: GardenPanelP
                   <div className="garden-seed__detail">
                     <div className="garden-seed__meta">
                       <span>{seed.status}</span>
-                      {seed.planter_member && <span>planted by {seed.planter_member}</span>}
+                      {seed.planter_member && <span>planted by {crewDisplayName(seed.planter_member)}</span>}
                       {tenderOf(seed) && <span>tended by {tenderOf(seed)}</span>}
                       {seed.reason && <span>{seed.reason}</span>}
                       {seed.template && <span>packet</span>}

--- a/app/src/components/GardenPanel.tsx
+++ b/app/src/components/GardenPanel.tsx
@@ -12,7 +12,7 @@
 // garden, so navigation costs no round trip.
 import { useMemo, useState } from 'react';
 import type { Seed } from '../hooks/useDaemonSocket';
-import { crewDisplayName } from '../utils/crewName';
+import { crewDisplayName, crewHolderName } from '../utils/crewName';
 import './GardenPanel.css';
 
 interface GardenPanelProps {
@@ -113,7 +113,7 @@ function relationsOf(index: GardenIndex, id: string): Relation[] {
 // session id is not pretty, but "somebody holds this" is the fact the panel owes
 // the reader — showing nothing would read as unclaimed.
 function tenderOf(seed: Seed): string {
-  return seed.tender_member ? crewDisplayName(seed.tender_member) : seed.tender_session || '';
+  return crewHolderName(seed.tender_member, seed.tender_session);
 }
 
 // crownOf is the crown a seed is part of, or '' when it stands on its own.

--- a/app/src/components/QueueBands.test.tsx
+++ b/app/src/components/QueueBands.test.tsx
@@ -468,6 +468,17 @@ describe('the crew in the sidebar', () => {
     expect(screen.queryByTestId('queue-crew-wake-keel')).toBeNull();
   });
 
+  it('writes a sleeping member as a name while the id stays the address', () => {
+    renderCrew([], { onWakeCrewMember: vi.fn() });
+    const row = screen.getByTestId('queue-crew-trellis');
+    // The row reads Trellis; every hook into it — test id, data attribute, the
+    // id handed back on wake — is the lowercase id.
+    expect(row.textContent).toContain('Trellis');
+    expect(row.textContent).not.toContain('trellis');
+    expect(row.getAttribute('data-crew-member')).toBe('trellis');
+    expect(screen.getByTestId('queue-crew-wake-trellis').getAttribute('aria-label')).toBe('Wake Trellis');
+  });
+
   it('keeps the band when the crew is the only thing in it', () => {
     // Without a crew the pinned band is absent, so the members had nowhere to
     // render before this.

--- a/app/src/components/QueueBands.tsx
+++ b/app/src/components/QueueBands.tsx
@@ -7,6 +7,7 @@ import { formatShortcut } from '../shortcuts/formatShortcut';
 import type { UISessionState } from '../types/sessionState';
 import { formatTurnAge, type QueueBands as QueueBandsModel, type QueueRow } from '../utils/queueBands';
 import { formatWakeTime } from '../utils/snoozeDurations';
+import { crewDisplayName } from '../utils/crewName';
 import { useNow, TURN_AGE_TICK_MS } from '../hooks/useNow';
 
 export interface QueueBandSessionView {
@@ -427,7 +428,10 @@ function CrewRowView({
   onOpenActions?: (event: ReactMouseEvent) => void;
 }) {
   const awake = Boolean(row);
-  const label = row?.session.label || member;
+  // An awake member arrives with the daemon's label; a sleeping one has no
+  // session to carry one, so the display rule names it here.
+  const name = crewDisplayName(member);
+  const label = row?.session.label || name;
   return (
     <div
       className={`session-item queue-row queue-row--crew ${selected ? 'selected' : ''}`.trim()}
@@ -441,7 +445,7 @@ function CrewRowView({
         type="button"
         className="queue-row-select"
         data-testid={`queue-crew-select-${member}`}
-        aria-label={awake ? `Open ${label}` : `Wake ${member}`}
+        aria-label={awake ? `Open ${label}` : `Wake ${name}`}
         onClick={awake ? onSelect : onWake}
       />
       {awake ? (
@@ -452,7 +456,7 @@ function CrewRowView({
         <span className="crew-asleep-dot" aria-hidden="true" />
       )}
       <SessionLabel label={label} />
-      <span className="crew-row-mark" title={awake ? `${member} is awake` : `${member} is asleep`}>
+      <span className="crew-row-mark" title={awake ? `${name} is awake` : `${name} is asleep`}>
         {awake ? 'crew' : 'asleep'}
       </span>
       {!awake && onWake && (
@@ -461,8 +465,8 @@ function CrewRowView({
             type="button"
             className="queue-row-wake"
             data-testid={`queue-crew-wake-${member}`}
-            title={`Wake ${member} — start its day`}
-            aria-label={`Wake ${member}`}
+            title={`Wake ${name} — start its day`}
+            aria-label={`Wake ${name}`}
             onClick={(event) => {
               event.stopPropagation();
               onWake();

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -61,6 +61,7 @@ import { createPtyTransportState } from '../pty/transportState';
 import { enqueuePerKey } from '../pty/attachQueue';
 import { parseLayoutJSON, tileContentKey, tileIdsFromLayoutJSON, type TerminalDockEdge, type TileContentState } from '../types/workspace';
 import { isSuspiciousTerminalSize } from '../utils/terminalDebug';
+import { crewDisplayName } from '../utils/crewName';
 import { collectWorkspaceLayoutDiagnostics } from '../utils/workspaceDiagnostics';
 import { recordDiag, recordLayout } from '../utils/terminalDiagnosticsLog';
 import { recordPtyCommand, recordWsBinaryPtyOutput, recordWsJsonParse } from '../utils/ptyPerf';
@@ -4774,7 +4775,7 @@ export function useDaemonSocket({
         setTimeout(() => {
           if (pendingActionsRef.current.has(key)) {
             pendingActionsRef.current.delete(key);
-            reject(new Error(`Waking ${member} timed out`));
+            reject(new Error(`Waking ${crewDisplayName(member)} timed out`));
           }
         }, 10000);
       });

--- a/app/src/utils/crewName.test.ts
+++ b/app/src/utils/crewName.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { crewDisplayName } from './crewName';
+
+describe('crewDisplayName', () => {
+  it('writes a member id as a name', () => {
+    expect(crewDisplayName('trellis')).toBe('Trellis');
+    expect(crewDisplayName('keel')).toBe('Keel');
+    expect(crewDisplayName('alder')).toBe('Alder');
+  });
+
+  it('capitalizes the first character only — a hyphenated id is one name', () => {
+    expect(crewDisplayName('mary-jane')).toBe('Mary-jane');
+    expect(crewDisplayName('a')).toBe('A');
+  });
+
+  it('has nothing to say about an empty name, and leaves a capital alone', () => {
+    expect(crewDisplayName('')).toBe('');
+    expect(crewDisplayName('   ')).toBe('');
+    expect(crewDisplayName('Trellis')).toBe('Trellis');
+  });
+
+  it('matches the daemon rule on a non-ASCII first letter', () => {
+    expect(crewDisplayName('ólafur')).toBe('Ólafur');
+  });
+});

--- a/app/src/utils/crewName.test.ts
+++ b/app/src/utils/crewName.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { crewDisplayName } from './crewName';
+import { crewDisplayName, crewHolderName } from './crewName';
 
 describe('crewDisplayName', () => {
   it('writes a member id as a name', () => {
@@ -21,5 +21,18 @@ describe('crewDisplayName', () => {
 
   it('matches the daemon rule on a non-ASCII first letter', () => {
     expect(crewDisplayName('ólafur')).toBe('Ólafur');
+  });
+});
+
+describe('crewHolderName', () => {
+  it('writes a member as a name and leaves a session id alone', () => {
+    expect(crewHolderName('trellis', 'sess-a')).toBe('Trellis');
+    expect(crewHolderName('', 'sess-a')).toBe('sess-a');
+    expect(crewHolderName(undefined, 'sess-a')).toBe('sess-a');
+  });
+
+  it('has nothing to say when nobody holds it', () => {
+    expect(crewHolderName(undefined, undefined)).toBe('');
+    expect(crewHolderName('  ', '  ')).toBe('');
   });
 });

--- a/app/src/utils/crewName.ts
+++ b/app/src/utils/crewName.ts
@@ -1,0 +1,19 @@
+/**
+ * How a crew member's id is written wherever a person reads it: Trellis, Keel,
+ * Alder. Display capitalizes, identity does not — the id stays lowercase in
+ * paths, CLI arguments, protocol fields and test ids, and this is the one place
+ * the two part ways.
+ *
+ * The daemon keeps the same rule in `internal/crew.DisplayName`; a member woken
+ * by the daemon already arrives with a capitalized session label, and this is
+ * what names a member the app draws without one — a sleeping row.
+ *
+ * The first character only. Ids may carry `-`, but no real member is two words,
+ * and title-casing one would invent a name nobody chose.
+ */
+export function crewDisplayName(id: string): string {
+  const trimmed = id.trim();
+  if (!trimmed) return '';
+  const [first] = trimmed;
+  return first.toUpperCase() + trimmed.slice(first.length);
+}

--- a/app/src/utils/crewName.ts
+++ b/app/src/utils/crewName.ts
@@ -17,3 +17,13 @@ export function crewDisplayName(id: string): string {
   const [first] = trimmed;
   return first.toUpperCase() + trimmed.slice(first.length);
 }
+
+/**
+ * How something's holder is written when it can be either a member or a bare
+ * session: the member reads as the name it is, and a session id is left exactly
+ * as it is rather than dressed up as one. The daemon keeps the same rule in
+ * `internal/crew.HolderName`.
+ */
+export function crewHolderName(member: string | undefined, session: string | undefined): string {
+  return member?.trim() ? crewDisplayName(member) : session?.trim() ?? '';
+}

--- a/changelog.d/crew-member-names-read-as-names.yaml
+++ b/changelog.d/crew-member-names-read-as-names.yaml
@@ -1,0 +1,9 @@
+kind: changed
+area: crew
+change: >
+  A crew member is written as a name wherever you read one — Trellis in the
+  sidebar, in `attn crew list`, on the session it wakes into, in the daemon
+  log, and in the sentences that refuse or report a wake. The id itself is
+  untouched: `attn crew wake trellis` is still what you type, and the home
+  path, the workspace it belongs to, and every field on the wire stay
+  lowercase.

--- a/cmd/attn/agent.go
+++ b/cmd/attn/agent.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/client"
+	"github.com/victorarias/attn/internal/crew"
 	"github.com/victorarias/attn/internal/protocol"
 )
 
@@ -149,7 +150,7 @@ func printAgentList(w io.Writer, rows []agentListRow) {
 			agentShortIDLength, agentShortID(row.ID),
 			agentListCell(row.Label, 18),
 			agentListCell(row.Agent, 8),
-			agentListCell(row.Member, 10),
+			agentListCell(crew.DisplayName(row.Member), 10),
 			agentListCell(row.Workspace, 20),
 			agentListCell(row.State, 16),
 			turn,
@@ -236,7 +237,7 @@ func agentPeekErrorMessage(target string, err error) string {
 func printAgentPeek(w io.Writer, result *protocol.AgentPeekResult) {
 	fmt.Fprintf(w, "session %s (%s) — %s\n", result.SessionID, result.Agent, result.Label)
 	if member := strings.TrimSpace(protocol.Deref(result.CrewMember)); member != "" {
-		fmt.Fprintf(w, "crew member: this session is %s today\n", member)
+		fmt.Fprintf(w, "crew member: this session is %s today\n", crew.DisplayName(member))
 	}
 	workspace := strings.TrimSpace(protocol.Deref(result.WorkspaceTitle))
 	if workspace != "" {

--- a/cmd/attn/crew.go
+++ b/cmd/attn/crew.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/victorarias/attn/internal/client"
+	"github.com/victorarias/attn/internal/crew"
 	"github.com/victorarias/attn/internal/protocol"
 )
 
@@ -161,11 +162,11 @@ func runCrewWake(args []string) {
 		return
 	}
 	if result.AlreadyAwake {
-		fmt.Printf("%s is already awake in session %s — nothing was launched.\n", result.Member, agentShortID(result.SessionID))
+		fmt.Printf("%s is already awake in session %s — nothing was launched.\n", crew.DisplayName(result.Member), agentShortID(result.SessionID))
 		return
 	}
 	fmt.Printf("%s is awake in session %s. `attn agent peek %[2]s` watches the day; the priming size is in the daemon log (grep `crew: priming`).\n",
-		result.Member, agentShortID(result.SessionID))
+		crew.DisplayName(result.Member), agentShortID(result.SessionID))
 }
 
 // crewDirList collects a repeatable flag. An explicit empty value clears the
@@ -225,7 +226,7 @@ func runCrewSet(args []string) {
 		return
 	}
 	record := result.Member
-	fmt.Printf("%s launches in %s\n", record.ID, valueOrDash(protocol.Deref(record.Cwd)))
+	fmt.Printf("%s launches in %s\n", crew.DisplayName(record.ID), valueOrDash(protocol.Deref(record.Cwd)))
 	fmt.Printf("awareness dirs: %s\n", valueOrDash(strings.Join(record.AwarenessDirs, ", ")))
 }
 
@@ -247,7 +248,7 @@ func printCrewList(w io.Writer, members []protocol.CrewMember) {
 		if id := strings.TrimSpace(protocol.Deref(member.BindingSession)); id != "" {
 			state, session = "awake", agentShortID(id)
 		}
-		fmt.Fprintf(w, "%-12s  %-8s  %-10s  %s\n", member.ID, state, session, member.HomeDir)
+		fmt.Fprintf(w, "%-12s  %-8s  %-10s  %s\n", crew.DisplayName(member.ID), state, session, member.HomeDir)
 	}
 	fmt.Fprintf(w, "\nAn awake member's SESSION is what `attn agent peek <id>` takes.\n")
 }

--- a/cmd/attn/crew_test.go
+++ b/cmd/attn/crew_test.go
@@ -31,7 +31,7 @@ func TestPrintCrewList_ShowsSleepingAndAwakeMembers(t *testing.T) {
 		{ID: "trellis", HomeDir: "/home/.attn/crew/trellis", BindingSession: protocol.Ptr("sess-abcdef123456")},
 	})
 	text := out.String()
-	for _, want := range []string{"keel", "asleep", "trellis", "awake", "sess-abc", "/home/.attn/crew/keel"} {
+	for _, want := range []string{"Keel", "asleep", "Trellis", "awake", "sess-abc", "/home/.attn/crew/keel"} {
 		if !strings.Contains(text, want) {
 			t.Errorf("crew list output is missing %q:\n%s", want, text)
 		}
@@ -39,6 +39,20 @@ func TestPrintCrewList_ShowsSleepingAndAwakeMembers(t *testing.T) {
 	// The session column is the short id `attn agent peek` takes, not the full one.
 	if strings.Contains(text, "sess-abcdef123456") {
 		t.Errorf("crew list printed a full session id:\n%s", text)
+	}
+}
+
+// The MEMBER column is a name, and the home beside it is the lowercase path the
+// id owns — the two never drift into one another.
+func TestPrintCrewList_WritesTheMemberAsAName(t *testing.T) {
+	var out bytes.Buffer
+	printCrewList(&out, []protocol.CrewMember{{ID: "trellis", HomeDir: "/home/.attn/crew/trellis"}})
+	text := out.String()
+	if !strings.Contains(text, "Trellis") {
+		t.Errorf("the MEMBER column is not written as a name:\n%s", text)
+	}
+	if !strings.Contains(text, "/home/.attn/crew/trellis") {
+		t.Errorf("the home path was rewritten:\n%s", text)
 	}
 }
 
@@ -81,7 +95,7 @@ func TestAgentListRows_CarryTheCrewMember(t *testing.T) {
 	var out bytes.Buffer
 	printAgentList(&out, rows)
 	text := out.String()
-	if !strings.Contains(text, "MEMBER") || !strings.Contains(text, "trellis") {
+	if !strings.Contains(text, "MEMBER") || !strings.Contains(text, "Trellis") {
 		t.Errorf("agent list does not show the member column:\n%s", text)
 	}
 	// An unbound session's cell is the same placeholder every empty cell uses,

--- a/cmd/attn/handoff.go
+++ b/cmd/attn/handoff.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/victorarias/attn/internal/client"
+	"github.com/victorarias/attn/internal/crew"
 	"github.com/victorarias/attn/internal/protocol"
 )
 
@@ -130,20 +131,20 @@ func runHandoff(args []string) {
 		return
 	}
 	if parsed.retry {
-		fmt.Printf("%s's letter was already filed at %s.\n", result.Member, result.Path)
+		fmt.Printf("%s's letter was already filed at %s.\n", crew.DisplayName(result.Member), result.Path)
 	} else {
-		fmt.Printf("%s's letter is filed at %s.\n", result.Member, result.Path)
+		fmt.Printf("%s's letter is filed at %s.\n", crew.DisplayName(result.Member), result.Path)
 	}
 	if napErr := strings.TrimSpace(protocol.Deref(result.NapError)); napErr != "" {
 		// The letter is on disk; only the successor is missing. Say both, and say
 		// which is which — this session is still alive and still the member.
-		fmt.Fprintf(os.Stderr, "handoff: no successor was woken: %s\nThis day is still running and %s is still bound to it. `attn handoff --retry` turns it over again with the letter above — it is filed, so do not write another.\n", napErr, result.Member)
+		fmt.Fprintf(os.Stderr, "handoff: no successor was woken: %s\nThis day is still running and %s is still bound to it. `attn handoff --retry` turns it over again with the letter above — it is filed, so do not write another.\n", napErr, crew.DisplayName(result.Member))
 		os.Exit(1)
 	}
 	if protocol.Deref(result.Outcome) == protocol.CrewDayCloseSleep {
-		fmt.Printf("%s is asleep. Nobody was woken behind you; the sidebar has %[1]s one click from a new day.\n", result.Member)
+		fmt.Printf("%s is asleep. Nobody was woken behind you; the sidebar has %[1]s one click from a new day.\n", crew.DisplayName(result.Member))
 		return
 	}
 	fmt.Printf("%s's next day is session %s, waking now. This one ends here.\n",
-		result.Member, agentShortID(protocol.Deref(result.SessionID)))
+		crew.DisplayName(result.Member), agentShortID(protocol.Deref(result.SessionID)))
 }

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/victorarias/attn/internal/buildinfo"
 	"github.com/victorarias/attn/internal/client"
 	"github.com/victorarias/attn/internal/config"
+	"github.com/victorarias/attn/internal/crew"
 	"github.com/victorarias/attn/internal/daemon"
 	"github.com/victorarias/attn/internal/daemonctl"
 	"github.com/victorarias/attn/internal/hooks"
@@ -2974,9 +2975,10 @@ func parseDirectLaunchArgs(args []string) (directLaunchArgs, error) {
 		}
 	}
 	if label == "" {
-		// A member's day is named after the member; -s still overrides.
+		// A member's day is named after the member, written as a name; -s still
+		// overrides.
 		if parsed.member != "" {
-			label = parsed.member
+			label = crew.DisplayName(parsed.member)
 		} else {
 			label = wrapper.DefaultLabel()
 		}

--- a/cmd/attn/main_test.go
+++ b/cmd/attn/main_test.go
@@ -266,7 +266,9 @@ func TestParseDirectLaunchArgs_MemberNamesTheSession(t *testing.T) {
 	if parsed.member != "trellis" {
 		t.Fatalf("member = %q, want trellis", parsed.member)
 	}
-	if parsed.label != "trellis" {
+	// The label is the display side of the same member: a name, while the id
+	// the binding takes stays lowercase.
+	if parsed.label != "Trellis" {
 		t.Fatalf("label = %q, want the member's name", parsed.label)
 	}
 }

--- a/cmd/attn/seed.go
+++ b/cmd/attn/seed.go
@@ -184,7 +184,7 @@ func gardenPrimeFromReady(ready *protocol.SeedReadyResult) *hooks.GardenPrime {
 		line := hooks.SeedPrime{ID: seed.ID, Title: seed.Title}
 		if handoff, ok := handoffs[seed.ID]; ok {
 			line.Handoff = handoff.Body
-			line.HandoffAuthor = holderName(handoff.AuthorMember, handoff.AuthorSession)
+			line.HandoffAuthor = crew.HolderName(handoff.AuthorMember, handoff.AuthorSession)
 		}
 		crown.ReadySeeds = append(crown.ReadySeeds, line)
 	}
@@ -380,7 +380,7 @@ func runSeedList(args []string) {
 	fmt.Fprintln(w, "ID\tSTATUS\tTENDER\tPLANTED\tTITLE")
 	for _, row := range seedRows(result.Seeds, *f.tree) {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s%s%s\n",
-			row.seed.ID, row.seed.Status, orDash(holderName(row.seed.TenderMember, row.seed.TenderSession)),
+			row.seed.ID, row.seed.Status, orDash(crew.HolderName(row.seed.TenderMember, row.seed.TenderSession)),
 			shortStamp(row.seed.CreatedAt), strings.Repeat("  ", row.depth), row.seed.Title, plotProgressSuffix(row.seed))
 	}
 	w.Flush()
@@ -547,7 +547,7 @@ func fprintHandoff(w io.Writer, handoff *protocol.SeedNote) {
 		return
 	}
 	fmt.Fprintf(w, "handoff — %s, %s\n",
-		orDash(holderName(handoff.AuthorMember, handoff.AuthorSession)), shortStamp(handoff.CreatedAt))
+		orDash(crew.HolderName(handoff.AuthorMember, handoff.AuthorSession)), shortStamp(handoff.CreatedAt))
 	for _, line := range strings.Split(strings.TrimRight(handoff.Body, "\n"), "\n") {
 		fmt.Fprintf(w, "  %s\n", line)
 	}
@@ -642,7 +642,7 @@ func runSeedReady(args []string) {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", seed.ID, seed.Status, shortStamp(seed.CreatedAt), seed.Title)
 		if handoff, ok := handoffs[seed.ID]; ok {
 			fmt.Fprintf(w, "\t\t\t↳ %s: %s\n",
-				orDash(holderName(handoff.AuthorMember, handoff.AuthorSession)), firstLine(handoff.Body))
+				orDash(crew.HolderName(handoff.AuthorMember, handoff.AuthorSession)), firstLine(handoff.Body))
 		}
 	}
 	w.Flush()
@@ -682,8 +682,8 @@ func fprintSeed(out io.Writer, seed protocol.Seed) {
 	fmt.Fprintf(w, "%s\t%s\n", seed.ID, seed.Title)
 	fmt.Fprintf(w, "status\t%s\n", seed.Status)
 	fmt.Fprintf(w, "step\t%s\n", seed.StepSlug)
-	fmt.Fprintf(w, "planted\t%s by %s\n", shortStamp(seed.CreatedAt), orDash(holderName(seed.PlanterMember, seed.PlanterSession)))
-	fmt.Fprintf(w, "tender\t%s\n", orDash(holderName(seed.TenderMember, seed.TenderSession)))
+	fmt.Fprintf(w, "planted\t%s by %s\n", shortStamp(seed.CreatedAt), orDash(crew.HolderName(seed.PlanterMember, seed.PlanterSession)))
+	fmt.Fprintf(w, "tender\t%s\n", orDash(crew.HolderName(seed.TenderMember, seed.TenderSession)))
 	if p := seed.PlotProgress; p != nil {
 		fmt.Fprintf(w, "plot\t%d of %d done — %d growing, %d ready, %d blocked, %d dormant, %d withered\n",
 			p.Done, p.Total, p.Growing, p.Ready, p.Blocked, p.Dormant, p.Withered)
@@ -711,15 +711,6 @@ func orDash(value string) string {
 		return "-"
 	}
 	return value
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, v := range values {
-		if strings.TrimSpace(v) != "" {
-			return v
-		}
-	}
-	return ""
 }
 
 // runSeedTransition drives the five lifecycle verbs. They share everything but
@@ -756,21 +747,11 @@ func fprintTransition(w io.Writer, result *protocol.SeedTransitionResult) {
 	}
 }
 
-// holderName is how a seed's planter, tender or author is written for a
-// reader: a
-// member reads as a name, and a bare session id is left exactly as it is.
-func holderName(member, session string) string {
-	if strings.TrimSpace(member) != "" {
-		return crew.DisplayName(member)
-	}
-	return session
-}
-
 // transitionLine is the one line a move prints: what the seed is now, and who
 // holds it if anybody does. An agent reads it to confirm the claim landed.
 func transitionLine(seed protocol.Seed) string {
 	line := fmt.Sprintf("%s is %s", seed.ID, seed.Status)
-	if tender := holderName(seed.TenderMember, seed.TenderSession); tender != "" {
+	if tender := crew.HolderName(seed.TenderMember, seed.TenderSession); tender != "" {
 		line += fmt.Sprintf(", tended by %s", tender)
 	}
 	if seed.Reason != nil && *seed.Reason != "" {
@@ -830,7 +811,7 @@ func fprintNotes(w io.Writer, notes []protocol.SeedNote, seedID string, withheld
 			fmt.Fprintln(w)
 		}
 		fmt.Fprintf(w, "%s  %s%s\n", shortStamp(note.CreatedAt),
-			orDash(holderName(note.AuthorMember, note.AuthorSession)), noteKindSuffix(note.Kind))
+			orDash(crew.HolderName(note.AuthorMember, note.AuthorSession)), noteKindSuffix(note.Kind))
 		fmt.Fprintf(w, "%s\n", strings.TrimRight(note.Body, "\n"))
 	}
 	if withheld > 0 {

--- a/cmd/attn/seed.go
+++ b/cmd/attn/seed.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/victorarias/attn/internal/client"
 	"github.com/victorarias/attn/internal/config"
+	"github.com/victorarias/attn/internal/crew"
 	"github.com/victorarias/attn/internal/garden"
 	"github.com/victorarias/attn/internal/hooks"
 	"github.com/victorarias/attn/internal/protocol"
@@ -183,7 +184,7 @@ func gardenPrimeFromReady(ready *protocol.SeedReadyResult) *hooks.GardenPrime {
 		line := hooks.SeedPrime{ID: seed.ID, Title: seed.Title}
 		if handoff, ok := handoffs[seed.ID]; ok {
 			line.Handoff = handoff.Body
-			line.HandoffAuthor = firstNonEmpty(handoff.AuthorMember, handoff.AuthorSession)
+			line.HandoffAuthor = holderName(handoff.AuthorMember, handoff.AuthorSession)
 		}
 		crown.ReadySeeds = append(crown.ReadySeeds, line)
 	}
@@ -379,7 +380,7 @@ func runSeedList(args []string) {
 	fmt.Fprintln(w, "ID\tSTATUS\tTENDER\tPLANTED\tTITLE")
 	for _, row := range seedRows(result.Seeds, *f.tree) {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s%s%s\n",
-			row.seed.ID, row.seed.Status, orDash(firstNonEmpty(row.seed.TenderMember, row.seed.TenderSession)),
+			row.seed.ID, row.seed.Status, orDash(holderName(row.seed.TenderMember, row.seed.TenderSession)),
 			shortStamp(row.seed.CreatedAt), strings.Repeat("  ", row.depth), row.seed.Title, plotProgressSuffix(row.seed))
 	}
 	w.Flush()
@@ -546,7 +547,7 @@ func fprintHandoff(w io.Writer, handoff *protocol.SeedNote) {
 		return
 	}
 	fmt.Fprintf(w, "handoff — %s, %s\n",
-		orDash(firstNonEmpty(handoff.AuthorMember, handoff.AuthorSession)), shortStamp(handoff.CreatedAt))
+		orDash(holderName(handoff.AuthorMember, handoff.AuthorSession)), shortStamp(handoff.CreatedAt))
 	for _, line := range strings.Split(strings.TrimRight(handoff.Body, "\n"), "\n") {
 		fmt.Fprintf(w, "  %s\n", line)
 	}
@@ -641,7 +642,7 @@ func runSeedReady(args []string) {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", seed.ID, seed.Status, shortStamp(seed.CreatedAt), seed.Title)
 		if handoff, ok := handoffs[seed.ID]; ok {
 			fmt.Fprintf(w, "\t\t\t↳ %s: %s\n",
-				orDash(firstNonEmpty(handoff.AuthorMember, handoff.AuthorSession)), firstLine(handoff.Body))
+				orDash(holderName(handoff.AuthorMember, handoff.AuthorSession)), firstLine(handoff.Body))
 		}
 	}
 	w.Flush()
@@ -681,8 +682,8 @@ func fprintSeed(out io.Writer, seed protocol.Seed) {
 	fmt.Fprintf(w, "%s\t%s\n", seed.ID, seed.Title)
 	fmt.Fprintf(w, "status\t%s\n", seed.Status)
 	fmt.Fprintf(w, "step\t%s\n", seed.StepSlug)
-	fmt.Fprintf(w, "planted\t%s by %s\n", shortStamp(seed.CreatedAt), orDash(firstNonEmpty(seed.PlanterMember, seed.PlanterSession)))
-	fmt.Fprintf(w, "tender\t%s\n", orDash(firstNonEmpty(seed.TenderMember, seed.TenderSession)))
+	fmt.Fprintf(w, "planted\t%s by %s\n", shortStamp(seed.CreatedAt), orDash(holderName(seed.PlanterMember, seed.PlanterSession)))
+	fmt.Fprintf(w, "tender\t%s\n", orDash(holderName(seed.TenderMember, seed.TenderSession)))
 	if p := seed.PlotProgress; p != nil {
 		fmt.Fprintf(w, "plot\t%d of %d done — %d growing, %d ready, %d blocked, %d dormant, %d withered\n",
 			p.Done, p.Total, p.Growing, p.Ready, p.Blocked, p.Dormant, p.Withered)
@@ -755,11 +756,21 @@ func fprintTransition(w io.Writer, result *protocol.SeedTransitionResult) {
 	}
 }
 
+// holderName is how a seed's planter, tender or author is written for a
+// reader: a
+// member reads as a name, and a bare session id is left exactly as it is.
+func holderName(member, session string) string {
+	if strings.TrimSpace(member) != "" {
+		return crew.DisplayName(member)
+	}
+	return session
+}
+
 // transitionLine is the one line a move prints: what the seed is now, and who
 // holds it if anybody does. An agent reads it to confirm the claim landed.
 func transitionLine(seed protocol.Seed) string {
 	line := fmt.Sprintf("%s is %s", seed.ID, seed.Status)
-	if tender := firstNonEmpty(seed.TenderMember, seed.TenderSession); tender != "" {
+	if tender := holderName(seed.TenderMember, seed.TenderSession); tender != "" {
 		line += fmt.Sprintf(", tended by %s", tender)
 	}
 	if seed.Reason != nil && *seed.Reason != "" {
@@ -819,7 +830,7 @@ func fprintNotes(w io.Writer, notes []protocol.SeedNote, seedID string, withheld
 			fmt.Fprintln(w)
 		}
 		fmt.Fprintf(w, "%s  %s%s\n", shortStamp(note.CreatedAt),
-			orDash(firstNonEmpty(note.AuthorMember, note.AuthorSession)), noteKindSuffix(note.Kind))
+			orDash(holderName(note.AuthorMember, note.AuthorSession)), noteKindSuffix(note.Kind))
 		fmt.Fprintf(w, "%s\n", strings.TrimRight(note.Body, "\n"))
 	}
 	if withheld > 0 {

--- a/cmd/attn/seed_handoff_print_test.go
+++ b/cmd/attn/seed_handoff_print_test.go
@@ -29,7 +29,7 @@ func TestFprintSeedShowPutsTheHandoffFirst(t *testing.T) {
 	})
 	out := buf.String()
 
-	if !strings.HasPrefix(out, "handoff — keel,") {
+	if !strings.HasPrefix(out, "handoff — Keel,") {
 		t.Fatalf("the handoff is not the first thing on the screen:\n%s", out)
 	}
 	if strings.Index(out, "the join test is the gate") > strings.Index(out, "s-7k3f9m") {
@@ -124,7 +124,7 @@ func TestFprintTransitionPrimesOnTend(t *testing.T) {
 	})
 	out := buf.String()
 
-	if !strings.HasPrefix(out, "s-7k3f9m is growing, tended by alder\n") {
+	if !strings.HasPrefix(out, "s-7k3f9m is growing, tended by Alder\n") {
 		t.Fatalf("the claim is not confirmed first:\n%s", out)
 	}
 	if !strings.Contains(out, "start at the docstore compiler") {

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -498,9 +498,15 @@ Plan:
 ## The crew
 
 The **crew** is the roster of durable named identities. A **crew member** —
-keel, alder, trellis — is a charter, a handoff line, and an address; its
+Keel, Alder, Trellis — is a charter, a handoff line, and an address; its
 sessions are its **days**. A member belongs to a home daemon, for the same
 reason the garden does: one roster across a fleet is its whole point.
+
+**Display capitalizes, identity does not.** The id is lowercase and stays that
+way wherever it addresses something — the home directory, `--member`, the
+fields on the wire, the store. Wherever a person reads the member, it is
+written as the name it is: you type `attn crew wake trellis` and Trellis is
+who answers.
 
 A member's **home** is plain markdown on disk at `~/.attn/crew/<name>/`: a
 `CHARTER.md` saying what it cares about, and dated **handoffs** it writes to

--- a/internal/crew/crew.go
+++ b/internal/crew/crew.go
@@ -21,6 +21,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/victorarias/attn/internal/docstore"
 )
@@ -148,6 +150,23 @@ func ValidateID(id string) error {
 		return fmt.Errorf("%q is not a member id: lowercase letters, digits and - only, starting with a letter, like `trellis`", id)
 	}
 	return docstore.ValidateDocumentID(id)
+}
+
+// DisplayName is how a member's id is written wherever a person reads it:
+// Trellis, Keel, Alder. Display capitalizes, identity does not — the id stays
+// lowercase in paths, CLI arguments, JSON fields and the store, and this is the
+// one place the two part ways. The frontend keeps its own copy of the same rule
+// in `app/src/utils/crewName.ts`.
+//
+// The first rune only. Ids may carry `-`, but no real member is two words, and
+// title-casing one would invent a name nobody chose.
+func DisplayName(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return ""
+	}
+	first, size := utf8.DecodeRuneInString(id)
+	return string(unicode.ToUpper(first)) + id[size:]
 }
 
 // Resolve finds the registered member a free-string name addresses, folding

--- a/internal/crew/crew.go
+++ b/internal/crew/crew.go
@@ -169,6 +169,17 @@ func DisplayName(id string) string {
 	return string(unicode.ToUpper(first)) + id[size:]
 }
 
+// HolderName is how something's holder is written for a reader when it can be
+// either a member or a bare session: the member reads as the name it is, and a
+// session id is left exactly as it is rather than dressed up as one. The
+// garden's tenders, planters and note authors are all this shape.
+func HolderName(member, session string) string {
+	if strings.TrimSpace(member) != "" {
+		return DisplayName(member)
+	}
+	return strings.TrimSpace(session)
+}
+
 // Resolve finds the registered member a free-string name addresses, folding
 // case so `Trellis` reaches `trellis`. The second return is false when nothing
 // is registered under that name — which is a normal answer, not an error: the

--- a/internal/crew/crew_test.go
+++ b/internal/crew/crew_test.go
@@ -221,3 +221,36 @@ func TestMembersSchema_IsAValidDeclaration(t *testing.T) {
 		t.Fatalf("MembersSchema is not declarable: %v", err)
 	}
 }
+
+// Display capitalizes, identity does not: the same string reads as a name to a
+// person and stays the lowercase id everywhere it addresses something.
+func TestDisplayName_WritesTheIDAsAName(t *testing.T) {
+	for id, want := range map[string]string{
+		"trellis":   "Trellis",
+		"keel":      "Keel",
+		"alder":     "Alder",
+		"a":         "A",
+		"mary-jane": "Mary-jane",
+		"Trellis":   "Trellis",
+		"":          "",
+		"  keel  ":  "Keel",
+		"ólafur":    "Ólafur",
+	} {
+		if got := DisplayName(id); got != want {
+			t.Errorf("DisplayName(%q) = %q, want %q", id, got, want)
+		}
+	}
+}
+
+// The rule is one-way: a display name still resolves to the member it names, so
+// nothing that looks up an id has to know about the capitalization.
+func TestDisplayName_StillResolvesToItsMember(t *testing.T) {
+	members := []Member{{ID: "trellis"}, {ID: "keel"}}
+	member, ok := Resolve(DisplayName("keel"), members)
+	if !ok || member.ID != "keel" {
+		t.Fatalf("Resolve(%q) = %q, %t; want keel", DisplayName("keel"), member.ID, ok)
+	}
+	if err := ValidateID(member.ID); err != nil {
+		t.Fatalf("the resolved id is not a member id: %v", err)
+	}
+}

--- a/internal/crew/crew_test.go
+++ b/internal/crew/crew_test.go
@@ -254,3 +254,17 @@ func TestDisplayName_StillResolvesToItsMember(t *testing.T) {
 		t.Fatalf("the resolved id is not a member id: %v", err)
 	}
 }
+
+// Where a holder can be either a member or a bare session, only the member
+// branch is a name: a session id is never dressed up as one.
+func TestHolderName_NamesTheMemberAndLeavesASessionAlone(t *testing.T) {
+	if got := HolderName("trellis", "sess-a"); got != "Trellis" {
+		t.Errorf("HolderName(trellis, sess-a) = %q, want Trellis", got)
+	}
+	if got := HolderName("", "sess-a"); got != "sess-a" {
+		t.Errorf("HolderName(\"\", sess-a) = %q, want the session id untouched", got)
+	}
+	if got := HolderName("  ", "  "); got != "" {
+		t.Errorf("an unheld thing displays as %q, want empty", got)
+	}
+}

--- a/internal/crew/handoff.go
+++ b/internal/crew/handoff.go
@@ -50,7 +50,7 @@ func FileHandoff(homeDir, member, note string, at time.Time) (string, error) {
 	}
 	dir := filepath.Join(homeDir, HandoffsDirName)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return "", fmt.Errorf("making %s's handoffs directory at %s: %w", member, dir, err)
+		return "", fmt.Errorf("making %s's handoffs directory at %s: %w", DisplayName(member), dir, err)
 	}
 	path := filepath.Join(dir, HandoffFileName(member, at))
 	// O_EXCL is the enforcement, not a check before one: two letters racing for
@@ -61,11 +61,11 @@ func FileHandoff(homeDir, member, note string, at time.Time) (string, error) {
 		if os.IsExist(err) {
 			return "", fmt.Errorf("%w: %s — a filed letter is never overwritten, so file the correction as its own letter a minute from now", ErrHandoffExists, path)
 		}
-		return "", fmt.Errorf("filing %s's letter at %s: %w", member, path, err)
+		return "", fmt.Errorf("filing %s's letter at %s: %w", DisplayName(member), path, err)
 	}
 	defer file.Close()
 	if _, err := file.WriteString(ensureTrailingNewline(note)); err != nil {
-		return "", fmt.Errorf("writing %s's letter at %s: %w", member, path, err)
+		return "", fmt.Errorf("writing %s's letter at %s: %w", DisplayName(member), path, err)
 	}
 	return path, nil
 }

--- a/internal/crew/lifecycle.go
+++ b/internal/crew/lifecycle.go
@@ -158,12 +158,13 @@ func (l WakeLedger) Within(now time.Time) []time.Time {
 // they must see: the caller prints this, it is never a silent no-op.
 func (l WakeLedger) Allows(memberID string, now time.Time) ([]time.Time, error) {
 	kept := l.Within(now)
+	name := DisplayName(memberID)
 	if l.Limit <= 0 {
-		return kept, fmt.Errorf("autonomous wakes are turned off (crew.wake_limit=%d), so %s was not woken; wake it yourself from the sidebar, or raise the limit", l.Limit, memberID)
+		return kept, fmt.Errorf("autonomous wakes are turned off (crew.wake_limit=%d), so %s was not woken; wake it yourself from the sidebar, or raise the limit", l.Limit, name)
 	}
 	if len(kept) >= l.Limit {
 		return kept, fmt.Errorf("%s has been woken %d times without the user in the last %s, and the limit is %d (crew.wake_limit=%d, crew.wake_limit_window_seconds=%d); nothing was woken. Wake it yourself from the sidebar, or raise the limit",
-			memberID, len(kept), l.Window, l.Limit, l.Limit, int(l.Window/time.Second))
+			name, len(kept), l.Window, l.Limit, l.Limit, int(l.Window/time.Second))
 	}
 	return append(kept, now), nil
 }

--- a/internal/crew/lifecycle_test.go
+++ b/internal/crew/lifecycle_test.go
@@ -179,7 +179,7 @@ func TestWakeLedger_RefusalNamesTheLimitAndTheAsk(t *testing.T) {
 	if err == nil {
 		t.Fatal("Allows() let a third wake through a limit of 2")
 	}
-	for _, want := range []string{"trellis", "crew.wake_limit=2", "crew.wake_limit_window_seconds=43200", "nothing was woken"} {
+	for _, want := range []string{"Trellis", "crew.wake_limit=2", "crew.wake_limit_window_seconds=43200", "nothing was woken"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("the refusal %q does not name %q", err, want)
 		}

--- a/internal/crew/priming.go
+++ b/internal/crew/priming.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"unicode"
 	"unicode/utf8"
 )
 
@@ -65,7 +64,7 @@ func (p Priming) Block() string {
 	if strings.TrimSpace(p.Member) == "" {
 		return ""
 	}
-	name := capitalized(p.Member)
+	name := DisplayName(p.Member)
 	var b strings.Builder
 	fmt.Fprintf(&b, `You are **%[1]s**, a crew member of this attn home.
 
@@ -131,17 +130,6 @@ func cut(text string, limit int, path string) string {
 		end--
 	}
 	return text[:end] + fmt.Sprintf("\n\n[cut at %d bytes of %d — the whole file is at %s]", end, len(text), path)
-}
-
-// capitalized renders a member id as the name it is in prose: Trellis speaking
-// to Trellis. Ids stay lowercase everywhere they are addresses — the home path,
-// the registry, the CLI.
-func capitalized(id string) string {
-	first, size := utf8.DecodeRuneInString(id)
-	if size == 0 {
-		return id
-	}
-	return string(unicode.ToUpper(first)) + id[size:]
 }
 
 func trimmed(values []string) []string {

--- a/internal/daemon/crew.go
+++ b/internal/daemon/crew.go
@@ -78,11 +78,11 @@ func (d *Daemon) importCrewHomes() {
 			if docstore.IsConflict(err) {
 				continue // already registered; the record is authoritative
 			}
-			d.logf("crew: importing %s: %v", member.ID, err)
+			d.logf("crew: importing %s: %v", crew.DisplayName(member.ID), err)
 			continue
 		}
 		d.publishFact(FactCrewRegistered, member.ID, nil)
-		d.logf("crew: imported member %s from %s", member.ID, member.HomeDir)
+		d.logf("crew: imported member %s from %s", crew.DisplayName(member.ID), member.HomeDir)
 	}
 }
 
@@ -227,7 +227,7 @@ func (d *Daemon) claimCrewBinding(memberName, sessionID string) (string, error) 
 		}
 		if d.crewBindingLive(member) {
 			return "", fmt.Errorf("%s is already awake in session %s; two agents with the same identity never run at once — wait for that day to end, or wake another member",
-				member.ID, shortSessionID(member.BindingSession))
+				crew.DisplayName(member.ID), shortSessionID(member.BindingSession))
 		}
 		// Past every refusal, so the claim is going to land: drop any other name
 		// this session already answered to. A refused claim is not reached here,
@@ -237,7 +237,7 @@ func (d *Daemon) claimCrewBinding(memberName, sessionID string) (string, error) 
 		err = d.writeCrewMember(*schema, member, docs[member.ID].Rev)
 		if err == nil {
 			d.publishFact(FactCrewBound, member.ID, nil)
-			d.logf("crew: session %s bound as %s", sessionID, member.ID)
+			d.logf("crew: session %s bound as %s", sessionID, crew.DisplayName(member.ID))
 			return member.ID, nil
 		}
 		if !docstore.IsConflict(err) {
@@ -280,11 +280,11 @@ func (d *Daemon) releaseCrewBindingsExcept(schema docstore.CollectionSchema, mem
 		}
 		member.BindingSession = ""
 		if err := d.writeCrewMember(schema, member, docs[member.ID].Rev); err != nil {
-			d.logf("crew: releasing %s's binding for session %s: %v", member.ID, sessionID, err)
+			d.logf("crew: releasing %s's binding for session %s: %v", crew.DisplayName(member.ID), sessionID, err)
 			continue
 		}
 		d.publishFact(FactCrewReleased, member.ID, nil)
-		d.logf("crew: session %s released %s's binding", sessionID, member.ID)
+		d.logf("crew: session %s released %s's binding", sessionID, crew.DisplayName(member.ID))
 	}
 }
 

--- a/internal/daemon/crew_handoff.go
+++ b/internal/daemon/crew_handoff.go
@@ -51,7 +51,7 @@ const crewNapPrompt = "Your predecessor just closed their day and left you the l
 func (d *Daemon) transferCrewBinding(memberID, from, to string) error {
 	_, err := d.updateCrewMember(memberID, func(member *crew.Member) (bool, error) {
 		if member.BindingSession != from {
-			return false, fmt.Errorf("%s's day is no longer session %s; nothing was moved", member.ID, shortSessionID(from))
+			return false, fmt.Errorf("%s's day is no longer session %s; nothing was moved", crew.DisplayName(member.ID), shortSessionID(from))
 		}
 		member.BindingSession = to
 		// The filed-letter fields are deliberately left alone. They name the
@@ -65,7 +65,7 @@ func (d *Daemon) transferCrewBinding(memberID, from, to string) error {
 		return err
 	}
 	d.publishFact(FactCrewBound, memberID, nil)
-	d.logf("crew: %s's binding moved from session %s to %s", memberID, from, to)
+	d.logf("crew: %s's binding moved from session %s to %s", crew.DisplayName(memberID), from, to)
 	return nil
 }
 
@@ -126,7 +126,7 @@ func (d *Daemon) crewHandoff(sessionID, note string, retry bool, close protocol.
 	result := &protocol.CrewHandoffResult{Member: member.ID, Path: path}
 	if d.crewDayEndsHere(close, time.Now()) {
 		d.closeNappedSession(sessionID)
-		d.logf("crew: %s went to sleep — session %s ended and nobody was woken behind it", member.ID, sessionID)
+		d.logf("crew: %s went to sleep — session %s ended and nobody was woken behind it", crew.DisplayName(member.ID), sessionID)
 		result.Outcome = protocol.Ptr(protocol.CrewDayCloseSleep)
 		return result, nil
 	}
@@ -134,7 +134,7 @@ func (d *Daemon) crewHandoff(sessionID, note string, retry bool, close protocol.
 	if err != nil {
 		// The letter is filed and the day's session is untouched: say why nobody
 		// was woken and leave the member awake where it is.
-		d.logf("crew: %s's letter is filed but the nap did not run: %v", member.ID, err)
+		d.logf("crew: %s's letter is filed but the nap did not run: %v", crew.DisplayName(member.ID), err)
 		result.NapError = protocol.Ptr(err.Error())
 		return result, nil
 	}
@@ -167,12 +167,12 @@ func (d *Daemon) crewLetterForHandoff(member crew.Member, sessionID, note string
 	filed, hasFiled := member.FiledLetterFor(sessionID)
 	if retry {
 		if !hasFiled {
-			return "", fmt.Errorf("%s's day has filed no letter yet, so there is no turnover to retry — write one with `attn handoff -m \"<your letter>\"`", member.ID)
+			return "", fmt.Errorf("%s's day has filed no letter yet, so there is no turnover to retry — write one with `attn handoff -m \"<your letter>\"`", crew.DisplayName(member.ID))
 		}
 		if _, err := os.Stat(filed); err != nil {
-			return "", fmt.Errorf("%s's filed letter is recorded at %s but is not readable there (%v); file this day's letter again with `attn handoff -m \"<your letter>\"`", member.ID, filed, err)
+			return "", fmt.Errorf("%s's filed letter is recorded at %s but is not readable there (%v); file this day's letter again with `attn handoff -m \"<your letter>\"`", crew.DisplayName(member.ID), filed, err)
 		}
-		d.logf("crew: %s is retrying its turnover with the letter already filed at %s", member.ID, filed)
+		d.logf("crew: %s is retrying its turnover with the letter already filed at %s", crew.DisplayName(member.ID), filed)
 		return filed, nil
 	}
 	if err := crew.ValidateHandoffNote(note); err != nil {
@@ -183,11 +183,11 @@ func (d *Daemon) crewLetterForHandoff(member crew.Member, sessionID, note string
 		if errors.Is(err, crew.ErrHandoffExists) && hasFiled {
 			// The one collision that is not a correction: this day wrote that letter
 			// minutes ago and the turnover behind it failed.
-			return "", fmt.Errorf("%s's letter for this minute is already filed at %s — if the turnover is what failed, `attn handoff --retry` runs it against that letter; if this is a correction, file it as its own letter a minute from now", member.ID, filed)
+			return "", fmt.Errorf("%s's letter for this minute is already filed at %s — if the turnover is what failed, `attn handoff --retry` runs it against that letter; if this is a correction, file it as its own letter a minute from now", crew.DisplayName(member.ID), filed)
 		}
 		return "", err
 	}
-	d.logf("crew: %s filed a letter at %s (%d bytes)", member.ID, path, len(note))
+	d.logf("crew: %s filed a letter at %s (%d bytes)", crew.DisplayName(member.ID), path, len(note))
 	d.recordCrewLetter(member.ID, sessionID, path)
 	return path, nil
 }
@@ -205,7 +205,7 @@ func (d *Daemon) recordCrewLetter(memberID, sessionID, path string) {
 		member.LetterSession = sessionID
 		return true, nil
 	}); err != nil {
-		d.logf("crew: recording %s's filed letter at %s: %v", memberID, path, err)
+		d.logf("crew: recording %s's filed letter at %s: %v", crew.DisplayName(memberID), path, err)
 	}
 }
 
@@ -239,7 +239,7 @@ func (d *Daemon) crewNap(member crew.Member, oldSessionID string) (string, error
 	}
 	undoBinding := func() {
 		if err := d.transferCrewBinding(member.ID, newSessionID, oldSessionID); err != nil {
-			d.logf("crew: could not give %s's binding back to session %s: %v", member.ID, oldSessionID, err)
+			d.logf("crew: could not give %s's binding back to session %s: %v", crew.DisplayName(member.ID), oldSessionID, err)
 		}
 	}
 
@@ -249,17 +249,17 @@ func (d *Daemon) crewNap(member crew.Member, oldSessionID string) (string, error
 		WorkspaceID: spawnMsg.WorkspaceID,
 		PaneID:      protocol.Ptr("pane-" + newSessionID),
 		SessionID:   newSessionID,
-		Title:       protocol.Ptr(member.ID),
+		Title:       protocol.Ptr(crew.DisplayName(member.ID)),
 	})
 	if _, err := readInternalActionResult(paneClient); err != nil {
 		undoBinding()
-		return "", fmt.Errorf("create %s's next pane: %w", member.ID, err)
+		return "", fmt.Errorf("create %s's next pane: %w", crew.DisplayName(member.ID), err)
 	}
 
 	if rejection := d.runSpawnPipeline(spawnMsg, policy); rejection != nil {
 		d.removeWorkspaceLayoutPaneForSession(newSessionID)
 		undoBinding()
-		return "", fmt.Errorf("wake %s's successor: %w", member.ID, rejection.reason())
+		return "", fmt.Errorf("wake %s's successor: %w", crew.DisplayName(member.ID), rejection.reason())
 	}
 
 	// The new day is running, so the old one can end. Closing it releases
@@ -267,7 +267,7 @@ func (d *Daemon) crewNap(member crew.Member, oldSessionID string) (string, error
 	// and releaseCrewBindingIfSession only clears a binding pointing at the id
 	// being closed.
 	d.closeNappedSession(oldSessionID)
-	d.logf("crew: %s napped — session %s ended, session %s is the new day", member.ID, oldSessionID, newSessionID)
+	d.logf("crew: %s napped — session %s ended, session %s is the new day", crew.DisplayName(member.ID), oldSessionID, newSessionID)
 	return newSessionID, nil
 }
 
@@ -284,19 +284,19 @@ func (d *Daemon) crewNapSpawn(member crew.Member, session *protocol.Session) (*p
 	if intent, ok := d.store.LaunchIntent(session.ID); ok {
 		spawnMsg, policy = buildStoredIntentSpawn(session, intent, cols, rows)
 	} else {
-		d.logf("crew: no launch intent for %s's closing day; the successor launches with defaults", member.ID)
+		d.logf("crew: no launch intent for %s's closing day; the successor launches with defaults", crew.DisplayName(member.ID))
 		spawnMsg = &protocol.SpawnSessionMessage{
 			Cmd:         protocol.CmdSpawnSession,
 			Cwd:         session.Directory,
 			Agent:       string(session.Agent),
 			WorkspaceID: session.WorkspaceID,
-			Label:       protocol.Ptr(member.ID),
+			Label:       protocol.Ptr(crew.DisplayName(member.ID)),
 			Cols:        cols,
 			Rows:        rows,
 		}
 	}
 	spawnMsg.ID = uuid.NewString()
-	spawnMsg.Label = protocol.Ptr(member.ID)
+	spawnMsg.Label = protocol.Ptr(crew.DisplayName(member.ID))
 	spawnMsg.InitialPrompt = protocol.Ptr(crewNapPrompt)
 	if model := crewWakeModelPin(spawnMsg.Agent); model != nil {
 		spawnMsg.Model = model

--- a/internal/daemon/crew_lifecycle.go
+++ b/internal/daemon/crew_lifecycle.go
@@ -354,21 +354,21 @@ func (d *Daemon) actOnCrewMember(member crew.Member, sessionID string, action cr
 			return
 		}
 		if err := d.typeDoorbell(sessionID, crewHeartbeatPrompt); err != nil {
-			d.logf("crew: %s's heartbeat did not reach session %s: %v", member.ID, sessionID, err)
+			d.logf("crew: %s's heartbeat did not reach session %s: %v", crew.DisplayName(member.ID), sessionID, err)
 			return
 		}
 		d.logf("crew: warmed %s's context in session %s (cache estimated %s old against a %s assumption)",
-			member.ID, sessionID, cache.Age.Round(time.Second), cache.TTL)
+			crew.DisplayName(member.ID), sessionID, cache.Age.Round(time.Second), cache.TTL)
 	case crew.ActionSleep:
 		if !d.crewMemo().mayAsk(sessionID, now, crewSleepPromptGrace) {
 			return
 		}
 		if err := d.typeDoorbell(sessionID, crewSleepPrompt); err != nil {
-			d.logf("crew: %s was not asked to close its day: %v", member.ID, err)
+			d.logf("crew: %s was not asked to close its day: %v", crew.DisplayName(member.ID), err)
 			return
 		}
 		d.logf("crew: asked %s to close its day — the user has been away and the cache is %s from lapsing",
-			member.ID, cache.Remaining().Round(time.Second))
+			crew.DisplayName(member.ID), cache.Remaining().Round(time.Second))
 	}
 }
 

--- a/internal/daemon/crew_lifecycle_test.go
+++ b/internal/daemon/crew_lifecycle_test.go
@@ -294,7 +294,7 @@ func TestChargeAutonomousWake_BooksWakesAndRefusesPastTheLimit(t *testing.T) {
 	if err == nil {
 		t.Fatal("a third wake was allowed past a limit of 2")
 	}
-	for _, want := range []string{"trellis", "crew.wake_limit=2", "nothing was woken"} {
+	for _, want := range []string{"Trellis", "crew.wake_limit=2", "nothing was woken"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("the refusal %q does not name %q", err, want)
 		}

--- a/internal/daemon/crew_test.go
+++ b/internal/daemon/crew_test.go
@@ -146,7 +146,7 @@ func TestCrew_SecondClaimOnALiveMemberIsRefusedByName(t *testing.T) {
 	if err == nil {
 		t.Fatal("a second keel was allowed to wake")
 	}
-	for _, want := range []string{"keel", "sess-fir"} {
+	for _, want := range []string{"Keel", "sess-fir"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("refusal %q does not name %q", err, want)
 		}

--- a/internal/daemon/crew_wake.go
+++ b/internal/daemon/crew_wake.go
@@ -87,10 +87,10 @@ func crewLaunchDir(member crew.Member) (string, error) {
 	}
 	info, err := os.Stat(dir)
 	if err != nil {
-		return "", fmt.Errorf("%s launches in %s, which is not there (%v); `attn crew set %[1]s --cwd <dir>` moves it", member.ID, dir, err)
+		return "", fmt.Errorf("%s launches in %s, which is not there (%v); `attn crew set %s --cwd <dir>` moves it", crew.DisplayName(member.ID), dir, err, member.ID)
 	}
 	if !info.IsDir() {
-		return "", fmt.Errorf("%s launches in %s, which is not a directory; `attn crew set %[1]s --cwd <dir>` moves it", member.ID, dir)
+		return "", fmt.Errorf("%s launches in %s, which is not a directory; `attn crew set %s --cwd <dir>` moves it", crew.DisplayName(member.ID), dir, member.ID)
 	}
 	return dir, nil
 }
@@ -109,14 +109,14 @@ func (d *Daemon) crewPriming(member crew.Member) crew.Priming {
 	if charter, err := os.ReadFile(member.CharterPath); err == nil {
 		priming.Charter = string(charter)
 	} else if !os.IsNotExist(err) {
-		d.logf("crew: reading %s's charter at %s: %v", member.ID, member.CharterPath, err)
+		d.logf("crew: reading %s's charter at %s: %v", crew.DisplayName(member.ID), member.CharterPath, err)
 	}
 
 	handoffsDir := filepath.Join(member.HomeDir, crew.HandoffsDirName)
 	entries, err := os.ReadDir(handoffsDir)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			d.logf("crew: reading %s's handoffs at %s: %v", member.ID, handoffsDir, err)
+			d.logf("crew: reading %s's handoffs at %s: %v", crew.DisplayName(member.ID), handoffsDir, err)
 		}
 		return priming
 	}
@@ -136,7 +136,7 @@ func (d *Daemon) crewPriming(member crew.Member) crew.Priming {
 	if letter, err := os.ReadFile(filepath.Join(handoffsDir, names[0])); err == nil {
 		priming.Handoff = string(letter)
 	} else {
-		d.logf("crew: reading %s's freshest handoff %s: %v", member.ID, names[0], err)
+		d.logf("crew: reading %s's freshest handoff %s: %v", crew.DisplayName(member.ID), names[0], err)
 	}
 	return priming
 }
@@ -218,12 +218,12 @@ func (d *Daemon) crewWake(name, agent string) (*protocol.CrewWakeResult, error) 
 		d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
 			Cmd:       protocol.CmdRegisterWorkspace,
 			ID:        workspaceID,
-			Title:     member.ID,
+			Title:     crew.DisplayName(member.ID),
 			Directory: directory,
 		})
 		if d.store.GetWorkspace(workspaceID) == nil {
 			d.releaseCrewBindingIfSession(sessionID)
-			return nil, fmt.Errorf("create %s's workspace", member.ID)
+			return nil, fmt.Errorf("create %s's workspace", crew.DisplayName(member.ID))
 		}
 	}
 	paneClient := newInternalWSClient()
@@ -232,11 +232,11 @@ func (d *Daemon) crewWake(name, agent string) (*protocol.CrewWakeResult, error) 
 		WorkspaceID: workspaceID,
 		PaneID:      protocol.Ptr("pane-" + sessionID),
 		SessionID:   sessionID,
-		Title:       protocol.Ptr(member.ID),
+		Title:       protocol.Ptr(crew.DisplayName(member.ID)),
 	})
 	if _, err := readInternalActionResult(paneClient); err != nil {
 		d.releaseCrewBindingIfSession(sessionID)
-		return nil, fmt.Errorf("create %s's pane: %w", member.ID, err)
+		return nil, fmt.Errorf("create %s's pane: %w", crew.DisplayName(member.ID), err)
 	}
 
 	spawnClient := newInternalWSClient()
@@ -249,15 +249,15 @@ func (d *Daemon) crewWake(name, agent string) (*protocol.CrewWakeResult, error) 
 		Model:         crewWakeModelPin(agent),
 		Cols:          80,
 		Rows:          24,
-		Label:         protocol.Ptr(member.ID),
+		Label:         protocol.Ptr(crew.DisplayName(member.ID)),
 		InitialPrompt: protocol.Ptr(crewWakePrompt),
 	})
 	if _, err := readInternalActionResult(spawnClient); err != nil {
 		d.removeWorkspaceLayoutPaneForSession(sessionID)
 		d.releaseCrewBindingIfSession(sessionID)
-		return nil, fmt.Errorf("wake %s: %w", member.ID, err)
+		return nil, fmt.Errorf("wake %s: %w", crew.DisplayName(member.ID), err)
 	}
-	d.logf("crew: woke %s in session %s at %s", member.ID, sessionID, directory)
+	d.logf("crew: woke %s in session %s at %s", crew.DisplayName(member.ID), sessionID, directory)
 	return &protocol.CrewWakeResult{
 		Member:      member.ID,
 		SessionID:   sessionID,
@@ -311,7 +311,7 @@ func (d *Daemon) crewPrimeForSession(sessionID string) (crew.Member, string, boo
 			handoff = "(none)"
 		}
 		d.logf("crew: priming %s for session %s: %d bytes (charter %d, handoff %s %d, older %d)",
-			member.ID, sessionID, len(block), len(priming.Charter),
+			crew.DisplayName(member.ID), sessionID, len(block), len(priming.Charter),
 			handoff, len(priming.Handoff), len(priming.OlderHandoffs))
 		return member, block, true
 	}

--- a/internal/daemon/crew_wake_test.go
+++ b/internal/daemon/crew_wake_test.go
@@ -119,6 +119,42 @@ func TestCrewWake_AnotherHarnessIsNotGivenTheClaudeModel(t *testing.T) {
 	}
 }
 
+// Display capitalizes, identity does not. Everything a person reads off a woken
+// member — its session label, its pane, its workspace — is written as a name,
+// while the workspace id, the binding and the wire's member field stay the
+// lowercase id.
+func TestCrewWake_NamesTheDayAndKeepsTheIDLowercase(t *testing.T) {
+	d, _, _ := newWakeableDaemon(t)
+
+	result, err := d.crewWake("trellis", "")
+	if err != nil {
+		t.Fatalf("wake: %v", err)
+	}
+	session := d.store.Get(result.SessionID)
+	if session == nil {
+		t.Fatalf("no session %q was stored", result.SessionID)
+	}
+	if session.Label != "Trellis" {
+		t.Errorf("session label = %q, want Trellis", session.Label)
+	}
+	workspace := d.store.GetWorkspace(result.WorkspaceID)
+	if workspace == nil {
+		t.Fatalf("no workspace %q was created", result.WorkspaceID)
+	}
+	if workspace.Title != "Trellis" {
+		t.Errorf("workspace title = %q, want Trellis", workspace.Title)
+	}
+	if result.WorkspaceID != "workspace-crew-trellis" {
+		t.Errorf("workspace id = %q, want workspace-crew-trellis", result.WorkspaceID)
+	}
+	if result.Member != "trellis" {
+		t.Errorf("wire member = %q, want the lowercase id", result.Member)
+	}
+	if got := protocol.Deref(memberByID(t, crewList(t, d), "trellis").BindingSession); got != result.SessionID {
+		t.Errorf("roster binding = %q, want %q", got, result.SessionID)
+	}
+}
+
 // Two agents with the same identity never run at once. The sidebar's one action
 // must not fail exactly when the member is present, so a second wake names the
 // live day instead of refusing — and launches nothing.
@@ -177,7 +213,8 @@ func TestCrewWake_ADirectoryThatMovedIsNamedAndNothingIsClaimed(t *testing.T) {
 	if err == nil {
 		t.Fatal("a member launched into a directory that is not there")
 	}
-	for _, want := range []string{"alder", launchDir, "attn crew set"} {
+	// The prose names Alder; the command it hands back takes the id.
+	for _, want := range []string{"Alder launches in", launchDir, "attn crew set alder --cwd"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("refusal %q does not name %q", err, want)
 		}
@@ -237,7 +274,7 @@ func TestCrewPrime_ABoundSessionIsPrimedWithItsHomeAndTheSizeIsLogged(t *testing
 	}
 
 	log := readLog()
-	if !strings.Contains(log, "crew: priming trellis") {
+	if !strings.Contains(log, "crew: priming Trellis") {
 		t.Fatalf("no greppable priming receipt in the daemon log:\n%s", log)
 	}
 	// The logged size is the size of what was injected, not an estimate of it.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -25,6 +25,7 @@ import (
 	"github.com/victorarias/attn/internal/bus"
 	"github.com/victorarias/attn/internal/classifier"
 	"github.com/victorarias/attn/internal/config"
+	"github.com/victorarias/attn/internal/crew"
 	"github.com/victorarias/attn/internal/diag"
 	"github.com/victorarias/attn/internal/enrollment"
 	"github.com/victorarias/attn/internal/fsdoc"
@@ -2929,7 +2930,7 @@ func (d *Daemon) handleRegister(conn net.Conn, msg *protocol.RegisterMessage) {
 			d.sendError(conn, fmt.Sprintf("crew bind %q: %v", member, err))
 			return
 		}
-		d.logf("session %s registering as crew member %s", msg.ID, memberID)
+		d.logf("session %s registering as crew member %s", msg.ID, crew.DisplayName(memberID))
 	} else {
 		d.releaseCrewBindingIfSession(msg.ID)
 	}

--- a/internal/daemon/garden.go
+++ b/internal/daemon/garden.go
@@ -1015,31 +1015,13 @@ func (d *Daemon) gardenPrime(sessionID string) (*hooks.GardenPrime, error) {
 		line := hooks.SeedPrime{ID: seed.ID, Title: seed.Title}
 		if handoff := d.gardenHandoff(seed.ID); handoff != nil {
 			line.Handoff = handoff.Body
-			line.HandoffAuthor = holderName(handoff.AuthorMember, handoff.AuthorSession)
+			line.HandoffAuthor = crew.HolderName(handoff.AuthorMember, handoff.AuthorSession)
 		}
 		plot.ReadySeeds = append(plot.ReadySeeds, line)
 	}
 	prime.Ready = len(plot.ReadySeeds)
 	prime.Crown = plot
 	return prime, nil
-}
-
-// holderName is how a note's or a seed's author is written for a reader: a
-// member reads as a name, and a bare session id is left exactly as it is.
-func holderName(member, session string) string {
-	if strings.TrimSpace(member) != "" {
-		return crew.DisplayName(member)
-	}
-	return session
-}
-
-func firstNonEmptyString(values ...string) string {
-	for _, v := range values {
-		if strings.TrimSpace(v) != "" {
-			return v
-		}
-	}
-	return ""
 }
 
 // gardenFacts is the verb-to-fact table. One fact per transition, each naming

--- a/internal/daemon/garden.go
+++ b/internal/daemon/garden.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/victorarias/attn/internal/crew"
 	"github.com/victorarias/attn/internal/docstore"
 	"github.com/victorarias/attn/internal/garden"
 	"github.com/victorarias/attn/internal/hooks"
@@ -1014,13 +1015,22 @@ func (d *Daemon) gardenPrime(sessionID string) (*hooks.GardenPrime, error) {
 		line := hooks.SeedPrime{ID: seed.ID, Title: seed.Title}
 		if handoff := d.gardenHandoff(seed.ID); handoff != nil {
 			line.Handoff = handoff.Body
-			line.HandoffAuthor = firstNonEmptyString(handoff.AuthorMember, handoff.AuthorSession)
+			line.HandoffAuthor = holderName(handoff.AuthorMember, handoff.AuthorSession)
 		}
 		plot.ReadySeeds = append(plot.ReadySeeds, line)
 	}
 	prime.Ready = len(plot.ReadySeeds)
 	prime.Crown = plot
 	return prime, nil
+}
+
+// holderName is how a note's or a seed's author is written for a reader: a
+// member reads as a name, and a bare session id is left exactly as it is.
+func holderName(member, session string) string {
+	if strings.TrimSpace(member) != "" {
+		return crew.DisplayName(member)
+	}
+	return session
 }
 
 func firstNonEmptyString(values ...string) string {

--- a/internal/daemon/garden_test.go
+++ b/internal/daemon/garden_test.go
@@ -200,7 +200,7 @@ func TestGarden_ASecondSessionCannotTakeALiveClaim(t *testing.T) {
 		t.Fatal("a second session took a claim that was already held")
 	}
 	message := protocol.Deref(refused.Error)
-	for _, want := range []string{seed.ID, "trellis", "attn seed note"} {
+	for _, want := range []string{seed.ID, "Trellis", "attn seed note"} {
 		if !strings.Contains(message, want) {
 			t.Fatalf("the refusal does not name %q:\n%s", want, message)
 		}
@@ -239,7 +239,7 @@ func TestGarden_ConcurrentClaimsProduceOneTender(t *testing.T) {
 	for _, session := range []string{"sess-a", "sess-b"} {
 		go func() {
 			start.Wait()
-			results <- outcome{transition(t, d, session, seed.ID, garden.VerbTend, "", session), session}
+			results <- outcome{transition(t, d, session, seed.ID, garden.VerbTend, "", ""), session}
 		}()
 	}
 	start.Done()

--- a/internal/daemon/session_title.go
+++ b/internal/daemon/session_title.go
@@ -120,9 +120,10 @@ func (d *Daemon) maybeGenerateSessionTitle(sessionID, transcriptPath string) {
 // sessionMayBeAutoTitled reports whether nobody has named this session yet.
 // Two ways a session is already named: a crew member is bound to it — the
 // member's name IS its identity — or its label was moved off the cwd basename
-// the launch gave it. The member check cannot be folded into the label one: a
-// member launches in its own home, so its name and its default label are the
-// same string.
+// the launch gave it. A woken member is caught by the label check on its own
+// (its label is the name, `Trellis`, and its home's basename is the id,
+// `trellis`); the member check stays as the backstop for a member session whose
+// label was renamed back to that basename.
 func (d *Daemon) sessionMayBeAutoTitled(session *protocol.Session) bool {
 	if session.Label != defaultSessionLabel(session.Directory, session.ID) {
 		return false

--- a/internal/garden/lifecycle.go
+++ b/internal/garden/lifecycle.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+
+	"github.com/victorarias/attn/internal/crew"
 )
 
 // A seed's life, as one table. `planted` → `growing` when someone tends it →
@@ -45,6 +47,16 @@ type Tender struct {
 func (t Tender) Name() string {
 	if member := strings.TrimSpace(t.Member); member != "" {
 		return member
+	}
+	return strings.TrimSpace(t.Session)
+}
+
+// DisplayName is Name() written for a person to read: a crew member reads as
+// the name it is, and a bare session id is left exactly as it is. Separate from
+// Name() because that one doubles as an identity and emptiness test.
+func (t Tender) DisplayName() string {
+	if member := strings.TrimSpace(t.Member); member != "" {
+		return crew.DisplayName(member)
 	}
 	return strings.TrimSpace(t.Session)
 }
@@ -196,7 +208,7 @@ func Transition(seed Seed, verb Verb, actor Tender, reason string, sessionLive f
 			return Seed{}, fmt.Errorf(
 				"%s is being tended by %s, and a seed has one tender at a time.\n"+
 					"Wait for %s to harvest or park it, or say what you need on the log: attn seed note %s -m \"…\"",
-				seed.ID, held.Name(), held.Name(), seed.ID)
+				seed.ID, held.DisplayName(), held.DisplayName(), seed.ID)
 		}
 	}
 	if rule.needsReason && reason == "" {

--- a/internal/garden/lifecycle.go
+++ b/internal/garden/lifecycle.go
@@ -54,12 +54,7 @@ func (t Tender) Name() string {
 // DisplayName is Name() written for a person to read: a crew member reads as
 // the name it is, and a bare session id is left exactly as it is. Separate from
 // Name() because that one doubles as an identity and emptiness test.
-func (t Tender) DisplayName() string {
-	if member := strings.TrimSpace(t.Member); member != "" {
-		return crew.DisplayName(member)
-	}
-	return strings.TrimSpace(t.Session)
-}
+func (t Tender) DisplayName() string { return crew.HolderName(t.Member, t.Session) }
 
 // Named reports whether this tender identifies anybody at all.
 func (t Tender) Named() bool { return t.Name() != "" }

--- a/internal/garden/lifecycle_test.go
+++ b/internal/garden/lifecycle_test.go
@@ -207,10 +207,30 @@ func TestTendRefusalNamesTheTenderAndTheWayForward(t *testing.T) {
 	if err == nil {
 		t.Fatal("a second session was allowed to take a live claim")
 	}
-	for _, want := range []string{held.ID, "alder", "attn seed note"} {
+	for _, want := range []string{held.ID, "Alder", "attn seed note"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("refusal does not name %q:\n%s", want, err)
 		}
+	}
+}
+
+// Display capitalizes, identity does not: a refusal names the member the way a
+// person says it, while Name() — which doubles as the identity test — is left
+// exactly as stored, and a session id is never dressed up as a name.
+func TestTenderDisplayName_WritesAMemberAsANameAndLeavesASessionAlone(t *testing.T) {
+	member := Tender{Session: "sess-a", Member: "trellis"}
+	if got := member.DisplayName(); got != "Trellis" {
+		t.Errorf("DisplayName() = %q, want Trellis", got)
+	}
+	if got := member.Name(); got != "trellis" {
+		t.Errorf("Name() = %q, want the stored id", got)
+	}
+	session := Tender{Session: "sess-a"}
+	if got := session.DisplayName(); got != "sess-a" {
+		t.Errorf("DisplayName() = %q, want the session id untouched", got)
+	}
+	if got := (Tender{}).DisplayName(); got != "" {
+		t.Errorf("an unnamed tender displays as %q, want empty", got)
 	}
 }
 
@@ -227,7 +247,7 @@ func TestTendRefusesAnotherMemberWhenNeitherCarriesASession(t *testing.T) {
 
 	if _, err := Transition(held, VerbTend, Tender{Member: "alder"}, "", alive); err == nil {
 		t.Fatal("a different member took a live claim; the seed has one tender at a time")
-	} else if !strings.Contains(err.Error(), "trellis") {
+	} else if !strings.Contains(err.Error(), "Trellis") {
 		t.Fatalf("refusal does not name who holds it: %v", err)
 	}
 


### PR DESCRIPTION
A crew member is identified by a lowercase id — `trellis`, `keel`, `alder` — and
every surface printed that id raw. The id was doing two jobs at once: it is an
address, and it is somebody's name. This separates them with one rule.

**Display capitalizes, identity does not.** You type `attn crew wake trellis`
and Trellis is who answers.

## The rule

`internal/crew.DisplayName` is the rule; `app/src/utils/crewName.ts` is the
frontend's copy of it, for the one thing the app names without the daemon — a
sleeping member's row. First rune uppercased; no title-casing of a hyphenated id,
because no real member is two words and inventing one would be a name nobody
chose. `internal/crew/priming.go` had grown its own private `capitalized` in
#910; that is now the same function, so there is one rule and not two.

## Surfaces

Routed through it — everything a person reads:

- **Sidebar.** A woken member's row (from the label the daemon writes) and a
  sleeping member's row, its wake button, and both tooltips.
- **Wake.** The session label, the pane title, and the member's workspace title.
  Stored capitalized rather than capitalized at draw: the label *is* the display
  string, it is user-renameable, and every generic reader of a session label —
  sidebar, tab, `attn agent list`, `agent peek` — then gets the name for free.
  It does not collide with the auto-titler, which only fires on a label equal to
  the cwd basename — capitalizing the label is in fact what makes a woken member
  differ from its home's basename, so the label check catches one on its own.
  Going forward only: a member awake when this lands keeps its lowercase label
  until its day ends and the next wake writes the name. Existing labels are not
  migrated.
- **CLI.** `crew list`'s MEMBER column, `crew wake` and `crew set` output,
  `agent list`'s MEMBER column, `agent peek`, `handoff`'s filed/asleep/next-day
  lines, and the seed log's tender, planter, and note/handoff authors.
- **Refusals.** The wake limit, the already-awake claim, a cwd that moved, the
  nap's retry and letter refusals, and the garden's one-tender-at-a-time refusal.
- **Daemon log.** Every `crew:` line that names a member as a subject —
  import, bind, release, wake, priming, warmed, asked-to-sleep, napped.
- **Toasts.** `Failed to wake …` and the wake timeout.
- **Glossary.** The rule is stated where the crew is defined.

Deliberately left lowercase — everything that addresses something:

- Home paths (`~/.attn/crew/trellis/`), handoff file names, the workspace id
  (`workspace-crew-trellis`), the doc id, `--member`, CLI arguments, every
  protocol field (`member`, `crew_member`, `tender_member`, …), the store, and
  the `data-crew-member` / test-id hooks the app and its tests reach rows by.
- The `%q`-quoted echo of a name that resolved to nobody: that is the user's own
  text handed back, not a member.
- The command inside a refusal. "Alder launches in … `attn crew set alder --cwd
  <dir>` moves it" — prose on the left, the id the command takes on the right.
- A holder that is a bare session id. Where the same slot can carry either a
  member or a session (`tended by`, note authors), only the member branch is
  capitalized; a session id is never dressed up as a name.

Where a holder can be either a member or a bare session — a seed's tender,
planter, and note authors — one rule answers on each side: `crew.HolderName` and
`crewHolderName`. `garden.Tender.DisplayName` is that call; `Tender.Name` stays
raw because it doubles as the identity and emptiness test.

Case-insensitive lookup already existed (`crew.Resolve` folds case), so
`attn crew wake Trellis` works and is covered.

## Verification

`make test-quick` and the full frontend suite are green. New tests: the rule
itself on both sides, the wake writing a name while the ids stay lowercase, the
`crew list` column beside its untouched home path, the sidebar row beside its
`data-crew-member`, and `Tender.DisplayName` beside `Tender.Name` — which stays
raw, because it doubles as the identity and emptiness test.

Live on a throwaway profile (`nameday`), two homes on disk: `crew list` shows
`Keel` / `Trellis` against `/Users/victor/.attn-nameday/crew/keel`, `crew list
--json` carries `"id": "keel"`, `agent list` shows label `Trellis` and member
`Trellis` while `--json` carries `"member": "trellis"`, and the daemon log reads
`crew: woke Trellis in session …`. The clip is the sidebar: Keel asleep, one
click on its wake button, and the row comes up awake as Keel with its pane
titled Keel over `/Users/victor/.attn-nameday/crew/keel`.

![clip](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/533f6a2793f3f0cfbcdbb5ceb9ea7a6a7ad48a02/delegate-member-names-d6788e4e/clip.gif)

[Full-quality recording (mp4)](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/533f6a2793f3f0cfbcdbb5ceb9ea7a6a7ad48a02/delegate-member-names-d6788e4e/clip.mp4)
