### PR TITLE
feat(crew): address a member whether awake or asleep

### DIFF
--- a/changelog.d/crew-addressing.yaml
+++ b/changelog.d/crew-addressing.yaml
@@ -1,0 +1,10 @@
+kind: added
+area: crew
+change: >
+  `attn agent msg <member> "text"` now addresses a crew member whether it is
+  awake or asleep. An awake member receives the same attributed message as a
+  session target; a sleeping member wakes on its pinned model and receives the
+  message as the new day's first prompt after its charter and predecessor's
+  letter. Message-triggered wakes use the autonomous wake limit, whose refusal
+  names the configured limit, the attempted member, that nothing was delivered,
+  and how to proceed.

--- a/cmd/attn/agent.go
+++ b/cmd/attn/agent.go
@@ -298,7 +298,7 @@ type agentMsgArgs struct {
 }
 
 func parseAgentMsgArgs(args []string, envSessionID string) (agentMsgArgs, error) {
-	const usage = "usage: attn agent msg <id> \"text\" [--source-session <id>]"
+	const usage = "usage: attn agent msg <session-or-member> \"text\" [--source-session <id>]"
 	literal := len(args) > 0 && args[0] == "--"
 	if literal {
 		args = args[1:]
@@ -382,7 +382,13 @@ func agentMsgOutcomeLine(result *protocol.AgentMsgResult) string {
 // mistyped one knows which.
 func agentMsgErrorMessage(parsed agentMsgArgs, err error) string {
 	message := strings.TrimSpace(err.Error())
-	switch strings.TrimSpace(strings.TrimPrefix(message, "daemon error: ")) {
+	code := client.ErrorCode(err)
+	if code == "" {
+		code = strings.TrimSpace(strings.TrimPrefix(message, "daemon error: "))
+	}
+	switch code {
+	case "session_or_crew_member_not_found":
+		return fmt.Sprintf("no session or crew member matches %q; `attn agent list` names sessions and `attn crew list` names members", parsed.target)
 	case "session_not_found":
 		return fmt.Sprintf("no session matches %q; `attn agent list` names the sessions on this daemon", parsed.target)
 	case "ambiguous_session":
@@ -406,12 +412,13 @@ commands:
         observe a session without interrupting it: state, todos, last
         assistant message, and the rendered screen. Passive — the observed
         agent never notices. <id> is a full session id or a unique prefix.
-  msg <id> "text" [--source-session <id>] [--json]
-        send a session a message. It lands in that session's conversation,
-        attributed to you, carrying the command to reply with. A target that
+  msg <session-or-member> "text" [--source-session <id>] [--json]
+        send a session or crew member a message. It lands in the live session,
+        or wakes a sleeping member and becomes its first prompt after priming.
+        It is attributed to you and carries the command to reply with. A target that
         cannot take input right now has it queued and delivered when it can;
         the result always says which. The sender defaults to this session
         (ATTN_SESSION_ID); pass --source-session when running outside one.
-        A message that starts with - goes after --, as: agent msg -- <id> "-text"
+        A message that starts with - goes after --, as: agent msg -- <session-or-member> "-text"
 `)
 }

--- a/cmd/attn/agent_test.go
+++ b/cmd/attn/agent_test.go
@@ -265,6 +265,12 @@ func TestAgentMsgErrorMessageSeparatesTargetFromSender(t *testing.T) {
 	if !strings.Contains(sender, `"yyyy"`) || !strings.Contains(sender, "sender") {
 		t.Fatalf("sender error = %q", sender)
 	}
+	unknown := agentMsgErrorMessage(parsed, errors.New("daemon error: session_or_crew_member_not_found"))
+	for _, want := range []string{`"zzzz"`, "attn agent list", "attn crew list"} {
+		if !strings.Contains(unknown, want) {
+			t.Fatalf("unknown-address error %q does not name %q", unknown, want)
+		}
+	}
 }
 
 // A message far past the limit never reaches the daemon's refusal: the socket

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -647,7 +647,7 @@ commands:
   presence                          check whether the current shell runs inside attn
   agent list                        name every session running here
   agent peek <id>                   read a session without interrupting it
-  agent msg <id> "text"             send a session a message, attributed to you
+  agent msg <session-or-member> "text"  message a live session or durable crew member
 	  session <command>                 inspect a session's conversation
   state explain <id>                replay why a session's state is what it is
   delegate --brief-file <path>      start another agent with a delegated brief

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -538,6 +538,13 @@ to be read, the freshest letter left for it inline, and how a day is closed.
 Skills retire into verbs and the verbs are taught, because an agent never told
 how to handoff cannot file one.
 
+A member is also an address: `attn agent msg <member> "…"` reaches its live
+day when it is awake. When it is asleep, the message wakes it within the same
+wake limit as every autonomous wake and becomes the new day's first attributed
+prompt after priming. The message is persisted before the day starts, so the
+wake-to-delivery gap cannot silently lose it; a refused wake delivers nothing
+and names the limit and its way out.
+
 A member's day ends with a **handoff**: `attn handoff -m "<letter>"`, the
 member's own letter to its successor. attn names the file and files it into the
 member's `handoffs/`; the line is **append-only**, so a name already taken is

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -407,13 +407,13 @@ func (c *Client) AgentPeek(targetSessionID string) (*protocol.AgentPeekResult, e
 	return resp.AgentPeekResult, nil
 }
 
-// AgentMsg sends another session a message. The daemon persists it, composes
-// the attribution, and delivers it — so the result says what became of it
-// (delivered, queued for later, or refused with the reason), never nothing.
-func (c *Client) AgentMsg(targetSessionID, sourceSessionID, content string) (*protocol.AgentMsgResult, error) {
+// AgentMsg sends a session or durable crew member a message. The daemon
+// resolves the address, persists the words, and delivers them — waking an
+// asleep member first — so the result always says what became of them.
+func (c *Client) AgentMsg(target, sourceSessionID, content string) (*protocol.AgentMsgResult, error) {
 	resp, err := c.send(protocol.AgentMsgMessage{
 		Cmd:             protocol.CmdAgentMsg,
-		TargetSessionID: targetSessionID,
+		TargetSessionID: target,
 		SourceSessionID: sourceSessionID,
 		Content:         content,
 	})

--- a/internal/daemon/agent_msg.go
+++ b/internal/daemon/agent_msg.go
@@ -50,6 +50,10 @@ var agentMessageTakenWindow = 3 * time.Second
 // errDoorbellNotTaken is a delivery whose target never picked it up.
 var errDoorbellNotTaken = errors.New("doorbell typed but the target did not take it")
 
+// An initial-prompt delivery owns the prompt until its submit hook. Anything
+// behind it must queue rather than paste into priming or a trust dialog.
+var errAgentMessageInitialPromptPending = errors.New("target is still taking its initial prompt")
+
 // agentMessageGuardVerdict is empty when a message is accepted. Otherwise it is
 // the sentence the sender is told: which limit it hit, that limit's value, and
 // what it asked for. An agent can act on that; "refused" alone it cannot.
@@ -222,6 +226,9 @@ func (d *Daemon) replyAgentMsgError(conn net.Conn, code, message string) {
 // not the same sentence in both cases: an approval clears on its own, a dead
 // session does not, and a sender that waits for a reply from one is stuck.
 func agentMessageQueuedDetail(err error) string {
+	if errors.Is(err, errAgentMessageInitialPromptPending) {
+		return "queued (target is waking and still reading its priming — lands immediately after its first prompt starts)"
+	}
 	if errors.Is(err, errDoorbellBlockedByApproval) {
 		return "queued (target is waiting on an approval — lands when the approval clears)"
 	}
@@ -237,6 +244,9 @@ func agentMessageQueuedDetail(err error) string {
 // took it, and stamps the row. Shared by the send path and the redelivery drain
 // so a queued message and a live one land identically.
 func (d *Daemon) deliverAgentMessage(record store.AgentMessage) error {
+	if d.initialAgentMessagePending(record.TargetSessionID, "") {
+		return errAgentMessageInitialPromptPending
+	}
 	sender := d.store.Get(record.SenderSessionID)
 	target := d.store.Get(record.TargetSessionID)
 	confirmable := target != nil && string(target.State) != protocol.StateWorking
@@ -415,7 +425,10 @@ func (d *Daemon) noteInitialAgentMessageSubmitted(sessionID, state string) {
 		return
 	}
 	_ = d.stampAgentMessageDelivered(messageID)
-	d.forgetQueuedAgentMessages(sessionID)
+	// Another sender can address this now-live member while its initial prompt
+	// is still blocked on priming. Keep the queue armed and drain anything behind
+	// the initial message now that the prompt-submit receipt opened the gate.
+	d.drainAgentMessagesAfterStateChange(sessionID, state)
 }
 
 // rollbackInitialAgentMessage is reached only when the wake itself failed. No
@@ -518,6 +531,9 @@ func (d *Daemon) seedQueuedAgentMessages() {
 func (d *Daemon) drainAgentMessagesAfterStateChange(sessionID, state string) {
 	if d.initialAgentMessagePending(sessionID, "") || !isNudgeDeliveryAllowed(state) || !d.hasQueuedAgentMessages(sessionID) {
 		return
+	}
+	if d.agentMessageDrainScheduledHook != nil {
+		d.agentMessageDrainScheduledHook(sessionID)
 	}
 	// Never inline: typeDoorbell takes doorbellMu and sleeps between the paste
 	// and its Enter, and applyState is on the state-report path.

--- a/internal/daemon/agent_msg.go
+++ b/internal/daemon/agent_msg.go
@@ -122,14 +122,15 @@ func (d *Daemon) handleAgentMsg(conn net.Conn, msg *protocol.AgentMsgMessage) {
 			}
 			target = d.store.Get(woken.SessionID)
 			if !woken.AlreadyAwake {
+				memberName := crew.DisplayName(member.ID)
 				result.MessageID = record.ID
 				result.TargetSessionID = woken.SessionID
 				if d.initialAgentMessagePending(woken.SessionID, record.ID) {
 					result.Status = protocol.AgentMsgStatusQueued
-					result.Detail = fmt.Sprintf("woke %s in session %s; queued as its first prompt after priming", member.ID, shortSessionID(woken.SessionID))
+					result.Detail = fmt.Sprintf("woke %s in session %s; queued as its first prompt after priming", memberName, shortSessionID(woken.SessionID))
 				} else {
 					result.Status = protocol.AgentMsgStatusDelivered
-					result.Detail = fmt.Sprintf("woke %s and delivered as its first prompt after priming", member.ID)
+					result.Detail = fmt.Sprintf("woke %s and delivered as its first prompt after priming", memberName)
 				}
 				d.replyAgentMsg(conn, result)
 				return
@@ -192,7 +193,11 @@ func (d *Daemon) handleAgentMsg(conn net.Conn, msg *protocol.AgentMsgMessage) {
 		result.Detail = agentMessageQueuedDetail(err)
 	} else {
 		result.Status = protocol.AgentMsgStatusDelivered
-		result.Detail = fmt.Sprintf("delivered to %s", sessionDisplayName(target))
+		targetName := sessionDisplayName(target)
+		if memberFound {
+			targetName = crew.DisplayName(member.ID)
+		}
+		result.Detail = fmt.Sprintf("delivered to %s", targetName)
 	}
 	d.replyAgentMsg(conn, result)
 }

--- a/internal/daemon/agent_msg.go
+++ b/internal/daemon/agent_msg.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/victorarias/attn/internal/crew"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/store"
 )
@@ -71,11 +72,6 @@ func agentMessageGuardVerdict(counts store.AgentMessageGuardCounts) string {
 }
 
 func (d *Daemon) handleAgentMsg(conn net.Conn, msg *protocol.AgentMsgMessage) {
-	target, errCode := d.resolveSessionByIDOrPrefix(msg.TargetSessionID)
-	if target == nil {
-		d.sendError(conn, errCode)
-		return
-	}
 	sender, errCode := d.resolveSessionByIDOrPrefix(msg.SourceSessionID)
 	if sender == nil {
 		d.sendError(conn, "sender_"+errCode)
@@ -84,8 +80,7 @@ func (d *Daemon) handleAgentMsg(conn net.Conn, msg *protocol.AgentMsgMessage) {
 
 	content := strings.TrimSpace(msg.Content)
 	result := &protocol.AgentMsgResult{
-		TargetSessionID: target.ID,
-		Status:          protocol.AgentMsgStatusRefused,
+		Status: protocol.AgentMsgStatusRefused,
 	}
 	switch {
 	case content == "":
@@ -94,8 +89,6 @@ func (d *Daemon) handleAgentMsg(conn net.Conn, msg *protocol.AgentMsgMessage) {
 		result.Detail = fmt.Sprintf(
 			"message is %d bytes and the limit is %d; send the gist and point at the rest",
 			len(content), protocol.AgentMessageMaxChars)
-	case sender.ID == target.ID:
-		result.Detail = "that is this session; a message to yourself is not a conversation"
 	}
 	if result.Detail != "" {
 		d.replyAgentMsg(conn, result)
@@ -103,6 +96,63 @@ func (d *Daemon) handleAgentMsg(conn net.Conn, msg *protocol.AgentMsgMessage) {
 	}
 
 	now := time.Now()
+	member, memberFound, memberErr := d.agentMessageMember(msg.TargetSessionID)
+	target, targetErrCode := d.resolveSessionByIDOrPrefix(msg.TargetSessionID)
+	if memberFound {
+		if d.crewBindingLive(member) {
+			target = d.store.Get(member.BindingSession)
+		} else {
+			record := store.AgentMessage{
+				ID:              uuid.NewString(),
+				SenderSessionID: sender.ID,
+				Content:         content,
+				CreatedAt:       now.UTC().Format(time.RFC3339),
+			}
+			woken, err := d.crewWakeWithDelivery(member.ID, "", true, &crewWakeDelivery{
+				Record: &record,
+				Prompt: d.composeAgentMessage(sender, record),
+			})
+			if err != nil {
+				d.sendError(conn, err.Error())
+				return
+			}
+			target = d.store.Get(woken.SessionID)
+			if !woken.AlreadyAwake {
+				result.MessageID = record.ID
+				result.TargetSessionID = woken.SessionID
+				if d.initialAgentMessagePending(woken.SessionID, record.ID) {
+					result.Status = protocol.AgentMsgStatusQueued
+					result.Detail = fmt.Sprintf("woke %s in session %s; queued as its first prompt after priming", member.ID, shortSessionID(woken.SessionID))
+				} else {
+					result.Status = protocol.AgentMsgStatusDelivered
+					result.Detail = fmt.Sprintf("woke %s and delivered as its first prompt after priming", member.ID)
+				}
+				d.replyAgentMsg(conn, result)
+				return
+			}
+		}
+	}
+	if target == nil {
+		if memberErr != nil {
+			d.sendError(conn, memberErr.Error())
+			return
+		}
+		if targetErrCode == "session_not_found" {
+			d.replyAgentMsgError(conn, "session_or_crew_member_not_found", fmt.Sprintf(
+				"no session or crew member matches %q; `attn agent list` names sessions and `attn crew list` names members",
+				strings.TrimSpace(msg.TargetSessionID)))
+			return
+		}
+		d.sendError(conn, targetErrCode)
+		return
+	}
+	result.TargetSessionID = target.ID
+	if sender.ID == target.ID {
+		result.Detail = "that is this session; a message to yourself is not a conversation"
+		d.replyAgentMsg(conn, result)
+		return
+	}
+
 	counts, err := d.store.AgentMessageGuardCounts(
 		sender.ID, target.ID, content,
 		now.Add(-agentMessageDedupeWindow), now.Add(-agentMessageRateWindow),
@@ -143,8 +193,29 @@ func (d *Daemon) handleAgentMsg(conn net.Conn, msg *protocol.AgentMsgMessage) {
 	d.replyAgentMsg(conn, result)
 }
 
+// agentMessageMember resolves only the durable-name half of an address. A
+// registered member wins over a coincidental session-id prefix; a direct
+// session address still works on an outpost, where the crew lookup is fenced.
+func (d *Daemon) agentMessageMember(address string) (crew.Member, bool, error) {
+	if err := d.requireHome(crew.Surface); err != nil {
+		return crew.Member{}, false, err
+	}
+	members, _, err := d.readCrewMembers()
+	if err != nil {
+		return crew.Member{}, false, err
+	}
+	member, ok := crew.Resolve(address, members)
+	return member, ok, nil
+}
+
 func (d *Daemon) replyAgentMsg(conn net.Conn, result *protocol.AgentMsgResult) {
 	_ = json.NewEncoder(conn).Encode(protocol.Response{Ok: true, AgentMsgResult: result})
+}
+
+func (d *Daemon) replyAgentMsgError(conn net.Conn, code, message string) {
+	_ = json.NewEncoder(conn).Encode(protocol.Response{
+		Ok: false, Error: protocol.Ptr(message), ErrorCode: protocol.Ptr(code),
+	})
 }
 
 // agentMessageQueuedDetail says what the sender should expect next, which is
@@ -311,6 +382,57 @@ func (d *Daemon) noteAgentMessageTaken(sessionID, state string) {
 	}
 }
 
+func (d *Daemon) noteInitialAgentMessage(sessionID, messageID string) {
+	d.agentMessageMu.Lock()
+	defer d.agentMessageMu.Unlock()
+	if d.agentMessageInitialPrompt == nil {
+		d.agentMessageInitialPrompt = make(map[string]string)
+	}
+	d.agentMessageInitialPrompt[sessionID] = messageID
+}
+
+func (d *Daemon) initialAgentMessagePending(sessionID, messageID string) bool {
+	d.agentMessageMu.Lock()
+	defer d.agentMessageMu.Unlock()
+	current := d.agentMessageInitialPrompt[sessionID]
+	return current != "" && (messageID == "" || current == messageID)
+}
+
+// noteInitialAgentMessageSubmitted is the receipt for a message carried as a
+// new member day's initial prompt. Worker state is not enough: a freshly
+// spawned Claude session reports `working` while still sitting at its trust
+// dialog. A hook's working evidence comes from UserPromptSubmit or a tool event,
+// both on the far side of that dialog and therefore prove the prompt was read.
+func (d *Daemon) noteInitialAgentMessageSubmitted(sessionID, state string) {
+	if state != protocol.StateWorking {
+		return
+	}
+	d.agentMessageMu.Lock()
+	messageID := d.agentMessageInitialPrompt[sessionID]
+	delete(d.agentMessageInitialPrompt, sessionID)
+	d.agentMessageMu.Unlock()
+	if messageID == "" {
+		return
+	}
+	_ = d.stampAgentMessageDelivered(messageID)
+	d.forgetQueuedAgentMessages(sessionID)
+}
+
+// rollbackInitialAgentMessage is reached only when the wake itself failed. No
+// process owns the planned session, so its queued row cannot ever deliver and
+// is removed rather than becoming an orphan that claims otherwise forever.
+func (d *Daemon) rollbackInitialAgentMessage(sessionID, messageID string) {
+	d.agentMessageMu.Lock()
+	if d.agentMessageInitialPrompt[sessionID] == messageID {
+		delete(d.agentMessageInitialPrompt, sessionID)
+	}
+	d.agentMessageMu.Unlock()
+	if err := d.store.DeleteQueuedAgentMessage(messageID); err != nil {
+		d.logf("agent msg rollback: session=%s id=%s err=%v", sessionID, messageID, err)
+	}
+	d.forgetQueuedAgentMessages(sessionID)
+}
+
 // composeAgentMessage builds what the target actually reads. The format is the
 // daemon's, never the sender's: the attribution line, the consent boundary
 // repeated on every delivery, and the exact command to answer with.
@@ -394,7 +516,7 @@ func (d *Daemon) seedQueuedAgentMessages() {
 // sent to a session waiting on an approval would sit queued until someone sent
 // another one.
 func (d *Daemon) drainAgentMessagesAfterStateChange(sessionID, state string) {
-	if !isNudgeDeliveryAllowed(state) || !d.hasQueuedAgentMessages(sessionID) {
+	if d.initialAgentMessagePending(sessionID, "") || !isNudgeDeliveryAllowed(state) || !d.hasQueuedAgentMessages(sessionID) {
 		return
 	}
 	// Never inline: typeDoorbell takes doorbellMu and sleeps between the paste

--- a/internal/daemon/agent_msg_test.go
+++ b/internal/daemon/agent_msg_test.go
@@ -224,6 +224,64 @@ func TestHandleAgentMsgWakesASleepingMemberWithTheMessageAsItsFirstPrompt(t *tes
 	}
 }
 
+// A member is live as soon as its day is durably created, before the initial
+// prompt clears priming. Messages arriving in that interval queue behind the
+// first ask; the prompt-submit receipt must open their drain rather than clear
+// the only bit that remembers they exist.
+func TestHandleAgentMsgDuringWakePrimingDrainsAfterTheInitialPrompt(t *testing.T) {
+	d, backend, _ := newWakeableDaemon(t)
+	addCharacterizationSession(t, d, "sender-session-id", protocol.SessionAgentClaude, protocol.SessionStateIdle)
+	doorbell := &recordingDoorbell{}
+	backend.onInput = doorbell.backend().onInput
+
+	first := callAgentMsg(t, d, "keel", "sender-session-id", "first ask")
+	if !first.Ok || first.AgentMsgResult == nil {
+		t.Fatalf("first response = %+v", first)
+	}
+	sessionID := first.AgentMsgResult.TargetSessionID
+	second := callAgentMsg(t, d, "keel", "sender-session-id", "second ask")
+	if !second.Ok || second.AgentMsgResult == nil || second.AgentMsgResult.TargetSessionID != sessionID || second.AgentMsgResult.Status != protocol.AgentMsgStatusQueued {
+		t.Fatalf("second response = %+v, want a queue behind the same waking day", second)
+	}
+	queued, err := d.store.UndeliveredAgentMessages(sessionID)
+	if err != nil || len(queued) != 2 {
+		t.Fatalf("messages queued during priming = %+v, %v", queued, err)
+	}
+	if prompts := doorbell.pasted(); len(prompts) != 0 {
+		t.Fatalf("a message jumped ahead of priming: %q", prompts)
+	}
+
+	scheduled := make(chan string, 1)
+	drained := make(chan int, 1)
+	d.agentMessageDrainScheduledHook = func(sessionID string) { scheduled <- sessionID }
+	d.agentMessageDrainHook = func(_ string, delivered int) { drained <- delivered }
+	hook := callHandler(t, func(conn net.Conn) {
+		d.handleState(conn, &protocol.StateMessage{ID: sessionID, State: protocol.StateWorking})
+	})
+	if !hook.Ok {
+		t.Fatalf("prompt-submit hook: %+v", hook)
+	}
+	select {
+	case got := <-scheduled:
+		if got != sessionID {
+			t.Fatalf("drain scheduled for %q, want %q", got, sessionID)
+		}
+	default:
+		t.Fatal("prompt-submit receipt did not open the queued-message drain")
+	}
+	if delivered := <-drained; delivered != 1 {
+		t.Fatalf("drained %d messages behind the initial prompt, want 1", delivered)
+	}
+	queued, err = d.store.UndeliveredAgentMessages(sessionID)
+	if err != nil || len(queued) != 0 {
+		t.Fatalf("queue after prompt submit = %+v, %v", queued, err)
+	}
+	prompts := doorbell.pasted()
+	if len(prompts) != 1 || !strings.Contains(prompts[0], "second ask") || strings.Contains(prompts[0], "first ask") {
+		t.Fatalf("doorbell prompts after priming = %q", prompts)
+	}
+}
+
 // A message-triggered wake is autonomous. The lifecycle's own limit decides,
 // and its loud refusal reaches the caller with the additional fact that no
 // message landed.

--- a/internal/daemon/agent_msg_test.go
+++ b/internal/daemon/agent_msg_test.go
@@ -137,6 +137,9 @@ func TestHandleAgentMsgResolvesAnAwakeCrewMemberToItsLiveSession(t *testing.T) {
 	if resp.AgentMsgResult.TargetSessionID != "keels-live-session" {
 		t.Fatalf("target = %q, want keel's live day", resp.AgentMsgResult.TargetSessionID)
 	}
+	if resp.AgentMsgResult.Detail != "delivered to Keel" {
+		t.Fatalf("detail = %q, want the member's display name", resp.AgentMsgResult.Detail)
+	}
 	if prompts := doorbell.pasted(); len(prompts) != 1 || !strings.Contains(prompts[0], "the garden is ready") {
 		t.Fatalf("delivered prompts = %q", prompts)
 	}
@@ -174,6 +177,9 @@ func TestHandleAgentMsgWakesASleepingMemberWithTheMessageAsItsFirstPrompt(t *tes
 	result := resp.AgentMsgResult
 	if result.Status != protocol.AgentMsgStatusQueued || result.MessageID == "" || result.TargetSessionID == "" {
 		t.Fatalf("result = %+v, want a durable queued delivery to the new day", result)
+	}
+	if !strings.Contains(result.Detail, "woke Trellis") {
+		t.Fatalf("detail = %q, want the member's display name", result.Detail)
 	}
 	for _, want := range []string{"📨 from session sender-s", "please inspect the broken build", "reply: attn agent msg sender-s"} {
 		if !strings.Contains(initialPrompt, want) {
@@ -295,7 +301,7 @@ func TestHandleAgentMsgWakeLimitRefusalDeliversNothing(t *testing.T) {
 		t.Fatalf("wake past the limit succeeded: %+v", resp)
 	}
 	detail := protocol.Deref(resp.Error)
-	for _, want := range []string{"crew.wake_limit=0", "alder", "sidebar", "nothing was delivered"} {
+	for _, want := range []string{"crew.wake_limit=0", "Alder", "sidebar", "nothing was delivered"} {
 		if !strings.Contains(detail, want) {
 			t.Errorf("refusal %q does not name %q", detail, want)
 		}

--- a/internal/daemon/agent_msg_test.go
+++ b/internal/daemon/agent_msg_test.go
@@ -2,8 +2,10 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -13,6 +15,7 @@ import (
 
 	"github.com/victorarias/attn/internal/client"
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/ptybackend"
 	"github.com/victorarias/attn/internal/store"
 )
 
@@ -111,6 +114,182 @@ func TestHandleAgentMsgDeliversAnAttributedPromptWithTheBoundary(t *testing.T) {
 	}
 	if len(queued) != 0 {
 		t.Fatalf("a delivered message is still queued: %+v", queued)
+	}
+}
+
+// A member name is its durable address. When its day is live, resolution lands
+// on that binding and uses the ordinary attributed delivery path; no second day
+// is started.
+func TestHandleAgentMsgResolvesAnAwakeCrewMemberToItsLiveSession(t *testing.T) {
+	d, backend, _ := newWakeableDaemon(t)
+	addCharacterizationSession(t, d, "sender-session-id", protocol.SessionAgentClaude, protocol.SessionStateIdle)
+	addCharacterizationSession(t, d, "keels-live-session", protocol.SessionAgentClaude, protocol.SessionStateIdle)
+	if _, err := d.claimCrewBinding("keel", "keels-live-session"); err != nil {
+		t.Fatalf("bind keel: %v", err)
+	}
+	doorbell := &recordingDoorbell{}
+	backend.onInput = doorbell.backend().onInput
+
+	resp := callAgentMsg(t, d, "Keel", "sender-session-id", "the garden is ready")
+	if !resp.Ok || resp.AgentMsgResult == nil || resp.AgentMsgResult.Status != protocol.AgentMsgStatusDelivered {
+		t.Fatalf("response = %+v", resp)
+	}
+	if resp.AgentMsgResult.TargetSessionID != "keels-live-session" {
+		t.Fatalf("target = %q, want keel's live day", resp.AgentMsgResult.TargetSessionID)
+	}
+	if prompts := doorbell.pasted(); len(prompts) != 1 || !strings.Contains(prompts[0], "the garden is ready") {
+		t.Fatalf("delivered prompts = %q", prompts)
+	}
+	backend.mu.Lock()
+	spawned := len(backend.spawnOpts)
+	backend.mu.Unlock()
+	if spawned != 0 {
+		t.Fatalf("messaging an awake member spawned %d sessions", spawned)
+	}
+}
+
+// Wake-and-deliver is one operation, not a wake followed by a best-effort
+// paste. The attributed message is persisted before spawn and replaces the
+// ordinary greeting as the day's initial prompt; the prompt-submit hook is the
+// receipt that clears the durable row.
+func TestHandleAgentMsgWakesASleepingMemberWithTheMessageAsItsFirstPrompt(t *testing.T) {
+	d, backend, _ := newWakeableDaemon(t)
+	addCharacterizationSession(t, d, "sender-session-id", protocol.SessionAgentClaude, protocol.SessionStateIdle)
+
+	var initialPrompt string
+	backend.onSpawn = func(opts ptybackend.SpawnOptions) {
+		body, err := os.ReadFile(opts.InitialPromptFile)
+		if err != nil {
+			t.Fatalf("read initial prompt: %v", err)
+		}
+		initialPrompt = string(body)
+	}
+	writes := 0
+	backend.onInput = func(_ string, _ []byte) { writes++ }
+
+	resp := callAgentMsg(t, d, "trellis", "sender-session-id", "please inspect the broken build")
+	if !resp.Ok || resp.AgentMsgResult == nil {
+		t.Fatalf("response = %+v", resp)
+	}
+	result := resp.AgentMsgResult
+	if result.Status != protocol.AgentMsgStatusQueued || result.MessageID == "" || result.TargetSessionID == "" {
+		t.Fatalf("result = %+v, want a durable queued delivery to the new day", result)
+	}
+	for _, want := range []string{"📨 from session sender-s", "please inspect the broken build", "reply: attn agent msg sender-s"} {
+		if !strings.Contains(initialPrompt, want) {
+			t.Errorf("initial prompt missing %q:\n%s", want, initialPrompt)
+		}
+	}
+	if strings.Contains(initialPrompt, crewWakePrompt) {
+		t.Fatalf("the generic greeting ran before the message:\n%s", initialPrompt)
+	}
+	if writes != 0 {
+		t.Fatalf("the message was pasted %d times in addition to the initial prompt", writes)
+	}
+	queued, err := d.store.UndeliveredAgentMessages(result.TargetSessionID)
+	if err != nil || len(queued) != 1 || queued[0].ID != result.MessageID {
+		t.Fatalf("message was not durable before the wake completed: queued=%+v err=%v", queued, err)
+	}
+
+	// Worker state alone is not the receipt: a live Claude wake reports working
+	// while its trust dialog is still in front of the initial prompt. It must
+	// neither stamp nor drain the queued row there.
+	if !d.applyState(sessionStateChange{
+		sessionID: result.TargetSessionID,
+		state:     protocol.StateWorking,
+		cause:     liveSignal{},
+	}) {
+		t.Fatal("the woken member did not enter working")
+	}
+	queued, err = d.store.UndeliveredAgentMessages(result.TargetSessionID)
+	if err != nil || len(queued) != 1 {
+		t.Fatalf("worker state claimed the initial prompt before the hook: %+v, %v", queued, err)
+	}
+	if writes != 0 {
+		t.Fatalf("worker state redelivered the initial prompt through the PTY %d times", writes)
+	}
+
+	hook := callHandler(t, func(conn net.Conn) {
+		d.handleState(conn, &protocol.StateMessage{ID: result.TargetSessionID, State: protocol.StateWorking})
+	})
+	if !hook.Ok {
+		t.Fatalf("prompt-submit hook: %+v", hook)
+	}
+	queued, err = d.store.UndeliveredAgentMessages(result.TargetSessionID)
+	if err != nil || len(queued) != 0 {
+		t.Fatalf("the prompt-submit receipt left the message queued: %+v, %v", queued, err)
+	}
+	if writes != 0 {
+		t.Fatalf("the prompt-submit receipt redelivered the initial prompt through the PTY %d times", writes)
+	}
+}
+
+// A message-triggered wake is autonomous. The lifecycle's own limit decides,
+// and its loud refusal reaches the caller with the additional fact that no
+// message landed.
+func TestHandleAgentMsgWakeLimitRefusalDeliversNothing(t *testing.T) {
+	d, backend, _ := newWakeableDaemon(t)
+	d.store.SetSetting(SettingCrewWakeLimit, "0")
+	addCharacterizationSession(t, d, "sender-session-id", protocol.SessionAgentClaude, protocol.SessionStateIdle)
+
+	resp := callAgentMsg(t, d, "alder", "sender-session-id", "wake up")
+	if resp.Ok {
+		t.Fatalf("wake past the limit succeeded: %+v", resp)
+	}
+	detail := protocol.Deref(resp.Error)
+	for _, want := range []string{"crew.wake_limit=0", "alder", "sidebar", "nothing was delivered"} {
+		if !strings.Contains(detail, want) {
+			t.Errorf("refusal %q does not name %q", detail, want)
+		}
+	}
+	backend.mu.Lock()
+	spawned := len(backend.spawnOpts)
+	backend.mu.Unlock()
+	if spawned != 0 {
+		t.Fatalf("the refused wake spawned %d sessions", spawned)
+	}
+	queued, err := d.store.TargetsWithQueuedAgentMessages()
+	if err != nil || len(queued) != 0 {
+		t.Fatalf("the refused wake queued a message anyway: %v, %v", queued, err)
+	}
+}
+
+func TestHandleAgentMsgFailedWakeLeavesNoUndeliverableMessage(t *testing.T) {
+	d, backend, _ := newWakeableDaemon(t)
+	backend.spawnErr = errors.New("the harness would not start")
+	addCharacterizationSession(t, d, "sender-session-id", protocol.SessionAgentClaude, protocol.SessionStateIdle)
+
+	resp := callAgentMsg(t, d, "keel", "sender-session-id", "please wake")
+	if resp.Ok || !strings.Contains(protocol.Deref(resp.Error), "would not start") {
+		t.Fatalf("response = %+v", resp)
+	}
+	targets, err := d.store.TargetsWithQueuedAgentMessages()
+	if err != nil || len(targets) != 0 {
+		t.Fatalf("failed wake left an undeliverable row: %v, %v", targets, err)
+	}
+	if binding := memberByID(t, crewList(t, d), "keel").BindingSession; binding != nil {
+		t.Fatalf("failed wake left keel bound to %q", *binding)
+	}
+}
+
+func TestHandleAgentMsgUnknownAddressNamesBothPlacesToLook(t *testing.T) {
+	d, backend, _ := newWakeableDaemon(t)
+	addCharacterizationSession(t, d, "sender-session-id", protocol.SessionAgentClaude, protocol.SessionStateIdle)
+
+	resp := callAgentMsg(t, d, "nobody", "sender-session-id", "hello")
+	if resp.Ok || protocol.Deref(resp.ErrorCode) != "session_or_crew_member_not_found" {
+		t.Fatalf("response = %+v", resp)
+	}
+	for _, want := range []string{`"nobody"`, "attn agent list", "attn crew list"} {
+		if !strings.Contains(protocol.Deref(resp.Error), want) {
+			t.Errorf("error %q does not name %q", protocol.Deref(resp.Error), want)
+		}
+	}
+	backend.mu.Lock()
+	spawned := len(backend.spawnOpts)
+	backend.mu.Unlock()
+	if spawned != 0 {
+		t.Fatalf("an unknown address spawned %d sessions", spawned)
 	}
 }
 

--- a/internal/daemon/crew_wake.go
+++ b/internal/daemon/crew_wake.go
@@ -6,12 +6,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	agentdriver "github.com/victorarias/attn/internal/agent"
 	"github.com/victorarias/attn/internal/crew"
 	"github.com/victorarias/attn/internal/docstore"
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
 )
 
 // Wake: a member's day starts at launch. The daemon claims the binding, then
@@ -59,6 +61,15 @@ const crewWakePrompt = "You have been woken for today. Orient from your charter 
 // every day. A workspace per wake would litter the sidebar with a new group
 // each morning.
 func crewWorkspaceID(memberID string) string { return "workspace-crew-" + memberID }
+
+// crewWakeDelivery is the message that caused an autonomous wake. Its
+// attributed prompt replaces the ordinary greeting as the first ask of the new
+// day, and its row is persisted before the process starts so the gap between
+// wake and delivery cannot lose it.
+type crewWakeDelivery struct {
+	Record *store.AgentMessage
+	Prompt string
+}
 
 // crewMember reads one member by id, behind the fence.
 func (d *Daemon) crewMember(name string) (crew.Member, docstore.Document, error) {
@@ -177,6 +188,10 @@ func (d *Daemon) handleCrewWakeWS(client *wsClient, msg *protocol.CrewWakeMessag
 }
 
 func (d *Daemon) crewWake(name, agent string) (*protocol.CrewWakeResult, error) {
+	return d.crewWakeWithDelivery(name, agent, false, nil)
+}
+
+func (d *Daemon) crewWakeWithDelivery(name, agent string, autonomous bool, delivery *crewWakeDelivery) (*protocol.CrewWakeResult, error) {
 	member, _, err := d.crewMember(name)
 	if err != nil {
 		return nil, err
@@ -203,6 +218,11 @@ func (d *Daemon) crewWake(name, agent string) (*protocol.CrewWakeResult, error) 
 	directory, err := crewLaunchDir(member)
 	if err != nil {
 		return nil, err
+	}
+	if autonomous {
+		if err := d.chargeAutonomousWake(member.ID, time.Now()); err != nil {
+			return nil, fmt.Errorf("%w; nothing was delivered", err)
+		}
 	}
 
 	sessionID := uuid.NewString()
@@ -239,6 +259,19 @@ func (d *Daemon) crewWake(name, agent string) (*protocol.CrewWakeResult, error) 
 		return nil, fmt.Errorf("create %s's pane: %w", crew.DisplayName(member.ID), err)
 	}
 
+	initialPrompt := crewWakePrompt
+	if delivery != nil {
+		delivery.Record.TargetSessionID = sessionID
+		if err := d.store.EnqueueAgentMessage(*delivery.Record); err != nil {
+			d.removeWorkspaceLayoutPaneForSession(sessionID)
+			d.releaseCrewBindingIfSession(sessionID)
+			return nil, err
+		}
+		d.noteQueuedAgentMessage(sessionID)
+		d.noteInitialAgentMessage(sessionID, delivery.Record.ID)
+		initialPrompt = delivery.Prompt
+	}
+
 	spawnClient := newInternalWSClient()
 	d.handleSpawnSession(spawnClient, &protocol.SpawnSessionMessage{
 		Cmd:           protocol.CmdSpawnSession,
@@ -250,9 +283,12 @@ func (d *Daemon) crewWake(name, agent string) (*protocol.CrewWakeResult, error) 
 		Cols:          80,
 		Rows:          24,
 		Label:         protocol.Ptr(crew.DisplayName(member.ID)),
-		InitialPrompt: protocol.Ptr(crewWakePrompt),
+		InitialPrompt: protocol.Ptr(initialPrompt),
 	})
 	if _, err := readInternalActionResult(spawnClient); err != nil {
+		if delivery != nil {
+			d.rollbackInitialAgentMessage(sessionID, delivery.Record.ID)
+		}
 		d.removeWorkspaceLayoutPaneForSession(sessionID)
 		d.releaseCrewBindingIfSession(sessionID)
 		return nil, fmt.Errorf("wake %s: %w", crew.DisplayName(member.ID), err)

--- a/internal/daemon/crew_wake.go
+++ b/internal/daemon/crew_wake.go
@@ -192,6 +192,12 @@ func (d *Daemon) crewWake(name, agent string) (*protocol.CrewWakeResult, error) 
 }
 
 func (d *Daemon) crewWakeWithDelivery(name, agent string, autonomous bool, delivery *crewWakeDelivery) (*protocol.CrewWakeResult, error) {
+	if d.crewWakeStartHook != nil {
+		d.crewWakeStartHook(strings.TrimSpace(strings.ToLower(name)))
+	}
+	d.crewWakeMu.Lock()
+	defer d.crewWakeMu.Unlock()
+
 	member, _, err := d.crewMember(name)
 	if err != nil {
 		return nil, err
@@ -231,6 +237,9 @@ func (d *Daemon) crewWakeWithDelivery(name, agent string, autonomous bool, deliv
 	// whose day is claimed by a launch that then fails is released below.
 	if _, err := d.claimCrewBinding(member.ID, sessionID); err != nil {
 		return nil, err
+	}
+	if d.crewWakeAfterClaimHook != nil {
+		d.crewWakeAfterClaimHook(member.ID, sessionID)
 	}
 
 	workspaceID := crewWorkspaceID(member.ID)

--- a/internal/daemon/crew_wake_test.go
+++ b/internal/daemon/crew_wake_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/victorarias/attn/internal/crew"
@@ -180,6 +181,65 @@ func TestCrewWake_AnAwakeMemberIsNotWokenTwice(t *testing.T) {
 	backend.mu.Unlock()
 	if spawned != 1 {
 		t.Fatalf("%d sessions were spawned for one member, want 1", spawned)
+	}
+}
+
+// The binding alone is not a liveness fence: the claimed session becomes
+// visible only later in the spawn pipeline. A second wake that enters during
+// that gap must wait, then resolve to the first day instead of stealing the
+// member and launching a second identity.
+func TestCrewWake_ConcurrentWakesShareTheFirstDay(t *testing.T) {
+	d, backend, _ := newWakeableDaemon(t)
+	started := make(chan string, 2)
+	firstClaimed := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var claims atomic.Int32
+	d.crewWakeStartHook = func(memberID string) { started <- memberID }
+	d.crewWakeAfterClaimHook = func(_, _ string) {
+		if claims.Add(1) == 1 {
+			close(firstClaimed)
+			<-releaseFirst
+		}
+	}
+
+	type outcome struct {
+		result *protocol.CrewWakeResult
+		err    error
+	}
+	results := make(chan outcome, 2)
+	wake := func() {
+		result, err := d.crewWake("keel", "")
+		results <- outcome{result: result, err: err}
+	}
+	go wake()
+	if member := <-started; member != "keel" {
+		t.Fatalf("first wake started for %q", member)
+	}
+	<-firstClaimed
+	go wake()
+	if member := <-started; member != "keel" {
+		t.Fatalf("second wake started for %q", member)
+	}
+	close(releaseFirst)
+
+	first, second := <-results, <-results
+	if first.err != nil || second.err != nil {
+		t.Fatalf("wake errors = %v, %v", first.err, second.err)
+	}
+	if first.result.SessionID != second.result.SessionID {
+		t.Fatalf("concurrent wakes launched sessions %q and %q", first.result.SessionID, second.result.SessionID)
+	}
+	if first.result.AlreadyAwake == second.result.AlreadyAwake {
+		t.Fatalf("results = %+v and %+v, want one launch and one live-day resolution", first.result, second.result)
+	}
+	if got := claims.Load(); got != 1 {
+		t.Fatalf("the member was claimed %d times, want one", got)
+	}
+	backend.mu.Lock()
+	spawned := len(backend.spawnOpts)
+	backend.mu.Unlock()
+	if spawned != 1 {
+		t.Fatalf("concurrent wakes spawned %d sessions, want one", spawned)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -255,7 +255,12 @@ type Daemon struct {
 	drainingAgentMessages       map[string]bool
 	agentMessageTaken           map[string][]chan struct{}
 	agentMessagesAwaitingSubmit map[string]bool
-	agentMessageDrainHook       func(sessionID string, delivered int) // tests only; nil in production
+	// A message-triggered crew wake carries the attributed message as the new
+	// day's initial prompt. The row stays queued until a prompt-submit hook
+	// proves the agent took it; across a daemon restart the ordinary queue drain
+	// is the conservative fallback, so the message can duplicate but not vanish.
+	agentMessageInitialPrompt map[string]string                     // session id -> message id
+	agentMessageDrainHook     func(sessionID string, delivered int) // tests only; nil in production
 	// stateTrace is the diagnostic ring of state observations behind
 	// `attn state explain`. Lazily built so a directly-constructed test daemon
 	// traces without an init site.
@@ -3043,6 +3048,7 @@ func (d *Daemon) handleUnregister(conn net.Conn, msg *protocol.UnregisterMessage
 // refreshing — was reachable only by a source that did not write state itself.
 func (d *Daemon) handleState(conn net.Conn, msg *protocol.StateMessage) {
 	d.logf("hook evidence: id=%s state=%s", msg.ID, msg.State)
+	d.noteInitialAgentMessageSubmitted(msg.ID, msg.State)
 	d.tracePermissionMode(msg.ID, protocol.Deref(msg.PermissionMode))
 	d.recordReviewerEvidenceFromPermissionMode(msg.ID, protocol.Deref(msg.PermissionMode))
 	d.recordBracketEvidence(msg.ID, msg.State)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -259,8 +259,17 @@ type Daemon struct {
 	// day's initial prompt. The row stays queued until a prompt-submit hook
 	// proves the agent took it; across a daemon restart the ordinary queue drain
 	// is the conservative fallback, so the message can duplicate but not vanish.
-	agentMessageInitialPrompt map[string]string                     // session id -> message id
-	agentMessageDrainHook     func(sessionID string, delivered int) // tests only; nil in production
+	agentMessageInitialPrompt map[string]string // session id -> message id
+	// Deterministic drain seams; nil outside tests.
+	agentMessageDrainScheduledHook func(sessionID string)
+	agentMessageDrainHook          func(sessionID string, delivered int)
+	// A wake owns the member from its liveness read through durable session
+	// creation. Without this fence, a second wake can steal the binding while
+	// the first claimed session is not yet visible to crewBindingLive.
+	crewWakeMu sync.Mutex
+	// Deterministic concurrency seams; nil outside tests.
+	crewWakeStartHook      func(memberID string)
+	crewWakeAfterClaimHook func(memberID, sessionID string)
 	// stateTrace is the diagnostic ring of state observations behind
 	// `attn state explain`. Lazily built so a directly-constructed test daemon
 	// traces without an init site.

--- a/internal/store/agent_messages.go
+++ b/internal/store/agent_messages.go
@@ -45,6 +45,22 @@ func (s *Store) EnqueueAgentMessage(msg AgentMessage) error {
 	return nil
 }
 
+// DeleteQueuedAgentMessage rolls back a delivery whose target could not be
+// launched. It deletes only an undelivered row: once a target took the message,
+// a late cleanup must not erase its receipt.
+func (s *Store) DeleteQueuedAgentMessage(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	_, err := s.db.Exec(`
+		DELETE FROM agent_messages WHERE id = ? AND delivered_at = ''
+	`, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete queued agent message: %w", err)
+	}
+	return nil
+}
+
 // UndeliveredAgentMessages returns the target's queued messages, oldest first —
 // the order the drain delivers them in.
 func (s *Store) UndeliveredAgentMessages(targetSessionID string) ([]AgentMessage, error) {

--- a/internal/store/agent_messages_test.go
+++ b/internal/store/agent_messages_test.go
@@ -89,6 +89,30 @@ func TestMarkAgentMessageDeliveredIsWriteOnce(t *testing.T) {
 	}
 }
 
+func TestDeleteQueuedAgentMessageRollsBackOnlyAnUndeliveredRow(t *testing.T) {
+	s := newAgentMessageStore(t)
+	now := time.Now()
+	enqueue(t, s, "queued", "sender", "target", "not launched", now)
+	enqueue(t, s, "delivered", "sender", "target", "already read", now)
+	if err := s.MarkAgentMessageDelivered("delivered", now); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.DeleteQueuedAgentMessage("queued"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DeleteQueuedAgentMessage("delivered"); err != nil {
+		t.Fatal(err)
+	}
+	var count int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM agent_messages`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("rows = %d, want only the delivered receipt", count)
+	}
+}
+
 // The guard's three counts, each scoped to exactly what its limit is about:
 // dedupe to one sender's identical text, the rate to one sender's traffic, and
 // the queue cap to the target's whole backlog from everyone.


### PR DESCRIPTION
## TL;DR

`attn agent msg` can now address a durable crew member by name. It delivers to the member's current day when awake, or performs a wake-limit-bounded wake and carries the attributed message as the sleeping member's first ask after charter and handoff priming.

## Why

Crew members outlive their sessions, but messaging previously required the caller to discover whichever session happened to hold the member's current day. That made “tell Keel X” depend on lifecycle state and left asleep members unaddressable.

## What changed

The daemon now resolves an `agent msg` target as a crew member before falling back to session ID/prefix resolution:

- An awake member routes through the existing attributed, durable session-message path.
- A sleeping member goes through the lifecycle's autonomous wake gate. Refusal preserves the lifecycle error—including the configured limit and way out—and adds that nothing was delivered.
- An accepted message is persisted before the session process starts and replaces the generic wake greeting as the launch prompt. Crew priming still runs first, so the charter and predecessor letter precede the attributed ask.
- Crew wakes serialize through durable session creation. Simultaneous messages to one sleeping member share the first new day instead of racing two claims, two wake charges, and two identities.
- The CLI returns `queued` once the new session is running. A prompt-submit hook, rather than the worker's early `working` signal, stamps delivery; Claude can report worker activity while its trust dialog still blocks the prompt. After a daemon restart, the normal durable queue is the conservative fallback, preferring a possible duplicate over loss.
- Messages that arrive after the session is created but before its initial prompt starts queue behind that prompt, then drain as soon as the prompt-submit receipt opens the gate.
- Unknown addresses now name both address books: `attn agent list` for sessions and `attn crew list` for members.

The protocol message and result shapes are unchanged—the existing target string now accepts a member name—so this does not bump the protocol version. The app UI, wake model/prose, auto-sleep, heartbeat, and lifecycle thresholds are unchanged.

## Manual verification

In an isolated `crew-msg` profile using the bundled CLI and daemon:

- Addressed awake Keel by name and observed the attributed message arrive in the existing session.
- Explicitly ended Keel's day with a sleeping handoff, then addressed `keel` again. The command returned `queued` with a new session; Keel replied after launch and explicitly reported reading its charter and predecessor letter before handling the message.
- Set `crew.wake_limit=0` and addressed sleeping Keel. The command refused with the limit name/value, the member, the sidebar/setting way out, and “nothing was delivered”; Keel remained unbound and no matching message row existed.
- Sent two simultaneous commands to sleeping Keel. Both resolved to the same new session, only one performed the wake, and both durable receipts and exact-token replies appeared once.
- After rebasing the member-display-name change, addressed lowercase `keel` while asleep. The result said `woke Keel`, the spawned session/workspace rendered `Keel`, JSON retained the lowercase member identity, and the attributed round trip completed with a durable receipt.

The full quick suite and Linux amd64 cross-build pass.
