### PR TITLE
feat(crew): ask twice before waking a member

### DIFF
--- a/app/scripts/real-app-harness/drive-wake-confirm.mjs
+++ b/app/scripts/real-app-harness/drive-wake-confirm.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// Drives the two-step crew wake in a running app. Attaches to whatever app is
+// already up for the profile — it never launches or restarts one — so it is the
+// way to watch the arm-and-confirm choreography in the packaged app.
+//
+//   node scripts/real-app-harness/drive-wake-confirm.mjs focus <member>
+//   node scripts/real-app-harness/drive-wake-confirm.mjs click <member>
+//   node scripts/real-app-harness/drive-wake-confirm.mjs story <asleep> <woken>
+//   node scripts/real-app-harness/drive-wake-confirm.mjs pointer <asleep> <woken>
+//
+// `focus` reveals the row's controls through :focus-within — CSS :hover does
+// not answer to dispatched pointer events, so a synthetic hover would leave the
+// sun invisible. `story` is the whole choreography in one run: arm and let it
+// stand down, then arm and confirm.
+//
+// `pointer` is the same choreography under the real cursor, for recording it.
+// It costs an Accessibility grant and a frontmost app, and it is worth both: a
+// bridge-driven run has to focus the row to see it, which paints a focus ring no
+// pointer user ever sees, and it stands the arm down on a timeout rather than
+// showing the outside click that is the rule people actually meet.
+
+import { MacOSDriver } from './macosDriver.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function connect() {
+  const client = new UiAutomationClient({});
+  await client.waitForManifest(10_000);
+  await client.waitForReady(15_000);
+  await client.waitForFrontendResponsive(15_000);
+  return client;
+}
+
+const focus = (client, member) =>
+  client.request('dom_focus', { selector: `[data-testid="queue-crew-select-${member}"]` });
+const click = (client, member) =>
+  client.request('dom_click', { selector: `[data-testid="queue-crew-wake-${member}"]` });
+
+// The input driver aims at the AX window frame, which starts at the titlebar;
+// the DOM measures from under it. Measured at 32 logical px on macOS by
+// comparing a wake button's DOM bounds against where the same button lands in a
+// window-relative screenshot, twice on different rows. A wrong offset does not
+// fail quietly: the click misses the sun, the member stays asleep, and both the
+// recording and `attn crew list` say so.
+const WINDOW_CHROME_PX = 32;
+
+async function pointerMapper(client) {
+  const { logicalBounds } = await client.request('get_window_bounds', {});
+  return (bounds) => ({
+    x: (bounds.x + bounds.width / 2) / logicalBounds.width,
+    y: (bounds.y + bounds.height / 2 + WINDOW_CHROME_PX) / logicalBounds.height,
+  });
+}
+
+async function main() {
+  const [verb, ...args] = process.argv.slice(2);
+  const client = await connect();
+
+  if (verb === 'focus') {
+    console.log(JSON.stringify(await focus(client, args[0])));
+    return;
+  }
+  if (verb === 'click') {
+    console.log(JSON.stringify(await click(client, args[0])));
+    return;
+  }
+  if (verb === 'story') {
+    const [standDown, woken] = args;
+    await focus(client, standDown);
+    await wait(1600);
+    await click(client, standDown);
+    console.log(`armed ${standDown}`);
+    await wait(4800);
+    console.log(`${standDown} stood down`);
+
+    await focus(client, woken);
+    await wait(1000);
+    await click(client, woken);
+    console.log(`armed ${woken}`);
+    await wait(1800);
+    await click(client, woken);
+    console.log(`confirmed ${woken}`);
+    await wait(4500);
+    return;
+  }
+  if (verb === 'pointer') {
+    const [standDown, woken] = args;
+    const driver = new MacOSDriver({ actionDelayMs: 120 });
+    await driver.activateApp();
+    const toWindow = await pointerMapper(client);
+
+    // Hover first and click second, both on the sun: the controls only exist
+    // under the pointer, so this is the order a person's hand takes.
+    const sunOf = async (member) => {
+      const { bounds } = await client.request('dom_hover', {
+        selector: `[data-testid="queue-crew-wake-${member}"]`,
+      });
+      return toWindow(bounds);
+    };
+    const hover = async (point) => driver.movePointerInWindow(point.x, point.y);
+    const press = async (point) => driver.clickWindow(point.x, point.y);
+
+    const standDownSun = await sunOf(standDown);
+    await hover(standDownSun);
+    await wait(900);
+    await press(standDownSun);
+    console.log(`armed ${standDown}`);
+    await wait(1500);
+
+    // Empty sidebar below the roster: the outside click is the stand-down rule
+    // a person meets first, and it reads faster on camera than four seconds of
+    // nothing.
+    await press({ x: 0.13, y: 0.7 });
+    console.log(`${standDown} stood down`);
+    await wait(1200);
+
+    const wokenSun = await sunOf(woken);
+    await hover(wokenSun);
+    await wait(700);
+    await press(wokenSun);
+    console.log(`armed ${woken}`);
+    await wait(1600);
+    await press(wokenSun);
+    console.log(`confirmed ${woken}`);
+    await wait(3500);
+    return;
+  }
+  throw new Error(`unknown verb ${verb ?? '(none)'}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/app/src/components/CrewWake.css
+++ b/app/src/components/CrewWake.css
@@ -1,0 +1,305 @@
+/* The two-step wake on a sleeping crew row: a sunrise you arm, then let break.
+   Every motion here is one-shot — a transition into the armed state, an
+   animation out of it. Nothing loops: attn draws GPU terminals all day, and a
+   permanent repaint is a battery bug no test catches. */
+
+.crew-sun {
+  --sun-ink: currentColor;
+  --sun-core: currentColor;
+  display: block;
+  width: calc(16px * var(--ui-scale));
+  height: calc(16px * var(--ui-scale));
+  /* The armed sun and its flare reach past the box; the button reserves the
+     resting footprint and the light spills. */
+  overflow: visible;
+  fill: none;
+  stroke: var(--sun-ink);
+  stroke-width: 1.3;
+  stroke-linecap: round;
+  transition: stroke 300ms ease;
+}
+
+/* Armed and breaking both burn in the brand's own sunrise orange, which is
+   theme-invariant, so the armed state reads the same in light and dark. */
+.crew-sun--armed,
+.crew-sun--breaking {
+  --sun-ink: var(--accent);
+  --sun-core: var(--accent);
+}
+
+.crew-sun-disc {
+  fill: var(--sun-core);
+  stroke: none;
+  transition: fill 300ms ease;
+}
+
+/* The rise, with a little overshoot at the top — the sun arrives and settles
+   rather than sliding into place. It also grows, because sixteen pixels is not
+   much room to say "this is a different state" with position alone.
+   fill-box rather than the viewBox, so the growth is about the sun's own centre
+   on every engine instead of the drawing's. */
+.crew-sun-body {
+  transform-box: fill-box;
+  transform-origin: center;
+  transform: translateY(0) scale(1);
+  transition: transform 420ms cubic-bezier(0.34, 1.42, 0.64, 1);
+}
+
+.crew-sun--armed .crew-sun-body,
+.crew-sun--breaking .crew-sun-body {
+  transform: translateY(-4px) scale(1.08);
+}
+
+/* Rays and ground both draw from the middle outward, so arming reads as light
+   spreading rather than parts appearing. `--ray` is the distance from the top
+   ray, so the fan opens from noon outward on both sides at once. */
+.crew-sun-ray,
+.crew-sun-horizon {
+  stroke-dasharray: 1;
+  transition: stroke-dashoffset 300ms ease-out, opacity 300ms ease-out;
+}
+
+.crew-sun-ray {
+  stroke-dashoffset: 0.55;
+  transition-delay: calc(var(--ray, 0) * 55ms);
+}
+
+.crew-sun-horizon {
+  /* Shorter than the disc is wide: at rest there is no ground to see, because
+     the sun has not risen off it yet. */
+  stroke-dashoffset: 0.72;
+  opacity: 0.45;
+}
+
+.crew-sun--armed .crew-sun-ray,
+.crew-sun--breaking .crew-sun-ray {
+  stroke-dashoffset: 0;
+}
+
+.crew-sun--armed .crew-sun-horizon,
+.crew-sun--breaking .crew-sun-horizon {
+  stroke-dashoffset: 0;
+  opacity: 0.9;
+}
+
+/* First light: blooms once, past where it lands, then holds. The hold is the
+   held breath — a still frame, not a pulse. */
+.crew-sun-glow {
+  fill: var(--accent);
+  stroke: none;
+  filter: blur(2.6px);
+  opacity: 0.22;
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: crew-sun-firstlight 620ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes crew-sun-firstlight {
+  0% {
+    opacity: 0;
+    transform: scale(0.35);
+  }
+  55% {
+    opacity: 0.42;
+    transform: scale(1.14);
+  }
+  100% {
+    opacity: 0.22;
+    transform: scale(1);
+  }
+}
+
+/* Confirm. The sun crouches, then clears the sky entirely; the ground it left
+   dissolves in the light and a ring of first light rings out past the row. */
+.crew-sun--breaking .crew-sun-body {
+  animation: crew-sun-leap 520ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@keyframes crew-sun-leap {
+  0% {
+    transform: translateY(-4px) scale(1.08);
+    opacity: 1;
+  }
+  18% {
+    transform: translateY(-2.8px) scale(0.92);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(-10px) scale(1.8);
+    opacity: 0;
+  }
+}
+
+.crew-sun--breaking .crew-sun-horizon {
+  animation: crew-sun-horizon-out 440ms ease-in both;
+}
+
+@keyframes crew-sun-horizon-out {
+  0% {
+    stroke-dashoffset: 0;
+    opacity: 0.9;
+  }
+  100% {
+    stroke-dashoffset: 0.9;
+    opacity: 0;
+  }
+}
+
+.crew-sun--breaking .crew-sun-glow {
+  animation: crew-sun-flood 520ms ease-out both;
+}
+
+@keyframes crew-sun-flood {
+  0% {
+    opacity: 0.22;
+    transform: scale(1);
+  }
+  30% {
+    opacity: 0.6;
+    transform: scale(1.5);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(2.4);
+  }
+}
+
+.crew-sun-shock {
+  fill: none;
+  stroke: var(--accent);
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: crew-sun-shock 560ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@keyframes crew-sun-shock {
+  0% {
+    transform: scale(0.5);
+    opacity: 0.95;
+    stroke-width: 2;
+  }
+  100% {
+    transform: scale(3);
+    opacity: 0;
+    stroke-width: 0.4;
+  }
+}
+
+/* What the next click does, in the row's own voice — the marks beside a label
+   are all small caps. It sits to the LEFT of the sun and the controls strip is
+   anchored to the row's right edge, so arming grows the strip leftward and the
+   confirm target does not move a pixel. */
+.crew-wake-confirm {
+  flex: 0 0 auto;
+  padding-right: 5px;
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  color: var(--accent);
+  animation: crew-wake-confirm-in 240ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes crew-wake-confirm-in {
+  from {
+    opacity: 0;
+    transform: translateX(6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* The row is the other arm-and-confirm target, so it says so: armed, it holds a
+   trace of the light building on it. The hover background under the glow is
+   spelled out rather than inherited so a keyboard-armed row looks the same as a
+   pointer-armed one, and the controls strip takes the identical pair — it is
+   opaque over the row and would otherwise sit on the warmth as a grey patch. */
+.queue-row.queue-row--crew[data-crew-wake='armed'],
+.queue-row.queue-row--crew[data-crew-wake='armed'] .queue-row-controls {
+  background-color: var(--color-bg-elevated);
+  background-image: linear-gradient(var(--accent-glow), var(--accent-glow));
+}
+
+/* Confirmed: the strip gets out of the light's way, and the word that says the
+   member is asleep goes with it — it stops being true here. */
+.queue-row.queue-row--crew[data-crew-wake='breaking'] .queue-row-controls {
+  background: none;
+}
+
+.queue-row.queue-row--crew[data-crew-wake='breaking'] .crew-row-mark {
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+/* Daybreak across the row. One pass, left to right, then gone — the wake is
+   the member's, not the button's.
+   The band travels by background-position rather than a transform, so nothing
+   leaves the row and the row needs no clip; a clip here would cut the sun's
+   own flare off at the row's edge. */
+.queue-row--crew[data-crew-wake='breaking']::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(
+    100deg,
+    transparent 30%,
+    var(--accent-glow) 42%,
+    rgba(255, 168, 92, 0.32) 50%,
+    var(--accent-glow) 58%,
+    transparent 70%
+  );
+  background-size: 300% 100%;
+  animation: crew-wake-daybreak 620ms ease-out both;
+}
+
+@keyframes crew-wake-daybreak {
+  0% {
+    background-position: 100% 0;
+    opacity: 0;
+  }
+  30% {
+    opacity: 1;
+  }
+  100% {
+    background-position: 0 0;
+    opacity: 0;
+  }
+}
+
+/* The two steps stay; the theater stops. Every armed value above is a
+   transition endpoint or an animation's resting frame, so removing the motion
+   leaves an armed sun that still reads as armed. */
+@media (prefers-reduced-motion: reduce) {
+  .crew-sun,
+  .crew-sun-disc,
+  .crew-sun-body,
+  .crew-sun-ray,
+  .crew-sun-horizon {
+    transition: none;
+  }
+
+  .crew-sun-glow,
+  .crew-sun-shock,
+  .crew-sun--breaking .crew-sun-body,
+  .crew-sun--breaking .crew-sun-glow,
+  .crew-sun--breaking .crew-sun-horizon,
+  .crew-wake-confirm,
+  .queue-row--crew[data-crew-wake='breaking']::after {
+    animation: none;
+  }
+
+  /* Without its animation the shockwave would sit on the sun as a static ring;
+     it exists only as motion. */
+  .crew-sun-shock,
+  .queue-row--crew[data-crew-wake='breaking']::after {
+    display: none;
+  }
+
+  .queue-row.queue-row--crew[data-crew-wake='breaking'] .crew-row-mark {
+    transition: none;
+  }
+}

--- a/app/src/components/CrewWake.tsx
+++ b/app/src/components/CrewWake.tsx
@@ -34,10 +34,11 @@ interface WakeConfirm {
 /**
  * The two-step over one member's wake.
  *
- * An armed wake disarms itself three ways — a click outside the row, Escape,
- * and the timeout above — so an arm nobody confirms never wakes anyone. The
- * outside-click rule also gives the roster single-arm for free: arming a second
- * member is a click outside the first one's row.
+ * An armed wake disarms itself four ways — a click outside the row, focus
+ * leaving the row, Escape, and the timeout above — so an arm nobody confirms
+ * never wakes anyone. Leaving the row is also what gives the roster single-arm
+ * for free: reaching a second member means leaving the first one's row, by
+ * pointer or by keyboard.
  */
 export function useWakeConfirm(onWake: (() => void) | undefined): WakeConfirm {
   const [phase, setPhase] = useState<WakePhase>('rest');
@@ -50,15 +51,24 @@ export function useWakeConfirm(onWake: (() => void) | undefined): WakeConfirm {
       if (rowRef.current?.contains(event.target as Node)) return;
       disarm();
     };
+    // Focus is the keyboard's pointer: tabbing to another row is that user
+    // leaving this one, and without this the roster's one-arm-at-a-time rule
+    // would hold for the mouse and quietly not for the keyboard.
+    const onFocusIn = (event: FocusEvent) => {
+      if (rowRef.current?.contains(event.target as Node)) return;
+      disarm();
+    };
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') disarm();
     };
     const timer = window.setTimeout(disarm, WAKE_ARM_TIMEOUT_MS);
     document.addEventListener('pointerdown', onPointerDown, true);
+    document.addEventListener('focusin', onFocusIn, true);
     document.addEventListener('keydown', onKeyDown, true);
     return () => {
       window.clearTimeout(timer);
       document.removeEventListener('pointerdown', onPointerDown, true);
+      document.removeEventListener('focusin', onFocusIn, true);
       document.removeEventListener('keydown', onKeyDown, true);
     };
   }, [phase]);
@@ -74,6 +84,10 @@ export function useWakeConfirm(onWake: (() => void) | undefined): WakeConfirm {
   // twice from the one confirmed click this whole two-step exists to earn.
   const trigger = useCallback(() => {
     if (!onWake) return;
+    // The flare is not a target. A click landing in it would otherwise re-arm a
+    // row whose wake is already sent, and the click after that would send a
+    // second one — the double-wake this whole two-step exists to prevent.
+    if (phase === 'breaking') return;
     if (phase !== 'armed') {
       setPhase('armed');
       return;

--- a/app/src/components/CrewWake.tsx
+++ b/app/src/components/CrewWake.tsx
@@ -1,0 +1,153 @@
+import { useCallback, useEffect, useRef, useState, type CSSProperties, type RefObject } from 'react';
+import './CrewWake.css';
+
+/**
+ * Waking a crew member starts a day of a durable identity and cannot be
+ * un-rung, so it takes two deliberate clicks: the first arms, the second wakes.
+ * Only the app asks twice — `attn crew wake` stays one step, because typing a
+ * command is already the conscious act this is reconstructing for a click.
+ */
+export type WakePhase = 'rest' | 'armed' | 'breaking';
+
+/**
+ * How long an armed wake waits before standing down.
+ *
+ * A tripwire, not a deadline: a deliberate confirm is a second click on a
+ * target the pointer is already over — a few hundred milliseconds — so four
+ * seconds is roughly ten times the gesture it must never interrupt, and short
+ * enough that an arm you walked away from is gone before you come back to the
+ * row. Nobody confirming should ever feel this number exists.
+ */
+export const WAKE_ARM_TIMEOUT_MS = 4000;
+
+/** How long the confirm flare owns the row before the row is just a row again. */
+const WAKE_BREAK_MS = 620;
+
+interface WakeConfirm {
+  phase: WakePhase;
+  /** Arms on the first call, wakes on the second. */
+  trigger: () => void;
+  /** Put this on the row: anything inside it counts as still holding the intent. */
+  rowRef: RefObject<HTMLDivElement | null>;
+}
+
+/**
+ * The two-step over one member's wake.
+ *
+ * An armed wake disarms itself three ways — a click outside the row, Escape,
+ * and the timeout above — so an arm nobody confirms never wakes anyone. The
+ * outside-click rule also gives the roster single-arm for free: arming a second
+ * member is a click outside the first one's row.
+ */
+export function useWakeConfirm(onWake: (() => void) | undefined): WakeConfirm {
+  const [phase, setPhase] = useState<WakePhase>('rest');
+  const rowRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (phase !== 'armed') return;
+    const disarm = () => setPhase('rest');
+    const onPointerDown = (event: PointerEvent) => {
+      if (rowRef.current?.contains(event.target as Node)) return;
+      disarm();
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') disarm();
+    };
+    const timer = window.setTimeout(disarm, WAKE_ARM_TIMEOUT_MS);
+    document.addEventListener('pointerdown', onPointerDown, true);
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => {
+      window.clearTimeout(timer);
+      document.removeEventListener('pointerdown', onPointerDown, true);
+      document.removeEventListener('keydown', onKeyDown, true);
+    };
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase !== 'breaking') return;
+    const timer = window.setTimeout(() => setPhase('rest'), WAKE_BREAK_MS);
+    return () => window.clearTimeout(timer);
+  }, [phase]);
+
+  // Reads `phase` rather than an updater, because sending the wake is a side
+  // effect and StrictMode runs an updater twice — which would wake the member
+  // twice from the one confirmed click this whole two-step exists to earn.
+  const trigger = useCallback(() => {
+    if (!onWake) return;
+    if (phase !== 'armed') {
+      setPhase('armed');
+      return;
+    }
+    setPhase('breaking');
+    // The command goes now, not when the flare ends: the animation reports the
+    // wake, it does not gate it.
+    onWake();
+  }, [onWake, phase]);
+
+  return { phase, trigger, rowRef };
+}
+
+/** Where the light fans, in degrees off vertical. Upward only — below the sun
+ *  is still night, and a ray drawn there would cross the horizon. */
+const RAY_ANGLES = [-72, -36, 0, 36, 72];
+const HORIZON_Y = 13;
+const RAY_INNER = 5;
+const RAY_OUTER = 7.6;
+
+function rayPath(angle: number): string {
+  const radians = (angle * Math.PI) / 180;
+  const point = (radius: number) => [
+    (10 + radius * Math.sin(radians)).toFixed(2),
+    (HORIZON_Y - radius * Math.cos(radians)).toFixed(2),
+  ];
+  const [x1, y1] = point(RAY_INNER);
+  const [x2, y2] = point(RAY_OUTER);
+  return `M${x1} ${y1}L${x2} ${y2}`;
+}
+
+/**
+ * A sunrise, held.
+ *
+ * At rest the sun sits on the horizon with its light barely out — dim, low,
+ * asleep. Arming raises it clear of the horizon, fans the rays from the top
+ * outward, widens the ground beneath it and warms everything to the brand's
+ * own sunrise orange, then stops and stays there: the held breath before
+ * morning is a still frame, because a loop that never stops repainting is a
+ * battery bug on a machine that runs attn all day.
+ *
+ * Confirming lets it break — the sun leaps, a shockwave of first light rings
+ * out, and the row itself takes the wash (`.queue-row--crew[data-crew-wake]`).
+ * Standing down runs the whole thing backwards, which is a sunset.
+ */
+export function CrewWakeSun({ phase }: { phase: WakePhase }) {
+  const lit = phase !== 'rest';
+  return (
+    <svg
+      className={`crew-sun crew-sun--${phase}`}
+      viewBox="0 0 20 20"
+      aria-hidden="true"
+      focusable="false"
+    >
+      {/* Drawn outward from directly beneath the sun, so the ground widens with
+          the light rather than being there all along. */}
+      <path className="crew-sun-horizon" d={`M10 ${HORIZON_Y}H3`} pathLength={1} />
+      <path className="crew-sun-horizon" d={`M10 ${HORIZON_Y}H17`} pathLength={1} />
+      {lit && <circle className="crew-sun-glow" cx="10" cy="8.8" r="6.4" />}
+      {phase === 'breaking' && <circle className="crew-sun-shock" cx="10" cy="8.8" r="3.4" />}
+      <g className="crew-sun-body">
+        {RAY_ANGLES.map((angle, index) => (
+          <path
+            key={angle}
+            className="crew-sun-ray"
+            // The fan opens from the top ray outward, so the light spreads
+            // instead of arriving all at once.
+            style={{ '--ray': Math.abs(index - 2) } as CSSProperties}
+            d={rayPath(angle)}
+            pathLength={1}
+          />
+        ))}
+        <circle className="crew-sun-disc" cx="10" cy={HORIZON_Y} r="3.4" />
+      </g>
+    </svg>
+  );
+}

--- a/app/src/components/QueueBands.test.tsx
+++ b/app/src/components/QueueBands.test.tsx
@@ -1,6 +1,8 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { Sidebar } from './Sidebar';
+import { WAKE_ARM_TIMEOUT_MS } from './CrewWake';
 import { buildQueueBands, formatTurnAge } from '../utils/queueBands';
 import { buildWorkspaceViewModels } from '../utils/workspaceViewModels';
 
@@ -449,7 +451,7 @@ describe('the crew in the sidebar', () => {
     expect(rows.filter((id) => id?.includes('keel'))).toEqual(['queue-crew-keel']);
   });
 
-  it('wakes a sleeping member with one click and focuses an awake one', () => {
+  it('wakes a sleeping member on the second click and focuses an awake one with the first', () => {
     const onWakeCrewMember = vi.fn();
     const onSelectSession = vi.fn();
     renderCrew(
@@ -458,8 +460,11 @@ describe('the crew in the sidebar', () => {
     );
 
     fireEvent.click(screen.getByTestId('queue-crew-wake-trellis'));
+    expect(onWakeCrewMember).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId('queue-crew-wake-trellis'));
     expect(onWakeCrewMember.mock.calls).toEqual([['trellis']]);
 
+    // Focusing an awake member is not consequential and stays one click.
     fireEvent.click(screen.getByTestId('queue-crew-select-keel'));
     expect(onSelectSession.mock.calls).toEqual([['sess-keel']]);
 
@@ -499,5 +504,134 @@ describe('the crew in the sidebar', () => {
   it('renders no crew rows while the queue arrangement is off', () => {
     renderSidebar(sessions, false, { crew: roster });
     expect(screen.queryByTestId('queue-crew-alder')).toBeNull();
+  });
+
+  describe('arming a wake', () => {
+    // Waking starts a day of a durable identity and cannot be un-rung, so it
+    // takes two deliberate clicks and an unconfirmed arm must never wake
+    // anyone. Every disarm route is a separate test below.
+
+    function armed(member: string) {
+      return screen.getByTestId(`queue-crew-${member}`).getAttribute('data-crew-wake');
+    }
+
+    it('says what the second click does, and says it without the animation', () => {
+      renderCrew([], { onWakeCrewMember: vi.fn() });
+      const button = screen.getByTestId('queue-crew-wake-trellis');
+      expect(armed('trellis')).toBeNull();
+
+      fireEvent.click(button);
+
+      expect(armed('trellis')).toBe('armed');
+      expect(button.getAttribute('aria-label')).toBe('Wake Trellis — click again to confirm');
+      // A word, not only a drawing: the motion is the delight, the text is the
+      // contract, and one of them survives prefers-reduced-motion untouched.
+      expect(screen.getByTestId('queue-crew-trellis').textContent).toContain('confirm');
+      // The fill button covers the whole row and is the other confirm target,
+      // so it has to make the same promise.
+      expect(screen.getByTestId('queue-crew-select-trellis').getAttribute('aria-label'))
+        .toBe('Wake Trellis — click again to confirm');
+    });
+
+    it('arms on the row and confirms on the sun, because they are one gesture', () => {
+      const onWakeCrewMember = vi.fn();
+      renderCrew([], { onWakeCrewMember });
+
+      fireEvent.click(screen.getByTestId('queue-crew-select-trellis'));
+      expect(onWakeCrewMember).not.toHaveBeenCalled();
+      expect(armed('trellis')).toBe('armed');
+
+      fireEvent.click(screen.getByTestId('queue-crew-wake-trellis'));
+      expect(onWakeCrewMember.mock.calls).toEqual([['trellis']]);
+      // The confirm hands the row over to the flare; it is no longer armed, so
+      // a third click starts a fresh two-step rather than waking twice.
+      expect(armed('trellis')).toBe('breaking');
+    });
+
+    it('stands down when the next click lands somewhere else', () => {
+      const onWakeCrewMember = vi.fn();
+      renderCrew([], { onWakeCrewMember });
+
+      fireEvent.click(screen.getByTestId('queue-crew-wake-trellis'));
+      fireEvent.pointerDown(document.body);
+      expect(armed('trellis')).toBeNull();
+
+      // Disarmed for real: the next click arms again rather than waking.
+      fireEvent.click(screen.getByTestId('queue-crew-wake-trellis'));
+      expect(onWakeCrewMember).not.toHaveBeenCalled();
+    });
+
+    it('arms one member at a time', () => {
+      const onWakeCrewMember = vi.fn();
+      renderCrew([], { onWakeCrewMember });
+
+      fireEvent.click(screen.getByTestId('queue-crew-wake-trellis'));
+      // Reaching for another member's row is a click outside this one.
+      fireEvent.pointerDown(screen.getByTestId('queue-crew-wake-alder'));
+      fireEvent.click(screen.getByTestId('queue-crew-wake-alder'));
+
+      expect(armed('trellis')).toBeNull();
+      expect(armed('alder')).toBe('armed');
+      expect(onWakeCrewMember).not.toHaveBeenCalled();
+    });
+
+    it('stands down on Escape', () => {
+      const onWakeCrewMember = vi.fn();
+      renderCrew([], { onWakeCrewMember });
+
+      fireEvent.click(screen.getByTestId('queue-crew-wake-trellis'));
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(armed('trellis')).toBeNull();
+      fireEvent.click(screen.getByTestId('queue-crew-wake-trellis'));
+      expect(onWakeCrewMember).not.toHaveBeenCalled();
+    });
+
+    it('wakes once even where React runs the click path twice', () => {
+      // StrictMode double-invokes state updaters, so sending the wake from
+      // inside one would spend two days on the one click this earns.
+      const onWakeCrewMember = vi.fn();
+      const data = sidebarData(sessions);
+      render(
+        <StrictMode>
+          <Sidebar
+            {...baseProps}
+            {...data}
+            crew={roster}
+            onWakeCrewMember={onWakeCrewMember}
+            queue={buildQueueBands(data.workspaces)}
+          />
+        </StrictMode>,
+      );
+
+      fireEvent.click(screen.getByTestId('queue-crew-wake-trellis'));
+      fireEvent.click(screen.getByTestId('queue-crew-wake-trellis'));
+
+      expect(onWakeCrewMember.mock.calls).toEqual([['trellis']]);
+    });
+
+    it('stands down on its own, and wakes nobody doing it', () => {
+      vi.useFakeTimers();
+      try {
+        const onWakeCrewMember = vi.fn();
+        renderCrew([], { onWakeCrewMember });
+
+        fireEvent.click(screen.getByTestId('queue-crew-wake-trellis'));
+        expect(armed('trellis')).toBe('armed');
+
+        act(() => {
+          vi.advanceTimersByTime(WAKE_ARM_TIMEOUT_MS - 1);
+        });
+        expect(armed('trellis')).toBe('armed');
+
+        act(() => {
+          vi.advanceTimersByTime(1);
+        });
+        expect(armed('trellis')).toBeNull();
+        expect(onWakeCrewMember).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });

--- a/app/src/components/QueueBands.test.tsx
+++ b/app/src/components/QueueBands.test.tsx
@@ -543,8 +543,21 @@ describe('the crew in the sidebar', () => {
 
       fireEvent.click(screen.getByTestId('queue-crew-wake-trellis'));
       expect(onWakeCrewMember.mock.calls).toEqual([['trellis']]);
-      // The confirm hands the row over to the flare; it is no longer armed, so
-      // a third click starts a fresh two-step rather than waking twice.
+      expect(armed('trellis')).toBe('breaking');
+    });
+
+    it('is not a target while it is flaring', () => {
+      // The flare lasts long enough to click into. Re-arming a row whose wake
+      // is already sent would put a second wake one click away.
+      const onWakeCrewMember = vi.fn();
+      renderCrew([], { onWakeCrewMember });
+
+      fireEvent.click(screen.getByTestId('queue-crew-wake-trellis'));
+      fireEvent.click(screen.getByTestId('queue-crew-wake-trellis'));
+      fireEvent.click(screen.getByTestId('queue-crew-wake-trellis'));
+      fireEvent.click(screen.getByTestId('queue-crew-wake-trellis'));
+
+      expect(onWakeCrewMember.mock.calls).toEqual([['trellis']]);
       expect(armed('trellis')).toBe('breaking');
     });
 
@@ -573,6 +586,33 @@ describe('the crew in the sidebar', () => {
       expect(armed('trellis')).toBeNull();
       expect(armed('alder')).toBe('armed');
       expect(onWakeCrewMember).not.toHaveBeenCalled();
+    });
+
+    it('arms one member at a time for the keyboard too', () => {
+      // A keyboard user reaches the next row by focusing it, never by clicking
+      // outside this one, so focus leaving the row has to disarm it as well.
+      const onWakeCrewMember = vi.fn();
+      renderCrew([], { onWakeCrewMember });
+
+      fireEvent.click(screen.getByTestId('queue-crew-wake-trellis'));
+      fireEvent.focusIn(screen.getByTestId('queue-crew-wake-alder'));
+      fireEvent.click(screen.getByTestId('queue-crew-wake-alder'));
+
+      expect(armed('trellis')).toBeNull();
+      expect(armed('alder')).toBe('armed');
+      expect(onWakeCrewMember).not.toHaveBeenCalled();
+    });
+
+    it('keeps the arm while focus moves inside its own row', () => {
+      const onWakeCrewMember = vi.fn();
+      renderCrew([], { onWakeCrewMember });
+
+      fireEvent.click(screen.getByTestId('queue-crew-select-trellis'));
+      fireEvent.focusIn(screen.getByTestId('queue-crew-wake-trellis'));
+
+      expect(armed('trellis')).toBe('armed');
+      fireEvent.click(screen.getByTestId('queue-crew-wake-trellis'));
+      expect(onWakeCrewMember.mock.calls).toEqual([['trellis']]);
     });
 
     it('stands down on Escape', () => {

--- a/app/src/components/QueueBands.tsx
+++ b/app/src/components/QueueBands.tsx
@@ -3,6 +3,7 @@ import { StateIndicator } from './StateIndicator';
 import { SessionLabel } from './SessionLabel';
 import { ChiefOfStaffBadge } from './ChiefOfStaffBadge';
 import { SidebarSettlingBar } from './SettlingIndicator';
+import { CrewWakeSun, useWakeConfirm } from './CrewWake';
 import { formatShortcut } from '../shortcuts/formatShortcut';
 import type { UISessionState } from '../types/sessionState';
 import { formatTurnAge, type QueueBands as QueueBandsModel, type QueueRow } from '../utils/queueBands';
@@ -411,6 +412,11 @@ function buildCrewRows(
  * One crew member's row. Awake, it is the session's row with the crew rail;
  * asleep, it is the member itself with one act on it — wake — and no state to
  * report, because there is nothing running to have a state.
+ *
+ * Waking takes two clicks. Both of the row's asleep targets — the fill button
+ * and the sun — arm on the first and wake on the second, and they share one
+ * armed state, so arming from the row and confirming on the sun is the same
+ * gesture. The daemon still hears one `crew_wake`, on the confirm.
  */
 function CrewRowView({
   member,
@@ -428,16 +434,21 @@ function CrewRowView({
   onOpenActions?: (event: ReactMouseEvent) => void;
 }) {
   const awake = Boolean(row);
+  const { phase, trigger, rowRef } = useWakeConfirm(onWake);
+  const armed = phase === 'armed';
   // An awake member arrives with the daemon's label; a sleeping one has no
   // session to carry one, so the display rule names it here.
   const name = crewDisplayName(member);
   const label = row?.session.label || name;
+  const wakeLabel = armed ? `Wake ${name} — click again to confirm` : `Wake ${name}`;
   return (
     <div
+      ref={rowRef}
       className={`session-item queue-row queue-row--crew ${selected ? 'selected' : ''}`.trim()}
       data-testid={`queue-crew-${member}`}
       data-crew-member={member}
       data-crew-state={awake ? 'awake' : 'asleep'}
+      data-crew-wake={awake || phase === 'rest' ? undefined : phase}
       data-state={row?.session.state}
       data-workspace-id={row?.workspaceId}
     >
@@ -445,8 +456,8 @@ function CrewRowView({
         type="button"
         className="queue-row-select"
         data-testid={`queue-crew-select-${member}`}
-        aria-label={awake ? `Open ${label}` : `Wake ${name}`}
-        onClick={awake ? onSelect : onWake}
+        aria-label={awake ? `Open ${label}` : wakeLabel}
+        onClick={awake ? onSelect : trigger}
       />
       {awake ? (
         <StateIndicator state={row!.session.state} size="md" seed={row!.session.id} reason={row!.session.state_reason} />
@@ -461,18 +472,19 @@ function CrewRowView({
       </span>
       {!awake && onWake && (
         <div className="queue-row-controls">
+          {armed && <span className="crew-wake-confirm">confirm</span>}
           <button
             type="button"
             className="queue-row-wake"
             data-testid={`queue-crew-wake-${member}`}
-            title={`Wake ${name} — start its day`}
-            aria-label={`Wake ${name}`}
+            title={armed ? `Click again to wake ${name}` : `Wake ${name} — start its day`}
+            aria-label={wakeLabel}
             onClick={(event) => {
               event.stopPropagation();
-              onWake();
+              trigger();
             }}
           >
-            ☀
+            <CrewWakeSun phase={phase} />
           </button>
         </div>
       )}

--- a/app/src/components/Sidebar.css
+++ b/app/src/components/Sidebar.css
@@ -1349,6 +1349,22 @@
   color: var(--color-text-primary);
 }
 
+/* The wake button holds a drawn sun rather than a glyph, so it centers its art
+   instead of a line of text. Armed, it stays lit whether or not the row is
+   hovered: the reveal rules above must not hide the thing waiting for its
+   second click. See CrewWake.css for the sun itself. */
+.queue-row-wake {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.queue-row--crew[data-crew-wake] .queue-row-controls,
+.queue-row--crew[data-crew-wake] .queue-row-wake {
+  opacity: 1;
+  pointer-events: auto;
+}
+
 /* When a deferred agent comes back. It sits where the turn age sits on a queued
    row — same column, same weight — because both answer the row's one question:
    a turn's is how long you have owed it, a snooze's is when it returns. */

--- a/changelog.d/crew-wake-two-step.yaml
+++ b/changelog.d/crew-wake-two-step.yaml
@@ -4,6 +4,6 @@ change: >
   Waking a sleeping crew member from the sidebar now takes two clicks. The
   first arms the row — the sun on it rises off the horizon, the light fans
   out, and the row says "confirm" — and the second wakes the member. An
-  armed row stands down on its own after four seconds, on Escape, or on a
-  click anywhere else, so an arm nobody confirms wakes nobody. `attn crew
-  wake` is unchanged: typing the command is already the deliberate act.
+  armed row stands down on its own after four seconds, on Escape, and as soon
+  as you leave it, so an arm nobody confirms wakes nobody. `attn crew wake` is
+  unchanged: typing the command is already the deliberate act.

--- a/changelog.d/crew-wake-two-step.yaml
+++ b/changelog.d/crew-wake-two-step.yaml
@@ -1,0 +1,9 @@
+kind: changed
+area: crew
+change: >
+  Waking a sleeping crew member from the sidebar now takes two clicks. The
+  first arms the row — the sun on it rises off the horizon, the light fans
+  out, and the row says "confirm" — and the second wakes the member. An
+  armed row stands down on its own after four seconds, on Escape, or on a
+  click anywhere else, so an arm nobody confirms wakes nobody. `attn crew
+  wake` is unchanged: typing the command is already the deliberate act.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -527,16 +527,19 @@ Parallelism means another member, never a second copy. A binding naming a
 session the daemon no longer knows has let go on its own, the same liveness
 rule a seed's tender follows.
 
-To **wake** a member is to start its day: `attn crew wake <name>`, or one click
-on its row in the sidebar, where every member is drawn awake or asleep. The
-daemon binds the member, then launches a session in its recorded cwd — its own
-home when none is recorded — reaching its **awareness dirs**, the directories
-its charter is about. Every wake runs on the same pinned model, hardcoded
-rather than configurable: a member subtly wrong takes a read of its prose to
-notice. The launch carries **priming**: what a member is, where its charter is
-to be read, the freshest letter left for it inline, and how a day is closed.
-Skills retire into verbs and the verbs are taught, because an agent never told
-how to handoff cannot file one.
+To **wake** a member is to start its day: `attn crew wake <name>`, or two
+clicks on its row in the sidebar, where every member is drawn awake or asleep.
+The sidebar asks twice because a day cannot be un-rung — the first click arms
+the row and the second wakes, and an armed row that is not confirmed stands
+down. The command does not ask twice: typing it is already the deliberate act
+the clicks reconstruct. Either way the daemon binds the member, then launches
+a session in its recorded cwd — its own home when none is recorded — reaching
+its **awareness dirs**, the directories its charter is about. Every wake runs
+on the same pinned model, hardcoded rather than configurable: a member subtly
+wrong takes a read of its prose to notice. The launch carries **priming**:
+what a member is, where its charter is to be read, the freshest letter left
+for it inline, and how a day is closed. Skills retire into verbs and the verbs
+are taught, because an agent never told how to handoff cannot file one.
 
 A member is also an address: `attn agent msg <member> "…"` reaches its live
 day when it is awake. When it is asleep, the message wakes it within the same


### PR DESCRIPTION
Waking a sleeping crew member starts a new day of a durable identity. It spends
that member's attention, it is billed, and it cannot be un-rung. Until now one
click on a sleeping row did it — and clicking a crew row to *look* at it was the
same click, so members got woken by accident.

The sidebar now asks twice. The first click arms the row, the second wakes. The
CLI is unchanged: `attn crew wake <name>` is one step, because typing a command
is already the deliberate act the two clicks reconstruct.

## What arming looks like

The wake button was the character `☀`. It is now a drawn sun, and the two steps
are a sunrise.

At rest it sits low and grey with its light barely out. Arming raises it clear
of the horizon with a little overshoot, fans five rays open from the top
outward, draws the ground out from beneath it, blooms first light past where it
settles, and warms everything to the brand accent — then stops and holds. The
row takes a trace of that warmth and says `confirm`. Confirming lets it break:
the sun crouches, leaps clear, a ring of first light rings out, the ground it
left dissolves, and a band of daylight sweeps across the row while the word
`asleep` fades off it. Standing down runs the sunrise backwards, which is a
sunset.

Nothing loops. Every armed value is either a transition endpoint or an
animation's resting frame, so the held state is a still frame — a permanent
repaint beside a GPU terminal is a battery bug no test catches — and
`prefers-reduced-motion` drops the motion while leaving an armed sun that still
reads as armed.

## Rules

- **Both asleep targets arm.** The row's fill button covers the whole row and
  was the bigger accident surface; it and the sun share one armed state, so
  arming on the row and confirming on the sun is one gesture. The confirm target
  is therefore the whole row, and it never moves: `confirm` renders to the *left*
  of the sun in a right-anchored strip.
- **An arm nobody confirms wakes nobody.** It stands down as soon as you leave
  the row — a click outside it or focus moving off it — on Escape, and on a
  4-second timeout. That number is a
  tripwire, not a deadline — a deliberate confirm is a second click on a target
  the pointer is already over, a few hundred milliseconds, so four seconds is
  about ten times the gesture it must never interrupt and short enough that an
  arm you walked away from is gone before you come back. Nobody confirming
  should feel it exists.
- **One member arms at a time**, which falls out of the leave-the-row rule:
  reaching a second member means leaving the first one's row, by pointer or by
  keyboard.
- **The confirm flare is not a target.** It lasts 620ms, which is long enough to
  click into; re-arming a row whose wake is already sent would put a second wake
  one click away.
- **The daemon hears exactly one `crew_wake`, on the confirm.** No wire or
  daemon change; `ProtocolVersion` is untouched.

![crew-wake](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/7ab3df3610eff358d0e27e15f73f8286417cec59/delegate-wake-confirm-f5c3238d/crew-wake.gif)

[Full-quality recording (mp4)](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/7ab3df3610eff358d0e27e15f73f8286417cec59/delegate-wake-confirm-f5c3238d/crew-wake.mp4)

Birch is armed and then stood down by a click elsewhere; Dune is armed and
confirmed, and its day starts. Real cursor, packaged app.

## Surfaces

CLI unchanged by design. No protocol, daemon, or Linux surface. `docs/glossary.md`
said a member is woken by "one click on its row" and now says what it does.
Changelog fragment added.

`scripts/real-app-harness/drive-wake-confirm.mjs` drives the choreography in a
packaged app two ways. Through the automation bridge it has to *focus* the row to
reveal its controls, because CSS `:hover` does not answer to dispatched pointer
events — which paints a focus ring no pointer user ever sees. Its `pointer` verb
runs the same steps under the real cursor instead, which is what the recording
above is, and is the only way to show the outside-click stand-down rather than
four seconds of nothing.

## Verification

43 tests in `QueueBands.test.tsx`, covering: one click arms and sends nothing;
the second sends exactly one; arming on the row and confirming on the sun;
disarm by outside click, by focus leaving the row, by Escape, and by timeout,
each sending nothing; one member armed at a time by pointer and by keyboard; a
click into the flare sending nothing more; and the armed row's spoken contract
(`aria-label` on both targets, the visible word) which survives
`prefers-reduced-motion` untouched.

Three of those pin mistakes rather than behavior, and each was verified by
writing the mistake and watching that one test — and only that one — go red:
sending the wake from inside a state updater (StrictMode spends two days on one
click), dropping the focus disarm, and dropping the flare guard.

Full frontend suite green (2867 passed), `tsc --noEmit` clean.

Live in a packaged app on an isolated profile, against a roster of six sleeping
members, twice — once driven through the automation bridge and once under the
real cursor. Each run: one click leaves the member `asleep` in `attn crew list`;
the second wakes exactly it; an armed row left alone stands down and wakes
nobody; and only the confirmed member is awake afterwards.

https://claude.ai/code/session_01J5MoVs2yeA2eB7v7fSAYsb
