### PR TITLE
Keep a crew member's ticket thread across days

### DIFF
--- a/changelog.d/crew-member-ticket-thread.yaml
+++ b/changelog.d/crew-member-ticket-thread.yaml
@@ -1,0 +1,10 @@
+kind: fixed
+area: crew
+change: >
+  Ticket participation now belongs to a crew member instead of one day's
+  session. A member keeps its subscriptions, unread cursor, and interruption
+  clock across day turnover; ticket commands attribute the member by its
+  `member:<id>` identity while the concrete session remains the assignee. Any
+  unread ticket activity wakes a sleeping member through the existing
+  autonomous wake limit, after charter and handoff priming. A refused wake is
+  surfaced as a warning and leaves the activity unread for the next manual wake.

--- a/docs/plans/2026-08-15-member-ticket-identity.md
+++ b/docs/plans/2026-08-15-member-ticket-identity.md
@@ -1,0 +1,121 @@
+# Plan: A member's ticket thread survives its sleep
+
+## Goal
+
+A crew member, not one day's session, owns its ticket participation. Subscriptions,
+authorship, cursors, interruption attention, and delivery follow `member:<id>` across
+day turnover. Any unread ticket activity may wake a sleeping member; the existing
+autonomous wake limit is the governor.
+
+The ticket assignee remains the concrete session doing the work. Taking a ticket
+also attaches the member identity beside that assignee, so the thread survives when
+the day ends without changing ticket/session ownership semantics.
+
+## Architecture Map
+
+```text
+member-bound ticket command
+  ticketIdentityForSession(session)
+    -> member:trellis
+  store mutation / subscription / cursor
+    -> durable member identity
+
+ticket event lands
+  notifyTicketObservers(ticket)
+    TicketParticipants(ticket)
+      ordinary session -> existing countdown delivery
+      role:chief_of_staff -> current chief session
+      member:trellis
+        awake -> current bound session -> existing countdown delivery
+        asleep + unread
+          -> crewWakeWithDelivery(autonomous=true)
+            charge existing wake ledger
+            claim one serialized day
+            inject charter + predecessor letter
+            submit the ordinary wake greeting after priming
+            wait for its prompt-submit receipt
+            arm the ticket doorbell from durable unread state
+          -> refresh the new session's existing unread indicator
+        wake refused
+          -> existing notification feed names the limit and manual wake action
+          -> member cursor remains unchanged
+```
+
+Day transitions adopt legacy session state before the binding moves or clears:
+
+```text
+ticket participant/subscription/cursor keyed by old session
+  -> ensure member subscription for every involved ticket
+  -> re-attribute historical ticket authorship to the member
+  -> merge cursor into member cursor with max(old, member)
+  -> delete old explicit subscriptions and cursors
+```
+
+On upgrade, startup applies the same migration to each member's current binding
+and recorded `LetterSession`, which covers the live day and immediate predecessor.
+Older session-only rows cannot be attributed to a member from the remaining data;
+they stay as ordinary historical session participation rather than being guessed or
+silently deleted.
+
+## Data Model / Interfaces
+
+No wire shape changes.
+
+```go
+TicketMemberIdentity("trellis") == "member:trellis"
+
+MigrateTicketIdentity(fromSession, memberIdentity, now)
+  // one SQLite transaction; idempotent; max cursor wins
+```
+
+The existing `ticket_participants` view already accepts arbitrary identities from
+subscriptions and event authors, so `member:<id>` needs no new participation table.
+Historical event and activity authors are re-attributed from the disposable session
+to the durable member. Without that rewrite the member's new self-author exclusion
+would replay its predecessor's own events as unread.
+
+## Boundaries
+
+- `internal/store` owns identity string helpers and the atomic participation/cursor
+  adoption.
+- `internal/daemon/ticket_identity.go` is the only session ↔ durable ticket identity
+  map. It resolves member identities through the crew binding.
+- Crew binding claim, transfer, and release call the store adoption before losing
+  the predecessor session id.
+- Ticket notification reuses `crewWakeWithDelivery`; it does not create another wake
+  path or advance a cursor to acknowledge a failed delivery.
+- Existing notifications make a wake-limit refusal visible without adding UI or
+  protocol surface.
+
+## Implementation Steps
+
+- [x] Add member identity parsing/formatting and atomic legacy-session adoption.
+- [x] Make member-bound subscribe, unsubscribe, inbox, attention, mutation authorship,
+      and take participation use the member identity.
+- [x] Resolve awake members and wake sleeping members from the notifier, with the
+      ticket doorbell after crew priming and a durable warning on refusal.
+- [x] Cover awake/asleep resolution, day-turnover cursor continuity, legacy migration,
+      wake refusal/unread preservation, unread indicator, and watch behavior.
+- [x] Add the changelog fragment; run targeted Go tests and `make test-quick`.
+- [x] Install and exercise a throwaway profile for successful wake and
+      `crew.wake_limit=0`, then clean it.
+- [ ] Rebase, publish a ready PR, and wait for green CI, figgyster approval, and zero
+      unresolved threads without merging.
+
+## Decisions
+
+- Every unread ticket event may wake a sleeping member. Importance filtering would
+  create a second policy beside the wake ledger; the wake limit already bounds the
+  unattended cost.
+- The assignee remains a concrete session. `member:<id>` is the durable participant
+  beside it, preserving existing reconciliation, resume, and active-ticket behavior.
+- A wake refusal creates a warning notification and leaves ticket cursors untouched.
+  A daemon log alone is not loud enough for an unattended refusal.
+- Existing session-authored ticket history is re-attributed to the member while its
+  participation and maximum cursor are adopted transactionally. This preserves both
+  durable attribution and the observable read position.
+
+## Follow-ups
+
+- Garden/seed identities deliberately remain session/member-name behavior from their
+  current design; this change establishes the ticket-only pattern requested here.

