### PR TITLE
feat(apps): dispatch declared reconcile handlers

### DIFF
--- a/apphost/package.json
+++ b/apphost/package.json
@@ -5,6 +5,7 @@
   "description": "attn's shared app runtime: the supervised Bun sidecar every installed app's handlers execute in.",
   "type": "module",
   "scripts": {
+    "test": "bun test",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/apphost/src/dispatch.test.ts
+++ b/apphost/src/dispatch.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { runDispatch, runReconcile } from "./dispatch.ts"
+import type { RpcConnection } from "./rpc.ts"
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+async function bundle(source: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "attn-apphost-reconcile-"))
+  roots.push(root)
+  const artifact = join(root, "bundle.mjs")
+  await writeFile(artifact, source)
+  return artifact
+}
+
+describe("reconcile dispatch", () => {
+  test("invokes the sibling export with the fixed reason and scoped current-state callback", async () => {
+    const artifact = await bundle(`
+      export default {
+        reconcile: async (reason, ctx) => {
+          const snapshot = await ctx.current.snapshot()
+          await ctx.collections.items.put("receipt", { reason, snapshot })
+        },
+      }
+    `)
+    const calls: Array<{ method: string; params: unknown }> = []
+    const notices: Array<{ method: string; params: unknown }> = []
+    const conn = {
+      call: async (method: string, params: unknown) => {
+        calls.push({ method, params })
+        if (method === "app.current.snapshot") return { asOfSeq: 41 }
+        return { id: "receipt", body: {}, rev: 1 }
+      },
+      notify: (method: string, params: unknown) => notices.push({ method, params }),
+    } as unknown as RpcConnection
+    const reason = {
+      causes: ["gap", "version_changed"] as const,
+      version: 7,
+      throughSeq: 41,
+      gap: { cursor: 8, earliest: 12, missed: 3 },
+      previousVersions: [3, 5],
+    }
+
+    const result = await runReconcile(conn, {
+      dispatch: "dispatch-1",
+      app: "reviewer",
+      version_id: 7,
+      artifact,
+      collections: ["items"],
+      reason: { ...reason, causes: [...reason.causes] },
+    })
+
+    expect(result).toEqual({ ok: true })
+    expect(calls[0]).toEqual({
+      method: "app.current.snapshot",
+      params: { dispatch: "dispatch-1" },
+    })
+    expect(calls[1]?.method).toBe("app.collection.put")
+    expect(calls[1]?.params).toEqual({
+      dispatch: "dispatch-1",
+      collection: "items",
+      id: "receipt",
+      body: { reason, snapshot: { asOfSeq: 41 } },
+      if_rev: undefined,
+    })
+    expect(notices).toEqual([
+      { method: "app_runtime.entered", params: { dispatch: "dispatch-1", app: "reviewer" } },
+      { method: "app_runtime.left", params: { dispatch: "dispatch-1", app: "reviewer" } },
+    ])
+  })
+
+  test("names a manifest and bundle that disagree about the sibling export", async () => {
+    const artifact = await bundle(`export default { subscriptions: {} }`)
+    const conn = { notify: () => {} } as unknown as RpcConnection
+    const result = await runReconcile(conn, {
+      dispatch: "dispatch-2",
+      app: "reviewer",
+      version_id: 9,
+      artifact,
+      collections: [],
+      reason: { causes: ["re_enabled"], version: 9, throughSeq: 2, previousVersions: [] },
+    })
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain("default export has no reconcile handler")
+  })
+})
+
+describe("ordinary handler context", () => {
+  test("exposes the same current-state snapshot callback", async () => {
+    const artifact = await bundle(`
+      export default {
+        subscriptions: {
+          "ticket.updated": async (_event, ctx) => {
+            await ctx.current.snapshot()
+          },
+        },
+      }
+    `)
+    const calls: Array<{ method: string; params: unknown }> = []
+    const conn = {
+      call: async (method: string, params: unknown) => {
+        calls.push({ method, params })
+        return { asOfSeq: 9 }
+      },
+      notify: () => {},
+    } as unknown as RpcConnection
+
+    const result = await runDispatch(conn, {
+      dispatch: "dispatch-event",
+      app: "reviewer",
+      version_id: 2,
+      artifact,
+      handler: "ticket.updated",
+      collections: [],
+      event: {
+        name: "ticket.updated",
+        subject: "t-1",
+        seq: 9,
+        payload: null,
+        published_at: "2026-08-15T00:00:00Z",
+      },
+    })
+
+    expect(result).toEqual({ ok: true })
+    expect(calls).toEqual([
+      { method: "app.current.snapshot", params: { dispatch: "dispatch-event" } },
+    ])
+  })
+})

--- a/apphost/src/dispatch.ts
+++ b/apphost/src/dispatch.ts
@@ -65,6 +65,28 @@ export interface CommandResult {
   payload?: unknown
 }
 
+export interface ReconcileReason {
+  causes: ("gap" | "re_enabled" | "version_changed")[]
+  version: number
+  throughSeq: number
+  gap?: {
+    cursor: number
+    earliest: number
+    missed: number
+  }
+  previousVersions: number[]
+}
+
+/** What the daemon sends to rebuild one app through a durable fence. */
+export interface ReconcileParams {
+  dispatch: string
+  app: string
+  version_id: number
+  artifact: string
+  collections: string[]
+  reason: ReconcileReason
+}
+
 /** A handler of either kind: the first argument is the fact or the payload. */
 type Handler = (arg: unknown, ctx: unknown) => unknown
 
@@ -76,7 +98,11 @@ type Handler = (arg: unknown, ctx: unknown) => unknown
  * a command and a subscription of the same name are two different handlers and
  * no key can be ambiguous.
  */
-type Bundle = Partial<Record<HandlerKind, Record<string, Handler>>>
+type Bundle = {
+  subscriptions?: Record<string, Handler>
+  commands?: Record<string, Handler>
+  reconcile?: Handler
+}
 
 type HandlerKind = "subscriptions" | "commands"
 
@@ -167,6 +193,21 @@ function collectionsFor(
   return out
 }
 
