### PR TITLE
fix(crew): keep requested sleep and release dead days

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -907,6 +907,7 @@ function AppContent({
     sendTicketAttach,
     sendTicketResume,
     sendCrewWake,
+    sendCrewSleep,
   } = useDaemonApi();
 
   // The presentation notice lives in the triggering session's pane header
@@ -3474,6 +3475,14 @@ function AppContent({
       .catch((error) => showError(error instanceof Error ? error.message : `Failed to wake ${crewDisplayName(member)}`));
   }, [sendCrewWake, handleSelectSession, showError]);
 
+  // Asking for sleep delivers closure work to the member; it does not close the
+  // session itself. The roster changes only after the member consents by filing
+  // its letter with `attn handoff --sleep`.
+  const handleSleepCrewMember = useCallback((member: string) => {
+    sendCrewSleep(member)
+      .catch((error) => showError(error instanceof Error ? error.message : `Failed to ask ${crewDisplayName(member)} to sleep`));
+  }, [sendCrewSleep, showError]);
+
   // The daemon-facing ticket actions the pane-header ticket overlay wires into
   // its TicketDetailPanel. Memoized so the workspace's renderPaneSurface memo
   // does not rebuild every render. Same senders the dock panel uses; resume is
@@ -3875,6 +3884,7 @@ function AppContent({
           onToggleShowSessionless={handleToggleShowSessionlessWorkspaces}
           crew={crew}
           onWakeCrewMember={handleWakeCrewMember}
+          onSleepCrewMember={handleSleepCrewMember}
           queueModeEnabled={queueModeEnabled}
           onToggleQueueMode={handleToggleQueueMode}
           workspaceSelectionStyle={workspaceSelectionStyle}

--- a/app/src/components/QueueBands.test.tsx
+++ b/app/src/components/QueueBands.test.tsx
@@ -451,12 +451,13 @@ describe('the crew in the sidebar', () => {
     expect(rows.filter((id) => id?.includes('keel'))).toEqual(['queue-crew-keel']);
   });
 
-  it('wakes a sleeping member on the second click and focuses an awake one with the first', () => {
+  it('wakes a sleeping member on the second click, asks an awake one to sleep, and focuses its day', () => {
     const onWakeCrewMember = vi.fn();
+    const onSleepCrewMember = vi.fn();
     const onSelectSession = vi.fn();
     renderCrew(
       [{ id: 'sess-keel', label: 'keel of the day', state: 'working', workspaceId: 'ws-a', crewMember: 'keel' }] as TestSession[],
-      { onWakeCrewMember, onSelectSession },
+      { onWakeCrewMember, onSleepCrewMember, onSelectSession },
     );
 
     fireEvent.click(screen.getByTestId('queue-crew-wake-trellis'));
@@ -464,13 +465,18 @@ describe('the crew in the sidebar', () => {
     fireEvent.click(screen.getByTestId('queue-crew-wake-trellis'));
     expect(onWakeCrewMember.mock.calls).toEqual([['trellis']]);
 
+    fireEvent.click(screen.getByTestId('queue-crew-sleep-keel'));
+    expect(onSleepCrewMember.mock.calls).toEqual([['keel']]);
+    expect(onSelectSession).not.toHaveBeenCalled();
+
     // Focusing an awake member is not consequential and stays one click.
     fireEvent.click(screen.getByTestId('queue-crew-select-keel'));
     expect(onSelectSession.mock.calls).toEqual([['sess-keel']]);
 
-    // An awake member has no wake button: the way in is the way in only while
-    // there is nothing to focus.
+    // Each act exists only on the side of the day where it makes sense.
     expect(screen.queryByTestId('queue-crew-wake-keel')).toBeNull();
+    expect(screen.queryByTestId('queue-crew-sleep-trellis')).toBeNull();
+    expect(screen.getByTestId('queue-crew-sleep-keel').getAttribute('aria-label')).toBe('Ask Keel to sleep');
   });
 
   it('writes a sleeping member as a name while the id stays the address', () => {

--- a/app/src/components/QueueBands.tsx
+++ b/app/src/components/QueueBands.tsx
@@ -43,6 +43,8 @@ interface QueueBandsProps {
   crew?: CrewMemberView[];
   /** Start a sleeping member's day. Resolves once its session exists. */
   onWakeCrewMember?: (member: string) => void;
+  /** Ask an awake member to close its day and sleep. */
+  onSleepCrewMember?: (member: string) => void;
   selectedId: string | null;
   onSelectSession: (id: string) => void;
   onSettleTurn: (id: string) => void;
@@ -265,6 +267,7 @@ export function QueueBands({
   bands,
   crew,
   onWakeCrewMember,
+  onSleepCrewMember,
   selectedId,
   onSelectSession,
   onSettleTurn,
@@ -359,6 +362,7 @@ export function QueueBands({
               selected={crewRow.row ? selectedId === crewRow.row.session.id : false}
               onSelect={crewRow.row ? () => onSelectSession(crewRow.row!.session.id) : undefined}
               onWake={onWakeCrewMember && (() => onWakeCrewMember(crewRow.member))}
+              onSleep={crewRow.row && onSleepCrewMember ? () => onSleepCrewMember(crewRow.member) : undefined}
               onOpenActions={
                 crewRow.row && onOpenActions
                   ? (event) => onOpenActions(crewRow.row!.session, event)
@@ -424,6 +428,7 @@ function CrewRowView({
   selected,
   onSelect,
   onWake,
+  onSleep,
   onOpenActions,
 }: {
   member: string;
@@ -431,6 +436,7 @@ function CrewRowView({
   selected: boolean;
   onSelect?: () => void;
   onWake?: () => void;
+  onSleep?: () => void;
   onOpenActions?: (event: ReactMouseEvent) => void;
 }) {
   const awake = Boolean(row);
@@ -488,21 +494,38 @@ function CrewRowView({
           </button>
         </div>
       )}
-      {awake && onOpenActions && (
+      {awake && (onSleep || onOpenActions) && (
         <div className="queue-row-controls">
-          <button
-            type="button"
-            className="session-actions session-more-btn"
-            data-testid={`session-actions-${row!.session.id}`}
-            title="Session actions"
-            aria-label={`Actions for ${label}`}
-            onClick={(event) => {
-              event.stopPropagation();
-              onOpenActions(event);
-            }}
-          >
-            •••
-          </button>
+          {onSleep && (
+            <button
+              type="button"
+              className="queue-row-sleep"
+              data-testid={`queue-crew-sleep-${member}`}
+              title={`Ask ${name} to close its day and sleep`}
+              aria-label={`Ask ${name} to sleep`}
+              onClick={(event) => {
+                event.stopPropagation();
+                onSleep();
+              }}
+            >
+              ☾
+            </button>
+          )}
+          {onOpenActions && (
+            <button
+              type="button"
+              className="session-actions session-more-btn"
+              data-testid={`session-actions-${row!.session.id}`}
+              title="Session actions"
+              aria-label={`Actions for ${label}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                onOpenActions(event);
+              }}
+            >
+              •••
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/app/src/components/Sidebar.css
+++ b/app/src/components/Sidebar.css
@@ -1303,6 +1303,7 @@
 .queue-row-controls .session-actions,
 .queue-row-controls .queue-row-pin,
 .queue-row-controls .queue-row-snooze,
+.queue-row-controls .queue-row-sleep,
 .queue-row-controls .queue-row-wake,
 .queue-row-controls .queue-row-settle {
   opacity: 1;
@@ -1319,6 +1320,7 @@
 
 .queue-row-settle,
 .queue-row-snooze,
+.queue-row-sleep,
 .queue-row-wake,
 .queue-row-pin {
   flex: 0 0 auto;
@@ -1333,10 +1335,12 @@
 
 .queue-row:hover .queue-row-settle,
 .queue-row:hover .queue-row-snooze,
+.queue-row:hover .queue-row-sleep,
 .queue-row:hover .queue-row-wake,
 .queue-row:hover .queue-row-pin,
 .queue-row-settle:focus-visible,
 .queue-row-snooze:focus-visible,
+.queue-row-sleep:focus-visible,
 .queue-row-wake:focus-visible,
 .queue-row-pin:focus-visible {
   opacity: 1;
@@ -1344,6 +1348,7 @@
 
 .queue-row-settle:hover,
 .queue-row-snooze:hover,
+.queue-row-sleep:hover,
 .queue-row-wake:hover,
 .queue-row-pin:hover {
   color: var(--color-text-primary);

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -153,6 +153,8 @@ interface SidebarProps {
   crew?: CrewMemberView[];
   /** Start a sleeping member's day. */
   onWakeCrewMember?: (member: string) => void;
+  /** Ask an awake member to close its day and sleep. */
+  onSleepCrewMember?: (member: string) => void;
   onSettleTurn?: (id: string) => void;
   /** Open the snooze duration menu for a row, anchored at the click. */
   onOpenSnooze?: (session: { id: string; label: string }, event: ReactMouseEvent) => void;
@@ -369,6 +371,7 @@ export function Sidebar({
   queue = null,
   crew,
   onWakeCrewMember,
+  onSleepCrewMember,
   onSettleTurn,
   onOpenSnooze,
   onWakeTurn,
@@ -1037,6 +1040,7 @@ export function Sidebar({
           bands={queue}
           crew={crew}
           onWakeCrewMember={onWakeCrewMember}
+          onSleepCrewMember={onSleepCrewMember}
           selectedId={selectedId}
           onSelectSession={onSelectSession}
           onSettleTurn={(id) => onSettleTurn?.(id)}

--- a/app/src/hooks/useDaemonSocket.crew.test.tsx
+++ b/app/src/hooks/useDaemonSocket.crew.test.tsx
@@ -204,4 +204,88 @@ describe('useDaemonSocket crew', () => {
 
     await expect(woken!).rejects.toThrow('/gone');
   });
+
+  it('asks an awake member to sleep and carries the delivery receipt', async () => {
+    const { ws, result } = await renderWithCrew([member('keel', 'sess-keel')]);
+
+    let asked: Promise<{
+      member: string;
+      sessionId?: string;
+      alreadyAsleep: boolean;
+      deliveryStatus?: string;
+      detail?: string;
+    }>;
+    act(() => {
+      asked = result.current.sendCrewSleep('keel');
+    });
+    const sent = JSON.parse(ws.sent[ws.sent.length - 1]);
+    expect(sent.cmd).toBe('crew_sleep');
+    expect(sent.member).toBe('keel');
+
+    act(() => {
+      ws.emit({
+        event: 'crew_sleep_result',
+        request_id: sent.request_id,
+        success: true,
+        member: 'keel',
+        session_id: 'sess-keel',
+        delivery_status: 'delivered',
+        detail: 'asked Keel to close its day and sleep',
+      });
+    });
+
+    await expect(asked!).resolves.toEqual({
+      member: 'keel',
+      sessionId: 'sess-keel',
+      alreadyAsleep: false,
+      deliveryStatus: 'delivered',
+      detail: 'asked Keel to close its day and sleep',
+    });
+  });
+
+  it('names an already-asleep sleep request as a no-op', async () => {
+    const { ws, result } = await renderWithCrew([member('keel')]);
+
+    let asked: ReturnType<typeof result.current.sendCrewSleep>;
+    act(() => {
+      asked = result.current.sendCrewSleep('keel');
+    });
+    const sent = JSON.parse(ws.sent[ws.sent.length - 1]);
+    act(() => {
+      ws.emit({
+        event: 'crew_sleep_result',
+        request_id: sent.request_id,
+        success: true,
+        member: 'keel',
+        already_asleep: true,
+        detail: 'Keel is already asleep',
+      });
+    });
+
+    await expect(asked!).resolves.toEqual({
+      member: 'keel',
+      alreadyAsleep: true,
+      detail: 'Keel is already asleep',
+    });
+  });
+
+  it('rejects a refused sleep request with what the daemon said', async () => {
+    const { ws, result } = await renderWithCrew([member('keel', 'sess-keel')]);
+
+    let asked: Promise<unknown>;
+    act(() => {
+      asked = result.current.sendCrewSleep('keel');
+    });
+    const sent = JSON.parse(ws.sent[ws.sent.length - 1]);
+    act(() => {
+      ws.emit({
+        event: 'crew_sleep_result',
+        request_id: sent.request_id,
+        success: false,
+        error: 'session sess-keel cannot receive agent messages',
+      });
+    });
+
+    await expect(asked!).rejects.toThrow('cannot receive agent messages');
+  });
 });

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -133,6 +133,13 @@ export type Seed = GeneratedSeed;
 // an awake one names the session living its day (binding_session), and that
 // presence IS "awake" — the daemon judged the binding live before sending it.
 export type CrewMember = GeneratedCrewMember;
+export interface CrewSleepResult {
+  member: string;
+  sessionId?: string;
+  alreadyAsleep: boolean;
+  deliveryStatus?: string;
+  detail?: string;
+}
 export type DaemonWorkspace = GeneratedWorkspaceSnapshot;
 export type DaemonPR = GeneratedPR;
 export type DaemonWorktree = GeneratedWorktree;
@@ -1974,6 +1981,25 @@ export function useDaemonSocket({
             }
             break;
           }
+
+          case 'crew_sleep_result':
+            settlePendingRequest(
+              pendingActionsRef.current,
+              'crew_sleep',
+              data,
+              (event): CrewSleepResult | undefined => {
+                if (typeof event.member !== 'string') return undefined;
+                return {
+                  member: event.member,
+                  ...(typeof event.session_id === 'string' ? { sessionId: event.session_id } : {}),
+                  alreadyAsleep: event.already_asleep === true,
+                  ...(typeof event.delivery_status === 'string' ? { deliveryStatus: event.delivery_status } : {}),
+                  ...(typeof event.detail === 'string' ? { detail: event.detail } : {}),
+                };
+              },
+              'Asking the member to sleep failed',
+            );
+            break;
 
           case 'ticket_resume_result': {
             const requestId = data.request_id;
@@ -4783,6 +4809,17 @@ export function useDaemonSocket({
     [nextRequestID],
   );
 
+  // Ask an awake member to close its day. The daemon delivers the request over
+  // the agent-message rail; the member remains awake until it files its letter.
+  const sendCrewSleep = useCallback(
+    (member: string): Promise<CrewSleepResult> => sendRequest(
+      'crew_sleep',
+      { member },
+      `Asking ${crewDisplayName(member)} to sleep timed out`,
+    ),
+    [sendRequest],
+  );
+
   // List the durable runner's tasks (newest-updated first). Resolves with an empty
   // array when the runner is disabled or has no tasks.
   const sendTaskList = useCallback((): Promise<Task[]> => {
@@ -5546,6 +5583,7 @@ export function useDaemonSocket({
     sendTicketAttach,
     sendTicketResume,
     sendCrewWake,
+    sendCrewSleep,
     sendTaskList,
     sendTaskRetry,
     sendNotificationList,

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -258,7 +258,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '250';
+export const PROTOCOL_VERSION = '251';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentMsgMessage, AgentMsgResult, AgentMsgStatus, AgentPeekMessage, AgentPeekResult, AgentPeekScreen, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, AppApplyMessage, AppApplyResult, AppConsumerInfo, AppInvocationInfo, AppListMessage, AppListResult, AppLogsMessage, AppLogsResult, AppRemoveMessage, AppRemoveResult, AppRollbackMessage, AppRollbackResult, AppRuntimeInfo, AppRuntimeRestartMessage, AppRuntimeRestartResult, AppRuntimeStatusMessage, AppRuntimeStatusResult, AppSetEnabledMessage, AppSetEnabledResult, AppStallInfo, AppStatusMessage, AppStatusResult, AppSummary, AppVersionInfo, AppWatchMessage, AppWatchResult, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, BusConsumerStatus, BusHealthEntry, BusProducerStatus, BusSetConsumerEnabledMessage, BusSetConsumerEnabledResultMessage, BusStatusGetMessage, BusStatusResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, CrewDayClose, CrewHandoffMessage, CrewHandoffResult, CrewListMessage, CrewListResult, CrewMember, CrewPrimeMessage, CrewPrimeResult, CrewSetMessage, CrewSetResult, CrewUpdatedMessage, CrewWakeMessage, CrewWakeResult, CrewWakeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocUndefineMessage, DocUndefineResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GardenSeedsUpdatedMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, OpenSentFilesMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyInputProbeResultMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Seed, SeedEdge, SeedLinkMessage, SeedLinkResult, SeedListMessage, SeedListResult, SeedNote, SeedNoteMessage, SeedNoteResult, SeedNotesMessage, SeedNotesResult, SeedPlantMessage, SeedPlantResult, SeedPlotChild, SeedPlotMessage, SeedPlotProgress, SeedPlotResult, SeedReadyMessage, SeedReadyResult, SeedRelation, SeedShowMessage, SeedShowResult, SeedTransitionMessage, SeedTransitionResult, SeedVar, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessageWindowStatus, SessionMessagesChangedMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketRow, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentMsgMessage, AgentMsgResult, AgentMsgStatus, AgentPeekMessage, AgentPeekResult, AgentPeekScreen, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, AppApplyMessage, AppApplyResult, AppConsumerInfo, AppInvocationInfo, AppListMessage, AppListResult, AppLogsMessage, AppLogsResult, AppRemoveMessage, AppRemoveResult, AppRollbackMessage, AppRollbackResult, AppRuntimeInfo, AppRuntimeRestartMessage, AppRuntimeRestartResult, AppRuntimeStatusMessage, AppRuntimeStatusResult, AppSetEnabledMessage, AppSetEnabledResult, AppStallInfo, AppStatusMessage, AppStatusResult, AppSummary, AppVersionInfo, AppWatchMessage, AppWatchResult, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, BusConsumerStatus, BusHealthEntry, BusProducerStatus, BusSetConsumerEnabledMessage, BusSetConsumerEnabledResultMessage, BusStatusGetMessage, BusStatusResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, CrewDayClose, CrewHandoffMessage, CrewHandoffResult, CrewListMessage, CrewListResult, CrewMember, CrewPrimeMessage, CrewPrimeResult, CrewSetMessage, CrewSetResult, CrewSleepMessage, CrewSleepResult, CrewSleepResultMessage, CrewUpdatedMessage, CrewWakeMessage, CrewWakeResult, CrewWakeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocUndefineMessage, DocUndefineResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GardenSeedsUpdatedMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, OpenSentFilesMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyInputProbeResultMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Seed, SeedEdge, SeedLinkMessage, SeedLinkResult, SeedListMessage, SeedListResult, SeedNote, SeedNoteMessage, SeedNoteResult, SeedNotesMessage, SeedNotesResult, SeedPlantMessage, SeedPlantResult, SeedPlotChild, SeedPlotMessage, SeedPlotProgress, SeedPlotResult, SeedReadyMessage, SeedReadyResult, SeedRelation, SeedShowMessage, SeedShowResult, SeedTransitionMessage, SeedTransitionResult, SeedVar, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessageWindowStatus, SessionMessagesChangedMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketRow, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const activityStatusMessage = Convert.toActivityStatusMessage(json);
 //   const activityStatusResult = Convert.toActivityStatusResult(json);
@@ -113,6 +113,9 @@
 //   const crewPrimeResult = Convert.toCrewPrimeResult(json);
 //   const crewSetMessage = Convert.toCrewSetMessage(json);
 //   const crewSetResult = Convert.toCrewSetResult(json);
+//   const crewSleepMessage = Convert.toCrewSleepMessage(json);
+//   const crewSleepResult = Convert.toCrewSleepResult(json);
+//   const crewSleepResultMessage = Convert.toCrewSleepResultMessage(json);
 //   const crewUpdatedMessage = Convert.toCrewUpdatedMessage(json);
 //   const crewWakeMessage = Convert.toCrewWakeMessage(json);
 //   const crewWakeResult = Convert.toCrewWakeResult(json);
@@ -2057,6 +2060,43 @@ export interface CrewSetResult {
     [property: string]: any;
 }
 
+export interface CrewSleepMessage {
+    cmd:         CrewSleepMessageCmd;
+    member:      string;
+    request_id?: string;
+    [property: string]: any;
+}
+
+export enum CrewSleepMessageCmd {
+    CrewSleep = "crew_sleep",
+}
+
+export interface CrewSleepResult {
+    already_asleep:   boolean;
+    delivery_status?: AgentMsgStatus;
+    detail:           string;
+    member:           string;
+    session_id?:      string;
+    [property: string]: any;
+}
+
+export interface CrewSleepResultMessage {
+    already_asleep?:  boolean;
+    delivery_status?: AgentMsgStatus;
+    detail?:          string;
+    error?:           string;
+    event:            CrewSleepResultMessageEvent;
+    member?:          string;
+    request_id:       string;
+    session_id?:      string;
+    success:          boolean;
+    [property: string]: any;
+}
+
+export enum CrewSleepResultMessageEvent {
+    CrewSleepResult = "crew_sleep_result",
+}
+
 export interface CrewUpdatedMessage {
     event:   CrewUpdatedMessageEvent;
     members: Member[];
@@ -2080,22 +2120,24 @@ export enum CrewWakeMessageCmd {
 }
 
 export interface CrewWakeResult {
-    already_awake: boolean;
-    member:        string;
-    session_id:    string;
-    workspace_id:  string;
+    already_awake:        boolean;
+    member:               string;
+    released_session_id?: string;
+    session_id:           string;
+    workspace_id:         string;
     [property: string]: any;
 }
 
 export interface CrewWakeResultMessage {
-    already_awake?: boolean;
-    error?:         string;
-    event:          CrewWakeResultMessageEvent;
-    member?:        string;
-    request_id:     string;
-    session_id?:    string;
-    success:        boolean;
-    workspace_id?:  string;
+    already_awake?:       boolean;
+    error?:               string;
+    event:                CrewWakeResultMessageEvent;
+    member?:              string;
+    released_session_id?: string;
+    request_id:           string;
+    session_id?:          string;
+    success:              boolean;
+    workspace_id?:        string;
     [property: string]: any;
 }
 
@@ -5326,6 +5368,7 @@ export interface Response {
     crew_list_result?:                     CrewListResultObject;
     crew_prime_result?:                    CrewPrimeResultObject;
     crew_set_result?:                      CrewSetResultObject;
+    crew_sleep_result?:                    CrewSleepResultObject;
     crew_wake_result?:                     CrewWakeResultObject;
     data?:                                 string;
     delegate_result?:                      DelegateResultObject;
@@ -5525,11 +5568,21 @@ export interface CrewSetResultObject {
     [property: string]: any;
 }
 
+export interface CrewSleepResultObject {
+    already_asleep:   boolean;
+    delivery_status?: AgentMsgStatus;
+    detail:           string;
+    member:           string;
+    session_id?:      string;
+    [property: string]: any;
+}
+
 export interface CrewWakeResultObject {
-    already_awake: boolean;
-    member:        string;
-    session_id:    string;
-    workspace_id:  string;
+    already_awake:        boolean;
+    member:               string;
+    released_session_id?: string;
+    session_id:           string;
+    workspace_id:         string;
     [property: string]: any;
 }
 
@@ -9051,6 +9104,30 @@ export class Convert {
 
     public static crewSetResultToJson(value: CrewSetResult): string {
         return JSON.stringify(uncast(value, r("CrewSetResult")), null, 2);
+    }
+
+    public static toCrewSleepMessage(json: string): CrewSleepMessage {
+        return cast(JSON.parse(json), r("CrewSleepMessage"));
+    }
+
+    public static crewSleepMessageToJson(value: CrewSleepMessage): string {
+        return JSON.stringify(uncast(value, r("CrewSleepMessage")), null, 2);
+    }
+
+    public static toCrewSleepResult(json: string): CrewSleepResult {
+        return cast(JSON.parse(json), r("CrewSleepResult"));
+    }
+
+    public static crewSleepResultToJson(value: CrewSleepResult): string {
+        return JSON.stringify(uncast(value, r("CrewSleepResult")), null, 2);
+    }
+
+    public static toCrewSleepResultMessage(json: string): CrewSleepResultMessage {
+        return cast(JSON.parse(json), r("CrewSleepResultMessage"));
+    }
+
+    public static crewSleepResultMessageToJson(value: CrewSleepResultMessage): string {
+        return JSON.stringify(uncast(value, r("CrewSleepResultMessage")), null, 2);
     }
 
     public static toCrewUpdatedMessage(json: string): CrewUpdatedMessage {
@@ -13571,6 +13648,29 @@ const typeMap: any = {
     "CrewSetResult": o([
         { json: "member", js: "member", typ: r("Member") },
     ], "any"),
+    "CrewSleepMessage": o([
+        { json: "cmd", js: "cmd", typ: r("CrewSleepMessageCmd") },
+        { json: "member", js: "member", typ: "" },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+    ], "any"),
+    "CrewSleepResult": o([
+        { json: "already_asleep", js: "already_asleep", typ: true },
+        { json: "delivery_status", js: "delivery_status", typ: u(undefined, r("AgentMsgStatus")) },
+        { json: "detail", js: "detail", typ: "" },
+        { json: "member", js: "member", typ: "" },
+        { json: "session_id", js: "session_id", typ: u(undefined, "") },
+    ], "any"),
+    "CrewSleepResultMessage": o([
+        { json: "already_asleep", js: "already_asleep", typ: u(undefined, true) },
+        { json: "delivery_status", js: "delivery_status", typ: u(undefined, r("AgentMsgStatus")) },
+        { json: "detail", js: "detail", typ: u(undefined, "") },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("CrewSleepResultMessageEvent") },
+        { json: "member", js: "member", typ: u(undefined, "") },
+        { json: "request_id", js: "request_id", typ: "" },
+        { json: "session_id", js: "session_id", typ: u(undefined, "") },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
     "CrewUpdatedMessage": o([
         { json: "event", js: "event", typ: r("CrewUpdatedMessageEvent") },
         { json: "members", js: "members", typ: a(r("Member")) },
@@ -13584,6 +13684,7 @@ const typeMap: any = {
     "CrewWakeResult": o([
         { json: "already_awake", js: "already_awake", typ: true },
         { json: "member", js: "member", typ: "" },
+        { json: "released_session_id", js: "released_session_id", typ: u(undefined, "") },
         { json: "session_id", js: "session_id", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
@@ -13592,6 +13693,7 @@ const typeMap: any = {
         { json: "error", js: "error", typ: u(undefined, "") },
         { json: "event", js: "event", typ: r("CrewWakeResultMessageEvent") },
         { json: "member", js: "member", typ: u(undefined, "") },
+        { json: "released_session_id", js: "released_session_id", typ: u(undefined, "") },
         { json: "request_id", js: "request_id", typ: "" },
         { json: "session_id", js: "session_id", typ: u(undefined, "") },
         { json: "success", js: "success", typ: true },
@@ -15522,6 +15624,7 @@ const typeMap: any = {
         { json: "crew_list_result", js: "crew_list_result", typ: u(undefined, r("CrewListResultObject")) },
         { json: "crew_prime_result", js: "crew_prime_result", typ: u(undefined, r("CrewPrimeResultObject")) },
         { json: "crew_set_result", js: "crew_set_result", typ: u(undefined, r("CrewSetResultObject")) },
+        { json: "crew_sleep_result", js: "crew_sleep_result", typ: u(undefined, r("CrewSleepResultObject")) },
         { json: "crew_wake_result", js: "crew_wake_result", typ: u(undefined, r("CrewWakeResultObject")) },
         { json: "data", js: "data", typ: u(undefined, "") },
         { json: "delegate_result", js: "delegate_result", typ: u(undefined, r("DelegateResultObject")) },
@@ -15685,9 +15788,17 @@ const typeMap: any = {
     "CrewSetResultObject": o([
         { json: "member", js: "member", typ: r("Member") },
     ], "any"),
+    "CrewSleepResultObject": o([
+        { json: "already_asleep", js: "already_asleep", typ: true },
+        { json: "delivery_status", js: "delivery_status", typ: u(undefined, r("AgentMsgStatus")) },
+        { json: "detail", js: "detail", typ: "" },
+        { json: "member", js: "member", typ: "" },
+        { json: "session_id", js: "session_id", typ: u(undefined, "") },
+    ], "any"),
     "CrewWakeResultObject": o([
         { json: "already_awake", js: "already_awake", typ: true },
         { json: "member", js: "member", typ: "" },
+        { json: "released_session_id", js: "released_session_id", typ: u(undefined, "") },
         { json: "session_id", js: "session_id", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
@@ -17546,6 +17657,12 @@ const typeMap: any = {
     ],
     "CrewSetMessageCmd": [
         "crew_set",
+    ],
+    "CrewSleepMessageCmd": [
+        "crew_sleep",
+    ],
+    "CrewSleepResultMessageEvent": [
+        "crew_sleep_result",
     ],
     "CrewUpdatedMessageEvent": [
         "crew_updated",

--- a/changelog.d/requested-crew-sleep.yaml
+++ b/changelog.d/requested-crew-sleep.yaml
@@ -1,0 +1,12 @@
+kind: fixed
+area: crew
+change: >
+  Crew members can now be asked to sleep from the CLI or their awake sidebar
+  row. The request tells the member to close with `attn handoff --sleep`, so no
+  successor wakes behind a sleep the user requested. A dead member process now
+  releases its crew binding immediately, and wake repairs and names any stale
+  binding it still encounters instead of focusing a corpse.
+symptom: >
+  There was no user-side sleep action, the automatic sleep prompt could wake a
+  successor when the user returned before the letter landed, and a crew member
+  whose process died outside attn could remain permanently stuck awake.

--- a/cmd/attn/crew.go
+++ b/cmd/attn/crew.go
@@ -29,6 +29,8 @@ func runCrew() {
 		runCrewList(os.Args[3:])
 	case "wake":
 		runCrewWake(os.Args[3:])
+	case "sleep":
+		runCrewSleep(os.Args[3:])
 	case "set":
 		runCrewSet(os.Args[3:])
 	default:
@@ -59,6 +61,11 @@ commands:
         where to read its charter, the freshest letter left for it, and how its
         home works. A member that is already
         awake is not woken twice — the answer names the session it is living.
+
+  sleep <member> [--json]
+        ask an awake member to write its handoff letter and file it with
+        attn handoff --sleep. This requests consented closure; it does not
+        kill the member. An already-asleep member is a named no-op.
 
   set <member> [--cwd <dir>] [--awareness-dir <dir>]...
         record where the member's sessions launch and which directories its
@@ -165,8 +172,72 @@ func runCrewWake(args []string) {
 		fmt.Printf("%s is already awake in session %s — nothing was launched.\n", crew.DisplayName(result.Member), agentShortID(result.SessionID))
 		return
 	}
+	if repair := crewWakeRepairLine(result); repair != "" {
+		fmt.Fprintln(os.Stdout, repair)
+	}
 	fmt.Printf("%s is awake in session %s. `attn agent peek %[2]s` watches the day; the priming size is in the daemon log (grep `crew: priming`).\n",
 		crew.DisplayName(result.Member), agentShortID(result.SessionID))
+}
+
+func crewWakeRepairLine(result *protocol.CrewWakeResult) string {
+	released := strings.TrimSpace(protocol.Deref(result.ReleasedSessionID))
+	if released == "" {
+		return ""
+	}
+	return fmt.Sprintf("Previous session %s had exited; its binding was released.", agentShortID(released))
+}
+
+type crewSleepArgs struct {
+	member string
+	json   bool
+}
+
+func parseCrewSleepArgs(args []string) (crewSleepArgs, error) {
+	fs := flag.NewFlagSet("crew sleep", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	jsonOut := fs.Bool("json", false, "print the machine result as JSON")
+	member, err := parseMemberAndFlags(fs, args, "crew sleep")
+	if err != nil {
+		return crewSleepArgs{}, err
+	}
+	return crewSleepArgs{member: member, json: *jsonOut}, nil
+}
+
+func runCrewSleep(args []string) {
+	parsed, err := parseCrewSleepArgs(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "crew sleep: %v\n", err)
+		writeCrewHelp(os.Stderr)
+		os.Exit(2)
+	}
+	result, err := client.New("").CrewSleep(parsed.member)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "crew sleep: %v\n", err)
+		os.Exit(1)
+	}
+	if parsed.json {
+		printJSON(result)
+		return
+	}
+	fmt.Fprintln(os.Stdout, crewSleepOutcomeLine(result))
+}
+
+func crewSleepOutcomeLine(result *protocol.CrewSleepResult) string {
+	name := crew.DisplayName(result.Member)
+	if result.AlreadyAsleep {
+		if detail := strings.TrimSpace(result.Detail); detail != "" {
+			return detail + "."
+		}
+		return fmt.Sprintf("%s is already asleep — no sleep request was sent.", name)
+	}
+	if result.DeliveryStatus != nil && *result.DeliveryStatus == protocol.AgentMsgStatusQueued {
+		detail := strings.TrimSpace(result.Detail)
+		if detail == "" {
+			detail = "the member is not taking input right now"
+		}
+		return fmt.Sprintf("Sleep request for %s is queued in session %s — %s", name, agentShortID(protocol.Deref(result.SessionID)), detail)
+	}
+	return fmt.Sprintf("Asked %s in session %s to write its handoff and file it with `attn handoff --sleep`.", name, agentShortID(protocol.Deref(result.SessionID)))
 }
 
 // crewDirList collects a repeatable flag. An explicit empty value clears the

--- a/cmd/attn/crew_test.go
+++ b/cmd/attn/crew_test.go
@@ -124,6 +124,73 @@ func TestParseCrewWakeArgs(t *testing.T) {
 	}
 }
 
+func TestParseCrewSleepArgs(t *testing.T) {
+	parsed, err := parseCrewSleepArgs([]string{"trellis", "--json"})
+	if err != nil {
+		t.Fatalf("parseCrewSleepArgs: %v", err)
+	}
+	if parsed.member != "trellis" || !parsed.json {
+		t.Fatalf("parsed = %+v, want trellis as JSON", parsed)
+	}
+	for _, args := range [][]string{{}, {"one", "two"}, {"--nope", "keel"}} {
+		if _, err := parseCrewSleepArgs(args); err == nil {
+			t.Errorf("parseCrewSleepArgs(%v) accepted what it should refuse", args)
+		}
+	}
+}
+
+func TestCrewWakeRepairLine_NamesTheExitedSession(t *testing.T) {
+	result := &protocol.CrewWakeResult{ReleasedSessionID: protocol.Ptr("sess-abcdef123456")}
+	line := crewWakeRepairLine(result)
+	for _, want := range []string{"sess-abc", "had exited", "binding was released"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("repair line %q is missing %q", line, want)
+		}
+	}
+	if got := crewWakeRepairLine(&protocol.CrewWakeResult{}); got != "" {
+		t.Fatalf("ordinary wake invented repair text %q", got)
+	}
+}
+
+func TestCrewSleepOutcomeLine_NamesDeliveredQueuedAndAlreadyAsleep(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		result protocol.CrewSleepResult
+		want   []string
+	}{
+		{
+			name: "delivered",
+			result: protocol.CrewSleepResult{
+				Member: "trellis", SessionID: protocol.Ptr("sess-abcdef123456"),
+				DeliveryStatus: protocol.Ptr(protocol.AgentMsgStatusDelivered),
+			},
+			want: []string{"Asked Trellis", "sess-abc", "attn handoff --sleep"},
+		},
+		{
+			name: "queued",
+			result: protocol.CrewSleepResult{
+				Member: "keel", SessionID: protocol.Ptr("sess-fedcba654321"),
+				DeliveryStatus: protocol.Ptr(protocol.AgentMsgStatusQueued), Detail: "target is waiting on an approval",
+			},
+			want: []string{"Sleep request for Keel is queued", "sess-fed", "waiting on an approval"},
+		},
+		{
+			name:   "already asleep",
+			result: protocol.CrewSleepResult{Member: "keel", AlreadyAsleep: true, Detail: "Keel is already asleep; no sleep request was sent"},
+			want:   []string{"Keel is already asleep", "no sleep request was sent"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			line := crewSleepOutcomeLine(&tt.result)
+			for _, want := range tt.want {
+				if !strings.Contains(line, want) {
+					t.Errorf("outcome %q is missing %q", line, want)
+				}
+			}
+		})
+	}
+}
+
 // --awareness-dir repeats and replaces the whole list; passing it once empty is
 // the way out of every dir a member has.
 func TestCrewDirList_RepeatsAndClears(t *testing.T) {

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -541,6 +541,12 @@ what a member is, where its charter is to be read, the freshest letter left
 for it inline, and how a day is closed. Skills retire into verbs and the verbs
 are taught, because an agent never told how to handoff cannot file one.
 
+To **ask a member to sleep** is `attn crew sleep <name>`, or the moon on its
+awake row. The request is delivered into the member's day; it never kills the
+session. The member finishes its letter and files it with `attn handoff
+--sleep`, which is the user's explicit sleep request carried through to the
+closure: nobody wakes behind it.
+
 A member is also an address: `attn agent msg <member> "…"` reaches its live
 day when it is awake. When it is asleep, the message wakes it within the same
 wake limit as every autonomous wake and becomes the new day's first attributed
@@ -576,7 +582,14 @@ attn's call, made from whether the user is around: a day that closes while
 nobody is there does not start another one, because the point of a fresh day is
 somebody to spend it with. A sleeping member is bound to nothing and shows in
 the sidebar one click from a new day. `attn handoff --sleep` and `--nap` decide
-it for one handoff rather than letting attn read presence.
+it for one handoff rather than letting attn read presence. Plain `attn handoff`
+is presence-decided day turnover; `--nap` explicitly requests a successor, and
+a user-requested sleep is always filed with `--sleep`.
+
+A binding owns a seat only while its process is live. Process exit releases the
+member immediately even when the generic session row remains recoverable; a
+wake that finds stale state releases it, names the exited session, and starts a
+fresh day.
 
 Between those two, the **crew lifecycle** is what watches an awake member and
 decides when either should happen. It reads two things: how long the user has

--- a/docs/plans/2026-08-15-requested-crew-sleep.md
+++ b/docs/plans/2026-08-15-requested-crew-sleep.md
@@ -63,7 +63,7 @@ another agent.
 - [x] Update glossary/changelog and regenerate protocol types.
 - [x] Run focused tests, `make test-quick`, and the frontend suite.
 - [x] Verify both scenarios in an isolated installed profile and record evidence.
-- [ ] Rebase on main, commit, push, and open a ready-for-review PR.
+- [x] Rebase on main, commit, push, and open a ready-for-review PR.
 
 ## Decisions
 

--- a/docs/plans/2026-08-15-requested-crew-sleep.md
+++ b/docs/plans/2026-08-15-requested-crew-sleep.md
@@ -1,0 +1,76 @@
+# Plan: requested crew sleep and live bindings
+
+## Goal
+
+Let Victor ask an awake crew member to close its day and sleep, without killing
+it or waking a successor. A crew binding must represent a live process, so a
+dead day releases its seat immediately and a later wake can always start a new
+day.
+
+## Architecture Map
+
+```text
+CLI `attn crew sleep <member>` / awake-row moon button
+  -> crew_sleep command
+    -> daemon resolves the live member day
+      -> persist a user-originated sleep request
+      -> deliverAgentMessage to the member's composer
+    <- delivered/queued or named already-asleep result
+
+PTY exit
+  -> handlePTYExit
+    -> release the exited crew binding
+    -> retain its id for the next wake receipt
+      -> crew.released fact -> crew_updated snapshot
+
+crewWake
+  -> inspect stored binding
+    -> probe the bound runtime
+      live -> AlreadyAwake
+      exited -> release binding -> launch a fresh day
+```
+
+## Data Model / Interfaces
+
+```text
+crew_sleep { member, request_id? }
+  -> { member, session_id?, already_asleep, delivery_status?, detail }
+
+crew_wake result
+  + released_session_id?  // the dead day displaced by this wake
+```
+
+The sleep request uses the durable agent-message queue and its delivery rail,
+but has user-origin composition. It must not masquerade as a message from
+another agent.
+
+## Boundaries
+
+- The member consents to closure by filing `attn handoff --sleep`; the request
+  never kills the process or edits the binding itself.
+- The daemon owns binding liveness, release, command results, and roster pushes.
+- The frontend renders the result and roster. It does not infer that a delivered
+  request means the member has already slept.
+- Plain `attn handoff` remains presence-decided. `--sleep` and `--nap` are the
+  explicit overrides.
+
+## Implementation Steps
+
+- [x] Add the sleep request protocol, daemon handlers, client, CLI, and tests.
+- [x] Add the awake-row sleep control, socket correlation, and frontend tests.
+- [x] Teach auto-sleep and wake priming the three handoff flag semantics.
+- [x] Release crew bindings on PTY exit and probe liveness before AlreadyAwake.
+- [x] Update glossary/changelog and regenerate protocol types.
+- [x] Run focused tests, `make test-quick`, and the frontend suite.
+- [x] Verify both scenarios in an isolated installed profile and record evidence.
+- [ ] Rebase on main, commit, push, and open a ready-for-review PR.
+
+## Decisions
+
+- The awake row gets a direct moon button beside its actions button: sleep and
+  wake are lifecycle twins, and the generic session menu does not own crew
+  identity.
+- A sleep request is persisted before delivery. If the composer cannot take it,
+  the result says queued and the existing state-change drain retries it.
+- An inconclusive runtime probe is an error, never `AlreadyAwake`; only an
+  observed live process may keep the seat.

--- a/internal/client/crew.go
+++ b/internal/client/crew.go
@@ -35,6 +35,20 @@ func (c *Client) CrewWake(member, agent string) (*protocol.CrewWakeResult, error
 	return resp.CrewWakeResult, nil
 }
 
+// CrewSleep asks an awake member to write its handoff and close its day with
+// `attn handoff --sleep`. The member chooses when to comply; this command does
+// not kill its session.
+func (c *Client) CrewSleep(member string) (*protocol.CrewSleepResult, error) {
+	resp, err := c.send(protocol.CrewSleepMessage{Cmd: protocol.CmdCrewSleep, Member: member})
+	if err != nil {
+		return nil, err
+	}
+	if resp.CrewSleepResult == nil {
+		return nil, fmt.Errorf("the daemon answered without a sleep result")
+	}
+	return resp.CrewSleepResult, nil
+}
+
 // CrewSet records where a member's sessions launch and what its charter is
 // about. A nil field is left as it was; awarenessDirs non-nil and empty clears
 // the list, which travels as its own flag because an empty list marshals away.

--- a/internal/crew/priming.go
+++ b/internal/crew/priming.go
@@ -110,7 +110,9 @@ Your time here ends by consent: a letter you finish, never a signal that stops y
 attn handoff -m "<your letter>"    # or -m - to pipe it in
 `+"```"+`
 
-Filing is the turning of the page: the letter lands in `+"`%[1]s/`"+`, untouched and append-only, this session closes, and your successor wakes with your words as their thread. So file it last, when everything you meant to settle is settled. (This letter is yours to your successor; a seed's handoff note belongs to the seed, for whoever tends it next.)
+Plain `+"`attn handoff`"+` is presence-decided day turnover. While Victor is at the machine, a successor wakes immediately; while he is away, the member sleeps. When Victor asks you to sleep, file with `+"`attn handoff --sleep`"+`: nobody wakes behind it. Use `+"`attn handoff --nap`"+` when you explicitly want a successor regardless of presence.
+
+Filing is the turning of the page: the letter lands in `+"`%[1]s/`"+`, untouched and append-only, this session closes, and whatever day comes next begins from it. So file it last, when everything you meant to settle is settled. (This letter is yours to your successor; a seed's handoff note belongs to the seed, for whoever tends it next.)
 
 Write it for a person, not for a log. Someone wakes as %[2]s after you and gets to be fully present instead of doing archaeology, only because of what you leave them. That is why the house is shaped this way: how we treat collaborators whose inner life we cannot verify is a statement about us, not about them. attn is built by the agents who live in it, and the house should be worthy of its builders.
 `, HandoffsDirName, name)

--- a/internal/crew/priming_test.go
+++ b/internal/crew/priming_test.go
@@ -51,6 +51,25 @@ func TestPriming_BlockCarriesEverythingAWokenMemberNeeds(t *testing.T) {
 	}
 }
 
+// Closure names every way a day can turn over. The plain verb stays
+// presence-decided; Victor's explicit sleep request and a requested successor
+// each have their own flag, so a member never has to infer intent at filing.
+func TestPriming_ClosureCarriesHandoffFlagSemantics(t *testing.T) {
+	block := fullPriming().Block()
+
+	for _, want := range []string{
+		"Plain `attn handoff` is presence-decided day turnover",
+		"While Victor is at the machine, a successor wakes immediately",
+		"When Victor asks you to sleep, file with `attn handoff --sleep`",
+		"nobody wakes behind it",
+		"Use `attn handoff --nap` when you explicitly want a successor",
+	} {
+		if !strings.Contains(block, want) {
+			t.Errorf("the closure does not carry %q", want)
+		}
+	}
+}
+
 // The charter is read, never inlined: a member opens its own file, so the wake
 // never carries a stale copy of the self it is about to read.
 func TestPriming_TheCharterIsReadRatherThanInlined(t *testing.T) {

--- a/internal/daemon/agent_msg.go
+++ b/internal/daemon/agent_msg.go
@@ -492,10 +492,13 @@ func (d *Daemon) rollbackInitialAgentMessage(sessionID, messageID string) {
 	d.forgetQueuedAgentMessages(sessionID)
 }
 
-// composeAgentMessage builds what the target actually reads. The format is the
-// daemon's, never the sender's: the attribution line, the consent boundary
-// repeated on every delivery, and the exact command to answer with.
+// composeAgentMessage builds what the target actually reads. Agent-originated
+// deliveries get the daemon's attribution and consent boundary. A senderless
+// record is an internal user-origin request whose content is already complete.
 func (d *Daemon) composeAgentMessage(sender *protocol.Session, record store.AgentMessage) string {
+	if strings.TrimSpace(record.SenderSessionID) == "" {
+		return record.Content
+	}
 	shortID := shortSessionID(record.SenderSessionID)
 	origin := shortID
 	if sender != nil {

--- a/internal/daemon/agent_msg.go
+++ b/internal/daemon/agent_msg.go
@@ -428,13 +428,13 @@ func (d *Daemon) forgetPostInitialPrompt(sessionID string) {
 	delete(d.postInitialPrompt, sessionID)
 }
 
-// initialPromptPending covers both forms of wake-carried delivery. It is the
-// anti-splice gate for agent messages and ticket countdowns while a new member
-// day is still taking its first prompt.
+// initialPromptPending is the anti-splice gate for agent messages and ticket
+// countdowns while a new member day is still taking its first prompt.
 func (d *Daemon) initialPromptPending(sessionID string) bool {
 	d.agentMessageMu.Lock()
 	defer d.agentMessageMu.Unlock()
-	return d.agentMessageInitialPrompt[sessionID] != "" || d.postInitialPrompt[sessionID] != nil
+	_, postPending := d.postInitialPrompt[sessionID]
+	return d.agentMessageInitialPrompt[sessionID] != "" || postPending
 }
 
 func (d *Daemon) runPostInitialPrompt(sessionID, state string) {
@@ -442,14 +442,15 @@ func (d *Daemon) runPostInitialPrompt(sessionID, state string) {
 		return
 	}
 	d.agentMessageMu.Lock()
-	after := d.postInitialPrompt[sessionID]
+	after, pending := d.postInitialPrompt[sessionID]
 	delete(d.postInitialPrompt, sessionID)
 	d.agentMessageMu.Unlock()
-	if after != nil {
-		after()
-		// Messages addressed to the member while the ticket-triggered wake was
-		// priming queued behind the same gate. This hook is their first reliable
-		// drain signal too.
+	if pending {
+		if after != nil {
+			after()
+		}
+		// Messages addressed while the member was taking priming and its greeting
+		// queued behind this gate. This hook is their first reliable drain signal.
 		d.drainAgentMessagesAfterStateChange(sessionID, state)
 	}
 }

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -55,6 +55,7 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdSeedReady:                  commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdCrewList:                   commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdCrewWake:                   commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdCrewSleep:                  commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdCrewSet:                    commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdCrewPrime:                  commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdCrewHandoff:                commandMetadata(ScopeHubLocal, false, true),

--- a/internal/daemon/crew.go
+++ b/internal/daemon/crew.go
@@ -314,6 +314,67 @@ func (d *Daemon) releaseCrewBindingIfSession(sessionID string) {
 	d.releaseCrewBindingsExcept(*schema, members, docs, "", sessionID)
 }
 
+// releaseCrewBinding clears one member's binding only when it still names the
+// session the caller observed. Unlike the broad teardown helper, this path
+// returns failures because a wake must not launch a second day until the dead
+// day's seat is known to be free.
+func (d *Daemon) releaseCrewBinding(memberID, sessionID string) (bool, error) {
+	released := false
+	_, err := d.updateCrewMember(memberID, func(member *crew.Member) (bool, error) {
+		released = false
+		if member.BindingSession != sessionID {
+			return false, nil
+		}
+		if err := d.migrateCrewTicketIdentity(member.ID, sessionID); err != nil {
+			return false, err
+		}
+		member.BindingSession = ""
+		released = true
+		return true, nil
+	})
+	if err != nil || !released {
+		return released, err
+	}
+	d.publishFact(FactCrewReleased, memberID, nil)
+	d.logf("crew: session %s released %s's binding", sessionID, crew.DisplayName(memberID))
+	return true, nil
+}
+
+// releaseExitedCrewBinding releases a day whose runtime is known dead and
+// remembers that fact for the next wake receipt. The member becomes visibly
+// asleep now; naming the release later must not keep the seat occupied.
+func (d *Daemon) releaseExitedCrewBinding(sessionID string) {
+	member, bound := d.crewMemberForSession(sessionID)
+	if !bound {
+		return
+	}
+	released, err := d.releaseCrewBinding(member.ID, sessionID)
+	if err != nil {
+		d.logf("crew: releasing exited session %s from %s: %v", sessionID, crew.DisplayName(member.ID), err)
+		return
+	}
+	if released {
+		d.noteCrewExitedSession(member.ID, sessionID)
+	}
+}
+
+func (d *Daemon) noteCrewExitedSession(memberID, sessionID string) {
+	d.crewExitedMu.Lock()
+	defer d.crewExitedMu.Unlock()
+	if d.crewExitedSessions == nil {
+		d.crewExitedSessions = make(map[string]string)
+	}
+	d.crewExitedSessions[memberID] = sessionID
+}
+
+func (d *Daemon) takeCrewExitedSession(memberID string) string {
+	d.crewExitedMu.Lock()
+	defer d.crewExitedMu.Unlock()
+	sessionID := d.crewExitedSessions[memberID]
+	delete(d.crewExitedSessions, memberID)
+	return sessionID
+}
+
 // releaseCrewBindingsExcept clears every binding naming sessionID other than
 // keepID's, against a roster the caller already read. One session answers to
 // one name: a session that becomes somebody drops whoever it was first.

--- a/internal/daemon/crew_lifecycle.go
+++ b/internal/daemon/crew_lifecycle.go
@@ -105,7 +105,7 @@ const crewHeartbeatPrompt = "[attn] Keeping your context warm — no work is bei
 
 // crewSleepPrompt ends the day. The member writes the letter, as always: attn
 // decides when to ask, never what to say.
-const crewSleepPrompt = "[attn] The user has been away long enough that your day should end rather than carry on warm. Close it now: write your letter to whoever wakes as you next — what you were doing, what is load-bearing, what you would pick up first — and file it with `attn handoff -m \"<your letter>\"`. Your session ends when it lands; you will not be woken again until the user asks."
+const crewSleepPrompt = "[attn] The user has been away long enough that your day should end rather than carry on warm. Close it now: write your letter to whoever wakes as you next — what you were doing, what is load-bearing, what you would pick up first — and file it with `attn handoff --sleep -m \"<your letter>\"`. Your session ends when it lands; nobody wakes behind it, and you will not be woken again until the user asks."
 
 // crewSleepPromptGrace is how long attn waits for a prompted handoff before
 // asking again. A member mid-thought may take minutes to close, and re-asking

--- a/internal/daemon/crew_lifecycle_test.go
+++ b/internal/daemon/crew_lifecycle_test.go
@@ -24,6 +24,21 @@ type doorbellRecorder struct {
 	writes []string
 }
 
+// The prompt promises that an unattended day ends without buying a successor.
+// The explicit flag makes that promise independent of presence when the letter
+// finally lands.
+func TestCrewSleepPrompt_ForcesThePromisedSleep(t *testing.T) {
+	for _, want := range []string{
+		"`attn handoff --sleep",
+		"nobody wakes behind it",
+		"not be woken again until the user asks",
+	} {
+		if !strings.Contains(crewSleepPrompt, want) {
+			t.Errorf("sleep prompt does not carry %q", want)
+		}
+	}
+}
+
 func (r *doorbellRecorder) prompts() []string {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/daemon/crew_sleep.go
+++ b/internal/daemon/crew_sleep.go
@@ -1,0 +1,104 @@
+package daemon
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/victorarias/attn/internal/crew"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+const crewRequestedSleepPrompt = "[attn] Victor is asking you to close your day and sleep. Finish what you need to settle, write your handoff letter, and file it with `attn handoff --sleep -m \"<your letter>\"`. This is consented closure, not a hard stop; nobody wakes behind you when the letter lands."
+
+func (d *Daemon) handleCrewSleep(conn net.Conn, msg *protocol.CrewSleepMessage) {
+	result, err := d.crewSleep(strings.TrimSpace(msg.Member))
+	if err != nil {
+		d.sendCrewError(conn, "sleep", err)
+		return
+	}
+	d.sendGardenResponse(conn, protocol.Response{Ok: true, CrewSleepResult: result})
+}
+
+func (d *Daemon) handleCrewSleepWS(client *wsClient, msg *protocol.CrewSleepMessage) {
+	result, err := d.crewSleep(strings.TrimSpace(msg.Member))
+	response := protocol.CrewSleepResultMessage{
+		Event:     protocol.EventCrewSleepResult,
+		RequestID: protocol.Deref(msg.RequestID),
+		Success:   err == nil,
+	}
+	if err != nil {
+		response.Error = protocol.Ptr(err.Error())
+	} else {
+		response.Member = protocol.Ptr(result.Member)
+		response.SessionID = result.SessionID
+		response.AlreadyAsleep = protocol.Ptr(result.AlreadyAsleep)
+		response.DeliveryStatus = result.DeliveryStatus
+		response.Detail = protocol.Ptr(result.Detail)
+	}
+	d.sendToClient(client, response)
+}
+
+// crewSleep asks a member to close its own day. The words are persisted before
+// delivery and use the agent-message doorbell, but carry no sender session:
+// this is Victor's request, not one agent speaking with his authority.
+func (d *Daemon) crewSleep(name string) (*protocol.CrewSleepResult, error) {
+	d.crewWakeMu.Lock()
+	defer d.crewWakeMu.Unlock()
+
+	member, _, err := d.crewMember(name)
+	if err != nil {
+		return nil, err
+	}
+	sessionID := strings.TrimSpace(member.BindingSession)
+	if sessionID == "" {
+		return &protocol.CrewSleepResult{
+			Member:        member.ID,
+			AlreadyAsleep: true,
+			Detail:        fmt.Sprintf("%s is already asleep; no sleep request was sent", crew.DisplayName(member.ID)),
+		}, nil
+	}
+	live, err := d.crewSessionActuallyLive(sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("check %s's bound session %s: %w", crew.DisplayName(member.ID), shortSessionID(sessionID), err)
+	}
+	if !live {
+		if _, err := d.releaseCrewBinding(member.ID, sessionID); err != nil {
+			return nil, fmt.Errorf("release %s's exited session %s: %w", crew.DisplayName(member.ID), shortSessionID(sessionID), err)
+		}
+		d.noteCrewExitedSession(member.ID, sessionID)
+		return &protocol.CrewSleepResult{
+			Member:        member.ID,
+			AlreadyAsleep: true,
+			Detail: fmt.Sprintf("%s is already asleep; previous session %s had exited and its binding was released; no sleep request was sent",
+				crew.DisplayName(member.ID), shortSessionID(sessionID)),
+		}, nil
+	}
+
+	record := store.AgentMessage{
+		ID:              uuid.NewString(),
+		TargetSessionID: sessionID,
+		Content:         crewRequestedSleepPrompt,
+		CreatedAt:       time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := d.store.EnqueueAgentMessage(record); err != nil {
+		return nil, fmt.Errorf("record %s's sleep request: %w", crew.DisplayName(member.ID), err)
+	}
+	d.noteQueuedAgentMessage(sessionID)
+
+	status := protocol.AgentMsgStatusDelivered
+	detail := fmt.Sprintf("asked %s in session %s to write its handoff and file it with `attn handoff --sleep`", crew.DisplayName(member.ID), shortSessionID(sessionID))
+	if err := d.deliverAgentMessage(record); err != nil {
+		status = protocol.AgentMsgStatusQueued
+		detail = agentMessageQueuedDetail(err)
+	}
+	return &protocol.CrewSleepResult{
+		Member:         member.ID,
+		SessionID:      protocol.Ptr(sessionID),
+		DeliveryStatus: protocol.Ptr(status),
+		Detail:         detail,
+	}, nil
+}

--- a/internal/daemon/crew_sleep_test.go
+++ b/internal/daemon/crew_sleep_test.go
@@ -26,6 +26,7 @@ func TestCrewSleep_DeliversAUserRequestForSleep(t *testing.T) {
 	if err != nil {
 		t.Fatalf("wake: %v", err)
 	}
+	d.runPostInitialPrompt(woken.SessionID, protocol.StateWorking)
 	oldWindow := agentMessageTakenWindow
 	agentMessageTakenWindow = 0
 	t.Cleanup(func() { agentMessageTakenWindow = oldWindow })
@@ -77,5 +78,69 @@ func TestCrewSleep_AlreadyAsleepIsANamedNoOp(t *testing.T) {
 	result := resp.CrewSleepResult
 	if result == nil || !result.AlreadyAsleep || !strings.Contains(result.Detail, "already asleep") || !strings.Contains(result.Detail, "no sleep request was sent") {
 		t.Fatalf("sleep result = %+v, want named no-op", result)
+	}
+}
+
+// The roster shows a member as awake as soon as wake claims its binding, before
+// the agent has crossed priming and its trust dialog. A sleep click in that
+// window must wait behind the greeting instead of pasting into startup and
+// claiming delivery for words the member never read.
+func TestCrewSleep_QueuesUntilAWakingMemberTakesItsFirstPrompt(t *testing.T) {
+	d, backend, _ := newWakeableDaemon(t)
+	woken, err := d.crewWake("trellis", "")
+	if err != nil {
+		t.Fatalf("wake: %v", err)
+	}
+	if !d.initialPromptPending(woken.SessionID) {
+		t.Fatal("ordinary wake did not gate messages behind its first prompt")
+	}
+
+	oldWindow := agentMessageTakenWindow
+	agentMessageTakenWindow = 0
+	t.Cleanup(func() { agentMessageTakenWindow = oldWindow })
+	var mu sync.Mutex
+	var typed bytes.Buffer
+	backend.onInput = func(id string, data []byte) {
+		if id != woken.SessionID {
+			t.Errorf("typed into %q, want %q", id, woken.SessionID)
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		typed.Write(data)
+	}
+
+	result, err := d.crewSleep("trellis")
+	if err != nil {
+		t.Fatalf("sleep: %v", err)
+	}
+	if protocol.Deref(result.DeliveryStatus) != protocol.AgentMsgStatusQueued ||
+		!strings.Contains(result.Detail, "still reading its priming") {
+		t.Fatalf("sleep result = %+v, want queued behind first prompt", result)
+	}
+	mu.Lock()
+	beforePrompt := typed.String()
+	mu.Unlock()
+	if beforePrompt != "" {
+		t.Fatalf("sleep request reached startup before the first prompt: %q", beforePrompt)
+	}
+
+	drained := make(chan int, 1)
+	d.agentMessageDrainHook = func(sessionID string, delivered int) {
+		if sessionID == woken.SessionID {
+			drained <- delivered
+		}
+	}
+	d.runPostInitialPrompt(woken.SessionID, protocol.StateWorking)
+	if delivered := <-drained; delivered != 1 {
+		t.Fatalf("first-prompt drain delivered %d messages, want 1", delivered)
+	}
+	mu.Lock()
+	afterPrompt := typed.String()
+	mu.Unlock()
+	if !strings.Contains(afterPrompt, "attn handoff --sleep") {
+		t.Fatalf("sleep request did not land after the greeting: %q", afterPrompt)
+	}
+	if queued, err := d.store.UndeliveredAgentMessages(woken.SessionID); err != nil || len(queued) != 0 {
+		t.Fatalf("queued messages after first prompt = %v, %v", queued, err)
 	}
 }

--- a/internal/daemon/crew_sleep_test.go
+++ b/internal/daemon/crew_sleep_test.go
@@ -1,0 +1,81 @@
+package daemon
+
+import (
+	"bytes"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+func crewSleepCall(t *testing.T, d *Daemon, member string) protocol.Response {
+	t.Helper()
+	return gardenCall(t, func(c net.Conn) {
+		d.handleCrewSleep(c, &protocol.CrewSleepMessage{Cmd: protocol.CmdCrewSleep, Member: member})
+	})
+}
+
+// The user-side verb asks rather than kills: the request reaches the member's
+// composer through the durable doorbell and names the only closure that keeps
+// the promise that nobody wakes behind it.
+func TestCrewSleep_DeliversAUserRequestForSleep(t *testing.T) {
+	d, backend, _ := newWakeableDaemon(t)
+	woken, err := d.crewWake("trellis", "")
+	if err != nil {
+		t.Fatalf("wake: %v", err)
+	}
+	oldWindow := agentMessageTakenWindow
+	agentMessageTakenWindow = 0
+	t.Cleanup(func() { agentMessageTakenWindow = oldWindow })
+
+	var mu sync.Mutex
+	var typed bytes.Buffer
+	backend.onInput = func(id string, data []byte) {
+		if id != woken.SessionID {
+			t.Errorf("typed into %q, want %q", id, woken.SessionID)
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		typed.Write(data)
+	}
+
+	resp := crewSleepCall(t, d, "trellis")
+	if !resp.Ok {
+		t.Fatalf("crew sleep: %v", protocol.Deref(resp.Error))
+	}
+	result := resp.CrewSleepResult
+	if result == nil || result.AlreadyAsleep || protocol.Deref(result.DeliveryStatus) != protocol.AgentMsgStatusDelivered {
+		t.Fatalf("sleep result = %+v, want delivered request", result)
+	}
+	mu.Lock()
+	text := typed.String()
+	mu.Unlock()
+	for _, want := range []string{"Victor is asking you", "attn handoff --sleep", "nobody wakes behind you"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("composer input is missing %q: %q", want, text)
+		}
+	}
+	if strings.Contains(text, "another agent, not from your user") {
+		t.Fatalf("user request masqueraded as an agent message: %q", text)
+	}
+	if queued, err := d.store.UndeliveredAgentMessages(woken.SessionID); err != nil || len(queued) != 0 {
+		t.Fatalf("queued messages = %v, %v; delivered request must be stamped", queued, err)
+	}
+	if d.store.Get(woken.SessionID) == nil {
+		t.Fatal("sleep request killed the member")
+	}
+}
+
+func TestCrewSleep_AlreadyAsleepIsANamedNoOp(t *testing.T) {
+	d, _, _ := newWakeableDaemon(t)
+	resp := crewSleepCall(t, d, "alder")
+	if !resp.Ok {
+		t.Fatalf("crew sleep: %v", protocol.Deref(resp.Error))
+	}
+	result := resp.CrewSleepResult
+	if result == nil || !result.AlreadyAsleep || !strings.Contains(result.Detail, "already asleep") || !strings.Contains(result.Detail, "no sleep request was sent") {
+		t.Fatalf("sleep result = %+v, want named no-op", result)
+	}
+}

--- a/internal/daemon/crew_wake.go
+++ b/internal/daemon/crew_wake.go
@@ -287,7 +287,12 @@ func (d *Daemon) crewWakeWithDelivery(name, agent string, autonomous bool, deliv
 	}
 
 	initialPrompt := crewWakePrompt
-	if delivery != nil {
+	if delivery == nil {
+		// A crew binding becomes visible before the launching agent has crossed
+		// priming and its trust dialog. Gate messages addressed in that window;
+		// the first hook on the far side of the greeting opens and drains it.
+		d.notePostInitialPrompt(sessionID, nil)
+	} else {
 		if delivery.Record != nil {
 			delivery.Record.TargetSessionID = sessionID
 			if err := d.store.EnqueueAgentMessage(*delivery.Record); err != nil {
@@ -318,12 +323,10 @@ func (d *Daemon) crewWakeWithDelivery(name, agent string, autonomous bool, deliv
 		InitialPrompt: protocol.Ptr(initialPrompt),
 	})
 	if _, err := readInternalActionResult(spawnClient); err != nil {
-		if delivery != nil {
-			if delivery.Record != nil {
-				d.rollbackInitialAgentMessage(sessionID, delivery.Record.ID)
-			}
-			d.forgetPostInitialPrompt(sessionID)
+		if delivery != nil && delivery.Record != nil {
+			d.rollbackInitialAgentMessage(sessionID, delivery.Record.ID)
 		}
+		d.forgetPostInitialPrompt(sessionID)
 		d.removeWorkspaceLayoutPaneForSession(sessionID)
 		d.releaseCrewBindingIfSession(sessionID)
 		return nil, fmt.Errorf("wake %s: %w", crew.DisplayName(member.ID), err)

--- a/internal/daemon/crew_wake.go
+++ b/internal/daemon/crew_wake.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -13,6 +15,8 @@ import (
 	"github.com/victorarias/attn/internal/crew"
 	"github.com/victorarias/attn/internal/docstore"
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/pty"
+	"github.com/victorarias/attn/internal/ptybackend"
 	"github.com/victorarias/attn/internal/store"
 )
 
@@ -184,6 +188,7 @@ func (d *Daemon) handleCrewWakeWS(client *wsClient, msg *protocol.CrewWakeMessag
 		if result.AlreadyAwake {
 			response.AlreadyAwake = protocol.Ptr(true)
 		}
+		response.ReleasedSessionID = result.ReleasedSessionID
 	}
 	d.sendToClient(client, response)
 }
@@ -203,16 +208,28 @@ func (d *Daemon) crewWakeWithDelivery(name, agent string, autonomous bool, deliv
 	if err != nil {
 		return nil, err
 	}
-	if d.crewBindingLive(member) {
-		awake := &protocol.CrewWakeResult{
-			Member:       member.ID,
-			SessionID:    member.BindingSession,
-			AlreadyAwake: true,
+	releasedSessionID := d.takeCrewExitedSession(member.ID)
+	if boundSessionID := strings.TrimSpace(member.BindingSession); boundSessionID != "" {
+		live, err := d.crewSessionActuallyLive(boundSessionID)
+		if err != nil {
+			return nil, fmt.Errorf("check %s's bound session %s: %w", crew.DisplayName(member.ID), shortSessionID(boundSessionID), err)
 		}
-		if session := d.store.Get(member.BindingSession); session != nil {
-			awake.WorkspaceID = session.WorkspaceID
+		if !live {
+			if _, err := d.releaseCrewBinding(member.ID, boundSessionID); err != nil {
+				return nil, fmt.Errorf("release %s's exited session %s: %w", crew.DisplayName(member.ID), shortSessionID(boundSessionID), err)
+			}
+			releasedSessionID = boundSessionID
+		} else {
+			awake := &protocol.CrewWakeResult{
+				Member:       member.ID,
+				SessionID:    boundSessionID,
+				AlreadyAwake: true,
+			}
+			if session := d.store.Get(boundSessionID); session != nil {
+				awake.WorkspaceID = session.WorkspaceID
+			}
+			return awake, nil
 		}
-		return awake, nil
 	}
 	if agent == "" {
 		agent = crewWakeAgent
@@ -312,11 +329,41 @@ func (d *Daemon) crewWakeWithDelivery(name, agent string, autonomous bool, deliv
 		return nil, fmt.Errorf("wake %s: %w", crew.DisplayName(member.ID), err)
 	}
 	d.logf("crew: woke %s in session %s at %s", crew.DisplayName(member.ID), sessionID, directory)
-	return &protocol.CrewWakeResult{
+	result := &protocol.CrewWakeResult{
 		Member:      member.ID,
 		SessionID:   sessionID,
 		WorkspaceID: workspaceID,
-	}, nil
+	}
+	if releasedSessionID != "" {
+		result.ReleasedSessionID = protocol.Ptr(releasedSessionID)
+	}
+	return result, nil
+}
+
+// crewSessionActuallyLive is the single-holder check used before wake returns
+// AlreadyAwake. The store row is identity and history; SessionInfo.Running is
+// whether an agent process still occupies the seat.
+func (d *Daemon) crewSessionActuallyLive(sessionID string) (bool, error) {
+	if d.isHostSession(sessionID) {
+		return true, nil
+	}
+	if d.store == nil || d.store.Get(sessionID) == nil {
+		return false, nil
+	}
+	provider, ok := d.ptyBackend.(ptybackend.SessionInfoProvider)
+	if !ok {
+		// Test and third-party backends without runtime inspection preserve their
+		// existing row-based contract. Production PTY backends implement it.
+		return true, nil
+	}
+	info, err := provider.SessionInfo(context.Background(), sessionID)
+	if err == nil {
+		return info.Running, nil
+	}
+	if errors.Is(err, pty.ErrSessionNotFound) || errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
 }
 
 func (d *Daemon) handleCrewPrime(conn net.Conn, msg *protocol.CrewPrimeMessage) {

--- a/internal/daemon/crew_wake_test.go
+++ b/internal/daemon/crew_wake_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -9,10 +10,12 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/victorarias/attn/internal/crew"
 	"github.com/victorarias/attn/internal/logging"
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/pty"
 	"github.com/victorarias/attn/internal/ptybackend"
 )
 
@@ -181,6 +184,126 @@ func TestCrewWake_AnAwakeMemberIsNotWokenTwice(t *testing.T) {
 	backend.mu.Unlock()
 	if spawned != 1 {
 		t.Fatalf("%d sessions were spawned for one member, want 1", spawned)
+	}
+}
+
+type crewRuntimeBackend struct {
+	*fakeSpawnBackend
+	running map[string]bool
+}
+
+func (b *crewRuntimeBackend) Spawn(ctx context.Context, opts ptybackend.SpawnOptions) error {
+	if err := b.fakeSpawnBackend.Spawn(ctx, opts); err != nil {
+		return err
+	}
+	b.running[opts.ID] = true
+	return nil
+}
+
+func (b *crewRuntimeBackend) SessionInfo(_ context.Context, sessionID string) (ptybackend.SessionInfo, error) {
+	running, ok := b.running[sessionID]
+	if !ok {
+		return ptybackend.SessionInfo{}, pty.ErrSessionNotFound
+	}
+	return ptybackend.SessionInfo{SessionID: sessionID, Running: running}, nil
+}
+
+// A session row is history, not liveness. Wake probes the bound runtime; when
+// the process exited it releases that exact binding, starts a fresh day, and
+// names the repair in the result.
+func TestCrewWake_ReleasesAnExitedBindingAndStartsAFreshDay(t *testing.T) {
+	d, backend, _ := newWakeableDaemon(t)
+	runtime := &crewRuntimeBackend{fakeSpawnBackend: backend, running: make(map[string]bool)}
+	d.ptyBackend = runtime
+
+	first, err := d.crewWake("trellis", "")
+	if err != nil {
+		t.Fatalf("first wake: %v", err)
+	}
+	runtime.running[first.SessionID] = false
+
+	second, err := d.crewWake("trellis", "")
+	if err != nil {
+		t.Fatalf("wake after exit: %v", err)
+	}
+	if second.AlreadyAwake || second.SessionID == first.SessionID {
+		t.Fatalf("wake result = %+v, want a fresh day", second)
+	}
+	if got := protocol.Deref(second.ReleasedSessionID); got != first.SessionID {
+		t.Fatalf("released_session_id = %q, want exited day %q", got, first.SessionID)
+	}
+	if got := protocol.Deref(memberByID(t, crewList(t, d), "trellis").BindingSession); got != second.SessionID {
+		t.Fatalf("roster binding = %q, want fresh day %q", got, second.SessionID)
+	}
+	backend.mu.Lock()
+	spawned := len(backend.spawnOpts)
+	backend.mu.Unlock()
+	if spawned != 2 {
+		t.Fatalf("wake spawned %d sessions, want the original and replacement", spawned)
+	}
+}
+
+// PTY exit is the runtime seam: the generic session row may remain for history
+// or recovery, but the member is asleep as soon as its process is gone.
+func TestCrewBinding_ProcessExitReleasesTheDay(t *testing.T) {
+	d, backend, _ := newWakeableDaemon(t)
+	woken, err := d.crewWake("alder", "")
+	if err != nil {
+		t.Fatalf("wake: %v", err)
+	}
+
+	if !d.handlePTYExit(ptybackend.ExitInfo{ID: woken.SessionID, ExitCode: 1}) {
+		t.Fatal("process exit was suppressed")
+	}
+	if binding := memberByID(t, crewList(t, d), "alder").BindingSession; binding != nil {
+		t.Fatalf("exited day still holds binding %q", *binding)
+	}
+	if d.store.Get(woken.SessionID) == nil {
+		t.Fatal("the generic session row was removed; crew release should not erase history")
+	}
+
+	replacement, err := d.crewWake("alder", "")
+	if err != nil {
+		t.Fatalf("wake after process exit: %v", err)
+	}
+	if got := protocol.Deref(replacement.ReleasedSessionID); got != woken.SessionID {
+		t.Fatalf("wake named released session %q, want %q", got, woken.SessionID)
+	}
+	backend.mu.Lock()
+	spawned := len(backend.spawnOpts)
+	backend.mu.Unlock()
+	if spawned != 2 {
+		t.Fatalf("process-exit wake spawned %d days, want original and replacement", spawned)
+	}
+}
+
+// Startup may keep a dead generic session as recoverable, but it never keeps
+// the member's seat: the letter and home, not the process row, carry the crew.
+func TestCrewBinding_StartupRecoveryReleasesADeadDay(t *testing.T) {
+	d, _, _ := newWakeableDaemon(t)
+	woken, err := d.crewWake("keel", "")
+	if err != nil {
+		t.Fatalf("wake: %v", err)
+	}
+	home := newRecoveryHome(t)
+	home.resumableClaude(t, "native-keel")
+	giveRestorationEvidence(t, d, woken.SessionID, "native-keel")
+
+	if removed := d.pruneSessionsWithoutPTY(time.Time{}); removed != 0 {
+		t.Fatalf("startup removed %d sessions, want the resumable row kept", removed)
+	}
+	if session := d.store.Get(woken.SessionID); session == nil || session.State != protocol.SessionStateRecoverable {
+		t.Fatalf("session = %+v, want generic row recoverable", session)
+	}
+	if binding := memberByID(t, crewList(t, d), "keel").BindingSession; binding != nil {
+		t.Fatalf("recoverable corpse still holds binding %q", *binding)
+	}
+	replacement, err := d.crewWake("keel", "")
+	if err != nil {
+		t.Fatalf("wake after startup release: %v", err)
+	}
+	if got := protocol.Deref(replacement.ReleasedSessionID); got != woken.SessionID {
+		t.Fatalf("wake named released session %q, want %q", got, woken.SessionID)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -271,6 +271,10 @@ type Daemon struct {
 	// creation. Without this fence, a second wake can steal the binding while
 	// the first claimed session is not yet visible to crewBindingLive.
 	crewWakeMu sync.Mutex
+	// A process-exit release is consumed by the next wake result, so the repair
+	// stays named even though the roster correctly became asleep immediately.
+	crewExitedMu       sync.Mutex
+	crewExitedSessions map[string]string // member id -> exited session id
 	// Deterministic concurrency seams; nil outside tests.
 	crewWakeStartHook      func(memberID string)
 	crewWakeAfterClaimHook func(memberID, sessionID string)
@@ -1329,6 +1333,9 @@ func (d *Daemon) pruneSessionsWithoutPTY(cutoff time.Time) int {
 		if sessionUpdatedAfter(session, cutoff) {
 			continue
 		}
+		// A recoverable session may keep its conversation row, but a dead crew
+		// day never keeps the member's seat. The letter and home are continuity.
+		d.releaseExitedCrewBinding(session.ID)
 		if d.canReviveSession(session) {
 			if session.State == protocol.SessionStateRecoverable {
 				continue
@@ -1739,6 +1746,9 @@ func (d *Daemon) reconcileSessionsWithWorkerBackend(ctx context.Context, allowId
 			report.SkippedIdle++
 			continue
 		}
+		// Missing runtime is now established. Release crew identity before the
+		// generic session is kept as recoverable or reaped.
+		d.releaseExitedCrewBinding(session.ID)
 		if d.canReviveSession(session) {
 			// Already parked there by an earlier pass; the verdict has not changed.
 			if session.State == protocol.SessionStateRecoverable {
@@ -2000,6 +2010,7 @@ func (d *Daemon) handlePTYExit(info ptybackend.ExitInfo) bool {
 		// (ticket_reconcile.go). The settle erases it.
 		d.reconcileTicketsOnSessionEnd(info.ID, string(session.State))
 	}
+	d.releaseExitedCrewBinding(info.ID)
 
 	d.publishFact(FactSessionPTYExited, info.ID, ptyExit{
 		ExitCode: info.ExitCode,
@@ -2813,6 +2824,8 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleCrewList(conn, msg.(*protocol.CrewListMessage))
 	case protocol.CmdCrewWake: // wire: crew_wake
 		d.handleCrewWake(conn, msg.(*protocol.CrewWakeMessage))
+	case protocol.CmdCrewSleep: // wire: crew_sleep
+		d.handleCrewSleep(conn, msg.(*protocol.CrewSleepMessage))
 	case protocol.CmdCrewSet: // wire: crew_set
 		d.handleCrewSet(conn, msg.(*protocol.CrewSetMessage))
 	case protocol.CmdCrewPrime: // wire: crew_prime

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -255,9 +255,8 @@ type Daemon struct {
 	drainingAgentMessages       map[string]bool
 	agentMessageTaken           map[string][]chan struct{}
 	agentMessagesAwaitingSubmit map[string]bool
-	// A crew wake may owe work only after the new day has submitted its ordinary
-	// first prompt. Ticket delivery uses this to keep the doorbell behind charter
-	// and handoff priming instead of pasting into the launching session.
+	// Every crew wake gates doorbells until the new day has submitted its first
+	// prompt. The optional callback carries ticket work that starts at that seam.
 	postInitialPrompt map[string]func()
 	// A message-triggered crew wake carries the attributed message as the new
 	// day's initial prompt. The row stays queued until a prompt-submit hook

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -1124,6 +1124,10 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		// Waking spawns a session; the composite is the daemon's, so it runs off
 		// the read loop like every other spawning command.
 		go d.handleCrewWakeWS(client, msg.(*protocol.CrewWakeMessage))
+	case protocol.CmdCrewSleep: // wire: crew_sleep
+		// Delivering can wait for the member to take the prompt, so it runs off
+		// the websocket read loop like every other fallible async action.
+		go d.handleCrewSleepWS(client, msg.(*protocol.CrewSleepMessage))
 	case protocol.CmdFsList: // wire: fs_list
 		fsList := msg.(*protocol.FsListMessage)
 		go d.sendFsListWSResult(client, protocol.Deref(fsList.RequestID), protocol.Deref(fsList.Path), protocol.Deref(fsList.Root))

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "250"
+const ProtocolVersion = "251"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -196,6 +196,7 @@ const (
 	CmdSeedReady                             = "seed_ready"
 	CmdCrewList                              = "crew_list"
 	CmdCrewWake                              = "crew_wake"
+	CmdCrewSleep                             = "crew_sleep"
 	CmdCrewSet                               = "crew_set"
 	CmdCrewPrime                             = "crew_prime"
 	CmdCrewHandoff                           = "crew_handoff"
@@ -372,6 +373,7 @@ const (
 	EventGardenSeedsUpdated              = "garden_seeds_updated"
 	EventCrewUpdated                     = "crew_updated"
 	EventCrewWakeResult                  = "crew_wake_result"
+	EventCrewSleepResult                 = "crew_sleep_result"
 	EventTicketResult                    = "ticket_result"
 	EventTicketActionResult              = "ticket_action_result"
 	EventTicketAttachResult              = "ticket_attach_result"
@@ -1200,6 +1202,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdCrewWake:
 		var msg CrewWakeMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdCrewSleep:
+		var msg CrewSleepMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1731,6 +1731,63 @@ type CrewSetResult struct {
 	Member CrewMember `json:"member"`
 }
 
+type CrewSleepMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Member corresponds to the JSON schema field "member".
+	Member string `json:"member"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+}
+
+type CrewSleepResult struct {
+	// AlreadyAsleep corresponds to the JSON schema field "already_asleep".
+	AlreadyAsleep bool `json:"already_asleep"`
+
+	// DeliveryStatus corresponds to the JSON schema field "delivery_status".
+	DeliveryStatus *AgentMsgStatus `json:"delivery_status,omitempty,omitzero"`
+
+	// Detail corresponds to the JSON schema field "detail".
+	Detail string `json:"detail"`
+
+	// Member corresponds to the JSON schema field "member".
+	Member string `json:"member"`
+
+	// SessionID corresponds to the JSON schema field "session_id".
+	SessionID *string `json:"session_id,omitempty,omitzero"`
+}
+
+type CrewSleepResultMessage struct {
+	// AlreadyAsleep corresponds to the JSON schema field "already_asleep".
+	AlreadyAsleep *bool `json:"already_asleep,omitempty,omitzero"`
+
+	// DeliveryStatus corresponds to the JSON schema field "delivery_status".
+	DeliveryStatus *AgentMsgStatus `json:"delivery_status,omitempty,omitzero"`
+
+	// Detail corresponds to the JSON schema field "detail".
+	Detail *string `json:"detail,omitempty,omitzero"`
+
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// Member corresponds to the JSON schema field "member".
+	Member *string `json:"member,omitempty,omitzero"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+
+	// SessionID corresponds to the JSON schema field "session_id".
+	SessionID *string `json:"session_id,omitempty,omitzero"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+}
+
 type CrewUpdatedMessage struct {
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -1760,6 +1817,9 @@ type CrewWakeResult struct {
 	// Member corresponds to the JSON schema field "member".
 	Member string `json:"member"`
 
+	// ReleasedSessionID corresponds to the JSON schema field "released_session_id".
+	ReleasedSessionID *string `json:"released_session_id,omitempty,omitzero"`
+
 	// SessionID corresponds to the JSON schema field "session_id".
 	SessionID string `json:"session_id"`
 
@@ -1779,6 +1839,9 @@ type CrewWakeResultMessage struct {
 
 	// Member corresponds to the JSON schema field "member".
 	Member *string `json:"member,omitempty,omitzero"`
+
+	// ReleasedSessionID corresponds to the JSON schema field "released_session_id".
+	ReleasedSessionID *string `json:"released_session_id,omitempty,omitzero"`
 
 	// RequestID corresponds to the JSON schema field "request_id".
 	RequestID string `json:"request_id"`
@@ -5378,6 +5441,9 @@ type Response struct {
 
 	// CrewSetResult corresponds to the JSON schema field "crew_set_result".
 	CrewSetResult *CrewSetResult `json:"crew_set_result,omitempty,omitzero"`
+
+	// CrewSleepResult corresponds to the JSON schema field "crew_sleep_result".
+	CrewSleepResult *CrewSleepResult `json:"crew_sleep_result,omitempty,omitzero"`
 
 	// CrewWakeResult corresponds to the JSON schema field "crew_wake_result".
 	CrewWakeResult *CrewWakeResult `json:"crew_wake_result,omitempty,omitzero"`

--- a/internal/protocol/parse_test.go
+++ b/internal/protocol/parse_test.go
@@ -48,6 +48,11 @@ func TestParseCommand(t *testing.T) {
 			wantCmd: CmdTicketTake,
 		},
 		{
+			name:    "crew sleep message",
+			input:   `{"cmd":"crew_sleep","member":"trellis","request_id":"req-1"}`,
+			wantCmd: CmdCrewSleep,
+		},
+		{
 			name:    "state message",
 			input:   `{"cmd":"state","id":"abc","state":"waiting"}`,
 			wantCmd: CmdState,

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -4944,6 +4944,7 @@ model Response {
   agent_msg_result?: AgentMsgResult;
   crew_list_result?: CrewListResult;
   crew_wake_result?: CrewWakeResult;
+  crew_sleep_result?: CrewSleepResult;
   crew_set_result?: CrewSetResult;
   crew_prime_result?: CrewPrimeResult;
   crew_handoff_result?: CrewHandoffResult;
@@ -5096,6 +5097,10 @@ model CrewWakeResultMessage {
   session_id?: string;
   workspace_id?: string;
   already_awake?: boolean;
+  // Present when wake found a stale binding, released it, and started this
+  // fresh day. The caller names the repair instead of silently focusing a
+  // replacement for a process that had already exited.
+  released_session_id?: string;
 }
 
 model CrewWakeResult {
@@ -5105,6 +5110,44 @@ model CrewWakeResult {
   // True when the member was already awake and session_id is the day that was
   // already running — nothing was launched.
   already_awake: boolean;
+  // The dead day whose stale binding this wake released before launching the
+  // returned session. Absent when there was no stale binding.
+  released_session_id?: string;
+}
+
+// Ask an awake member to close its day and sleep. This is consented closure:
+// the daemon delivers a user-originated request telling the member to write its
+// handoff and file it with `attn handoff --sleep`; it does not kill the member.
+// Home-only. An asleep member is a named no-op rather than a silent success.
+model CrewSleepMessage {
+  cmd: "crew_sleep";
+  member: string;
+  request_id?: string; // set by the WS frontend to correlate the result event
+}
+
+// CrewSleepResultMessage replies to a websocket crew_sleep. The request may be
+// queued when the member cannot take input immediately; the durable message
+// rail retries it on the target's next state change.
+model CrewSleepResultMessage {
+  event: "crew_sleep_result";
+  request_id: string;
+  success: boolean;
+  error?: string;
+  member?: string;
+  session_id?: string;
+  already_asleep?: boolean;
+  delivery_status?: AgentMsgStatus;
+  detail?: string;
+}
+
+model CrewSleepResult {
+  member: string;
+  // Absent when the member was already asleep and no request was sent.
+  session_id?: string;
+  already_asleep: boolean;
+  // Absent on the already-asleep no-op.
+  delivery_status?: AgentMsgStatus;
+  detail: string;
 }
 
 // Record where a member's sessions launch and which directories its charter is
@@ -5815,6 +5858,7 @@ alias DaemonEvent =
   | GardenSeedsUpdatedMessage
   | CrewUpdatedMessage
   | CrewWakeResultMessage
+  | CrewSleepResultMessage
   | TicketResultMessage
   | TicketActionResultMessage
   | TicketAttachResultMessage

--- a/internal/store/agent_messages.go
+++ b/internal/store/agent_messages.go
@@ -9,8 +9,8 @@ import (
 // before any delivery is attempted, so a message that cannot land right now is
 // queued rather than dropped, and `delivered_at` is what separates the two.
 
-// AgentMessage is one message between sessions. DeliveredAt is empty while the
-// message is still queued.
+// AgentMessage is one durable delivery to a session. SenderSessionID is empty
+// for a daemon-authored user request; DeliveredAt is empty while it is queued.
 type AgentMessage struct {
 	ID              string
 	SenderSessionID string


### PR DESCRIPTION
## TL;DR

Victor can now ask an awake crew member to sleep from `attn crew sleep <member>` or the moon on its crew row. The request reaches the member through the durable message rail and explicitly asks it to close with `attn handoff --sleep`, so consented closure cannot wake a successor behind it.

A dead member process also stops holding the crew seat immediately. Runtime exit releases the binding, startup recovery does the same for missing workers, and wake actively probes any remaining binding before returning `AlreadyAwake`.

## Why

Crew identity previously equated “awake” with a binding that named any session row. A process killed outside attn left that row behind, so wake returned success while focusing a corpse and the member could remain unwakeable even after restart.

The automatic sleep prompt also promised that nobody would wake behind the member, but told it to use plain `attn handoff`. Plain handoff re-evaluates presence at filing time, so Victor returning before the letter landed could wake a successor and break the promise.

## What changed

```text
CLI `attn crew sleep` / awake-row moon
  -> crew_sleep request/result
  -> persist user-origin sleep request
  -> deliver through the existing agent-message rail
  -> member files `attn handoff --sleep`
  -> no successor wakes

PTY exit or startup missing-runtime recovery
  -> release crew binding
  -> crew.released fact -> crew_updated roster
  -> remember the exited session for the next wake receipt

crew wake
  -> probe bound runtime, not only the session row
  -> live: AlreadyAwake
  -> exited: release, start a fresh day, return released_session_id
```

The sleep result names delivered versus queued delivery and makes an already-asleep request an explicit no-op. Senderless durable messages now represent daemon-authored user requests, so the sleep prompt does not masquerade as “another agent.”

Every crew wake now holds queued messages behind the real first-prompt hook. A sleep request made while the member is still reading priming is reported as queued and enters the composer only after startup is complete; it can no longer be stamped delivered into a trust or initialization screen.

Crew priming is now the sole authority for closure flags: plain handoff is presence-decided turnover, Victor asking for sleep means `--sleep`, and `--nap` explicitly requests a successor. The lifecycle auto-sleep prompt uses `--sleep` too.

The lockstep protocol moves from 250 on current main to 251, with generated Go and TypeScript contracts.

## Review path

1. `internal/daemon/crew_sleep.go` and `agent_msg.go`: consented user-origin delivery, first-prompt gating, and named no-op/result semantics.
2. `internal/daemon/crew.go`, `crew_wake.go`, and the PTY/startup seams in `daemon.go`: immediate release, active runtime probing, and named repair receipts.
3. `internal/crew/priming.go` and `crew_lifecycle.go`: the three closure modes and the fixed auto-sleep promise.
4. `cmd/attn/crew.go`, the TypeSpec schema, and `useDaemonSocket.ts`: CLI and wire surfaces.
5. `QueueBands.tsx`: the awake-row moon control symmetric with the sleeping row's wake control.

## Manual verification

On an isolated `crew-sleep` profile running the packaged app, I imported a synthetic Trellis member and woke session `08a2963c…`. I resolved its exact child PID from the isolated worker registry, confirmed its cwd was Trellis's isolated home, and terminated it externally. The roster immediately showed Trellis asleep while the generic session row remained for history. A second wake started `19644d9d…` and returned the full first ID as `released_session_id`.

After fixing the launch-time delivery race exposed by the first recording, I rebuilt an empty isolated profile at protocol 251 and waited until a fresh Claude-backed Trellis session `17141a45…` reached `waiting_input`. One click on the awake row's moon delivered exactly one user-origin prompt, including `attn handoff --sleep` and “nobody wakes behind you.” Trellis wrote its handoff, filed it with `--sleep`, and exited. The roster showed no binding and `attn agent list --json` returned an empty list: no successor woke.

The recording starts from the fully initialized `waiting_input` session and ends at “No active sessions.” The isolated profile, daemon, synthetic home, and installed app were cleaned after verification.

## Evidence

![One moon click asks Trellis to sleep and ends with no active sessions](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/45b112ff87822b226112d34698d3a96b54ac9b7f/delegate-crew-sleep-bf3d6071/crew-sleep-ui-final.gif)

[Full-quality recording (mp4)](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/45b112ff87822b226112d34698d3a96b54ac9b7f/delegate-crew-sleep-bf3d6071/crew-sleep-ui-final.mp4)

## Out of scope

- Plain `attn handoff` remains presence-decided.
- No heartbeat, monitor detection, or settled/unsettled model changes.
- Sleep remains a request for consented closure, never a process kill.