--- a/internal/daemon/agent_msg.go
+++ b/internal/daemon/agent_msg.go
@@ -249,7 +249,7 @@ func agentMessageQueuedDetail(err error) string {
 // took it, and stamps the row. Shared by the send path and the redelivery drain
 // so a queued message and a live one land identically.
 func (d *Daemon) deliverAgentMessage(record store.AgentMessage) error {
-	if d.initialAgentMessagePending(record.TargetSessionID, "") {
+	if d.initialPromptPending(record.TargetSessionID) {
 		return errAgentMessageInitialPromptPending
 	}
 	sender := d.store.Get(record.SenderSessionID)
@@ -413,6 +413,47 @@ func (d *Daemon) initialAgentMessagePending(sessionID, messageID string) bool {
 	return current != "" && (messageID == "" || current == messageID)
 }
 
+func (d *Daemon) notePostInitialPrompt(sessionID string, after func()) {
+	d.agentMessageMu.Lock()
+	defer d.agentMessageMu.Unlock()
+	if d.postInitialPrompt == nil {
+		d.postInitialPrompt = make(map[string]func())
+	}
+	d.postInitialPrompt[sessionID] = after
+}
+
+func (d *Daemon) forgetPostInitialPrompt(sessionID string) {
+	d.agentMessageMu.Lock()
+	defer d.agentMessageMu.Unlock()
+	delete(d.postInitialPrompt, sessionID)
+}
+
+// initialPromptPending covers both forms of wake-carried delivery. It is the
+// anti-splice gate for agent messages and ticket countdowns while a new member
+// day is still taking its first prompt.
+func (d *Daemon) initialPromptPending(sessionID string) bool {
+	d.agentMessageMu.Lock()
+	defer d.agentMessageMu.Unlock()
+	return d.agentMessageInitialPrompt[sessionID] != "" || d.postInitialPrompt[sessionID] != nil
+}
+
+func (d *Daemon) runPostInitialPrompt(sessionID, state string) {
+	if state != protocol.StateWorking {
+		return
+	}
+	d.agentMessageMu.Lock()
+	after := d.postInitialPrompt[sessionID]
+	delete(d.postInitialPrompt, sessionID)
+	d.agentMessageMu.Unlock()
+	if after != nil {
+		after()
+		// Messages addressed to the member while the ticket-triggered wake was
+		// priming queued behind the same gate. This hook is their first reliable
+		// drain signal too.
+		d.drainAgentMessagesAfterStateChange(sessionID, state)
+	}
+}
+
 // noteInitialAgentMessageSubmitted is the receipt for a message carried as a
 // new member day's initial prompt. Worker state is not enough: a freshly
 // spawned Claude session reports `working` while still sitting at its trust
@@ -534,7 +575,7 @@ func (d *Daemon) seedQueuedAgentMessages() {
 // sent to a session waiting on an approval would sit queued until someone sent
 // another one.
 func (d *Daemon) drainAgentMessagesAfterStateChange(sessionID, state string) {
-	if d.initialAgentMessagePending(sessionID, "") || !isNudgeDeliveryAllowed(state) || !d.hasQueuedAgentMessages(sessionID) {
+	if d.initialPromptPending(sessionID) || !isNudgeDeliveryAllowed(state) || !d.hasQueuedAgentMessages(sessionID) {
 		return
 	}
 	if d.agentMessageDrainScheduledHook != nil {

--- a/internal/daemon/crew.go
+++ b/internal/daemon/crew.go
@@ -193,6 +193,40 @@ func (d *Daemon) crewBindingLive(member crew.Member) bool {
 	return member.BindingSession != "" && d.sessionExists(member.BindingSession)
 }
 
+// migrateCrewTicketIdentity adopts one day's ticket participation into the
+// member before a binding moves or disappears. It is idempotent, so registration
+// retries and daemon restarts can safely run it again.
+func (d *Daemon) migrateCrewTicketIdentity(memberID string, sessionIDs ...string) error {
+	identity := store.TicketMemberIdentity(memberID)
+	for _, sessionID := range sessionIDs {
+		sessionID = strings.TrimSpace(sessionID)
+		if sessionID == "" {
+			continue
+		}
+		if err := d.store.MigrateTicketIdentity(sessionID, identity, time.Now()); err != nil {
+			return fmt.Errorf("carry session %s's ticket participation into %s: %w", shortSessionID(sessionID), identity, err)
+		}
+	}
+	return nil
+}
+
+// migrateCrewTicketIdentities upgrades session-keyed ticket state already on
+// disk. Claim/release cannot cover a daemon upgrade whose live binding survives
+// the restart, and LetterSession recovers the immediate predecessor after a
+// sleep completed before this version first ran.
+func (d *Daemon) migrateCrewTicketIdentities() error {
+	members, _, err := d.readCrewMembers()
+	if err != nil {
+		return err
+	}
+	for _, member := range members {
+		if err := d.migrateCrewTicketIdentity(member.ID, member.BindingSession, member.LetterSession); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // claimCrewBinding stamps sessionID as memberName's active binding — the
 // identity mechanism: the session is the member because this claim succeeded
 // at its launch. It refuses an unregistered name, and refuses a member whose
@@ -223,6 +257,9 @@ func (d *Daemon) claimCrewBinding(memberName, sessionID string) (string, error) 
 			return "", fmt.Errorf("no crew member %q is registered; `attn crew list` names the roster", memberName)
 		}
 		if member.BindingSession == sessionID {
+			if err := d.migrateCrewTicketIdentity(member.ID, sessionID); err != nil {
+				return "", err
+			}
 			return member.ID, nil
 		}
 		if d.crewBindingLive(member) {
@@ -233,9 +270,16 @@ func (d *Daemon) claimCrewBinding(memberName, sessionID string) (string, error) 
 		// this session already answered to. A refused claim is not reached here,
 		// and leaves the session the member it already was.
 		d.releaseCrewBindingsExcept(*schema, members, docs, member.ID, sessionID)
+		previousSessionID := member.BindingSession
+		if err := d.migrateCrewTicketIdentity(member.ID, previousSessionID); err != nil {
+			return "", err
+		}
 		member.BindingSession = sessionID
 		err = d.writeCrewMember(*schema, member, docs[member.ID].Rev)
 		if err == nil {
+			if err := d.migrateCrewTicketIdentity(member.ID, sessionID); err != nil {
+				return "", err
+			}
 			d.publishFact(FactCrewBound, member.ID, nil)
 			d.logf("crew: session %s bound as %s", sessionID, crew.DisplayName(member.ID))
 			return member.ID, nil
@@ -276,6 +320,10 @@ func (d *Daemon) releaseCrewBindingIfSession(sessionID string) {
 func (d *Daemon) releaseCrewBindingsExcept(schema docstore.CollectionSchema, members []crew.Member, docs map[string]docstore.Document, keepID, sessionID string) {
 	for _, member := range members {
 		if member.BindingSession != sessionID || member.ID == keepID {
+			continue
+		}
+		if err := d.migrateCrewTicketIdentity(member.ID, sessionID); err != nil {
+			d.logf("crew: keeping %s's stale binding for session %s because ticket participation did not move: %v", crew.DisplayName(member.ID), sessionID, err)
 			continue
 		}
 		member.BindingSession = ""

--- a/internal/daemon/crew_handoff.go
+++ b/internal/daemon/crew_handoff.go
@@ -64,6 +64,22 @@ func (d *Daemon) transferCrewBinding(memberID, from, to string) error {
 	if err != nil {
 		return err
 	}
+	if err := d.migrateCrewTicketIdentity(memberID, from, to); err != nil {
+		// The migration is one SQL transaction. Put the registry back when it
+		// refuses so the caller never sees a moved identity without its ticket
+		// state; a concurrent successor wins the CAS and is left untouched.
+		_, rollbackErr := d.updateCrewMember(memberID, func(member *crew.Member) (bool, error) {
+			if member.BindingSession != to {
+				return false, nil
+			}
+			member.BindingSession = from
+			return true, nil
+		})
+		if rollbackErr != nil {
+			return errors.Join(err, fmt.Errorf("restore %s's binding after ticket migration refusal: %w", crew.DisplayName(memberID), rollbackErr))
+		}
+		return err
+	}
 	d.publishFact(FactCrewBound, memberID, nil)
 	d.logf("crew: %s's binding moved from session %s to %s", crew.DisplayName(memberID), from, to)
 	return nil

--- a/internal/daemon/crew_wake.go
+++ b/internal/daemon/crew_wake.go
@@ -62,13 +62,14 @@ const crewWakePrompt = "You have been woken for today. Orient from your charter 
 // each morning.
 func crewWorkspaceID(memberID string) string { return "workspace-crew-" + memberID }
 
-// crewWakeDelivery is the message that caused an autonomous wake. Its
-// attributed prompt replaces the ordinary greeting as the first ask of the new
-// day, and its row is persisted before the process starts so the gap between
-// wake and delivery cannot lose it.
+// crewWakeDelivery is work carried by the one serialized wake path. An agent
+// message replaces the ordinary greeting and persists its row before spawn. A
+// ticket nudge keeps the greeting and runs AfterInitialPrompt only after a hook
+// proves the new day got through priming and submitted that greeting.
 type crewWakeDelivery struct {
-	Record *store.AgentMessage
-	Prompt string
+	Record             *store.AgentMessage
+	Prompt             string
+	AfterInitialPrompt func(sessionID string)
 }
 
 // crewMember reads one member by id, behind the fence.
@@ -270,15 +271,20 @@ func (d *Daemon) crewWakeWithDelivery(name, agent string, autonomous bool, deliv
 
 	initialPrompt := crewWakePrompt
 	if delivery != nil {
-		delivery.Record.TargetSessionID = sessionID
-		if err := d.store.EnqueueAgentMessage(*delivery.Record); err != nil {
-			d.removeWorkspaceLayoutPaneForSession(sessionID)
-			d.releaseCrewBindingIfSession(sessionID)
-			return nil, err
+		if delivery.Record != nil {
+			delivery.Record.TargetSessionID = sessionID
+			if err := d.store.EnqueueAgentMessage(*delivery.Record); err != nil {
+				d.removeWorkspaceLayoutPaneForSession(sessionID)
+				d.releaseCrewBindingIfSession(sessionID)
+				return nil, err
+			}
+			d.noteQueuedAgentMessage(sessionID)
+			d.noteInitialAgentMessage(sessionID, delivery.Record.ID)
+			initialPrompt = delivery.Prompt
 		}
-		d.noteQueuedAgentMessage(sessionID)
-		d.noteInitialAgentMessage(sessionID, delivery.Record.ID)
-		initialPrompt = delivery.Prompt
+		if delivery.AfterInitialPrompt != nil {
+			d.notePostInitialPrompt(sessionID, func() { delivery.AfterInitialPrompt(sessionID) })
+		}
 	}
 
 	spawnClient := newInternalWSClient()
@@ -296,7 +302,10 @@ func (d *Daemon) crewWakeWithDelivery(name, agent string, autonomous bool, deliv
 	})
 	if _, err := readInternalActionResult(spawnClient); err != nil {
 		if delivery != nil {
-			d.rollbackInitialAgentMessage(sessionID, delivery.Record.ID)
+			if delivery.Record != nil {
+				d.rollbackInitialAgentMessage(sessionID, delivery.Record.ID)
+			}
+			d.forgetPostInitialPrompt(sessionID)
 		}
 		d.removeWorkspaceLayoutPaneForSession(sessionID)
 		d.releaseCrewBindingIfSession(sessionID)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -255,6 +255,10 @@ type Daemon struct {
 	drainingAgentMessages       map[string]bool
 	agentMessageTaken           map[string][]chan struct{}
 	agentMessagesAwaitingSubmit map[string]bool
+	// A crew wake may owe work only after the new day has submitted its ordinary
+	// first prompt. Ticket delivery uses this to keep the doorbell behind charter
+	// and handoff priming instead of pasting into the launching session.
+	postInitialPrompt map[string]func()
 	// A message-triggered crew wake carries the attributed message as the new
 	// day's initial prompt. The row stays queued until a prompt-submit hook
 	// proves the agent took it; across a daemon restart the ordinary queue drain
@@ -1040,6 +1044,12 @@ func (d *Daemon) Start() error {
 	d.ensureGardenCollections()
 	d.ensureCrewCollections()
 	d.importCrewHomes()
+	if err := d.migrateCrewTicketIdentities(); err != nil {
+		return fmt.Errorf("migrate crew ticket identities: %w", err)
+	}
+	if err := d.seedCrewTicketWakeDeliveries(); err != nil {
+		return fmt.Errorf("restore crew ticket wake deliveries: %w", err)
+	}
 	if d.hubManager == nil {
 		d.hubManager = hub.NewManager(
 			d.store,
@@ -2175,6 +2185,7 @@ func (d *Daemon) dropSessionRecord(sessionID string) {
 		d.reconcileTicketsOnSessionEnd(sessionID, string(session.State))
 	}
 	d.clearNudgeState(sessionID)
+	d.forgetPostInitialPrompt(sessionID)
 	d.clearAutoSettleState(sessionID)
 	d.clearSnoozeState(sessionID)
 	d.clearPTYWriteFence(sessionID)
@@ -3058,6 +3069,7 @@ func (d *Daemon) handleUnregister(conn net.Conn, msg *protocol.UnregisterMessage
 func (d *Daemon) handleState(conn net.Conn, msg *protocol.StateMessage) {
 	d.logf("hook evidence: id=%s state=%s", msg.ID, msg.State)
 	d.noteInitialAgentMessageSubmitted(msg.ID, msg.State)
+	d.runPostInitialPrompt(msg.ID, msg.State)
 	d.tracePermissionMode(msg.ID, protocol.Deref(msg.PermissionMode))
 	d.recordReviewerEvidenceFromPermissionMode(msg.ID, protocol.Deref(msg.PermissionMode))
 	d.recordBracketEvidence(msg.ID, msg.State)

--- a/internal/daemon/delegate_ticket.go
+++ b/internal/daemon/delegate_ticket.go
@@ -41,7 +41,7 @@ func (d *Daemon) createDelegatedTicket(creatorSessionID string, ownedByChiefRole
 			return "", err
 		}
 	}
-	ownerRole, subscribers := delegationTicketAttachment(creatorSessionID, ownedByChiefRole)
+	author, ownerRole, subscribers := d.delegationTicketAttachment(creatorSessionID, ownedByChiefRole)
 	created, err := d.createTicketWithUniqueSlug(store.Ticket{
 		Title:       label,
 		Description: brief,
@@ -49,7 +49,7 @@ func (d *Daemon) createDelegatedTicket(creatorSessionID string, ownedByChiefRole
 		Assignee:    session.ID,
 		Cwd:         session.Directory,
 		LastAgentID: agent,
-	}, ticketSlug(label), creatorSessionID, ownerRole, subscribers, time.Now())
+	}, ticketSlug(label), author, ownerRole, subscribers, time.Now())
 	if err != nil {
 		return "", err
 	}
@@ -61,9 +61,9 @@ func (d *Daemon) createDelegatedTicket(creatorSessionID string, ownedByChiefRole
 // description already went out in the spawn prompt); the previous assignee stays
 // subscribed.
 func (d *Daemon) adoptDelegatedTicket(creatorSessionID string, ownedByChiefRole bool, session *protocol.Session, ticketID, agent string, confirm bool) (string, error) {
-	ownerRole, subscribers := delegationTicketAttachment(creatorSessionID, ownedByChiefRole)
+	author, ownerRole, subscribers := d.delegationTicketAttachment(creatorSessionID, ownedByChiefRole)
 	adopted, err := d.store.AdoptTicketForDelegation(
-		ticketID, session.ID, session.Directory, agent, creatorSessionID,
+		ticketID, session.ID, session.Directory, agent, author,
 		ownerRole, subscribers, confirm, time.Now(),
 	)
 	if err != nil {
@@ -72,18 +72,20 @@ func (d *Daemon) adoptDelegatedTicket(creatorSessionID string, ownedByChiefRole 
 	return adopted.ID, nil
 }
 
-// delegationTicketAttachment decides who the delegating side attaches as. A chief
-// delegation attaches the ROLE and nothing else: the role owner row is the
-// attachment, and the events the acting session writes carry that role, so the
+// delegationTicketAttachment decides who the delegating side acts and attaches
+// as. A chief delegation attaches the ROLE and nothing else: the role owner row
+// is the attachment, and the events the acting session writes carry that role, so the
 // attachment moves with the role instead of stranding a personal subscription on
 // the session that happened to hold it. Any other delegator attaches personally
 // and pulls the chief role in as a subscriber, because the chief follows every
-// delegation whether or not it started it.
-func delegationTicketAttachment(creatorSessionID string, ownedByChiefRole bool) (ownerRole string, subscribers []string) {
+// delegation whether or not it started it. For a crew member, personally means
+// the durable member identity rather than today's disposable session.
+func (d *Daemon) delegationTicketAttachment(creatorSessionID string, ownedByChiefRole bool) (author, ownerRole string, subscribers []string) {
 	if ownedByChiefRole {
-		return store.TicketRoleChiefOfStaff, nil
+		return creatorSessionID, store.TicketRoleChiefOfStaff, nil
 	}
-	return "", []string{creatorSessionID, store.TicketRoleIdentity(store.TicketRoleChiefOfStaff)}
+	author = d.ticketActorIdentity(creatorSessionID)
+	return author, "", []string{author, store.TicketRoleIdentity(store.TicketRoleChiefOfStaff)}
 }
 
 // ticketSlugSequentialAttempts bounds the readable base-2, base-3, ... walk

--- a/internal/daemon/delegate_ticket_test.go
+++ b/internal/daemon/delegate_ticket_test.go
@@ -132,3 +132,123 @@ func TestCreateDelegatedTicketParticipants(t *testing.T) {
 		})
 	}
 }
+
+func TestCrewMemberDelegationUsesDurableMemberIdentity(t *testing.T) {
+	memberIdentity := store.TicketMemberIdentity("trellis")
+	chiefRole := store.TicketRoleIdentity(store.TicketRoleChiefOfStaff)
+	for _, tc := range []struct {
+		name string
+		bind func(t *testing.T, d *Daemon, delegated *protocol.Session) string
+	}{
+		{
+			name: "create",
+			bind: func(t *testing.T, d *Daemon, delegated *protocol.Session) string {
+				t.Helper()
+				id, err := d.createDelegatedTicket("trellis-today", false, delegated, "the brief", "Member work", "codex")
+				if err != nil {
+					t.Fatalf("createDelegatedTicket: %v", err)
+				}
+				return id
+			},
+		},
+		{
+			name: "adopt",
+			bind: func(t *testing.T, d *Daemon, delegated *protocol.Session) string {
+				t.Helper()
+				if _, err := d.store.CreateTicket(store.Ticket{ID: "member-work", Title: "Member work", Description: "the brief"}, "filer", time.Now()); err != nil {
+					t.Fatalf("seed ticket: %v", err)
+				}
+				id, err := d.adoptDelegatedTicket("trellis-today", false, delegated, "member-work", "codex", false)
+				if err != nil {
+					t.Fatalf("adoptDelegatedTicket: %v", err)
+				}
+				return id
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newCrewDaemon(t)
+			addSession(t, d, "trellis-today")
+			if _, err := d.claimCrewBinding("trellis", "trellis-today"); err != nil {
+				t.Fatalf("claim crew binding: %v", err)
+			}
+			delegated := &protocol.Session{ID: "sess-delegated", Directory: "/tmp/x"}
+			ticketID := tc.bind(t, d, delegated)
+
+			participants, err := d.store.TicketParticipants(ticketID)
+			if err != nil {
+				t.Fatalf("TicketParticipants: %v", err)
+			}
+			got := map[string]bool{}
+			for _, participant := range participants {
+				got[participant] = true
+			}
+			for _, want := range []string{delegated.ID, memberIdentity, chiefRole} {
+				if !got[want] {
+					t.Errorf("participants = %v, missing %q", participants, want)
+				}
+			}
+			if got["trellis-today"] {
+				t.Errorf("participants = %v, disposable member session is attached", participants)
+			}
+
+			events, err := d.store.TicketEventsSince(0)
+			if err != nil {
+				t.Fatalf("TicketEventsSince: %v", err)
+			}
+			delegationEvents := 0
+			for _, event := range events {
+				if event.TicketID != ticketID || (event.Kind == store.TicketEventCreated && tc.name == "adopt") {
+					continue
+				}
+				delegationEvents++
+				if event.Author != memberIdentity || event.AuthorRole != "" {
+					t.Errorf("delegation event = %+v, want author %q without a role", event, memberIdentity)
+				}
+			}
+			wantEvents := 1
+			if tc.name == "adopt" {
+				wantEvents = 2
+			}
+			if delegationEvents != wantEvents {
+				t.Errorf("delegation events = %d, want %d", delegationEvents, wantEvents)
+			}
+		})
+	}
+}
+
+func TestChiefMemberDelegationKeepsChiefRoleAttachment(t *testing.T) {
+	d := newCrewDaemon(t)
+	addSession(t, d, "trellis-today")
+	if _, err := d.claimCrewBinding("trellis", "trellis-today"); err != nil {
+		t.Fatalf("claim crew binding: %v", err)
+	}
+	delegated := &protocol.Session{ID: "sess-delegated", Directory: "/tmp/x"}
+	ticketID, err := d.createDelegatedTicket("trellis-today", true, delegated, "the brief", "Chief work", "codex")
+	if err != nil {
+		t.Fatalf("createDelegatedTicket: %v", err)
+	}
+	participants, err := d.store.TicketParticipants(ticketID)
+	if err != nil {
+		t.Fatalf("TicketParticipants: %v", err)
+	}
+	got := map[string]bool{}
+	for _, participant := range participants {
+		got[participant] = true
+	}
+	chiefRole := store.TicketRoleIdentity(store.TicketRoleChiefOfStaff)
+	if !got[delegated.ID] || !got[chiefRole] {
+		t.Errorf("participants = %v, want delegated session and %q", participants, chiefRole)
+	}
+	if got["trellis-today"] || got[store.TicketMemberIdentity("trellis")] {
+		t.Errorf("participants = %v, chief delegation also attached its acting member", participants)
+	}
+	events, err := d.store.TicketEventsSince(0)
+	if err != nil {
+		t.Fatalf("TicketEventsSince: %v", err)
+	}
+	created := events[0]
+	if created.Author != "trellis-today" || created.AuthorRole != store.TicketRoleChiefOfStaff {
+		t.Fatalf("created event = %+v, want concrete audit author carrying the chief role", created)
+	}
+}

--- a/internal/daemon/nudge_countdown.go
+++ b/internal/daemon/nudge_countdown.go
@@ -314,6 +314,9 @@ func (d *Daemon) runNudgeDelivery(sessionID string) string {
 	if d.ptyBackend == nil || d.store == nil {
 		return "noop"
 	}
+	if d.initialPromptPending(sessionID) {
+		return "priming"
+	}
 	session := d.store.Get(sessionID)
 	if session == nil || !isNudgeDeliveryAllowed(string(session.State)) {
 		return "blocked"
@@ -408,6 +411,9 @@ func isNudgeDeliveryAllowed(state string) bool {
 func (d *Daemon) handleTriggerNudge(msg *protocol.TriggerNudgeMessage) {
 	sessionID := strings.TrimSpace(msg.SessionID)
 	if sessionID == "" {
+		return
+	}
+	if d.initialPromptPending(sessionID) {
 		return
 	}
 	d.cancelNudgeCountdown(sessionID, "user triggered")

--- a/internal/daemon/ticket_attach.go
+++ b/internal/daemon/ticket_attach.go
@@ -77,9 +77,10 @@ func (d *Daemon) submitTicketAttach(msg *protocol.TicketAttachMessage, author st
 	if strings.TrimSpace(author) == "" {
 		return nil, errors.New("source_session_id is required")
 	}
+	sourceSessionID := author
 	ticketID := strings.TrimSpace(protocol.Deref(msg.TicketID))
 	if ticketID == "" && resolveBound {
-		ticket, err := d.store.ActiveTicketForSession(author)
+		ticket, err := d.store.ActiveTicketForSession(sourceSessionID)
 		if err != nil {
 			return nil, err
 		}
@@ -147,7 +148,8 @@ func (d *Daemon) submitTicketAttach(msg *protocol.TicketAttachMessage, author st
 	}
 	options := expectedTicketMutationOptions(msg.ExpectedEventSeq)
 	if resolveBound {
-		options = d.ticketMutationOptions(author)
+		options = d.ticketMutationOptions(sourceSessionID)
+		author = d.ticketActorIdentity(sourceSessionID)
 	}
 	d.deliveryMu.Lock()
 	record, outcome, err := d.store.SubmitTicketAttachWithOptions(
@@ -160,7 +162,7 @@ func (d *Daemon) submitTicketAttach(msg *protocol.TicketAttachMessage, author st
 		return nil, err
 	}
 	catchUp := ticketMutationCatchUp(ticketID, outcome.CatchUp)
-	d.afterTicketMutationCatchUpLocked(author, outcome.CatchUp)
+	d.afterTicketMutationCatchUpLocked(sourceSessionID, outcome.CatchUp)
 	if outcome.Blocked {
 		rollbackInstalledAttachFiles(staged)
 		d.deliveryMu.Unlock()

--- a/internal/daemon/ticket_comment.go
+++ b/internal/daemon/ticket_comment.go
@@ -37,8 +37,9 @@ func (d *Daemon) handleTicketComment(conn net.Conn, msg *protocol.TicketCommentM
 	// (touchTicketTx affects no rows), so an agent naming a bad ticket gets a clear
 	// error rather than a silently dropped comment.
 	d.deliveryMu.Lock()
+	author := d.ticketActorIdentity(sourceSessionID)
 	_, outcome, err := d.store.AddTicketCommentWithOptions(
-		ticketID, sourceSessionID, comment,
+		ticketID, author, comment,
 		d.ticketMutationOptions(sourceSessionID), time.Now(),
 	)
 	if err != nil {

--- a/internal/daemon/ticket_comment_test.go
+++ b/internal/daemon/ticket_comment_test.go
@@ -70,6 +70,38 @@ func TestHandleTicketCommentValidatesTicket(t *testing.T) {
 	}
 }
 
+func TestCrewMemberCommentIsAttributedToTheMemberWithoutSubscribingIt(t *testing.T) {
+	d := newCrewDaemon(t)
+	addSession(t, d, "trellis-today")
+	if _, err := d.claimCrewBinding("trellis", "trellis-today"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.store.CreateTicket(store.Ticket{ID: "peer-ticket", Title: "Peer"}, "you", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if resp := callTicketComment(t, d, "trellis-today", "peer-ticket", "one useful note"); !resp.Ok {
+		t.Fatalf("comment response = %+v", resp)
+	}
+	ticket, err := d.store.GetTicket("peer-ticket")
+	if err != nil || ticket == nil {
+		t.Fatalf("GetTicket = %+v, %v", ticket, err)
+	}
+	last := ticket.Activity[len(ticket.Activity)-1]
+	identity := store.TicketMemberIdentity("trellis")
+	if last.Author != identity {
+		t.Fatalf("comment author = %q, want %q", last.Author, identity)
+	}
+	participants, err := d.store.TicketParticipants("peer-ticket")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, participant := range participants {
+		if participant == identity {
+			t.Fatalf("comment-only member became a participant: %v", participants)
+		}
+	}
+}
+
 // The core of the feature: commenting informs a ticket's participants WITHOUT
 // enrolling the commenter. X comments on Z's ticket; Z (the assignee) is nudged,
 // X is not nudged about its own note — and crucially, a LATER event on that ticket

--- a/internal/daemon/ticket_create.go
+++ b/internal/daemon/ticket_create.go
@@ -19,11 +19,12 @@ import (
 // title and auto-suffixed on collision, exactly like delegation. There are no
 // participants to notify, so the only side effect is the board re-broadcast.
 func (d *Daemon) handleTicketCreate(conn net.Conn, msg *protocol.TicketCreateMessage) {
-	author := strings.TrimSpace(msg.SourceSessionID)
-	if author == "" {
+	sourceSessionID := strings.TrimSpace(msg.SourceSessionID)
+	if sourceSessionID == "" {
 		d.sendError(conn, "ticket new: source_session_id is required")
 		return
 	}
+	author := d.ticketActorIdentity(sourceSessionID)
 	title := strings.TrimSpace(msg.Title)
 	if title == "" {
 		d.sendError(conn, "ticket new: title is required")

--- a/internal/daemon/ticket_identity.go
+++ b/internal/daemon/ticket_identity.go
@@ -7,10 +7,11 @@ import (
 
 // Ticket notification identities, and the mapping between them and live sessions.
 //
-// A session always observes through its own session identity. The session
-// currently filling a durable product role ALSO observes through that role's
-// identity, whose per-(identity, ticket) cursors survive the role moving to a
-// different session — that is the whole point of a role identity.
+// An ordinary session observes through its own identity. A session filling a
+// durable profile role ALSO observes through that role. A crew day instead acts
+// through the member identity: its session id is disposable, while the member's
+// per-ticket cursors survive every turnover. The concrete session remains only
+// the delivery target and, where applicable, the ticket assignee.
 //
 // Three questions get asked of that mapping, in three different places, and they
 // must stay mutually consistent:
@@ -24,14 +25,18 @@ import (
 // disagreement whose symptom is an identity that is never delivered to, with no
 // error anywhere.
 
-// ticketRoleIdentitiesForSession returns the durable role identities the session
-// currently fills, in the order they take precedence. Empty for an ordinary
-// session.
-func (d *Daemon) ticketRoleIdentitiesForSession(sessionID string) []string {
-	if d.isChiefOfStaffSession(sessionID) {
-		return []string{store.TicketRoleIdentity(store.TicketRoleChiefOfStaff)}
+// ticketDurableIdentitiesForSession returns the durable identities the session
+// currently fills, in the order they take precedence. A member comes first: its
+// subscriptions, cursor and attention clock belong to the member across days.
+func (d *Daemon) ticketDurableIdentitiesForSession(sessionID string) []string {
+	var identities []string
+	if member := d.crewMemberBoundTo(sessionID); member != "" {
+		identities = append(identities, store.TicketMemberIdentity(member))
 	}
-	return nil
+	if d.isChiefOfStaffSession(sessionID) {
+		identities = append(identities, store.TicketRoleIdentity(store.TicketRoleChiefOfStaff))
+	}
+	return identities
 }
 
 // ticketSessionForIdentity is the inverse: the live session an identity's
@@ -42,19 +47,44 @@ func (d *Daemon) ticketSessionForIdentity(identity string) string {
 	if identity == store.TicketRoleIdentity(store.TicketRoleChiefOfStaff) {
 		return d.chiefOfStaffSessionID()
 	}
+	if memberID, ok := store.ParseTicketMemberIdentity(identity); ok {
+		member, _, err := d.crewMember(memberID)
+		if err != nil || !d.crewBindingLive(member) {
+			return ""
+		}
+		return member.BindingSession
+	}
 	return identity
 }
 
+// ticketActorIdentity is how a session-bound ticket action is attributed. A
+// member acts as the member, not as today's disposable session; ordinary and
+// chief sessions keep their existing concrete-session attribution.
+func (d *Daemon) ticketActorIdentity(sessionID string) string {
+	for _, identity := range d.ticketDurableIdentitiesForSession(sessionID) {
+		if _, ok := store.ParseTicketMemberIdentity(identity); ok {
+			return identity
+		}
+	}
+	return sessionID
+}
+
 // ticketObserversForSession builds the effective notification identities for a
-// session. AuthorID stays the session on every observer, so self-authored events
-// are excluded no matter which identity's cursor is being read; DeliveryID is the
-// session, because that is what can actually be nudged.
+// session. A member reads only through durable identities; other role fillers
+// retain their concrete-session observer too. AuthorID is the acting identity so
+// a member never receives its own event through another observer. DeliveryID is
+// always the concrete session, because that is what can actually be nudged.
 func (d *Daemon) ticketObserversForSession(sessionID string) []ticketnotify.Observer {
-	observers := []ticketnotify.Observer{{ID: sessionID, AuthorID: sessionID, DeliveryID: sessionID}}
-	for _, roleIdentity := range d.ticketRoleIdentitiesForSession(sessionID) {
+	authorID := d.ticketActorIdentity(sessionID)
+	durable := d.ticketDurableIdentitiesForSession(sessionID)
+	observers := make([]ticketnotify.Observer, 0, len(durable)+1)
+	if _, member := store.ParseTicketMemberIdentity(authorID); !member {
+		observers = append(observers, ticketnotify.Observer{ID: sessionID, AuthorID: authorID, DeliveryID: sessionID})
+	}
+	for _, roleIdentity := range durable {
 		observers = append(observers, ticketnotify.Observer{
 			ID:         roleIdentity,
-			AuthorID:   sessionID,
+			AuthorID:   authorID,
 			DeliveryID: sessionID,
 		})
 	}
@@ -65,9 +95,9 @@ func (d *Daemon) ticketObserversForSession(sessionID string) []ticketnotify.Obse
 // session's buffered delivery. A role-filling session uses the role's key, so the
 // budget follows the role across a transfer rather than resetting with each new
 // session. With more than one role the highest-precedence one wins, matching the
-// order ticketRoleIdentitiesForSession returns.
+// order ticketDurableIdentitiesForSession returns.
 func (d *Daemon) ticketAttentionKey(sessionID string) string {
-	if roles := d.ticketRoleIdentitiesForSession(sessionID); len(roles) > 0 {
+	if roles := d.ticketDurableIdentitiesForSession(sessionID); len(roles) > 0 {
 		return roles[0]
 	}
 	return sessionID

--- a/internal/daemon/ticket_identity_test.go
+++ b/internal/daemon/ticket_identity_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"testing"
+	"time"
 
 	"github.com/victorarias/attn/internal/store"
 )
@@ -94,5 +95,88 @@ func TestTicketIdentityUnfilledRoleHasNoSession(t *testing.T) {
 	d, _ := newChiefOfStaffTestDaemon(t)
 	if got := d.ticketSessionForIdentity(store.TicketRoleIdentity(store.TicketRoleChiefOfStaff)); got != "" {
 		t.Fatalf("unfilled role resolved to %q, want no session", got)
+	}
+}
+
+func TestTicketIdentityFollowsCrewMemberDayTurnover(t *testing.T) {
+	d := newCrewDaemon(t)
+	addSession(t, d, "day-a")
+	addSession(t, d, "day-b")
+	if _, err := d.claimCrewBinding("trellis", "day-a"); err != nil {
+		t.Fatal(err)
+	}
+
+	identity := store.TicketMemberIdentity("trellis")
+	observers := d.ticketObserversForSession("day-a")
+	if len(observers) != 1 || observers[0].ID != identity || observers[0].AuthorID != identity || observers[0].DeliveryID != "day-a" {
+		t.Fatalf("day-a observers = %+v, want the durable member delivered to day-a", observers)
+	}
+	if got := d.ticketSessionForIdentity(identity); got != "day-a" {
+		t.Fatalf("member inverse = %q, want day-a", got)
+	}
+	if got := d.ticketAttentionKey("day-a"); got != identity {
+		t.Fatalf("day-a attention = %q, want %q", got, identity)
+	}
+
+	if err := d.transferCrewBinding("trellis", "day-a", "day-b"); err != nil {
+		t.Fatal(err)
+	}
+	if got := d.ticketSessionForIdentity(identity); got != "day-b" {
+		t.Fatalf("member inverse after turnover = %q, want day-b", got)
+	}
+	if got := d.ticketAttentionKey("day-b"); got != identity {
+		t.Fatalf("day-b attention = %q, want %q", got, identity)
+	}
+}
+
+func TestStaleCrewBindingTransferDoesNotMigrateTicketIdentity(t *testing.T) {
+	d := newCrewDaemon(t)
+	addSession(t, d, "day-a")
+	addSession(t, d, "day-b")
+	if _, err := d.claimCrewBinding("trellis", "day-b"); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	if _, err := d.store.CreateTicket(store.Ticket{ID: "stale-transfer", Title: "Stale transfer"}, "you", now); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.store.AddTicketSubscription("day-a", "stale-transfer", now); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := d.transferCrewBinding("trellis", "day-a", "next-day"); err == nil {
+		t.Fatal("stale transfer succeeded")
+	}
+	if subscribed, err := d.store.IsTicketSubscribed(store.TicketMemberIdentity("trellis"), "stale-transfer"); err != nil || subscribed {
+		t.Fatalf("stale transfer migrated member subscription = %v, err %v", subscribed, err)
+	}
+	if subscribed, err := d.store.IsTicketSubscribed("day-a", "stale-transfer"); err != nil || !subscribed {
+		t.Fatalf("stale transfer removed source subscription = %v, err %v", subscribed, err)
+	}
+}
+
+func TestCrewStartupSweepMigratesAnExistingLiveBinding(t *testing.T) {
+	d := newCrewDaemon(t)
+	addSession(t, d, "day-a")
+	if _, err := d.claimCrewBinding("trellis", "day-a"); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	if _, err := d.store.CreateTicket(store.Ticket{ID: "upgrade-thread", Title: "Upgrade thread"}, "you", now); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.store.AddTicketSubscription("day-a", "upgrade-thread", now); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := d.migrateCrewTicketIdentities(); err != nil {
+		t.Fatal(err)
+	}
+	identity := store.TicketMemberIdentity("trellis")
+	if subscribed, err := d.store.IsTicketSubscribed(identity, "upgrade-thread"); err != nil || !subscribed {
+		t.Fatalf("startup member subscription = %v, err %v", subscribed, err)
+	}
+	if subscribed, err := d.store.IsTicketSubscribed("day-a", "upgrade-thread"); err != nil || subscribed {
+		t.Fatalf("startup source subscription survived = %v, err %v", subscribed, err)
 	}
 }

--- a/internal/daemon/ticket_notify.go
+++ b/internal/daemon/ticket_notify.go
@@ -1,9 +1,12 @@
 package daemon
 
 import (
+	"fmt"
 	"strconv"
 	"time"
 
+	"github.com/victorarias/attn/internal/crew"
+	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/store"
 )
 
@@ -110,7 +113,16 @@ func (d *Daemon) notifyTicketObservers(ticketID string) {
 	}
 	now := time.Now()
 	targets := make(map[string]bool, len(participants))
+	var sleepingMembers []string
 	for _, identity := range participants {
+		if _, member := store.ParseTicketMemberIdentity(identity); member {
+			if id := d.ticketSessionForIdentity(identity); id != "" {
+				targets[id] = true
+			} else {
+				sleepingMembers = append(sleepingMembers, identity)
+			}
+			continue
+		}
 		if id := d.ticketSessionForIdentity(identity); id != "" {
 			targets[id] = true
 		}
@@ -118,6 +130,113 @@ func (d *Daemon) notifyTicketObservers(ticketID string) {
 	for id := range targets {
 		d.notifyTicketSession(id, now)
 	}
+	for _, identity := range sleepingMembers {
+		d.notifySleepingTicketMember(identity, ticketID)
+	}
+}
+
+// notifySleepingTicketMember wakes a member only when this ticket still has
+// unread activity for the durable member identity. The unread event is the
+// durable delivery: neither a failed wake nor its warning advances the cursor.
+func (d *Daemon) notifySleepingTicketMember(identity, ticketID string) {
+	memberID, ok := store.ParseTicketMemberIdentity(identity)
+	if !ok {
+		return
+	}
+	events, err := d.store.UnreadTicketEventsFor(identity, identity)
+	if err != nil {
+		d.logf("ticket notify: unread for %s: %v", identity, err)
+		return
+	}
+	unread := false
+	for _, event := range events {
+		if event.TicketID == ticketID {
+			unread = true
+			break
+		}
+	}
+	if !unread {
+		return
+	}
+
+	result, err := d.crewWakeWithDelivery(memberID, "", true, &crewWakeDelivery{
+		AfterInitialPrompt: func(sessionID string) {
+			d.notifyTicketSession(sessionID, time.Now())
+		},
+	})
+	if err != nil {
+		d.notifyTicketMemberWakeRefused(memberID, ticketID, err)
+		return
+	}
+	if result.AlreadyAwake {
+		d.notifyTicketSession(result.SessionID, time.Now())
+		return
+	}
+	// The indicator can show immediately, but the actual nudge waits on the
+	// prompt-submit receipt registered above, behind charter and handoff priming.
+	d.refreshTicketUnread(result.SessionID)
+}
+
+// seedCrewTicketWakeDeliveries reconstructs the priming gate after a daemon
+// restart. Its premise is durable: a live member binding plus unread member
+// activity. Rebuilding from those facts prevents a restart between spawn and
+// prompt submission from either splicing the nudge ahead of priming or losing
+// it altogether.
+func (d *Daemon) seedCrewTicketWakeDeliveries() error {
+	members, _, err := d.readCrewMembers()
+	if err != nil {
+		return err
+	}
+	for _, member := range members {
+		if !d.crewBindingLive(member) {
+			continue
+		}
+		identity := store.TicketMemberIdentity(member.ID)
+		events, err := d.store.UnreadTicketEventsFor(identity, identity)
+		if err != nil {
+			return err
+		}
+		if len(events) == 0 {
+			continue
+		}
+		sessionID := member.BindingSession
+		session := d.store.Get(sessionID)
+		if session == nil {
+			continue
+		}
+		state := string(session.State)
+		if state == protocol.StateLaunching || state == protocol.StateWorking {
+			d.notePostInitialPrompt(sessionID, func() { d.notifyTicketSession(sessionID, time.Now()) })
+			d.refreshTicketUnread(sessionID)
+			continue
+		}
+		// A settled session has already crossed its first prompt. Restore its
+		// ordinary unread delivery immediately instead of waiting for a hook it
+		// may never emit while idle.
+		d.notifyTicketSession(sessionID, time.Now())
+	}
+	return nil
+}
+
+const notificationKindCrewTicketWakeRefused = "crew_ticket_wake_refused"
+
+func (d *Daemon) notifyTicketMemberWakeRefused(memberID, ticketID string, wakeErr error) {
+	name := crew.DisplayName(memberID)
+	d.logf("ticket notify: could not wake %s for %s: %v; activity remains unread", name, ticketID, wakeErr)
+	record, err := d.store.AddNotification(store.NotificationRecord{
+		Kind:       notificationKindCrewTicketWakeRefused,
+		Severity:   store.NotificationWarning,
+		Title:      fmt.Sprintf("Could not wake %s for ticket activity", name),
+		Body:       fmt.Sprintf("Ticket %s is still unread. Wake %s from the sidebar or run `attn crew wake %s`.", ticketID, name, memberID),
+		Detail:     wakeErr.Error(),
+		SourceKind: "ticket",
+		SourceID:   ticketID,
+	}, time.Now())
+	if err != nil {
+		d.logf("notifications: add crew ticket wake refusal for %s: %v", memberID, err)
+		return
+	}
+	d.publishFact(FactNotificationCreated, record.ID, nil)
 }
 
 // notifyTicketSession runs Notify for one session's observer when it is a live
@@ -165,7 +284,7 @@ func (d *Daemon) notifyUnreadTicketSessionLocked(sessionID string, now time.Time
 		return
 	}
 	session := d.store.Get(sessionID)
-	if session == nil || !isNudgeDeliveryAllowed(string(session.State)) {
+	if session == nil || d.initialPromptPending(sessionID) || !isNudgeDeliveryAllowed(string(session.State)) {
 		return
 	}
 	var deadline time.Time

--- a/internal/daemon/ticket_notify_test.go
+++ b/internal/daemon/ticket_notify_test.go
@@ -2,6 +2,8 @@ package daemon
 
 import (
 	"fmt"
+	"net"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -10,6 +12,8 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/ptybackend"
+	"github.com/victorarias/attn/internal/store"
 )
 
 // delegateForNotify runs a real delegation with the given agent and returns the
@@ -431,6 +435,171 @@ func TestTicketWatchDrainClearsSharedCountdown(t *testing.T) {
 	}
 	if wasNudged(inputs(agentID)) {
 		t.Fatal("watch-drained queue was still doorbelled")
+	}
+}
+
+func TestTicketActivityWakesSleepingMemberAndNudgesAfterPriming(t *testing.T) {
+	d, backend, _ := newWakeableDaemon(t)
+	d.nudgeWindowOverride = time.Hour
+	t.Cleanup(d.stopNudgeCountdowns)
+	doorbell := &recordingDoorbell{}
+	backend.onInput = doorbell.backend().onInput
+	var initialPrompt string
+	backend.onSpawn = func(opts ptybackend.SpawnOptions) {
+		body, err := os.ReadFile(opts.InitialPromptFile)
+		if err != nil {
+			t.Fatalf("read initial prompt: %v", err)
+		}
+		initialPrompt = string(body)
+	}
+
+	identity := store.TicketMemberIdentity("trellis")
+	now := time.Now()
+	if _, err := d.store.CreateTicket(store.Ticket{ID: "sleeping-thread", Title: "Sleeping thread"}, "you", now); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.store.AddTicketSubscription(identity, "sleeping-thread", now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.store.AddTicketComment("sleeping-thread", "you", "new activity", now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	d.notifyTicketObservers("sleeping-thread")
+
+	member := memberByID(t, crewList(t, d), "trellis")
+	sessionID := protocol.Deref(member.BindingSession)
+	if sessionID == "" {
+		t.Fatal("ticket activity did not wake Trellis")
+	}
+	if initialPrompt != crewWakePrompt {
+		t.Fatalf("wake initial prompt = %q, want the ordinary post-priming greeting", initialPrompt)
+	}
+	if prompts := doorbell.pasted(); len(prompts) != 0 {
+		t.Fatalf("ticket nudge landed before priming completed: %q", prompts)
+	}
+	d.handleTriggerNudge(&protocol.TriggerNudgeMessage{SessionID: sessionID})
+	if prompts := doorbell.pasted(); len(prompts) != 0 {
+		t.Fatalf("manual nudge spliced into priming: %q", prompts)
+	}
+	decorated := d.sessionForBroadcast(d.store.Get(sessionID))
+	if decorated == nil || !protocol.Deref(decorated.TicketUnread) {
+		t.Fatalf("woken member session = %+v, want unread indicator", decorated)
+	}
+
+	hook := callHandler(t, func(conn net.Conn) {
+		d.handleState(conn, &protocol.StateMessage{ID: sessionID, State: protocol.StateWorking})
+	})
+	if !hook.Ok {
+		t.Fatalf("prompt-submit hook = %+v", hook)
+	}
+	if currentNudgeTimer(d, sessionID) == nil {
+		t.Fatal("prompt-submit receipt did not arm the ticket nudge")
+	}
+	fireNudgeNow(t, d, sessionID)
+	if !wasNudged(doorbell.pasted()) {
+		t.Fatalf("woken member was not nudged after priming: %q", doorbell.pasted())
+	}
+}
+
+func TestTicketWakeLimitRefusalIsVisibleAndLeavesMemberUnread(t *testing.T) {
+	d, backend, logs := newWakeableDaemon(t)
+	d.store.SetSetting(SettingCrewWakeLimit, "0")
+	identity := store.TicketMemberIdentity("alder")
+	now := time.Now()
+	if _, err := d.store.CreateTicket(store.Ticket{ID: "refused-thread", Title: "Refused thread"}, "you", now); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.store.AddTicketSubscription(identity, "refused-thread", now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.store.AddTicketComment("refused-thread", "you", "wake up", now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	d.notifyTicketObservers("refused-thread")
+
+	backend.mu.Lock()
+	spawned := len(backend.spawnOpts)
+	backend.mu.Unlock()
+	if spawned != 0 {
+		t.Fatalf("wake-limit refusal spawned %d sessions", spawned)
+	}
+	events, err := d.store.UnreadTicketEventsFor(identity, identity)
+	if err != nil || len(events) == 0 {
+		t.Fatalf("member unread after refusal = %+v, %v", events, err)
+	}
+	notifications, err := d.store.ListNotifications()
+	if err != nil || len(notifications) != 1 {
+		t.Fatalf("refusal notifications = %+v, %v", notifications, err)
+	}
+	note := notifications[0]
+	if note.Kind != notificationKindCrewTicketWakeRefused || note.SourceID != "refused-thread" ||
+		!strings.Contains(note.Detail, "crew.wake_limit=0") || !strings.Contains(note.Body, "still unread") {
+		t.Fatalf("refusal notification = %+v", note)
+	}
+	if log := logs(); !strings.Contains(log, "activity remains unread") {
+		t.Fatalf("refusal was not logged loudly:\n%s", log)
+	}
+}
+
+func TestCrewTicketWakeGateRebuildsFromDurableUnreadState(t *testing.T) {
+	d := newCrewDaemon(t)
+	addSession(t, d, "woken-day")
+	d.store.UpdateState("woken-day", protocol.StateWorking)
+	if _, err := d.claimCrewBinding("trellis", "woken-day"); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	identity := store.TicketMemberIdentity("trellis")
+	if _, err := d.store.CreateTicket(store.Ticket{ID: "restart-thread", Title: "Restart thread"}, "you", now); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.store.AddTicketSubscription(identity, "restart-thread", now); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := d.seedCrewTicketWakeDeliveries(); err != nil {
+		t.Fatal(err)
+	}
+	if !d.initialPromptPending("woken-day") {
+		t.Fatal("restart did not restore the initial-prompt gate")
+	}
+	if timer := currentNudgeTimer(d, "woken-day"); timer != nil {
+		t.Fatal("restart armed a nudge before the prompt receipt")
+	}
+	d.runPostInitialPrompt("woken-day", protocol.StateWorking)
+	if d.initialPromptPending("woken-day") {
+		t.Fatal("prompt receipt did not clear the restored gate")
+	}
+	if timer := currentNudgeTimer(d, "woken-day"); timer == nil {
+		t.Fatal("prompt receipt did not arm the waiting ticket nudge")
+	}
+}
+
+func TestCrewTicketRestartNudgesAnAlreadySettledDay(t *testing.T) {
+	d := newCrewDaemon(t)
+	addSession(t, d, "settled-day")
+	d.store.UpdateState("settled-day", protocol.StateIdle)
+	if _, err := d.claimCrewBinding("trellis", "settled-day"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(d.stopNudgeCountdowns)
+	now := time.Now()
+	identity := store.TicketMemberIdentity("trellis")
+	if _, err := d.store.CreateTicket(store.Ticket{ID: "settled-thread", Title: "Settled thread"}, "you", now); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.store.AddTicketSubscription(identity, "settled-thread", now); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := d.seedCrewTicketWakeDeliveries(); err != nil {
+		t.Fatal(err)
+	}
+	if d.initialPromptPending("settled-day") {
+		t.Fatal("settled day was incorrectly put back behind its first-prompt gate")
+	}
+	if timer := currentNudgeTimer(d, "settled-day"); timer == nil {
+		t.Fatal("restart did not restore ordinary unread delivery for a settled day")
 	}
 }
 

--- a/internal/daemon/ticket_read_test.go
+++ b/internal/daemon/ticket_read_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/store"
@@ -110,6 +111,49 @@ func TestTicketInboxConsumesByIdentity(t *testing.T) {
 	}
 	if ev.Comment == nil || *ev.Comment != "take a look" {
 		t.Fatalf("chief inbox status event comment = %v, want the supplied note", ev.Comment)
+	}
+}
+
+func TestCrewMemberCursorSurvivesDayTurnoverAndWatchUsesIt(t *testing.T) {
+	d := newCrewDaemon(t)
+	addSession(t, d, "day-a")
+	addSession(t, d, "day-b")
+	if _, err := d.claimCrewBinding("trellis", "day-a"); err != nil {
+		t.Fatal(err)
+	}
+	identity := store.TicketMemberIdentity("trellis")
+	now := time.Now()
+	if _, err := d.store.CreateTicket(store.Ticket{ID: "member-thread", Title: "Member thread"}, "you", now); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.store.AddTicketSubscription(identity, "member-thread", now); err != nil {
+		t.Fatal(err)
+	}
+	if bundles := callTicketInbox(t, d, "day-a"); len(bundles) != 1 {
+		t.Fatalf("day-a first inbox = %+v, want the subscribed history", bundles)
+	}
+	before, err := d.store.GetTicketCursor(identity, "member-thread")
+	if err != nil || before == 0 {
+		t.Fatalf("member cursor before turnover = %d, %v", before, err)
+	}
+
+	if err := d.transferCrewBinding("trellis", "day-a", "day-b"); err != nil {
+		t.Fatal(err)
+	}
+	if replay := callTicketInbox(t, d, "day-b"); len(replay) != 0 {
+		t.Fatalf("successor replayed predecessor history: %+v", replay)
+	}
+	if _, err := d.store.SetTicketStatus("member-thread", store.TicketStatusDone, "you", "finished", now.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	watch := protocol.TicketInboxModeWatch
+	bundles := callTicketInboxMode(t, d, "day-b", &watch)
+	if len(bundles) != 1 || bundles[0].TicketID != "member-thread" || len(bundles[0].Events) != 1 {
+		t.Fatalf("successor watch = %+v, want exactly the post-turnover event", bundles)
+	}
+	after, err := d.store.GetTicketCursor(identity, "member-thread")
+	if err != nil || after <= before {
+		t.Fatalf("member cursor after successor watch = %d, before %d, err %v", after, before, err)
 	}
 }
 

--- a/internal/daemon/ticket_status.go
+++ b/internal/daemon/ticket_status.go
@@ -72,8 +72,9 @@ func (d *Daemon) handleSetTicketStatus(conn net.Conn, msg *protocol.SetTicketSta
 		comment = strings.TrimSpace(*msg.Comment)
 	}
 	d.deliveryMu.Lock()
+	author := d.ticketActorIdentity(sourceSessionID)
 	updated, outcome, err := d.store.SetTicketStatusWithOptions(
-		ticketID, status, sourceSessionID, comment,
+		ticketID, status, author, comment,
 		d.ticketMutationOptions(sourceSessionID), time.Now(),
 	)
 	if err != nil {

--- a/internal/daemon/ticket_subscribe.go
+++ b/internal/daemon/ticket_subscribe.go
@@ -31,7 +31,8 @@ func (d *Daemon) handleTicketSubscribe(conn net.Conn, msg *protocol.TicketSubscr
 	// AddTicketSubscription fails with ErrTicketNotFound for an unknown id, so an
 	// agent subscribing to a phantom ticket gets a clear error rather than a silent
 	// no-op. Re-subscribing is idempotent.
-	if err := d.store.AddTicketSubscription(sourceSessionID, ticketID, time.Now()); err != nil {
+	identity := d.ticketActorIdentity(sourceSessionID)
+	if err := d.store.AddTicketSubscription(identity, ticketID, time.Now()); err != nil {
 		d.sendError(conn, "ticket subscribe: "+err.Error())
 		return
 	}
@@ -59,7 +60,7 @@ func (d *Daemon) handleTicketUnsubscribe(conn net.Conn, msg *protocol.TicketUnsu
 		d.sendError(conn, "ticket unsubscribe: ticket_id is required")
 		return
 	}
-	if err := d.store.RemoveTicketSubscription(sourceSessionID, ticketID); err != nil {
+	if err := d.store.RemoveTicketSubscription(d.ticketActorIdentity(sourceSessionID), ticketID); err != nil {
 		d.sendError(conn, "ticket unsubscribe: "+err.Error())
 		return
 	}

--- a/internal/daemon/ticket_subscribe_test.go
+++ b/internal/daemon/ticket_subscribe_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
 )
 
 func callTicketSubscribe(t *testing.T, d *Daemon, sessionID, ticketID string) protocol.Response {
@@ -22,6 +23,33 @@ func callTicketSubscribe(t *testing.T, d *Daemon, sessionID, ticketID string) pr
 		t.Fatalf("decode ticket-subscribe response: %v", err)
 	}
 	return resp
+}
+
+func TestCrewMemberSubscribesAndUnsubscribesAsTheMember(t *testing.T) {
+	d := newCrewDaemon(t)
+	addSession(t, d, "trellis-today")
+	if _, err := d.claimCrewBinding("trellis", "trellis-today"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.store.CreateTicket(store.Ticket{ID: "watched", Title: "Watched"}, "you", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if resp := callTicketSubscribe(t, d, "trellis-today", "watched"); !resp.Ok {
+		t.Fatalf("subscribe response = %+v", resp)
+	}
+	identity := store.TicketMemberIdentity("trellis")
+	if subscribed, err := d.store.IsTicketSubscribed(identity, "watched"); err != nil || !subscribed {
+		t.Fatalf("member subscription = %v, %v", subscribed, err)
+	}
+	if subscribed, err := d.store.IsTicketSubscribed("trellis-today", "watched"); err != nil || subscribed {
+		t.Fatalf("day subscription = %v, %v; want none", subscribed, err)
+	}
+	if resp := callTicketUnsubscribe(t, d, "trellis-today", "watched"); !resp.Ok {
+		t.Fatalf("unsubscribe response = %+v", resp)
+	}
+	if subscribed, err := d.store.IsTicketSubscribed(identity, "watched"); err != nil || subscribed {
+		t.Fatalf("member subscription after unsubscribe = %v, %v", subscribed, err)
+	}
 }
 
 func callTicketUnsubscribe(t *testing.T, d *Daemon, sessionID, ticketID string) protocol.Response {

--- a/internal/daemon/ticket_take.go
+++ b/internal/daemon/ticket_take.go
@@ -66,7 +66,7 @@ func (d *Daemon) handleTicketTake(conn net.Conn, msg *protocol.TicketTakeMessage
 		d.sendError(conn, "ticket take: ticket "+ticketID+" is already assigned to "+previous+"; pass --confirm to take it over")
 		return
 	}
-	if err := d.store.AssignTicket(ticketID, sourceSessionID, sourceSessionID, time.Now()); err != nil {
+	if err := d.store.AssignTicket(ticketID, sourceSessionID, d.ticketActorIdentity(sourceSessionID), time.Now()); err != nil {
 		d.sendError(conn, "ticket take: "+err.Error())
 		return
 	}

--- a/internal/daemon/ticket_take_test.go
+++ b/internal/daemon/ticket_take_test.go
@@ -119,3 +119,33 @@ func TestTicketTakeUnassignedSelfAndUnknown(t *testing.T) {
 		t.Fatalf("take of unknown ticket returned ok: %+v", resp)
 	}
 }
+
+func TestCrewMemberTakeKeepsConcreteAssigneeAndDurableParticipant(t *testing.T) {
+	d := newCrewDaemon(t)
+	addSession(t, d, "trellis-today")
+	if _, err := d.claimCrewBinding("trellis", "trellis-today"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.store.CreateTicket(store.Ticket{ID: "backlog-member", Title: "Member work"}, "you", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if resp := callTicketTake(t, d, "trellis-today", "backlog-member", false); !resp.Ok {
+		t.Fatalf("take response = %+v", resp)
+	}
+	ticket, err := d.store.GetTicket("backlog-member")
+	if err != nil || ticket == nil || ticket.Assignee != "trellis-today" {
+		t.Fatalf("ticket after take = %+v, %v", ticket, err)
+	}
+	participants, err := d.store.TicketParticipants("backlog-member")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := store.TicketMemberIdentity("trellis")
+	found := false
+	for _, identity := range participants {
+		found = found || identity == want
+	}
+	if !found {
+		t.Fatalf("participants = %v, want durable %q beside the concrete assignee", participants, want)
+	}
+}

--- a/internal/store/ticket_identity.go
+++ b/internal/store/ticket_identity.go
@@ -1,0 +1,103 @@
+package store
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+const ticketMemberIdentityPrefix = "member:"
+
+// TicketMemberIdentity returns the durable ticket identity for a crew member.
+func TicketMemberIdentity(memberID string) string {
+	memberID = strings.TrimSpace(memberID)
+	if memberID == "" {
+		return ""
+	}
+	return ticketMemberIdentityPrefix + memberID
+}
+
+// ParseTicketMemberIdentity extracts a crew member id from its ticket identity.
+func ParseTicketMemberIdentity(identity string) (string, bool) {
+	identity = strings.TrimSpace(identity)
+	memberID, ok := strings.CutPrefix(identity, ticketMemberIdentityPrefix)
+	if !ok || memberID == "" || memberID != strings.TrimSpace(memberID) {
+		return "", false
+	}
+	return memberID, true
+}
+
+// MigrateTicketIdentity carries a disposable ticket identity into a durable one.
+// Every ticket the source currently participates in becomes an explicit target
+// subscription, while cursor and interruption-clock progress move forward by
+// their respective maxima. Historical authorship is re-attributed to the durable
+// identity too: otherwise changing the observer's self-author identity would
+// replay its predecessor's own events as unread. Source subscriptions, cursors,
+// and attention are then removed in the same transaction.
+func (s *Store) MigrateTicketIdentity(from, to string, now time.Time) error {
+	from = strings.TrimSpace(from)
+	to = strings.TrimSpace(to)
+	if from == "" || to == "" {
+		return fmt.Errorf("ticket identity migration requires non-empty source and target identities")
+	}
+	if from == to {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return nil
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin ticket identity migration: %w", err)
+	}
+	defer tx.Rollback()
+
+	stamp := formatTicketTime(now)
+	if _, err := tx.Exec(`
+		INSERT INTO ticket_subscriptions (identity, ticket_id, created_at)
+		SELECT ?, ticket_id, ? FROM ticket_participants WHERE identity = ?
+		ON CONFLICT(identity, ticket_id) DO NOTHING
+	`, to, stamp, from); err != nil {
+		return fmt.Errorf("carry ticket participation: %w", err)
+	}
+	if _, err := tx.Exec(`UPDATE ticket_events SET author = ? WHERE author = ?`, to, from); err != nil {
+		return fmt.Errorf("carry ticket event authorship: %w", err)
+	}
+	if _, err := tx.Exec(`UPDATE ticket_activity SET author = ? WHERE author = ?`, to, from); err != nil {
+		return fmt.Errorf("carry ticket activity authorship: %w", err)
+	}
+	if _, err := tx.Exec(`
+		INSERT INTO ticket_event_cursors (identity, ticket_id, cursor, updated_at)
+		SELECT ?, ticket_id, cursor, ? FROM ticket_event_cursors WHERE identity = ?
+		ON CONFLICT(identity, ticket_id) DO UPDATE SET
+			cursor = MAX(ticket_event_cursors.cursor, excluded.cursor),
+			updated_at = MAX(ticket_event_cursors.updated_at, excluded.updated_at)
+	`, to, stamp, from); err != nil {
+		return fmt.Errorf("carry ticket cursors: %w", err)
+	}
+	if _, err := tx.Exec(`
+		INSERT INTO ticket_delivery_attention (observer_key, last_attention_at)
+		SELECT ?, last_attention_at FROM ticket_delivery_attention WHERE observer_key = ?
+		ON CONFLICT(observer_key) DO UPDATE SET
+			last_attention_at = MAX(ticket_delivery_attention.last_attention_at, excluded.last_attention_at)
+	`, to, from); err != nil {
+		return fmt.Errorf("carry ticket delivery attention: %w", err)
+	}
+	if _, err := tx.Exec(`DELETE FROM ticket_subscriptions WHERE identity = ?`, from); err != nil {
+		return fmt.Errorf("remove source ticket subscriptions: %w", err)
+	}
+	if _, err := tx.Exec(`DELETE FROM ticket_event_cursors WHERE identity = ?`, from); err != nil {
+		return fmt.Errorf("remove source ticket cursors: %w", err)
+	}
+	if _, err := tx.Exec(`DELETE FROM ticket_delivery_attention WHERE observer_key = ?`, from); err != nil {
+		return fmt.Errorf("remove source ticket delivery attention: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit ticket identity migration: %w", err)
+	}
+	return nil
+}

--- a/internal/store/ticket_identity_test.go
+++ b/internal/store/ticket_identity_test.go
@@ -1,0 +1,174 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTicketMemberIdentityRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		input    string
+		identity string
+		member   string
+		ok       bool
+	}{
+		{input: "trellis", identity: "member:trellis", member: "trellis", ok: true},
+		{input: "  keel  ", identity: "member:keel", member: "keel", ok: true},
+		{input: "", identity: "", member: "", ok: false},
+	} {
+		identity := TicketMemberIdentity(tc.input)
+		if identity != tc.identity {
+			t.Errorf("TicketMemberIdentity(%q) = %q, want %q", tc.input, identity, tc.identity)
+		}
+		member, ok := ParseTicketMemberIdentity(identity)
+		if member != tc.member || ok != tc.ok {
+			t.Errorf("ParseTicketMemberIdentity(%q) = (%q, %v), want (%q, %v)", identity, member, ok, tc.member, tc.ok)
+		}
+	}
+
+	for _, identity := range []string{"trellis", "role:trellis", "member:", "member: trellis"} {
+		if member, ok := ParseTicketMemberIdentity(identity); ok || member != "" {
+			t.Errorf("ParseTicketMemberIdentity(%q) = (%q, %v), want no member", identity, member, ok)
+		}
+	}
+}
+
+func TestMigrateTicketIdentityCarriesParticipationAndMaxProgress(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	const from = "session-old"
+	to := TicketMemberIdentity("trellis")
+	base := time.Date(2026, 8, 15, 8, 0, 0, 0, time.UTC)
+
+	if _, err := s.CreateTicket(Ticket{ID: "subscribed", Title: "Subscribed"}, "other", base); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddTicketSubscription(from, "subscribed", base.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.CreateTicket(Ticket{ID: "authored", Title: "Authored"}, from, base.Add(2*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.CreateTicket(Ticket{ID: "assigned", Title: "Assigned", Assignee: from}, "other", base.Add(3*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.CreateTicket(Ticket{ID: "unrelated", Title: "Unrelated"}, "other", base.Add(4*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Source wins one conflict; target wins the other.
+	if err := s.SetTicketCursor(from, "subscribed", 9, base.Add(5*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetTicketCursor(to, "subscribed", 4, base.Add(6*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetTicketCursor(from, "authored", 3, base.Add(7*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetTicketCursor(to, "authored", 11, base.Add(8*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetTicketDeliveryAttention(from, base.Add(9*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetTicketDeliveryAttention(to, base.Add(10*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	migratedAt := base.Add(11 * time.Minute)
+	if err := s.MigrateTicketIdentity(from, to, migratedAt); err != nil {
+		t.Fatalf("MigrateTicketIdentity: %v", err)
+	}
+	// The operation is deliberately safe to repeat after the source was removed.
+	if err := s.MigrateTicketIdentity(from, to, migratedAt.Add(time.Minute)); err != nil {
+		t.Fatalf("idempotent MigrateTicketIdentity: %v", err)
+	}
+
+	for _, ticketID := range []string{"subscribed", "authored", "assigned"} {
+		if subscribed, err := s.IsTicketSubscribed(to, ticketID); err != nil || !subscribed {
+			t.Errorf("target subscription on %s = %v (err %v), want true", ticketID, subscribed, err)
+		}
+	}
+	if subscribed, err := s.IsTicketSubscribed(to, "unrelated"); err != nil || subscribed {
+		t.Errorf("target subscription on unrelated = %v (err %v), want false", subscribed, err)
+	}
+	if subscribed, err := s.IsTicketSubscribed(from, "subscribed"); err != nil || subscribed {
+		t.Errorf("source subscription survived = %v (err %v)", subscribed, err)
+	}
+
+	for ticketID, want := range map[string]int64{"subscribed": 9, "authored": 11} {
+		if got, err := s.GetTicketCursor(to, ticketID); err != nil || got != want {
+			t.Errorf("target cursor on %s = %d (err %v), want %d", ticketID, got, err, want)
+		}
+		if got, err := s.GetTicketCursor(from, ticketID); err != nil || got != 0 {
+			t.Errorf("source cursor on %s = %d (err %v), want removed", ticketID, got, err)
+		}
+	}
+
+	attention, found, err := s.TicketDeliveryAttention(to)
+	if err != nil || !found || !attention.LastAttentionAt.Equal(base.Add(10*time.Minute)) {
+		t.Errorf("target attention = %+v, found %v, err %v; want later target value", attention, found, err)
+	}
+	if _, found, err := s.TicketDeliveryAttention(from); err != nil || found {
+		t.Errorf("source attention found = %v (err %v), want removed", found, err)
+	}
+}
+
+func TestMigrateTicketIdentityDoesNotReplayPredecessorAuthorship(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	const from = "session-old"
+	to := TicketMemberIdentity("trellis")
+	base := time.Date(2026, 8, 15, 8, 0, 0, 0, time.UTC)
+	if _, err := s.CreateTicket(Ticket{ID: "thread", Title: "Thread"}, from, base); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.AddTicketComment("thread", from, "my own note", base.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.SetTicketStatus("thread", TicketStatusWorking, "other", "", base.Add(2*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.MigrateTicketIdentity(from, to, base.Add(3*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	unread, err := s.UnreadTicketEventsFor(to, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unread) != 1 || unread[0].Kind != TicketEventStatusChanged {
+		t.Fatalf("unread = %+v, want only the other author's status event", unread)
+	}
+	ticket, err := s.GetTicket("thread")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ticket.Activity) != 2 || ticket.Activity[0].Author != to || ticket.Activity[1].Author != "other" {
+		t.Fatalf("migrated activity = %+v, want durable member author then other", ticket.Activity)
+	}
+}
+
+func TestMigrateTicketIdentityUsesLaterSourceAttention(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	base := time.Date(2026, 8, 15, 8, 0, 0, 0, time.UTC)
+	if err := s.SetTicketDeliveryAttention("session-old", base.Add(2*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetTicketDeliveryAttention("member:trellis", base.Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MigrateTicketIdentity("session-old", "member:trellis", base.Add(3*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	attention, found, err := s.TicketDeliveryAttention("member:trellis")
+	if err != nil || !found || !attention.LastAttentionAt.Equal(base.Add(2*time.Hour)) {
+		t.Fatalf("target attention = %+v, found %v, err %v; want later source value", attention, found, err)
+	}
+}


### PR DESCRIPTION
## TL;DR

Ticket participation now belongs to a crew member rather than to one disposable day session. Subscriptions, authorship, cursors, and delivery follow `member:<id>` across sleep and turnover; unread activity wakes a sleeping member through the existing autonomous wake limit, after the normal charter/handoff priming completes.

## Why

Ticket participants were keyed by session id. When a member ended its day, the successor inherited the charter and handoff but not the predecessor's ticket subscriptions or cursor. The notifier then resolved the dead session to no live target and silently skipped it.

## What changed

- `member:<id>` is a durable ticket identity resolved through the current crew binding. Member-bound ticket commands act as that identity; `ticket take` still assigns the concrete session while attaching the member through event authorship.
- Existing session participation is migrated transactionally when a binding is claimed, transferred, released, or loaded at startup. Subscriptions are carried forward, cursor and attention clocks merge by maximum, and historical ticket authorship is re-attributed to the member so predecessor-authored events do not replay as unread.
- The notifier resolves an awake member to its live day. A sleeping member is woken through `crewWakeWithDelivery`, so wake serialization and `crew.wake_limit` remain the single policy rail.
- A wake-limit refusal creates a warning naming the configured limit and manual wake action. It never advances the ticket cursor.

The ordering invariant is:

```mermaid
sequenceDiagram
    participant Ticket as Ticket event
    participant Wake as Crew wake rail
    participant Member as New member day
    Ticket->>Wake: unread activity for member:trellis
    Wake->>Wake: charge wake ledger and claim one day
    Wake->>Member: charter + predecessor letter priming
    Wake->>Member: ordinary wake greeting
    Member-->>Wake: prompt-submit receipt
    Wake->>Member: arm existing ticket nudge countdown
```

The ticket nudge is never concatenated with or pasted into the wake prompt. A restart reconstructs the gate from the live member binding, session state, and durable unread activity; session teardown clears the in-memory continuation.

## Review path

1. `internal/daemon/ticket_identity.go` — member/session mapping, actor identity, cursor and attention ownership.
2. `internal/store/ticket_identity.go` — atomic upgrade and day-transition migration.
3. `internal/daemon/ticket_notify.go` and `crew_wake.go` — sleeping-member wake, refusal visibility, and post-priming delivery.
4. Ticket command handlers and `delegate_ticket.go` — consistent member attribution across subscribe/unsubscribe/inbox/watch/take and mutation/delegation entry points.

## Manual verification

On an isolated `member-inbox` profile, Trellis subscribed to a ticket, filed a handoff, and slept. A comment posted during sleep woke a fresh day; that successor read its charter and predecessor letter first, then consumed the comment from its inbox and replied on the ticket.

The scenario was repeated with `crew.wake_limit=0`. The daemon kept Trellis asleep and logged the named limit refusal plus “activity remains unread.” After a manual wake, the successor inbox returned exactly the refused comment. The isolated profile and its workers were then cleaned.

## Scope

- Every unread ticket event may wake a sleeping member; the existing wake limit is the governor.
- No protocol or frontend shape changed.
- Non-member ticket behavior and garden/seed identity are unchanged.
- Startup can migrate the current binding and recorded immediate predecessor. Older session-only rows have no remaining member provenance, so they remain ordinary historical session participation rather than being guessed or deleted.