+/** Builds the context shared by subscriptions, commands, and reconciliation. */
+function contextFor(
+  conn: RpcConnection,
+  params: { dispatch: string; app: string; version_id: number; collections: string[] },
+): Record<string, unknown> {
+  return {
+    app: params.app,
+    version: params.version_id,
+    collections: collectionsFor(conn, params.dispatch, params.collections),
+    current: {
+      snapshot: () => conn.call("app.current.snapshot", { dispatch: params.dispatch }),
+    },
+  }
+}
+
 /**
  * Runs one dispatch and describes what happened.
  *
@@ -196,11 +237,7 @@ export async function runDispatch(
     }
   }
 
-  const ctx = {
-    app: params.app,
-    version: params.version_id,
-    collections: collectionsFor(conn, params.dispatch, params.collections),
-  }
+  const ctx = contextFor(conn, params)
   // Announced before the call, because a handler that never yields would keep any
   // later announcement from ever being written. This is the daemon's only witness
   // of which handler is on the event loop, and it needs it exactly when this
@@ -252,11 +289,7 @@ export async function runCommand(
     }
   }
 
-  const ctx = {
-    app: params.app,
-    version: params.version_id,
-    collections: collectionsFor(conn, params.dispatch, params.collections),
-  }
+  const ctx = contextFor(conn, params)
   const scope = { dispatch: params.dispatch, app: params.app }
   conn.notify("app_runtime.entered", scope)
   try {
@@ -265,6 +298,42 @@ export async function runCommand(
     // field off is what tells the caller that apart from a handler that
     // deliberately returned null.
     return payload === undefined ? { ok: true } : { ok: true, payload }
+  } catch (err) {
+    return { ok: false, error: describeFailure(err) }
+  } finally {
+    conn.notify("app_runtime.left", scope)
+  }
+}
+
+/** Runs the serving version's reconcile sibling export. */
+export async function runReconcile(
+  conn: RpcConnection,
+  params: ReconcileParams,
+): Promise<DispatchResult> {
+  appByArtifact.set(params.artifact, params.app)
+
+  let bundle: Bundle
+  try {
+    bundle = await loadBundle(params.artifact)
+  } catch (err) {
+    return { ok: false, error: describeFailure(err) }
+  }
+
+  const handler = typeof bundle.reconcile === "function" ? bundle.reconcile : undefined
+  if (!handler) {
+    return {
+      ok: false,
+      error:
+        `app ${params.app} version ${params.version_id} declares reconcile but its default export has no reconcile handler. ` +
+        "The generated Handlers type makes this a compile error — the bundle is out of step with its manifest.",
+    }
+  }
+
+  const scope = { dispatch: params.dispatch, app: params.app }
+  conn.notify("app_runtime.entered", scope)
+  try {
+    await handler(params.reason, contextFor(conn, params))
+    return { ok: true }
   } catch (err) {
     return { ok: false, error: describeFailure(err) }
   } finally {

--- a/apphost/src/index.ts
+++ b/apphost/src/index.ts
@@ -21,8 +21,10 @@ import {
   appForStack,
   runCommand,
   runDispatch,
+  runReconcile,
   type CommandParams,
   type DispatchParams,
+  type ReconcileParams,
 } from "./dispatch.ts"
 
 /**
@@ -32,7 +34,7 @@ import {
  *
  * Bump it together with appRuntimeAPIVersion in internal/daemon/app_runtime.go.
  */
-const APP_RUNTIME_API_VERSION = 4
+const APP_RUNTIME_API_VERSION = 5
 
 /**
  * Which app a line of output came from.
@@ -173,6 +175,10 @@ async function main(): Promise<void> {
       case "app.command": {
         const params = request.params as CommandParams
         return currentApp.run(params.app, () => runCommand(connection, params))
+      }
+      case "app.reconcile": {
+        const params = request.params as ReconcileParams
+        return currentApp.run(params.app, () => runReconcile(connection, params))
       }
       case "app.runtime.ping":
         // A liveness answer the daemon can ask for without running app code.

--- a/apphost/src/rpc.ts
+++ b/apphost/src/rpc.ts
@@ -148,8 +148,8 @@ export class RpcConnection {
     this.socket.write(`${JSON.stringify(frame)}\n`)
   }
 
-  private consume(chunk: Buffer): void {
-    this.buffer += chunk.toString("utf8")
+  private consume(chunk: Buffer | string): void {
+    this.buffer += typeof chunk === "string" ? chunk : chunk.toString("utf8")
     for (;;) {
       const newline = this.buffer.indexOf("\n")
       if (newline < 0) break

--- a/apphost/tsconfig.json
+++ b/apphost/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "types": ["bun"],
     "strict": true,
     "noUncheckedIndexedAccess": true,

--- a/changelog.d/app-reconcile-contract.yaml
+++ b/changelog.d/app-reconcile-contract.yaml
@@ -1,0 +1,7 @@
+kind: added
+area: apps
+change: >
+  Subscribed apps can now declare a reconcile handler that rebuilds their
+  collections from a typed current-state snapshot after a bus gap, re-enable,
+  or version change. The handler runs in the ordinary app lane before later
+  facts, with the claimed reasons and bus fence fixed across retries.

--- a/docs/plans/2026-08-14-ext-app-reconcile-handler.md
+++ b/docs/plans/2026-08-14-ext-app-reconcile-handler.md
@@ -184,12 +184,13 @@ type CurrentStateSnapshot = {
   tickets: TicketRow[]
   seeds: Seed[]
   crew: CrewMember[]
-  apps: AppSummary[]
+  apps: AppRegistryEntry[]
 }
 ```
 
 These are the state-bearing domain fields assembled for `InitialStateMessage`
-in `internal/daemon/websocket.go`; A5 adds `apps` to that projection. Protocol
+in `internal/daemon/websocket.go`; A5 adds `apps` as its registry projection,
+not the operator-oriented `AppSummary`. Protocol
 identity, warnings, client-only metadata, and the untyped `settings` map are
 not app state and are not included. In particular, `settings` is the daemon's
 entire settings table plus derived client capability flags, not a bounded app

--- a/internal/appbuild/build_test.go
+++ b/internal/appbuild/build_test.go
@@ -230,7 +230,8 @@ func TestScaffoldRefusesADirectoryNameThatIsNotAnAppName(t *testing.T) {
 }
 
 func TestGeneratedTypesCarryTheAppsIdentityAndItsSubscriptions(t *testing.T) {
-	m, err := ParseManifest(validManifest(t, viewBlock+commandBlock))
+	text := strings.Replace(validManifest(t, viewBlock+commandBlock), `entrypoint = "src/index.ts"`, "entrypoint = \"src/index.ts\"\nreconcile = true", 1)
+	m, err := ParseManifest(text)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -247,6 +248,7 @@ func TestGeneratedTypesCarryTheAppsIdentityAndItsSubscriptions(t *testing.T) {
 		`  commands: {`,
 		`"approve": (payload: unknown, ctx: Ctx) => unknown`,
 		`"reject": (payload: unknown, ctx: Ctx) => unknown`,
+		`reconcile: ReconcileHandler<AppCollections>`,
 	} {
 		if !strings.Contains(types, want) {
 			t.Errorf("generated.ts does not contain %q:\n%s", want, types)
@@ -312,6 +314,40 @@ func TestBuild_UndeclaredCommandHandlerIsACompilerError(t *testing.T) {
 	}
 	if !strings.Contains(msg, "remember") {
 		t.Errorf("error does not name the undeclared handler: %s", msg)
+	}
+}
+
+func TestBuild_DeclaredReconcileWithNoHandlerIsACompilerError(t *testing.T) {
+	env := newBuildEnv(t, "unreconciled-app")
+	env.editManifest(t, `entrypoint = "src/index.ts"`, "entrypoint = \"src/index.ts\"\nreconcile = true")
+
+	_, err := env.build(t)
+	if err == nil {
+		t.Fatal("build accepted a reconcile declaration with no handler")
+	}
+	msg := err.Error()
+	if !tscError.MatchString(msg) {
+		t.Fatalf("error does not carry file(line,col): %s", msg)
+	}
+	if !strings.Contains(msg, "reconcile") {
+		t.Errorf("error does not name the missing reconcile handler: %s", msg)
+	}
+}
+
+func TestBuild_UndeclaredReconcileHandlerIsACompilerError(t *testing.T) {
+	env := newBuildEnv(t, "overreconciled-app")
+	env.edit(t, "src/index.ts", "commands: { forget },", "commands: { forget },\n  reconcile: onSessionState,")
+
+	_, err := env.build(t)
+	if err == nil {
+		t.Fatal("build accepted a reconcile handler the manifest never declared")
+	}
+	msg := err.Error()
+	if !tscError.MatchString(msg) {
+		t.Fatalf("error does not carry file(line,col): %s", msg)
+	}
+	if !strings.Contains(msg, "reconcile") {
+		t.Errorf("error does not name the undeclared reconcile handler: %s", msg)
 	}
 }
 

--- a/internal/appbuild/codegen.go
+++ b/internal/appbuild/codegen.go
@@ -47,7 +47,7 @@ func GenerateTypes(m Manifest) string {
 	b.WriteString(fmt.Sprintf("// app %s — bus consumer %s, documents under %s\n",
 		m.Name, apps.ConsumerName(m.Name), apps.Namespace(m.Name)))
 	b.WriteString("\n")
-	b.WriteString(fmt.Sprintf("import type { AppContext, AppEvent, Collection } from %q\n\n", SDKModule))
+	b.WriteString(fmt.Sprintf("import type { AppContext, AppEvent, Collection, ReconcileHandler } from %q\n\n", SDKModule))
 
 	b.WriteString("// The collections this app declared. Reachable as ctx.collections.<name>;\n")
 	b.WriteString("// a name that is not declared is a compile error, not an empty read.\n")
@@ -73,6 +73,11 @@ func GenerateTypes(m Manifest) string {
 		"(event: AppEvent, ctx: Ctx) => void | Promise<void>")
 	writeHandlerGroup(&b, "commands", m.CommandNames(),
 		"(payload: unknown, ctx: Ctx) => unknown")
+	if m.Reconcile {
+		b.WriteString("  reconcile: ReconcileHandler<AppCollections>\n")
+	} else {
+		b.WriteString("  reconcile?: never\n")
+	}
 	b.WriteString("}\n")
 	return b.String()
 }

--- a/internal/appbuild/manifest.go
+++ b/internal/appbuild/manifest.go
@@ -51,6 +51,7 @@ type Manifest struct {
 	Description string       `toml:"description" json:"description,omitempty"`
 	AttnAppAPI  int          `toml:"attn_app_api" json:"attn_app_api"`
 	Entrypoint  string       `toml:"entrypoint" json:"entrypoint"`
+	Reconcile   bool         `toml:"reconcile" json:"reconcile,omitempty"`
 	Subscribe   []Subscribe  `toml:"subscribe" json:"subscribe,omitempty"`
 	Collections []Collection `toml:"collections" json:"collections,omitempty"`
 	Views       []View       `toml:"views" json:"views,omitempty"`
@@ -228,7 +229,7 @@ func refuseUnknownKeys(md toml.MetaData) error {
 	if len(keys) > 1 {
 		subject, verb = "these", "they"
 	}
-	return fmt.Errorf("declares %s, which this attn does not understand (attn_app_api %d supports the tables %s, and the top-level keys name, description, attn_app_api, entrypoint). "+
+	return fmt.Errorf("declares %s, which this attn does not understand (attn_app_api %d supports the tables %s, and the top-level keys name, description, attn_app_api, entrypoint, reconcile). "+
 		"An app must not half-load: %s ignored, %s would leave the app declaring behavior nothing provides",
 		strings.Join(quoteAll(keys), ", "), APIVersion, strings.Join(knownTables, ", "), subject, verb)
 }

--- a/internal/appbuild/manifest_test.go
+++ b/internal/appbuild/manifest_test.go
@@ -34,7 +34,7 @@ func TestParseManifest_Valid(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseManifest: %v", err)
 	}
-	if m.Name != "approval-gate" || m.Entrypoint != "src/index.ts" || m.AttnAppAPI != APIVersion {
+	if m.Name != "approval-gate" || m.Entrypoint != "src/index.ts" || m.AttnAppAPI != APIVersion || m.Reconcile {
 		t.Fatalf("manifest = %+v", m)
 	}
 	if got := m.EventPatterns(); len(got) != 2 || got[0] != "delegation.*" || got[1] != "session.state.changed" {
@@ -109,6 +109,29 @@ func TestParseManifest_UnknownTopLevelKeyIsRefused(t *testing.T) {
 	_, err := ParseManifest(text)
 	if err == nil || !strings.Contains(err.Error(), `"author"`) {
 		t.Fatalf("err = %v, want a refusal naming author", err)
+	}
+}
+
+func TestParseManifest_ReconcileDefaultsFalseAndFreezesTrue(t *testing.T) {
+	m, err := ParseManifest(validManifest(t, ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Reconcile {
+		t.Fatal("reconcile defaults true")
+	}
+
+	with := strings.Replace(validManifest(t, ""), `entrypoint = "src/index.ts"`, "entrypoint = \"src/index.ts\"\nreconcile = true", 1)
+	m, err = ParseManifest(with)
+	if err != nil {
+		t.Fatal(err)
+	}
+	declaration, err := m.Declaration()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(declaration, `"reconcile":true`) {
+		t.Fatalf("declaration does not freeze reconcile support: %s", declaration)
 	}
 }
 
@@ -513,7 +536,8 @@ func TestLoadManifest_NoManifestSaysWhatToDo(t *testing.T) {
 // The frozen snapshot is what a version row carries, so it has to survive the
 // round trip with the fields the runtime will read back.
 func TestManifest_DeclarationRoundTrips(t *testing.T) {
-	m, err := ParseManifest(validManifest(t, ""))
+	text := strings.Replace(validManifest(t, ""), `entrypoint = "src/index.ts"`, "entrypoint = \"src/index.ts\"\nreconcile = true", 1)
+	m, err := ParseManifest(text)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -525,7 +549,7 @@ func TestManifest_DeclarationRoundTrips(t *testing.T) {
 	if err := json.Unmarshal([]byte(snapshot), &back); err != nil {
 		t.Fatalf("declaration is not JSON: %v", err)
 	}
-	if back.Name != m.Name || back.Entrypoint != m.Entrypoint || len(back.Subscribe) != len(m.Subscribe) {
+	if back.Name != m.Name || back.Entrypoint != m.Entrypoint || !back.Reconcile || len(back.Subscribe) != len(m.Subscribe) {
 		t.Fatalf("declaration lost fields: %+v", back)
 	}
 	if len(back.Collections) != 1 || back.Collections[0].Name != "decisions" {

--- a/internal/appbuild/sdkdist/currentState.d.ts
+++ b/internal/appbuild/sdkdist/currentState.d.ts
@@ -9,6 +9,8 @@ export interface Session {
     readonly branch?: string;
     readonly chief_of_staff?: boolean;
     readonly context_window_cap?: number;
+    readonly cost_unknown?: boolean;
+    readonly cost_usd?: number;
     readonly crew_member?: string;
     readonly delegated_from_chief?: boolean;
     readonly directory: string;

--- a/internal/appbuild/sdkdist/currentState.d.ts
+++ b/internal/appbuild/sdkdist/currentState.d.ts
@@ -1,0 +1,217 @@
+/** One agent session in attn's current state. */
+export interface Session {
+    readonly activity?: string;
+    readonly activity_at?: string;
+    readonly agent: string;
+    readonly auto_settle_dismiss_armed?: boolean;
+    readonly auto_settle_fires_at?: string;
+    readonly auto_settle_held?: boolean;
+    readonly branch?: string;
+    readonly chief_of_staff?: boolean;
+    readonly context_window_cap?: number;
+    readonly crew_member?: string;
+    readonly delegated_from_chief?: boolean;
+    readonly directory: string;
+    readonly endpoint_id?: string;
+    readonly id: string;
+    readonly is_worktree?: boolean;
+    readonly label: string;
+    readonly last_seen: string;
+    readonly main_repo?: string;
+    readonly nudge_fires_at?: string;
+    readonly parent_session_id?: string;
+    readonly pinned_at?: string;
+    readonly state: "idle" | "launching" | "pending_approval" | "recoverable" | "scheduled" | "unknown" | "waiting_input" | "working";
+    readonly state_reason?: string;
+    readonly state_since: string;
+    readonly state_updated_at: string;
+    readonly ticket_unread?: boolean;
+    readonly todos?: readonly string[];
+    readonly turn_opened_at?: string;
+    readonly turn_owed?: boolean;
+    readonly turn_snoozed_until?: string;
+    readonly workspace_id: string;
+    readonly workspace_muted?: boolean;
+}
+export interface EndpointCapabilities {
+    readonly agents_available: readonly string[];
+    readonly daemon_instance_id?: string;
+    readonly projects_directory?: string;
+    readonly protocol_version: string;
+    readonly pty_backend_mode?: string;
+    readonly tailscale_auth_url?: string;
+    readonly tailscale_domain?: string;
+    readonly tailscale_enabled?: boolean;
+    readonly tailscale_error?: string;
+    readonly tailscale_status?: string;
+    readonly tailscale_url?: string;
+}
+export interface EndpointInfo {
+    readonly capabilities?: EndpointCapabilities;
+    readonly enabled?: boolean;
+    readonly id: string;
+    readonly name: string;
+    readonly profile?: string;
+    readonly session_count?: number;
+    readonly ssh_target: string;
+    readonly status: string;
+    readonly status_message?: string;
+}
+export interface WorkspacePane {
+    readonly error?: string;
+    readonly kind: "agent";
+    readonly pane_id: string;
+    readonly runtime_id?: string;
+    readonly session_id?: string;
+    readonly status: "failed" | "ready" | "spawning";
+    readonly title: string;
+    readonly workspace_id: string;
+}
+export interface WorkspaceLayout {
+    readonly active_pane_id: string;
+    readonly layout_json: string;
+    readonly panes: readonly WorkspacePane[];
+    readonly updated_at?: string;
+    readonly workspace_id: string;
+}
+export interface Workspace {
+    readonly directory: string;
+    readonly endpoint_id?: string;
+    readonly id: string;
+    readonly layout?: WorkspaceLayout;
+    readonly muted: boolean;
+    readonly pinned: boolean;
+    readonly rank: string;
+    readonly status: "idle" | "launching" | "pending_approval" | "scheduled" | "unknown" | "waiting_input" | "working";
+    readonly title: string;
+}
+export interface PR {
+    readonly approved_by_me: boolean;
+    readonly author: string;
+    readonly ci_status?: string;
+    readonly comment_count?: number;
+    readonly details_fetched: boolean;
+    readonly details_fetched_at?: string;
+    readonly has_new_changes: boolean;
+    readonly head_branch?: string;
+    readonly head_sha?: string;
+    readonly heat_state?: "cold" | "hot" | "warm";
+    readonly host: string;
+    readonly id: string;
+    readonly last_heat_activity_at?: string;
+    readonly last_polled: string;
+    readonly last_updated: string;
+    readonly mergeable?: boolean;
+    readonly mergeable_state?: string;
+    readonly muted: boolean;
+    readonly number: number;
+    readonly reason: string;
+    readonly repo: string;
+    readonly review_status?: string;
+    readonly role: "author" | "reviewer";
+    readonly state: string;
+    readonly title: string;
+    readonly url: string;
+}
+export interface RepoState {
+    readonly collapsed: boolean;
+    readonly muted: boolean;
+    readonly repo: string;
+}
+export interface AuthorState {
+    readonly author: string;
+    readonly muted: boolean;
+}
+export interface TicketRow {
+    readonly assignee: string;
+    readonly closed_at?: string;
+    readonly cwd: string;
+    readonly id: string;
+    readonly last_agent_id: string;
+    readonly reconciled_at?: string;
+    readonly status: "blocked" | "crashed" | "done" | "failed" | "in_review" | "todo" | "working";
+    readonly title: string;
+    readonly updated_at: string;
+}
+export interface SeedEdge {
+    readonly kind: string;
+    readonly to: string;
+}
+export interface SeedPlotProgress {
+    readonly blocked: number;
+    readonly done: number;
+    readonly dormant: number;
+    readonly growing: number;
+    readonly ready: number;
+    readonly total: number;
+    readonly withered: number;
+}
+export interface SeedVar {
+    readonly default?: string;
+    readonly description?: string;
+    readonly enum?: readonly string[];
+    readonly name: string;
+    readonly pattern?: string;
+    readonly required?: boolean;
+}
+export interface Seed {
+    readonly body: string;
+    readonly created_at: string;
+    readonly edges: readonly SeedEdge[];
+    readonly gate: boolean;
+    readonly id: string;
+    readonly planter_member: string;
+    readonly planter_session: string;
+    readonly plot_progress?: SeedPlotProgress;
+    readonly ready: boolean;
+    readonly reason?: string;
+    readonly rev: number;
+    readonly status: string;
+    readonly step_slug: string;
+    readonly template: boolean;
+    readonly tender_member: string;
+    readonly tender_session: string;
+    readonly title: string;
+    readonly updated_at: string;
+    readonly vars: readonly SeedVar[];
+}
+export interface CrewMember {
+    readonly awareness_dirs: readonly string[];
+    readonly binding_session?: string;
+    readonly charter_path: string;
+    readonly cwd?: string;
+    readonly home_dir: string;
+    readonly id: string;
+}
+export interface AppViewInfo {
+    readonly kind: string;
+    readonly name: string;
+    readonly params_label?: string;
+    readonly params_placeholder?: string;
+    readonly title: string;
+}
+/** The app projection Initial State uses for mounting views. */
+export interface AppRegistryEntry {
+    readonly content_hash?: string;
+    readonly description?: string;
+    readonly enabled: boolean;
+    readonly name: string;
+    readonly version_id?: number;
+    readonly views: readonly AppViewInfo[];
+}
+/** The state-bearing domains shared with attn's Initial State projection. */
+export interface CurrentStateSnapshot {
+    /** Bus head captured before the projection was assembled. */
+    readonly asOfSeq: number;
+    readonly sessions: readonly Session[];
+    readonly endpoints: readonly EndpointInfo[];
+    readonly workspaces: readonly Workspace[];
+    readonly prs: readonly PR[];
+    readonly repos: readonly RepoState[];
+    readonly authors: readonly AuthorState[];
+    readonly githubHosts: readonly string[];
+    readonly tickets: readonly TicketRow[];
+    readonly seeds: readonly Seed[];
+    readonly crew: readonly CrewMember[];
+    readonly apps: readonly AppRegistryEntry[];
+}

--- a/internal/appbuild/sdkdist/index.d.ts
+++ b/internal/appbuild/sdkdist/index.d.ts
@@ -1,3 +1,4 @@
+import type { CurrentStateSnapshot } from "./currentState";
 export { Fragment, useCallback, useEffect, useMemo, useReducer, useRef, useState, } from "react";
 export type { ReactElement, ReactNode } from "react";
 /** The app contract version this SDK describes — attn-app.toml's attn_app_api. */
@@ -84,6 +85,10 @@ export interface AppContext<Collections> {
     readonly version: number;
     /** The collections declared in attn-app.toml, by name. */
     readonly collections: Collections;
+    /** Read-only current truth, from the same domain projection as Initial State. */
+    readonly current: {
+        snapshot(): Promise<CurrentStateSnapshot>;
+    };
 }
 /**
  * A handler. Throwing fails that delivery: the bus retries it with backoff
@@ -92,6 +97,27 @@ export interface AppContext<Collections> {
  * log open for everyone.
  */
 export type Handler<Collections> = (event: AppEvent, ctx: AppContext<Collections>) => void | Promise<void>;
+/** Why attn requires the app to rebuild its derived collections. */
+export type ReconcileCause = "gap" | "re_enabled" | "version_changed";
+export type { AppRegistryEntry, AppViewInfo, AuthorState, CrewMember, CurrentStateSnapshot, EndpointCapabilities, EndpointInfo, PR, RepoState, Seed, SeedEdge, SeedPlotProgress, SeedVar, Session, TicketRow, Workspace, WorkspaceLayout, WorkspacePane, } from "./currentState";
+/** The durable requests coalesced into one reconcile invocation. */
+export interface ReconcileReason {
+    /** Sorted as gap, re_enabled, version_changed, independent of arrival order. */
+    readonly causes: readonly ReconcileCause[];
+    /** The version whose reconcile handler is running. */
+    readonly version: number;
+    /** The bus position the rebuilt state supersedes. */
+    readonly throughSeq: number;
+    readonly gap?: {
+        readonly cursor: number;
+        readonly earliest: number;
+        readonly missed: number;
+    };
+    /** Distinct prior versions named by pointer moves, in request order. */
+    readonly previousVersions: readonly number[];
+}
+/** Rebuilds the app's collections from current truth. It must be idempotent. */
+export type ReconcileHandler<Collections> = (reason: ReconcileReason, ctx: AppContext<Collections>) => void | Promise<void>;
 /**
  * What a view is given. A view is a function of where it sits: the first three
  * are ambient, and `params` is what the user typed when docking, which is what

--- a/internal/daemon/app_consumers.go
+++ b/internal/daemon/app_consumers.go
@@ -193,8 +193,8 @@ func (d *Daemon) registerAppConsumer(name string) error {
 }
 
 func (d *Daemon) appPreDrain(name string) bus.PreDrain {
-	return func(_ context.Context, consumer bus.Consumer, gap *bus.Gap) error {
-		manifest, _, err := d.appDeclaration(name)
+	return func(ctx context.Context, consumer bus.Consumer, gap *bus.Gap) error {
+		manifest, version, err := d.appDeclaration(name)
 		if err != nil {
 			return err
 		}
@@ -227,8 +227,100 @@ func (d *Daemon) appPreDrain(name string) bus.PreDrain {
 		if len(claim.Requests) == 0 {
 			return nil
 		}
-		return fmt.Errorf("app %q reconciliation is owed through bus seq %d; its handler has not completed", name, claim.ThroughSeq)
+		if !manifest.Reconcile {
+			return fmt.Errorf("app %q reconciliation is owed through bus seq %d, but version %d does not declare reconcile", name, claim.ThroughSeq, version.ID)
+		}
+		return d.runAppReconcile(ctx, name, manifest, version, claim)
 	}
+}
+
+func (d *Daemon) runAppReconcile(ctx context.Context, name string, manifest appbuild.Manifest, version store.AppVersion, claim store.AppReconcileClaim) error {
+	plan := &appDispatchPlan{
+		app:       name,
+		namespace: apps.Namespace(name),
+		versionID: version.ID,
+		artifact:  version.ArtifactPath,
+		label:     "reconcile",
+	}
+	for _, collection := range manifest.Collections {
+		plan.collections = append(plan.collections, collection.Name)
+	}
+
+	reason := foldAppReconcileReason(version.ID, claim)
+	result, err := d.dispatchAppReconcile(ctx, plan, reason)
+	if err != nil {
+		return err
+	}
+	if !result.OK {
+		return fmt.Errorf("app %s reconcile threw: %s", name, firstLine(result.Error))
+	}
+	return d.store.CompleteAppReconcile(name, claim.ThroughRequestID, claim.ThroughSeq, d.appNow())
+}
+
+func foldAppReconcileReason(versionID int64, claim store.AppReconcileClaim) appReconcileReason {
+	reason := appReconcileReason{
+		Version:          versionID,
+		ThroughSeq:       claim.ThroughSeq,
+		Causes:           make([]string, 0, 3),
+		PreviousVersions: []int64{},
+	}
+	seenCauses := make(map[string]bool, 3)
+	seenVersions := make(map[int64]bool)
+	for _, request := range claim.Requests {
+		seenCauses[request.Reason] = true
+		if request.Reason == store.AppReconcileGap && reason.Gap == nil {
+			reason.Gap = &appReconcileGap{Cursor: request.Cursor, Earliest: request.Earliest, Missed: request.Missed}
+		}
+		if request.Reason == store.AppReconcileVersionChange && request.PreviousVersionID != 0 && !seenVersions[request.PreviousVersionID] {
+			seenVersions[request.PreviousVersionID] = true
+			reason.PreviousVersions = append(reason.PreviousVersions, request.PreviousVersionID)
+		}
+	}
+	for _, cause := range []string{store.AppReconcileGap, store.AppReconcileReEnabled, store.AppReconcileVersionChange} {
+		if seenCauses[cause] {
+			reason.Causes = append(reason.Causes, cause)
+		}
+	}
+	return reason
+}
+
+func (d *Daemon) dispatchAppReconcile(ctx context.Context, plan *appDispatchPlan, reason appReconcileReason) (appDispatchResult, error) {
+	runtime, err := d.awaitAppRuntime(ctx)
+	if err != nil {
+		return appDispatchResult{}, err
+	}
+	dispatch := &appDispatch{
+		app:         plan.app,
+		namespace:   plan.namespace,
+		versionID:   plan.versionID,
+		collections: make(map[string]struct{}, len(plan.collections)),
+	}
+	for _, collection := range plan.collections {
+		dispatch.collections[collection] = struct{}{}
+	}
+	d.registerAppDispatch(dispatch)
+	defer d.releaseAppDispatch(dispatch.id)
+
+	request := appReconcileRequest{
+		Dispatch: dispatch.id, App: plan.app, VersionID: plan.versionID,
+		Artifact: plan.artifact, Collections: plan.collections, Reason: reason,
+	}
+	if request.Collections == nil {
+		request.Collections = []string{}
+	}
+	callCtx, cancel := context.WithTimeout(ctx, d.appDispatchBudget())
+	defer cancel()
+	result, err := runtime.reconcile(callCtx, request)
+	if err != nil {
+		if ctx.Err() == nil && callCtx.Err() != nil {
+			return appDispatchResult{}, d.attributeWedgedDispatch(ctx, runtime, plan.app)
+		}
+		if ctx.Err() != nil {
+			return appDispatchResult{}, ctx.Err()
+		}
+		return appDispatchResult{}, runtimeFailure("%v", err)
+	}
+	return result, nil
 }
 
 // appFilter reads an app's declared subscriptions off its current version.

--- a/internal/daemon/app_reconcile_test.go
+++ b/internal/daemon/app_reconcile_test.go
@@ -2,7 +2,11 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -10,6 +14,153 @@ import (
 	"github.com/victorarias/attn/internal/bus"
 	"github.com/victorarias/attn/internal/store"
 )
+
+func TestFoldAppReconcileReasonSortsCausesAndDeduplicatesPreviousVersions(t *testing.T) {
+	claim := store.AppReconcileClaim{
+		ThroughSeq: 18,
+		Requests: []store.AppReconcileRequest{
+			{Reason: store.AppReconcileReEnabled},
+			{Reason: store.AppReconcileVersionChange, PreviousVersionID: 3},
+			{Reason: store.AppReconcileGap, Cursor: 4, Earliest: 8, Missed: 3},
+			{Reason: store.AppReconcileVersionChange, PreviousVersionID: 3},
+			{Reason: store.AppReconcileVersionChange, PreviousVersionID: 7},
+		},
+	}
+	got := foldAppReconcileReason(11, claim)
+	if !reflect.DeepEqual(got.Causes, []string{"gap", "re_enabled", "version_changed"}) {
+		t.Fatalf("causes = %v", got.Causes)
+	}
+	if got.Version != 11 || got.ThroughSeq != 18 {
+		t.Fatalf("reason = %+v", got)
+	}
+	if got.Gap == nil || *got.Gap != (appReconcileGap{Cursor: 4, Earliest: 8, Missed: 3}) {
+		t.Fatalf("gap = %+v", got.Gap)
+	}
+	if !reflect.DeepEqual(got.PreviousVersions, []int64{3, 7}) {
+		t.Fatalf("previous versions = %v", got.PreviousVersions)
+	}
+}
+
+func TestAppPreDrainDispatchesReconcileAndCompletesItsClaim(t *testing.T) {
+	d := newDaemonForTest(t)
+	now := time.Now().UTC()
+	version, _, err := d.store.CommitAppVersion(store.AppVersion{
+		AppName: "approval-gate", ContentHash: "sha256:approval-gate",
+		Declaration:  `{"name":"approval-gate","reconcile":true,"subscribe":[{"events":["ticket.*"]}],"collections":[{"name":"decisions"}]}`,
+		ArtifactPath: "bundle.js",
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedAppConsumer(t, d, "approval-gate", true, 1)
+	for i := 0; i < 6; i++ {
+		if _, err := d.store.AppendBusEvent(store.BusEvent{Name: "ticket.updated", Subject: "t-1"}, now); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := d.store.RequestAppReconcileGap("approval-gate", 1, 4, 6, now); err != nil {
+		t.Fatal(err)
+	}
+	runtime := startFakeAppRuntime(t, d, nil)
+	snapshots := make(chan appCurrentStateSnapshot, 1)
+	runtime.reconcile = func(f *fakeAppRuntime, req appReconcileRequest) error {
+		data, err := f.call("app.current.snapshot", appCurrentStateParams{Dispatch: req.Dispatch})
+		if err != nil {
+			return err
+		}
+		var snapshot appCurrentStateSnapshot
+		if err := json.Unmarshal(data, &snapshot); err != nil {
+			return err
+		}
+		snapshots <- snapshot
+		return nil
+	}
+
+	hook := d.appPreDrain("approval-gate")
+	if err := hook(context.Background(), bus.Consumer{Name: apps.ConsumerName("approval-gate")}, nil); err != nil {
+		t.Fatalf("pre-drain reconcile: %v", err)
+	}
+	log := runtime.reconcileLog()
+	if len(log) != 1 {
+		t.Fatalf("reconciles = %+v", log)
+	}
+	request := log[0]
+	if request.App != "approval-gate" || request.VersionID != version.ID || request.Artifact != "bundle.js" {
+		t.Fatalf("request = %+v", request)
+	}
+	if !reflect.DeepEqual(request.Collections, []string{"decisions"}) || !reflect.DeepEqual(request.Reason.Causes, []string{"gap"}) {
+		t.Fatalf("request = %+v", request)
+	}
+	if request.Reason.Gap == nil || request.Reason.ThroughSeq != 6 {
+		t.Fatalf("reason = %+v", request.Reason)
+	}
+	snapshot := <-snapshots
+	if snapshot.AsOfSeq < request.Reason.ThroughSeq || snapshot.Apps == nil || snapshot.Crew == nil {
+		t.Fatalf("current snapshot = %+v", snapshot)
+	}
+	if claim, err := d.store.AppReconcilePending("approval-gate"); err != nil || len(claim.Requests) != 0 {
+		t.Fatalf("pending after success = %+v, %v", claim, err)
+	}
+	consumer, _, err := d.store.GetBusConsumer(apps.ConsumerName("approval-gate"))
+	if err != nil || consumer.Cursor != 6 {
+		t.Fatalf("consumer = %+v, %v", consumer, err)
+	}
+}
+
+func TestAppPreDrainRetriesTheSameClaimAfterAThrow(t *testing.T) {
+	d := newDaemonForTest(t)
+	now := time.Now().UTC()
+	_, _, err := d.store.CommitAppVersion(store.AppVersion{
+		AppName: "approval-gate", ContentHash: "sha256:approval-gate",
+		Declaration:  `{"name":"approval-gate","reconcile":true,"subscribe":[{"events":["ticket.*"]}]}`,
+		ArtifactPath: "bundle.js",
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedAppConsumer(t, d, "approval-gate", true, 1)
+	if _, err := d.store.RequestAppReconcileGap("approval-gate", 1, 4, 6, now); err != nil {
+		t.Fatal(err)
+	}
+	runtime := startFakeAppRuntime(t, d, nil)
+	var attempts atomic.Int32
+	runtime.reconcile = func(_ *fakeAppRuntime, _ appReconcileRequest) error {
+		if attempts.Add(1) == 1 {
+			return errors.New("rebuild failed")
+		}
+		return nil
+	}
+
+	hook := d.appPreDrain("approval-gate")
+	consumer := bus.Consumer{Name: apps.ConsumerName("approval-gate")}
+	if err := hook(context.Background(), consumer, nil); err == nil || !strings.Contains(err.Error(), "rebuild failed") {
+		t.Fatalf("first reconcile = %v", err)
+	}
+	claim, err := d.store.AppReconcilePending("approval-gate")
+	if err != nil || len(claim.Requests) != 1 {
+		t.Fatalf("claim after throw = %+v, %v", claim, err)
+	}
+	stored, _, err := d.store.GetBusConsumer(consumer.Name)
+	if err != nil || stored.Cursor != 1 {
+		t.Fatalf("cursor after throw = %d, %v", stored.Cursor, err)
+	}
+
+	if err := hook(context.Background(), consumer, nil); err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	log := runtime.reconcileLog()
+	if len(log) != 2 || !reflect.DeepEqual(log[0].Reason, log[1].Reason) {
+		t.Fatalf("retry reasons = %+v", log)
+	}
+	claim, err = d.store.AppReconcilePending("approval-gate")
+	if err != nil || len(claim.Requests) != 0 {
+		t.Fatalf("claim after retry = %+v, %v", claim, err)
+	}
+	stored, _, err = d.store.GetBusConsumer(consumer.Name)
+	if err != nil || stored.Cursor != 6 {
+		t.Fatalf("cursor after retry = %d, %v", stored.Cursor, err)
+	}
+}
 
 func TestAppPreDrainRecordsOneGapAndFencesFactsUntilCompletion(t *testing.T) {
 	d := newDaemonForTest(t)

--- a/internal/daemon/app_runtime.go
+++ b/internal/daemon/app_runtime.go
@@ -56,7 +56,7 @@ const (
 	// app's bundle: the host loads it. Bump it here and in apphost/src/index.ts
 	// together — TestAppRuntimeAPIVersionMatchesTheHost is what fails when only
 	// one moves.
-	appRuntimeAPIVersion = 4
+	appRuntimeAPIVersion = 5
 )
 
 // appRuntimeHostOverride lets a test — and a developer running a checkout's
@@ -476,6 +476,32 @@ type appCommandRequest struct {
 	Handler     string          `json:"handler"`
 	Collections []string        `json:"collections"`
 	Payload     json.RawMessage `json:"payload,omitempty"`
+}
+
+// appReconcileRequest is `app.reconcile`, the lifecycle call that rebuilds an
+// app's collections through a durable bus fence. Reconcile is a sibling export,
+// so there is no handler key: the method itself selects it.
+type appReconcileRequest struct {
+	Dispatch    string             `json:"dispatch"`
+	App         string             `json:"app"`
+	VersionID   int64              `json:"version_id"`
+	Artifact    string             `json:"artifact"`
+	Collections []string           `json:"collections"`
+	Reason      appReconcileReason `json:"reason"`
+}
+
+type appReconcileReason struct {
+	Causes           []string         `json:"causes"`
+	Version          int64            `json:"version"`
+	ThroughSeq       int64            `json:"throughSeq"`
+	Gap              *appReconcileGap `json:"gap,omitempty"`
+	PreviousVersions []int64          `json:"previousVersions"`
+}
+
+type appReconcileGap struct {
+	Cursor   int64 `json:"cursor"`
+	Earliest int64 `json:"earliest"`
+	Missed   int64 `json:"missed"`
 }
 
 // appCommandDispatchResult is appDispatchResult plus what the handler returned.

--- a/internal/daemon/app_runtime_rpc.go
+++ b/internal/daemon/app_runtime_rpc.go
@@ -22,9 +22,10 @@ import (
 // plugin registry: a plugin is an extension the user installed, and this is one
 // process attn ships and owns.
 //
-// The methods the sidecar may call are exactly the collection operations, and
-// each one is scoped by the daemon's own record of the dispatch in flight — see
-// appDispatch. There is no namespace on the wire to get wrong.
+// The methods the sidecar may call are the collection operations and the
+// bounded current-state snapshot. Each is scoped by the daemon's own record of
+// the dispatch in flight — see appDispatch. There is no namespace on the wire
+// to get wrong.
 
 const appRuntimeHelloMethod = "app_runtime.hello"
 
@@ -59,6 +60,14 @@ func (c *appRuntimeConnection) command(ctx context.Context, req appCommandReques
 	var result appCommandDispatchResult
 	if err := c.request(ctx, "app runtime", "app.command", req, &result); err != nil {
 		return appCommandDispatchResult{}, err
+	}
+	return result, nil
+}
+
+func (c *appRuntimeConnection) reconcile(ctx context.Context, req appReconcileRequest) (appDispatchResult, error) {
+	var result appDispatchResult
+	if err := c.request(ctx, "app runtime", "app.reconcile", req, &result); err != nil {
+		return appDispatchResult{}, err
 	}
 	return result, nil
 }
@@ -309,12 +318,25 @@ type appCollectionParams struct {
 	Query      *docstore.Query `json:"query"`
 }
 
+type appCurrentStateParams struct {
+	Dispatch string `json:"dispatch"`
+}
+
 func (d *Daemon) appRuntimeMethod(msg jsonRPCMessage) (any, error) {
 	if msg.Method == appRuntimeCrashedMethod {
 		return d.appRuntimeCrashed(msg)
 	}
 
 	switch msg.Method {
+	case "app.current.snapshot":
+		var params appCurrentStateParams
+		if err := json.Unmarshal(msg.Params, &params); err != nil {
+			return nil, fmt.Errorf("decode %s params: %w", msg.Method, err)
+		}
+		if _, err := d.lookupAppDispatch(params.Dispatch); err != nil {
+			return nil, err
+		}
+		return d.appCurrentStateSnapshot()
 	case "app.collection.get", "app.collection.put", "app.collection.delete",
 		"app.collection.query", "app.collection.count":
 	default:

--- a/internal/daemon/app_runtime_test.go
+++ b/internal/daemon/app_runtime_test.go
@@ -52,12 +52,15 @@ type fakeAppRuntime struct {
 	// no payload, which is what a handler returning nothing looks like on the
 	// wire. Returning an error is a handler that threw.
 	command func(*fakeAppRuntime, appCommandRequest) (json.RawMessage, error)
+	// reconcile runs in place of the bundle's reconcile sibling export.
+	reconcile func(*fakeAppRuntime, appReconcileRequest) error
 
 	writeMu sync.Mutex
 
 	mu         sync.Mutex
 	dispatches []appDispatchRequest
 	commands   []appCommandRequest
+	reconciles []appReconcileRequest
 	pending    map[string]chan jsonRPCMessage
 	nextID     int
 	// loopFrozen models a blocked event loop. A real host does everything off one
@@ -178,8 +181,12 @@ func (f *fakeAppRuntime) serve(reader *bufio.Reader) {
 			f.serveCommand(msg)
 			continue
 		}
+		if msg.Method == "app.reconcile" {
+			f.serveReconcile(msg)
+			continue
+		}
 		if msg.Method != "app.dispatch" {
-			f.sendRaw(jsonRPCFailure(msg.ID, jsonRPCInvalidRequest, "the fake sidecar only serves app.dispatch, app.command and app.runtime.ping"))
+			f.sendRaw(jsonRPCFailure(msg.ID, jsonRPCInvalidRequest, "the fake sidecar only serves app.dispatch, app.command, app.reconcile and app.runtime.ping"))
 			continue
 		}
 		var req appDispatchRequest
@@ -217,6 +224,34 @@ func (f *fakeAppRuntime) serve(reader *bufio.Reader) {
 			f.sendRaw(jsonRPCResult(id, result))
 		}(msg.ID, req)
 	}
+}
+
+func (f *fakeAppRuntime) serveReconcile(msg jsonRPCMessage) {
+	var req appReconcileRequest
+	if err := json.Unmarshal(msg.Params, &req); err != nil {
+		f.sendRaw(jsonRPCFailure(msg.ID, jsonRPCInvalidRequest, err.Error()))
+		return
+	}
+	f.mu.Lock()
+	f.reconciles = append(f.reconciles, req)
+	f.mu.Unlock()
+	f.sendRaw(jsonRPCMessage{
+		JSONRPC: "2.0", Method: appRuntimeEnteredMethod,
+		Params: mustMarshalHandlerParams(f.t, appRuntimeHandlerParams{Dispatch: req.Dispatch, App: req.App}),
+	})
+	go func(id json.RawMessage, req appReconcileRequest) {
+		result := appDispatchResult{OK: true}
+		if f.reconcile != nil {
+			if err := f.reconcile(f, req); err != nil {
+				result = appDispatchResult{OK: false, Error: err.Error()}
+			}
+		}
+		f.sendRaw(jsonRPCMessage{
+			JSONRPC: "2.0", Method: appRuntimeLeftMethod,
+			Params: mustMarshalHandlerParams(f.t, appRuntimeHandlerParams{Dispatch: req.Dispatch, App: req.App}),
+		})
+		f.sendRaw(jsonRPCResult(id, result))
+	}(msg.ID, req)
 }
 
 // serveCommand is the command half of the loop above, with the same
@@ -265,6 +300,14 @@ func (f *fakeAppRuntime) commandLog() []appCommandRequest {
 	return out
 }
 
+func (f *fakeAppRuntime) reconcileLog() []appReconcileRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]appReconcileRequest, len(f.reconciles))
+	copy(out, f.reconciles)
+	return out
+}
+
 func mustMarshalHandlerParams(t *testing.T, params appRuntimeHandlerParams) json.RawMessage {
 	t.Helper()
 	data, err := json.Marshal(params)
@@ -284,8 +327,8 @@ func (f *fakeAppRuntime) sendRaw(msg jsonRPCMessage) {
 	_, _ = f.conn.Write(append(data, '\n'))
 }
 
-// call makes a collection callback, the way a handler's ctx.collections does.
-func (f *fakeAppRuntime) call(method string, params appCollectionParams) (json.RawMessage, error) {
+// call makes a context callback, the way a handler's ctx does.
+func (f *fakeAppRuntime) call(method string, params any) (json.RawMessage, error) {
 	f.mu.Lock()
 	f.nextID++
 	id := json.RawMessage(fmt.Sprintf(`"cb-%d"`, f.nextID))

--- a/internal/daemon/current_state.go
+++ b/internal/daemon/current_state.go
@@ -1,0 +1,83 @@
+package daemon
+
+import "github.com/victorarias/attn/internal/protocol"
+
+// currentStateProjection is the state-bearing part of Initial State. Keeping
+// its assembly here gives app handlers the same local-and-relayed view as the
+// frontend without exposing settings, warnings, or protocol metadata.
+type currentStateProjection struct {
+	Sessions    []protocol.Session
+	Endpoints   []protocol.EndpointInfo
+	Workspaces  []protocol.Workspace
+	Prs         []protocol.PR
+	Repos       []protocol.RepoState
+	Authors     []protocol.AuthorState
+	GithubHosts []string
+	Tickets     []protocol.TicketRow
+	Seeds       []protocol.Seed
+	Crew        []protocol.CrewMember
+	Apps        []protocol.AppRegistryEntry
+}
+
+func (d *Daemon) currentStateProjection() currentStateProjection {
+	return currentStateProjection{
+		Sessions:    d.mergedSessionsForBroadcast(),
+		Endpoints:   d.listEndpointInfos(),
+		Workspaces:  d.listWorkspaces(),
+		Prs:         protocol.PRsToValues(d.store.ListPRs("")),
+		Repos:       protocol.RepoStatesToValues(d.store.ListRepoStates()),
+		Authors:     protocol.AuthorStatesToValues(d.store.ListAuthorStates()),
+		GithubHosts: d.gitHubHosts(),
+		Tickets:     d.ticketsForBroadcast(),
+		Seeds:       d.seedsForBroadcast(),
+		Crew:        d.crewForBroadcast(),
+		Apps:        d.appRegistryForWire(),
+	}
+}
+
+// appCurrentStateSnapshot is the SDK's bounded current-state read. The bus
+// position is captured before the projection is assembled, so every mutation
+// at or below it is already visible and any later mutation still has a fact.
+type appCurrentStateSnapshot struct {
+	AsOfSeq     int64                       `json:"asOfSeq"`
+	Sessions    []protocol.Session          `json:"sessions"`
+	Endpoints   []protocol.EndpointInfo     `json:"endpoints"`
+	Workspaces  []protocol.Workspace        `json:"workspaces"`
+	Prs         []protocol.PR               `json:"prs"`
+	Repos       []protocol.RepoState        `json:"repos"`
+	Authors     []protocol.AuthorState      `json:"authors"`
+	GithubHosts []string                    `json:"githubHosts"`
+	Tickets     []protocol.TicketRow        `json:"tickets"`
+	Seeds       []protocol.Seed             `json:"seeds"`
+	Crew        []protocol.CrewMember       `json:"crew"`
+	Apps        []protocol.AppRegistryEntry `json:"apps"`
+}
+
+func (d *Daemon) appCurrentStateSnapshot() (appCurrentStateSnapshot, error) {
+	_, head, err := d.store.BusBounds()
+	if err != nil {
+		return appCurrentStateSnapshot{}, err
+	}
+	state := d.currentStateProjection()
+	return appCurrentStateSnapshot{
+		AsOfSeq:     head,
+		Sessions:    snapshotSlice(state.Sessions),
+		Endpoints:   snapshotSlice(state.Endpoints),
+		Workspaces:  snapshotSlice(state.Workspaces),
+		Prs:         snapshotSlice(state.Prs),
+		Repos:       snapshotSlice(state.Repos),
+		Authors:     snapshotSlice(state.Authors),
+		GithubHosts: snapshotSlice(state.GithubHosts),
+		Tickets:     snapshotSlice(state.Tickets),
+		Seeds:       snapshotSlice(state.Seeds),
+		Crew:        snapshotSlice(state.Crew),
+		Apps:        snapshotSlice(state.Apps),
+	}, nil
+}
+
+func snapshotSlice[T any](values []T) []T {
+	if values == nil {
+		return []T{}
+	}
+	return values
+}

--- a/internal/daemon/current_state_test.go
+++ b/internal/daemon/current_state_test.go
@@ -1,0 +1,77 @@
+package daemon
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/apps"
+	"github.com/victorarias/attn/internal/store"
+)
+
+func TestAppCurrentStateSnapshotCapturesTheBusHeadBeforeBuildingInitialState(t *testing.T) {
+	d := newDaemonForTest(t)
+	seq, err := d.store.AppendBusEvent(store.BusEvent{
+		Name: "ticket.updated", Subject: "t-1", Source: "test",
+	}, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	dispatch := &appDispatch{
+		app: "approval-gate", namespace: apps.Namespace("approval-gate"),
+		collections: map[string]struct{}{},
+	}
+	d.registerAppDispatch(dispatch)
+
+	result, err := d.appRuntimeMethod(jsonRPCMessage{
+		Method: "app.current.snapshot",
+		Params: mustJSON(t, appCurrentStateParams{Dispatch: dispatch.id}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, ok := result.(appCurrentStateSnapshot)
+	if !ok {
+		t.Fatalf("snapshot type = %T", result)
+	}
+	if snapshot.AsOfSeq != seq {
+		t.Fatalf("asOfSeq = %d, want bus head %d", snapshot.AsOfSeq, seq)
+	}
+	state := d.currentStateProjection()
+	if len(snapshot.Sessions) != len(state.Sessions) || len(snapshot.Crew) != len(state.Crew) || len(snapshot.Apps) != len(state.Apps) {
+		t.Fatalf("snapshot did not use the Initial State projection: snapshot=%+v state=%+v", snapshot, state)
+	}
+	encoded, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatal(err)
+	}
+	wantFields := []string{
+		"asOfSeq", "sessions", "endpoints", "workspaces", "prs", "repos",
+		"authors", "githubHosts", "tickets", "seeds", "crew", "apps",
+	}
+	if len(fields) != len(wantFields) {
+		t.Fatalf("snapshot fields = %s", encoded)
+	}
+	for _, name := range wantFields {
+		value, ok := fields[name]
+		if !ok {
+			t.Errorf("snapshot has no %s: %s", name, encoded)
+		} else if name != "asOfSeq" && string(value) == "null" {
+			t.Errorf("snapshot %s is null, want an array: %s", name, encoded)
+		}
+	}
+
+	d.releaseAppDispatch(dispatch.id)
+	_, err = d.appRuntimeMethod(jsonRPCMessage{
+		Method: "app.current.snapshot",
+		Params: mustJSON(t, appCurrentStateParams{Dispatch: dispatch.id}),
+	})
+	if err == nil || !strings.Contains(err.Error(), "not in flight") {
+		t.Fatalf("snapshot after handler returned: %v", err)
+	}
+}

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -781,26 +781,27 @@ func (d *Daemon) sendInitialState(client *wsClient) {
 	if status, err := d.enrollmentStatus(); err == nil {
 		homeDaemonID = status.HomeDaemonID
 	}
+	state := d.currentStateProjection()
 	event := &protocol.InitialStateMessage{
 		Event:             protocol.EventInitialState,
 		ProtocolVersion:   protocol.Ptr(protocol.ProtocolVersion),
 		SourceFingerprint: protocol.Ptr(buildinfo.SourceFingerprint),
 		DaemonInstanceID:  protocol.Ptr(d.daemonInstanceID),
 		HomeDaemonID:      protocol.Ptr(homeDaemonID),
-		Sessions:          d.mergedSessionsForBroadcast(),
-		Endpoints:         d.listEndpointInfos(),
-		Workspaces:        d.listWorkspaces(),
-		Prs:               protocol.PRsToValues(d.store.ListPRs("")),
-		Repos:             protocol.RepoStatesToValues(d.store.ListRepoStates()),
-		Authors:           protocol.AuthorStatesToValues(d.store.ListAuthorStates()),
-		GithubHosts:       d.gitHubHosts(),
+		Sessions:          state.Sessions,
+		Endpoints:         state.Endpoints,
+		Workspaces:        state.Workspaces,
+		Prs:               state.Prs,
+		Repos:             state.Repos,
+		Authors:           state.Authors,
+		GithubHosts:       state.GithubHosts,
 		Settings:          d.settingsWithAgentAvailability(),
 		Warnings:          d.getWarnings(),
-		Tickets:           d.ticketsForBroadcast(),
-		Seeds:             d.seedsForBroadcast(),
+		Tickets:           state.Tickets,
+		Seeds:             state.Seeds,
 		SeedsTotal:        protocol.Ptr(d.countSeedsForBroadcast()),
-		Apps:              d.appRegistryForWire(),
-		Crew:              d.crewForBroadcast(),
+		Apps:              state.Apps,
+		Crew:              state.Crew,
 	}
 	data, err := json.Marshal(event)
 	if err != nil {

--- a/sdk/attn-app/src/currentState.ts
+++ b/sdk/attn-app/src/currentState.ts
@@ -9,6 +9,8 @@ export interface Session {
   readonly branch?: string
   readonly chief_of_staff?: boolean
   readonly context_window_cap?: number
+  readonly cost_unknown?: boolean
+  readonly cost_usd?: number
   readonly crew_member?: string
   readonly delegated_from_chief?: boolean
   readonly directory: string

--- a/sdk/attn-app/src/currentState.ts
+++ b/sdk/attn-app/src/currentState.ts
@@ -1,0 +1,234 @@
+/** One agent session in attn's current state. */
+export interface Session {
+  readonly activity?: string
+  readonly activity_at?: string
+  readonly agent: string
+  readonly auto_settle_dismiss_armed?: boolean
+  readonly auto_settle_fires_at?: string
+  readonly auto_settle_held?: boolean
+  readonly branch?: string
+  readonly chief_of_staff?: boolean
+  readonly context_window_cap?: number
+  readonly crew_member?: string
+  readonly delegated_from_chief?: boolean
+  readonly directory: string
+  readonly endpoint_id?: string
+  readonly id: string
+  readonly is_worktree?: boolean
+  readonly label: string
+  readonly last_seen: string
+  readonly main_repo?: string
+  readonly nudge_fires_at?: string
+  readonly parent_session_id?: string
+  readonly pinned_at?: string
+  readonly state: "idle" | "launching" | "pending_approval" | "recoverable" | "scheduled" | "unknown" | "waiting_input" | "working"
+  readonly state_reason?: string
+  readonly state_since: string
+  readonly state_updated_at: string
+  readonly ticket_unread?: boolean
+  readonly todos?: readonly string[]
+  readonly turn_opened_at?: string
+  readonly turn_owed?: boolean
+  readonly turn_snoozed_until?: string
+  readonly workspace_id: string
+  readonly workspace_muted?: boolean
+}
+
+export interface EndpointCapabilities {
+  readonly agents_available: readonly string[]
+  readonly daemon_instance_id?: string
+  readonly projects_directory?: string
+  readonly protocol_version: string
+  readonly pty_backend_mode?: string
+  readonly tailscale_auth_url?: string
+  readonly tailscale_domain?: string
+  readonly tailscale_enabled?: boolean
+  readonly tailscale_error?: string
+  readonly tailscale_status?: string
+  readonly tailscale_url?: string
+}
+
+export interface EndpointInfo {
+  readonly capabilities?: EndpointCapabilities
+  readonly enabled?: boolean
+  readonly id: string
+  readonly name: string
+  readonly profile?: string
+  readonly session_count?: number
+  readonly ssh_target: string
+  readonly status: string
+  readonly status_message?: string
+}
+
+export interface WorkspacePane {
+  readonly error?: string
+  readonly kind: "agent"
+  readonly pane_id: string
+  readonly runtime_id?: string
+  readonly session_id?: string
+  readonly status: "failed" | "ready" | "spawning"
+  readonly title: string
+  readonly workspace_id: string
+}
+
+export interface WorkspaceLayout {
+  readonly active_pane_id: string
+  readonly layout_json: string
+  readonly panes: readonly WorkspacePane[]
+  readonly updated_at?: string
+  readonly workspace_id: string
+}
+
+export interface Workspace {
+  readonly directory: string
+  readonly endpoint_id?: string
+  readonly id: string
+  readonly layout?: WorkspaceLayout
+  readonly muted: boolean
+  readonly pinned: boolean
+  readonly rank: string
+  readonly status: "idle" | "launching" | "pending_approval" | "scheduled" | "unknown" | "waiting_input" | "working"
+  readonly title: string
+}
+
+export interface PR {
+  readonly approved_by_me: boolean
+  readonly author: string
+  readonly ci_status?: string
+  readonly comment_count?: number
+  readonly details_fetched: boolean
+  readonly details_fetched_at?: string
+  readonly has_new_changes: boolean
+  readonly head_branch?: string
+  readonly head_sha?: string
+  readonly heat_state?: "cold" | "hot" | "warm"
+  readonly host: string
+  readonly id: string
+  readonly last_heat_activity_at?: string
+  readonly last_polled: string
+  readonly last_updated: string
+  readonly mergeable?: boolean
+  readonly mergeable_state?: string
+  readonly muted: boolean
+  readonly number: number
+  readonly reason: string
+  readonly repo: string
+  readonly review_status?: string
+  readonly role: "author" | "reviewer"
+  readonly state: string
+  readonly title: string
+  readonly url: string
+}
+
+export interface RepoState {
+  readonly collapsed: boolean
+  readonly muted: boolean
+  readonly repo: string
+}
+
+export interface AuthorState {
+  readonly author: string
+  readonly muted: boolean
+}
+
+export interface TicketRow {
+  readonly assignee: string
+  readonly closed_at?: string
+  readonly cwd: string
+  readonly id: string
+  readonly last_agent_id: string
+  readonly reconciled_at?: string
+  readonly status: "blocked" | "crashed" | "done" | "failed" | "in_review" | "todo" | "working"
+  readonly title: string
+  readonly updated_at: string
+}
+
+export interface SeedEdge {
+  readonly kind: string
+  readonly to: string
+}
+
+export interface SeedPlotProgress {
+  readonly blocked: number
+  readonly done: number
+  readonly dormant: number
+  readonly growing: number
+  readonly ready: number
+  readonly total: number
+  readonly withered: number
+}
+
+export interface SeedVar {
+  readonly default?: string
+  readonly description?: string
+  readonly enum?: readonly string[]
+  readonly name: string
+  readonly pattern?: string
+  readonly required?: boolean
+}
+
+export interface Seed {
+  readonly body: string
+  readonly created_at: string
+  readonly edges: readonly SeedEdge[]
+  readonly gate: boolean
+  readonly id: string
+  readonly planter_member: string
+  readonly planter_session: string
+  readonly plot_progress?: SeedPlotProgress
+  readonly ready: boolean
+  readonly reason?: string
+  readonly rev: number
+  readonly status: string
+  readonly step_slug: string
+  readonly template: boolean
+  readonly tender_member: string
+  readonly tender_session: string
+  readonly title: string
+  readonly updated_at: string
+  readonly vars: readonly SeedVar[]
+}
+
+export interface CrewMember {
+  readonly awareness_dirs: readonly string[]
+  readonly binding_session?: string
+  readonly charter_path: string
+  readonly cwd?: string
+  readonly home_dir: string
+  readonly id: string
+}
+
+export interface AppViewInfo {
+  readonly kind: string
+  readonly name: string
+  readonly params_label?: string
+  readonly params_placeholder?: string
+  readonly title: string
+}
+
+/** The app projection Initial State uses for mounting views. */
+export interface AppRegistryEntry {
+  readonly content_hash?: string
+  readonly description?: string
+  readonly enabled: boolean
+  readonly name: string
+  readonly version_id?: number
+  readonly views: readonly AppViewInfo[]
+}
+
+/** The state-bearing domains shared with attn's Initial State projection. */
+export interface CurrentStateSnapshot {
+  /** Bus head captured before the projection was assembled. */
+  readonly asOfSeq: number
+  readonly sessions: readonly Session[]
+  readonly endpoints: readonly EndpointInfo[]
+  readonly workspaces: readonly Workspace[]
+  readonly prs: readonly PR[]
+  readonly repos: readonly RepoState[]
+  readonly authors: readonly AuthorState[]
+  readonly githubHosts: readonly string[]
+  readonly tickets: readonly TicketRow[]
+  readonly seeds: readonly Seed[]
+  readonly crew: readonly CrewMember[]
+  readonly apps: readonly AppRegistryEntry[]
+}

--- a/sdk/attn-app/src/index.ts
+++ b/sdk/attn-app/src/index.ts
@@ -10,6 +10,8 @@
 //
 // Design: docs/plans/2026-08-13-ext-a5-ui-host-and-app-sdk.md.
 
+import type { CurrentStateSnapshot } from "./currentState"
+
 // React, re-exported by name.
 //
 // An app never writes the specifier `react` — there is no `react` in an app's
@@ -117,6 +119,10 @@ export interface AppContext<Collections> {
   readonly version: number
   /** The collections declared in attn-app.toml, by name. */
   readonly collections: Collections
+  /** Read-only current truth, from the same domain projection as Initial State. */
+  readonly current: {
+    snapshot(): Promise<CurrentStateSnapshot>
+  }
 }
 
 /**
@@ -127,6 +133,53 @@ export interface AppContext<Collections> {
  */
 export type Handler<Collections> = (
   event: AppEvent,
+  ctx: AppContext<Collections>,
+) => void | Promise<void>
+
+/** Why attn requires the app to rebuild its derived collections. */
+export type ReconcileCause = "gap" | "re_enabled" | "version_changed"
+
+export type {
+  AppRegistryEntry,
+  AppViewInfo,
+  AuthorState,
+  CrewMember,
+  CurrentStateSnapshot,
+  EndpointCapabilities,
+  EndpointInfo,
+  PR,
+  RepoState,
+  Seed,
+  SeedEdge,
+  SeedPlotProgress,
+  SeedVar,
+  Session,
+  TicketRow,
+  Workspace,
+  WorkspaceLayout,
+  WorkspacePane,
+} from "./currentState"
+
+/** The durable requests coalesced into one reconcile invocation. */
+export interface ReconcileReason {
+  /** Sorted as gap, re_enabled, version_changed, independent of arrival order. */
+  readonly causes: readonly ReconcileCause[]
+  /** The version whose reconcile handler is running. */
+  readonly version: number
+  /** The bus position the rebuilt state supersedes. */
+  readonly throughSeq: number
+  readonly gap?: {
+    readonly cursor: number
+    readonly earliest: number
+    readonly missed: number
+  }
+  /** Distinct prior versions named by pointer moves, in request order. */
+  readonly previousVersions: readonly number[]
+}
+
+/** Rebuilds the app's collections from current truth. It must be idempotent. */
+export type ReconcileHandler<Collections> = (
+  reason: ReconcileReason,
   ctx: AppContext<Collections>,
 ) => void | Promise<void>
 


### PR DESCRIPTION
## TL;DR

Apps can now declare a reconcile capability, implement it as a sibling export beside subscriptions and commands, and rebuild their collections from a typed snapshot of attn's current state. The daemon keeps the durable request and cursor fence from slice 1 authoritative; this slice only makes that owed work dispatchable through the shared app runtime.

## Why

Slice 1 made reconciliation durable and blocked fact delivery while it is owed, but the runtime had no contract for actually running the app's rebuild. An app therefore needs three pieces in lockstep: a frozen manifest declaration, a compiler-checked handler export, and a bounded current-state read that sees the same state-bearing domains as Initial State.

## What changed

- `reconcile = true` becomes part of the frozen app declaration. Generated `Handlers` requires the sibling `reconcile` export when declared and rejects it when undeclared, so apply catches manifest/bundle drift without evaluating app code.
- `@victorarias/attn-app` gains `ReconcileReason`, `ReconcileHandler`, and `ctx.current.snapshot()`. `CurrentStateSnapshot` is fully typed and deliberately excludes settings, warnings, and protocol metadata; `apps` uses the registry projection that Initial State uses to mount views.
- The daemon extracts Initial State's state-bearing assembly into one shared projection. Snapshot reads capture the bus head first, return non-null arrays, and are fenced to the active dispatch id.
- The sidecar accepts `app.reconcile`, loads the named content-addressed bundle, invokes its sibling export with the fixed durable reason, and exposes the same current-state callback to ordinary handlers.

The runtime ordering is:

```text
app consumer pre-drain
  -> resolve serving version + coalesced durable reason
  -> app.reconcile in the shared sidecar
  -> bundle.reconcile(reason, scoped context)
  -> ctx.current.snapshot() callback to the daemon
  -> shared Initial State domain projection
  -> handler converges its declared collections
```

## Review path

1. `internal/daemon/current_state.go` — verify the snapshot's bus-position ordering and parity with Initial State.
2. `internal/daemon/app_consumers.go` and `app_runtime_rpc.go` — verify the durable pre-drain plan and dispatch-id fence.
3. `apphost/src/dispatch.ts` — verify reconcile is its own sibling kind and receives the same scoped context as other handlers.
4. `sdk/attn-app/src/index.ts` and `currentState.ts` — verify the public types match the daemon JSON exactly.

## Manual verification

Installed the exact branch as an isolated signed app at protocol 251 and passed bundled preflight. A throwaway app declared reconcile, called `ctx.current.snapshot()`, and wrote a receipt from its handler. Disabling and re-enabling it produced one `re_enabled` receipt with `throughSeq=34`, snapshot `asOfSeq=38`, and `apps=["reconcile-proof"]`; the consumer then reached cursor 39 with zero lag and the shared runtime remained connected. The profile and proof app were removed afterward.

## Scope boundary

Invocation rows, timeout/interruption handling, operator status, command refusal, missing-handler policy, and packaged-app failure proofs remain slice 3. The current tree still has slice 1's `re_enabled` durable cause, so this slice dispatches it; the amended plan assigns removing that trigger and SDK enum to slice 3 together with the new retention-floor and delivery witnesses.

Related design: `docs/plans/2026-08-14-ext-app-reconcile-handler.md`.
