### PR TITLE
fix(profile): fence non-production worlds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,10 @@ output as product evidence.
 ### Packaged-app harness
 
 - Single-tenant: never run packaged-app scenarios in parallel.
+- Crew fixtures in harness and verification profiles use obviously synthetic
+  names, never real member names such as `keel`, `alder`, or `trellis`. Pin
+  synthetic members explicitly to `claude-haiku-4-5`; use a stronger model only
+  when the scenario is testing work that needs its intelligence.
 - Multiple scenarios: `pnpm --dir app run real-app:serial-matrix`.
 - Rebuild before evidence-sensitive runs.
 - Harness uses active `ATTN_PROFILE`, otherwise `dev`;

--- a/app/src-tauri/src/profile.rs
+++ b/app/src-tauri/src/profile.rs
@@ -3,9 +3,9 @@
 //! The `ATTN_BUILD_PROFILE` env var is read at *compile* time and baked
 //! into the binary. At startup a profile-baked app makes that profile
 //! authoritative for daemon routing: it sets `ATTN_PROFILE` and
-//! `ATTN_WS_PORT`, and removes socket/database/config paths inherited from
-//! a parent attn terminal. That prevents the dev bundle from reaching the
-//! production daemon while being launched from a production session.
+//! `ATTN_WS_PORT`, and removes path overrides inherited from a parent attn
+//! terminal. That prevents any bundle from reaching another profile while
+//! being launched from one of its sessions.
 //!
 //! A named per-profile build additionally bakes `ATTN_BUILD_WS_PORT` and
 //! `ATTN_BUILD_BUNDLE_ID`, both resolved by the single authority
@@ -27,6 +27,15 @@ const BUILD_PROFILE: Option<&str> = option_env!("ATTN_BUILD_PROFILE");
 // crate. Default/prod builds leave these unset and use the fallbacks below.
 const BUILD_WS_PORT: Option<&str> = option_env!("ATTN_BUILD_WS_PORT");
 const BUILD_BUNDLE_ID: Option<&str> = option_env!("ATTN_BUILD_BUNDLE_ID");
+const ROUTING_PATH_OVERRIDES: [&str; 7] = [
+    "ATTN_SOCKET_PATH",
+    "ATTN_DB_PATH",
+    "ATTN_CONFIG_PATH",
+    "ATTN_DATA_DIR",
+    "ATTN_PLUGIN_DIR",
+    "ATTN_DAEMON_BINARY",
+    "ATTN_BUNDLED_PLUGIN_DIR",
+];
 
 /// Returns the compile-time profile name (empty string for default).
 pub fn build_profile() -> &'static str {
@@ -68,13 +77,15 @@ pub fn default_port_for_build_profile() -> &'static str {
 /// `ATTN_WS_PORT` (directly or via a spawned subprocess).
 pub fn apply_build_profile_env() {
     let profile = build_profile();
-    if !profile.is_empty() {
-        for key in ["ATTN_SOCKET_PATH", "ATTN_DB_PATH", "ATTN_CONFIG_PATH"] {
-            env::remove_var(key);
-        }
-        env::set_var("ATTN_PROFILE", profile);
-        env::set_var("ATTN_WS_PORT", default_port_for_build_profile());
+    for key in ROUTING_PATH_OVERRIDES {
+        env::remove_var(key);
     }
+    if profile.is_empty() {
+        env::remove_var("ATTN_PROFILE");
+    } else {
+        env::set_var("ATTN_PROFILE", profile);
+    }
+    env::set_var("ATTN_WS_PORT", default_port_for_build_profile());
 }
 
 fn data_dir() -> Result<PathBuf, String> {
@@ -176,6 +187,19 @@ fn decide_automation_enabled(automation: Option<&str>, profile: Option<&str>) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn every_path_that_can_redirect_a_bundle_is_scrubbed() {
+        for key in ROUTING_PATH_OVERRIDES {
+            env::set_var(key, format!("foreign-{key}"));
+        }
+
+        apply_build_profile_env();
+
+        for key in ROUTING_PATH_OVERRIDES {
+            assert_eq!(env::var_os(key), None, "{key} survived app startup");
+        }
+    }
 
     #[test]
     fn unbaked_build_falls_back_to_prod_resources() {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -115,6 +115,7 @@ import {
 } from './utils/agentAvailability';
 import { normalizeInstallChannel, shouldCheckForReleaseUpdates } from './utils/installChannel';
 import { boundTicketForSession } from './utils/tickets';
+import { BUILD_PROFILE } from './utils/buildProfile';
 import { buildWorkspaceViewModels, filterSessionsRepresentedInWorkspaceLayouts } from './utils/workspaceViewModels';
 import {
   advanceAfterTurnClosed,
@@ -3854,6 +3855,7 @@ function AppContent({
           selectedTile={selectedTile}
           tileContents={tileContents}
           collapsed={sidebarCollapsed}
+          profile={BUILD_PROFILE}
           headerActions={sidebarHeaderActions}
           criticalNotifications={criticalNotifications}
           onOpenNotifications={openNotificationsPanel}

--- a/app/src/components/Sidebar.css
+++ b/app/src/components/Sidebar.css
@@ -33,6 +33,36 @@
     linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent);
 }
 
+.sidebar-profile-marker {
+  align-self: flex-start;
+  max-width: 100%;
+  padding: 3px 7px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--color-text-secondary);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  line-height: 1.2;
+  letter-spacing: 0.02em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-profile-marker strong {
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+
+.sidebar-profile-marker--collapsed {
+  box-sizing: border-box;
+  width: calc(100% - 10px);
+  margin: 6px 5px 2px;
+  padding-inline: 4px;
+  text-align: center;
+}
+
 .sidebar-tool-row,
 .sidebar-header-row {
   display: flex;

--- a/app/src/components/Sidebar.test.tsx
+++ b/app/src/components/Sidebar.test.tsx
@@ -105,6 +105,15 @@ const baseProps = {
 };
 
 describe('Sidebar', () => {
+  it('shows only a non-default profile marker', () => {
+    const data = buildSidebarData([]);
+    const { rerender } = render(<Sidebar {...baseProps} {...data} />);
+    expect(screen.queryByTestId('sidebar-profile-marker')).not.toBeInTheDocument();
+
+    rerender(<Sidebar {...baseProps} {...data} profile="fixture-lab" />);
+    expect(screen.getByTestId('sidebar-profile-marker')).toHaveTextContent('profile fixture-lab');
+  });
+
   it('uses regular state indicator for codex sessions', () => {
     const sessions: TestSession[] = [{
       id: 's1',

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -132,6 +132,8 @@ interface SidebarProps {
   selectedTile?: SelectedTile | null;
   tileContents?: Record<string, TileContentState>;
   collapsed: boolean;
+  /** The non-default build profile. Empty keeps the production sidebar exact. */
+  profile?: string;
   headerActions: SidebarHeaderAction[];
   // The ambient critical-notification surface. Optional so existing Sidebar
   // tests render without wiring it; absent or zero-count renders nothing.
@@ -358,6 +360,7 @@ export function Sidebar({
   selectedTile = null,
   tileContents = {},
   collapsed,
+  profile = '',
   headerActions,
   criticalNotifications,
   onOpenNotifications,
@@ -852,6 +855,11 @@ export function Sidebar({
   if (collapsed) {
     return (
       <div className="sidebar collapsed">
+        {profile && (
+          <div className="sidebar-profile-marker sidebar-profile-marker--collapsed" title={`Profile: ${profile}`}>
+            {profile}
+          </div>
+        )}
         <div className="icon-rail">
           <button
             className={`icon-btn ${homeActive ? 'active' : ''}`}
@@ -910,6 +918,11 @@ export function Sidebar({
   return (
     <div className={`sidebar sidebar--display-${displayMode}`}>
       <div className="sidebar-header">
+        {profile && (
+          <div className="sidebar-profile-marker" data-testid="sidebar-profile-marker">
+            profile <strong>{profile}</strong>
+          </div>
+        )}
         <div className="sidebar-tool-row">
           {gridLayout && onSelectGridLayout && (
             <GridLayoutControl layout={gridLayout} onSelect={onSelectGridLayout} />

--- a/changelog.d/profile-isolation-fences.yaml
+++ b/changelog.d/profile-isolation-fences.yaml
@@ -1,0 +1,10 @@
+kind: fixed
+area: profiles
+change: >
+  Named-profile windows now identify themselves at a glance, and every process
+  they launch carries that profile's routing even when a login shell exports a
+  conflicting value. App bundles discard inherited data and plugin directory
+  overrides; copied crew registries are refused before they can read or write
+  another profile's member homes; crew working directories cannot point into a
+  different profile's homes; and non-default daemons no longer rewrite global
+  agent skills. Remote binary caches now live inside the active profile too.

--- a/changelog.d/profile-isolation-fences.yaml
+++ b/changelog.d/profile-isolation-fences.yaml
@@ -6,5 +6,6 @@ change: >
   conflicting value. App bundles discard inherited data and plugin directory
   overrides; copied crew registries are refused before they can read or write
   another profile's member homes; crew working directories cannot point into a
-  different profile's homes; and non-default daemons no longer rewrite global
-  agent skills. Remote binary caches now live inside the active profile too.
+  different profile's homes; and verification daemons other than dev no longer
+  rewrite global agent skills. Remote binary caches now live inside the active
+  profile too.

--- a/cmd/attn/crew.go
+++ b/cmd/attn/crew.go
@@ -15,7 +15,7 @@ import (
 
 // `attn crew` is the roster's agent surface. A crew member is a durable named
 // identity — charter, handoff line, address — whose sessions are its days; the
-// registry serves reads over the plain-markdown homes at `~/.attn/crew/`.
+// registry serves reads over the active profile's plain-markdown crew homes.
 // Launching bound is `attn <agent> --member <name>`; this command answers who
 // exists and who is awake.
 
@@ -42,8 +42,9 @@ func writeCrewHelp(w io.Writer) {
 	fmt.Fprint(w, `usage: attn crew <command>
 
 The crew is the roster of durable named identities. A member's home is plain
-markdown at ~/.attn/crew/<name>/; the registry serves reads over it, and a
-session becomes a member by launching as one: attn <agent> --member <name>.
+markdown under the active profile's crew directory; the registry serves reads
+over it, and a session becomes a member by launching as one:
+attn <agent> --member <name>.
 
 The crew lives at the home daemon. On an outpost every command here refuses,
 naming the home to run it on.
@@ -239,7 +240,7 @@ func valueOrDash(value string) string {
 
 func printCrewList(w io.Writer, members []protocol.CrewMember) {
 	if len(members) == 0 {
-		fmt.Fprintln(w, "No crew members are registered. A home at ~/.attn/crew/<name>/CHARTER.md joins the roster at the daemon's next start.")
+		fmt.Fprintln(w, "No crew members are registered. A <name>/CHARTER.md home in the active profile's crew directory joins the roster at the daemon's next start.")
 		return
 	}
 	fmt.Fprintf(w, "%-12s  %-8s  %-10s  %s\n", "MEMBER", "STATE", "SESSION", "HOME")

--- a/cmd/attn/handoff.go
+++ b/cmd/attn/handoff.go
@@ -26,9 +26,9 @@ func writeHandoffHelp(w io.Writer) {
 	fmt.Fprint(w, `usage: attn handoff -m "<your letter>"
 
 File the letter closing this crew member's day. You write it; attn files it into
-~/.attn/crew/<member>/handoffs/ under a UTC-stamped name and never edits the
-prose. The line is append-only: a filed letter is never overwritten, so a
-correction is a new letter.
+the active profile's crew directory under <member>/handoffs/, with a UTC-stamped
+name, and never edits the prose. The line is append-only: a filed letter is never
+overwritten, so a correction is a new letter.
 
 Filing ends the day. The moment the letter lands, attn closes this session and
 wakes the member's successor, primed by what you just wrote — one motion.

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -484,6 +484,12 @@ func runPTYWorker() {
 			os.Exit(1)
 		}
 	}
+	if daemonEnvJSON := os.Getenv("ATTN_PTY_DAEMON_ENV"); daemonEnvJSON != "" {
+		if err := json.Unmarshal([]byte(daemonEnvJSON), &cfg.DaemonEnv); err != nil {
+			fmt.Fprintf(os.Stderr, "pty-worker error: invalid ATTN_PTY_DAEMON_ENV: %v\n", err)
+			os.Exit(1)
+		}
+	}
 	if cols > 0 {
 		if cols > 65535 {
 			fmt.Fprintf(os.Stderr, "pty-worker error: --cols must be <= 65535 (got %d)\n", cols)

--- a/docs/plans/2026-08-15-profile-isolation-fences.md
+++ b/docs/plans/2026-08-15-profile-isolation-fences.md
@@ -1,0 +1,62 @@
+# Plan: Profile isolation fences and legibility
+
+## Goal
+
+Make a non-default profile unmistakable in the app and incapable of reaching the default profile through inherited routing, copied crew records, global skill synchronization, or shared remote caches.
+
+## Architecture Map
+
+```text
+App bundle startup
+  profile::apply_build_profile_env
+    scrub every path override, including default/prod bundles
+  Sidebar
+    render build profile only when non-default
+
+Session spawn
+  daemon spawn plan
+    PTY manager / conversation host
+      merge daemon env <- login shell <- plugin env
+      re-apply daemon profile + exact data/db/socket/config/plugin paths last
+
+Crew path use
+  imported/stored Member
+    validate HomeDir + CharterPath under <dataRoot>/crew
+    validate cwd + awareness dirs are not in another ~/.attn*/crew
+      wake / priming / handoff / turnover
+
+User-global side effects
+  skill synchronization
+    default profile -> install/prune
+    named profile -> skip and log
+  remote artifact cache
+    <active dataRoot>/remotes
+```
+
+## Boundaries
+
+- The Tauri build profile owns app routing. Runtime parent environment cannot redirect a bundle.
+- The daemon profile and exact socket own every child session's routing. Login-shell and plugin environment remain inputs, never authorities for these keys.
+- The daemon validates stored crew paths immediately before filesystem or launch use. Project cwd and awareness directories remain unrestricted except for another profile's crew homes.
+- User-global skill directories belong to the default profile. Remote artifacts are ordinary profile data.
+- Harness crew identities are visibly synthetic and explicitly pinned to `claude-haiku-4-5` unless a scenario documents why it needs a stronger model.
+
+## Implementation Steps
+
+- [x] Add the fixture naming/model rules and correct profile-aware crew CLI prose.
+- [x] Show a quiet persistent profile marker in non-default app sidebars; leave default rendering unchanged.
+- [x] Scrub all app-shell routing overrides in every bundle.
+- [x] Pin profile and socket after every PTY/host environment merge, with conflicting-login-shell tests.
+- [x] Fence member filesystem paths and foreign-profile crew work directories at import and each use.
+- [x] Skip global skill synchronization outside the default profile and move remote caches under `config.DataDir()`.
+- [x] Add focused Go, Rust, and frontend tests; run `make test-quick` and the frontend suite.
+- [x] Install an isolated profile, run preflight, prove the marker/profile env/synthetic crew behavior live, and record visible evidence.
+- [x] Confirm the branch is based on current main before live verification.
+- [ ] Commit, push, and open a ready PR without merging.
+
+## Decisions
+
+- Inject the complete routing block, not only `ATTN_PROFILE`. Direct CLI commands can open the database or plugin tree without using the socket, so every daemon-owned path must win over login-shell and plugin environment.
+- Resolve paths through existing ancestors before containment checks so symlinked roots work and symlink escapes do not.
+- Keep project directories open. Only another `~/.attn*/crew` tree is forbidden for cwd and awareness.
+- Treat an invalid stored member path as a named operation refusal, not a silently omitted member or an automatic rewrite of copied state.

--- a/docs/plans/2026-08-15-profile-isolation-fences.md
+++ b/docs/plans/2026-08-15-profile-isolation-fences.md
@@ -52,7 +52,7 @@ User-global side effects
 - [x] Add focused Go, Rust, and frontend tests; run `make test-quick` and the frontend suite.
 - [x] Install an isolated profile, run preflight, prove the marker/profile env/synthetic crew behavior live, and record visible evidence.
 - [x] Confirm the branch is based on current main before live verification.
-- [ ] Commit, push, and open a ready PR without merging.
+- [x] Commit, push, and open a ready PR without merging.
 
 ## Decisions
 

--- a/docs/plans/2026-08-15-profile-isolation-fences.md
+++ b/docs/plans/2026-08-15-profile-isolation-fences.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Make a non-default profile unmistakable in the app and incapable of reaching the default profile through inherited routing, copied crew records, global skill synchronization, or shared remote caches.
+Make a non-default profile unmistakable in the app and incapable of reaching the default profile through inherited routing, copied crew records, or shared remote caches. Fence user-global skill synchronization to the default and dev profiles.
 
 ## Architecture Map
 
@@ -17,7 +17,7 @@ Session spawn
   daemon spawn plan
     PTY manager / conversation host
       merge daemon env <- login shell <- plugin env
-      re-apply daemon profile + exact data/db/socket/config/plugin paths last
+      re-apply daemon profile + exact data/db/socket/ws/config/plugin paths last
 
 Crew path use
   imported/stored Member
@@ -27,8 +27,8 @@ Crew path use
 
 User-global side effects
   skill synchronization
-    default profile -> install/prune
-    named profile -> skip and log
+    default or dev profile -> install/prune
+    other named profile -> skip and log
   remote artifact cache
     <active dataRoot>/remotes
 ```
@@ -38,7 +38,7 @@ User-global side effects
 - The Tauri build profile owns app routing. Runtime parent environment cannot redirect a bundle.
 - The daemon profile and exact socket own every child session's routing. Login-shell and plugin environment remain inputs, never authorities for these keys.
 - The daemon validates stored crew paths immediately before filesystem or launch use. Project cwd and awareness directories remain unrestricted except for another profile's crew homes.
-- User-global skill directories belong to the default profile. Remote artifacts are ordinary profile data.
+- User-global skill directories are shared by the default and dev profiles so the attn-on-attn development loop sees the freshly bundled skill. Every other named profile skips them. Remote artifacts are ordinary profile data.
 - Harness crew identities are visibly synthetic and explicitly pinned to `claude-haiku-4-5` unless a scenario documents why it needs a stronger model.
 
 ## Implementation Steps
@@ -48,7 +48,7 @@ User-global side effects
 - [x] Scrub all app-shell routing overrides in every bundle.
 - [x] Pin profile and socket after every PTY/host environment merge, with conflicting-login-shell tests.
 - [x] Fence member filesystem paths and foreign-profile crew work directories at import and each use.
-- [x] Skip global skill synchronization outside the default profile and move remote caches under `config.DataDir()`.
+- [x] Skip global skill synchronization outside the default and dev profiles, and move remote caches under `config.DataDir()`.
 - [x] Add focused Go, Rust, and frontend tests; run `make test-quick` and the frontend suite.
 - [x] Install an isolated profile, run preflight, prove the marker/profile env/synthetic crew behavior live, and record visible evidence.
 - [x] Confirm the branch is based on current main before live verification.
@@ -60,3 +60,4 @@ User-global side effects
 - Resolve paths through existing ancestors before containment checks so symlinked roots work and symlink escapes do not.
 - Keep project directories open. Only another `~/.attn*/crew` tree is forbidden for cwd and awareness.
 - Treat an invalid stored member path as a named operation refusal, not a silently omitted member or an automatic rewrite of copied state.
+- Keep `dev` as the sole named-profile exception for user-global skill synchronization because it is the attn-on-attn development loop; verification profiles remain fenced.

--- a/internal/agent/attn_skill.go
+++ b/internal/agent/attn_skill.go
@@ -140,11 +140,12 @@ func ensureAttnCopilotSkillInstalled() error {
 }
 
 func userGlobalSkillSyncEnabled() bool {
-	return config.Profile() == ""
+	profile := config.Profile()
+	return profile == "" || profile == "dev"
 }
 
 // EnsureClaudeSkillInstalled installs the bundled skill only for the default
-// profile. The bool reports whether synchronization ran.
+// and dev profiles. The bool reports whether synchronization ran.
 func EnsureClaudeSkillInstalled() (bool, error) {
 	if !userGlobalSkillSyncEnabled() {
 		return false, nil
@@ -153,7 +154,7 @@ func EnsureClaudeSkillInstalled() (bool, error) {
 }
 
 // EnsureAgentsSkillInstalled installs the shared agent skill only for the
-// default profile. The bool reports whether synchronization ran.
+// default and dev profiles. The bool reports whether synchronization ran.
 func EnsureAgentsSkillInstalled() (bool, error) {
 	if !userGlobalSkillSyncEnabled() {
 		return false, nil
@@ -162,7 +163,7 @@ func EnsureAgentsSkillInstalled() (bool, error) {
 }
 
 // EnsureCopilotSkillInstalled installs the bundled skill only for the default
-// profile. The bool reports whether synchronization ran.
+// and dev profiles. The bool reports whether synchronization ran.
 func EnsureCopilotSkillInstalled() (bool, error) {
 	if !userGlobalSkillSyncEnabled() {
 		return false, nil

--- a/internal/agent/attn_skill.go
+++ b/internal/agent/attn_skill.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/toolhome"
 )
 
@@ -138,14 +139,33 @@ func ensureAttnCopilotSkillInstalled() error {
 	return installAttnSkill(filepath.Join(homeDir, ".copilot", "skills", "attn"))
 }
 
-func EnsureClaudeSkillInstalled() error {
-	return ensureAttnClaudeSkillInstalled()
+func userGlobalSkillSyncEnabled() bool {
+	return config.Profile() == ""
 }
 
-func EnsureAgentsSkillInstalled() error {
-	return ensureAttnAgentsSkillInstalled()
+// EnsureClaudeSkillInstalled installs the bundled skill only for the default
+// profile. The bool reports whether synchronization ran.
+func EnsureClaudeSkillInstalled() (bool, error) {
+	if !userGlobalSkillSyncEnabled() {
+		return false, nil
+	}
+	return true, ensureAttnClaudeSkillInstalled()
 }
 
-func EnsureCopilotSkillInstalled() error {
-	return ensureAttnCopilotSkillInstalled()
+// EnsureAgentsSkillInstalled installs the shared agent skill only for the
+// default profile. The bool reports whether synchronization ran.
+func EnsureAgentsSkillInstalled() (bool, error) {
+	if !userGlobalSkillSyncEnabled() {
+		return false, nil
+	}
+	return true, ensureAttnAgentsSkillInstalled()
+}
+
+// EnsureCopilotSkillInstalled installs the bundled skill only for the default
+// profile. The bool reports whether synchronization ran.
+func EnsureCopilotSkillInstalled() (bool, error) {
+	if !userGlobalSkillSyncEnabled() {
+		return false, nil
+	}
+	return true, ensureAttnCopilotSkillInstalled()
 }

--- a/internal/agent/attn_skill_test.go
+++ b/internal/agent/attn_skill_test.go
@@ -175,7 +175,7 @@ func TestEnsureAttnCopilotSkillInstalledPrunesOrphanedFiles(t *testing.T) {
 	assertAttnSkillTree(t, skillDir)
 }
 
-func TestUserGlobalSkillSyncIsSkippedOutsideTheDefaultProfile(t *testing.T) {
+func TestUserGlobalSkillSyncIsSkippedOutsideDefaultAndDevProfiles(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv(toolhome.EnvVar, home)
 	t.Setenv("ATTN_PROFILE", "fixture-lab")
@@ -191,14 +191,40 @@ func TestUserGlobalSkillSyncIsSkippedOutsideTheDefaultProfile(t *testing.T) {
 				t.Fatalf("ensure skill: %v", err)
 			}
 			if synced {
-				t.Fatal("a non-default profile synchronized a user-global skill")
+				t.Fatal("a verification profile synchronized a user-global skill")
 			}
 		})
 	}
 
 	for _, root := range []string{".claude", ".agents", ".copilot"} {
 		if _, err := os.Stat(filepath.Join(home, root)); !os.IsNotExist(err) {
-			t.Fatalf("non-default profile wrote %s: stat err = %v", root, err)
+			t.Fatalf("verification profile wrote %s: stat err = %v", root, err)
 		}
+	}
+}
+
+func TestUserGlobalSkillSyncRunsForDevProfile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv(toolhome.EnvVar, home)
+	t.Setenv("ATTN_PROFILE", "dev")
+
+	for name, test := range map[string]struct {
+		ensure   func() (bool, error)
+		skillDir string
+	}{
+		"claude":  {EnsureClaudeSkillInstalled, filepath.Join(home, ".claude", "skills", "attn")},
+		"agents":  {EnsureAgentsSkillInstalled, filepath.Join(home, ".agents", "skills", "attn")},
+		"copilot": {EnsureCopilotSkillInstalled, filepath.Join(home, ".copilot", "skills", "attn")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			synced, err := test.ensure()
+			if err != nil {
+				t.Fatalf("ensure skill: %v", err)
+			}
+			if !synced {
+				t.Fatal("dev profile skipped user-global skill synchronization")
+			}
+			assertAttnSkillTree(t, test.skillDir)
+		})
 	}
 }

--- a/internal/agent/attn_skill_test.go
+++ b/internal/agent/attn_skill_test.go
@@ -174,3 +174,31 @@ func TestEnsureAttnCopilotSkillInstalledPrunesOrphanedFiles(t *testing.T) {
 	}
 	assertAttnSkillTree(t, skillDir)
 }
+
+func TestUserGlobalSkillSyncIsSkippedOutsideTheDefaultProfile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv(toolhome.EnvVar, home)
+	t.Setenv("ATTN_PROFILE", "fixture-lab")
+
+	for name, ensure := range map[string]func() (bool, error){
+		"claude":  EnsureClaudeSkillInstalled,
+		"agents":  EnsureAgentsSkillInstalled,
+		"copilot": EnsureCopilotSkillInstalled,
+	} {
+		t.Run(name, func(t *testing.T) {
+			synced, err := ensure()
+			if err != nil {
+				t.Fatalf("ensure skill: %v", err)
+			}
+			if synced {
+				t.Fatal("a non-default profile synchronized a user-global skill")
+			}
+		})
+	}
+
+	for _, root := range []string{".claude", ".agents", ".copilot"} {
+		if _, err := os.Stat(filepath.Join(home, root)); !os.IsNotExist(err) {
+			t.Fatalf("non-default profile wrote %s: stat err = %v", root, err)
+		}
+	}
+}

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -551,7 +551,7 @@ func claudeHasBareModeAuthentication() bool {
 // PrepareLaunch copies resume transcripts into the target project folder so
 // Claude can resolve --resume when the resumed transcript belongs to another project folder.
 func (c *Claude) PrepareLaunch(opts SpawnOpts) error {
-	if err := ensureAttnClaudeSkillInstalled(); err != nil {
+	if _, err := EnsureClaudeSkillInstalled(); err != nil {
 		return err
 	}
 	if strings.TrimSpace(opts.ResumeSessionID) == "" {

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -128,7 +128,8 @@ func (c *Codex) BuildEnv(opts SpawnOpts) []string {
 }
 
 func (c *Codex) PrepareLaunch(opts SpawnOpts) error {
-	return ensureAttnAgentsSkillInstalled()
+	_, err := EnsureAgentsSkillInstalled()
+	return err
 }
 
 func (c *Codex) RunHeadlessTask(ctx context.Context, request HeadlessTaskRequest) (HeadlessTaskResult, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -267,6 +267,14 @@ func DataDir() string {
 	return attnDir()
 }
 
+// ConfigPath returns the config file whose routing this process loaded.
+func ConfigPath() string {
+	if envPath := strings.TrimSpace(os.Getenv("ATTN_CONFIG_PATH")); envPath != "" {
+		return filepath.Clean(envPath)
+	}
+	return filepath.Join(attnDir(), "config.json")
+}
+
 // PluginDir returns the installed plugin directory for the active profile.
 // Priority: ATTN_PLUGIN_DIR env var > per-profile data directory default.
 func PluginDir() string {

--- a/internal/daemon/crew.go
+++ b/internal/daemon/crew.go
@@ -73,7 +73,21 @@ func (d *Daemon) importCrewHomes() {
 		d.logf("crew: importing homes: %v", err)
 		return
 	}
+	registered, _, err := d.readCrewMembersRaw()
+	if err != nil && !docstore.IsUndeclaredCollection(err) {
+		d.logf("crew: checking registered homes before import: %v", err)
+		return
+	}
+	for _, member := range registered {
+		if err := d.validateCrewMemberPaths(member); err != nil {
+			d.logf("crew: import refused stored member %s: %v", crew.DisplayName(member.ID), err)
+		}
+	}
 	for _, member := range members {
+		if err := d.validateCrewMemberPaths(member); err != nil {
+			d.logf("crew: import refused member %s: %v", crew.DisplayName(member.ID), err)
+			continue
+		}
 		if err := d.writeCrewMember(*schema, member, docstore.ExpectAbsent); err != nil {
 			if docstore.IsConflict(err) {
 				continue // already registered; the record is authoritative
@@ -100,6 +114,9 @@ func (d *Daemon) crewCollection() (*docstore.CollectionSchema, error) {
 // docstore's own change fact so live queries on the roster wake like any other
 // write.
 func (d *Daemon) writeCrewMember(schema docstore.CollectionSchema, member crew.Member, expected int64) error {
+	if err := d.validateCrewMemberPaths(member); err != nil {
+		return err
+	}
 	body, err := member.Encode()
 	if err != nil {
 		return err
@@ -123,6 +140,22 @@ func (d *Daemon) writeCrewMember(schema docstore.CollectionSchema, member crew.M
 // 2026-08-14 at a three-member roster, 25µs on an M5. That is what a session
 // broadcast pays, and what a garden action pays to resolve its tender.
 func (d *Daemon) readCrewMembers() ([]crew.Member, map[string]docstore.Document, error) {
+	members, docs, err := d.readCrewMembersRaw()
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, member := range members {
+		if err := d.validateCrewMemberPaths(member); err != nil {
+			return nil, nil, err
+		}
+	}
+	return members, docs, nil
+}
+
+// readCrewMembersRaw is reserved for startup import, where invalid copied rows
+// must be enumerated so each refusal can be logged. Every operational read goes
+// through readCrewMembers and therefore through the path fence.
+func (d *Daemon) readCrewMembersRaw() ([]crew.Member, map[string]docstore.Document, error) {
 	read, _, err := d.runDocQuery(docstore.Query{
 		Namespace:  crew.Namespace,
 		Collection: crew.CollectionMembers,

--- a/internal/daemon/crew_handoff.go
+++ b/internal/daemon/crew_handoff.go
@@ -180,10 +180,16 @@ func (d *Daemon) crewDayEndsHere(close protocol.CrewDayClose, now time.Time) boo
 // "a letter is already filed under that name" is the same sentence for a retry
 // and for a correction and the caller cannot tell which it is in.
 func (d *Daemon) crewLetterForHandoff(member crew.Member, sessionID, note string, retry bool) (string, error) {
+	if err := d.validateCrewMemberPaths(member); err != nil {
+		return "", err
+	}
 	filed, hasFiled := member.FiledLetterFor(sessionID)
 	if retry {
 		if !hasFiled {
 			return "", fmt.Errorf("%s's day has filed no letter yet, so there is no turnover to retry — write one with `attn handoff -m \"<your letter>\"`", crew.DisplayName(member.ID))
+		}
+		if err := d.validateCrewLetterPath(member, filed); err != nil {
+			return "", err
 		}
 		if _, err := os.Stat(filed); err != nil {
 			return "", fmt.Errorf("%s's filed letter is recorded at %s but is not readable there (%v); file this day's letter again with `attn handoff -m \"<your letter>\"`", crew.DisplayName(member.ID), filed, err)
@@ -192,6 +198,9 @@ func (d *Daemon) crewLetterForHandoff(member crew.Member, sessionID, note string
 		return filed, nil
 	}
 	if err := crew.ValidateHandoffNote(note); err != nil {
+		return "", err
+	}
+	if _, err := d.validateCrewHandoffsDir(member); err != nil {
 		return "", err
 	}
 	path, err := crew.FileHandoff(member.HomeDir, member.ID, note, time.Now())
@@ -230,6 +239,12 @@ func (d *Daemon) recordCrewLetter(memberID, sessionID, path string) {
 // primed by the letter that was just filed. The old session is closed only once
 // the new one is running.
 func (d *Daemon) crewNap(member crew.Member, oldSessionID string) (string, error) {
+	if err := d.validateCrewMemberPaths(member); err != nil {
+		return "", err
+	}
+	if err := d.validateCrewWorkDirs(member); err != nil {
+		return "", err
+	}
 	session := d.store.Get(oldSessionID)
 	if session == nil {
 		return "", fmt.Errorf("session %s is no longer here", shortSessionID(oldSessionID))
@@ -245,6 +260,11 @@ func (d *Daemon) crewNap(member crew.Member, oldSessionID string) (string, error
 		}
 	}
 	spawnMsg, policy := d.crewNapSpawn(member, session)
+	launchDir, err := d.resolveCrewWorkDir(spawnMsg.Cwd)
+	if err != nil {
+		return "", fmt.Errorf("wake %s's successor in %s: %w", crew.DisplayName(member.ID), spawnMsg.Cwd, err)
+	}
+	spawnMsg.Cwd = launchDir
 	newSessionID := spawnMsg.ID
 
 	// Moved before the spawn for the same reason the wake claims before it

--- a/internal/daemon/crew_handoff_test.go
+++ b/internal/daemon/crew_handoff_test.go
@@ -123,6 +123,80 @@ func handoffFiles(t *testing.T, d *Daemon, member string) []string {
 	return names
 }
 
+func TestCrewHandoff_RefusesASymlinkedHandoffsDirectory(t *testing.T) {
+	d, backend, _ := newWakeableDaemon(t)
+	woken, err := d.crewWake("keel", "")
+	if err != nil {
+		t.Fatalf("wake: %v", err)
+	}
+	handoffsDir := filepath.Join(d.dataRoot, crew.HomesDirName, "keel", crew.HandoffsDirName)
+	if err := os.RemoveAll(handoffsDir); err != nil {
+		t.Fatalf("remove fixture handoffs: %v", err)
+	}
+	foreign := t.TempDir()
+	if err := os.Symlink(foreign, handoffsDir); err != nil {
+		t.Fatalf("symlink handoffs: %v", err)
+	}
+
+	resp := crewHandoffCall(t, d, woken.SessionID, "This must stay in my profile.")
+	if resp.Ok {
+		t.Fatal("a handoff was filed through a symlink leaving the member home")
+	}
+	refusal := protocol.Deref(resp.Error)
+	for _, want := range []string{handoffsDir, filepath.Join(d.dataRoot, crew.HomesDirName, "keel"), "symlink"} {
+		if !strings.Contains(refusal, want) {
+			t.Errorf("refusal %q does not name %q", refusal, want)
+		}
+	}
+	if entries, err := os.ReadDir(foreign); err != nil || len(entries) != 0 {
+		t.Fatalf("foreign handoff target was written: entries=%v err=%v", entries, err)
+	}
+	if len(spawnedSessions(t, backend)) != 1 {
+		t.Fatal("a refused filing spawned a successor")
+	}
+}
+
+func TestCrewPriming_RefusesASymlinkedLetter(t *testing.T) {
+	d, _, _ := newWakeableDaemon(t)
+	members, _, err := d.readCrewMembers()
+	if err != nil {
+		t.Fatalf("read roster: %v", err)
+	}
+	member, ok := crew.Resolve("keel", members)
+	if !ok {
+		t.Fatal("keel is missing from the fixture roster")
+	}
+	handoffsDir := filepath.Join(member.HomeDir, crew.HandoffsDirName)
+	if err := os.RemoveAll(handoffsDir); err != nil {
+		t.Fatalf("remove fixture handoffs: %v", err)
+	}
+	if err := os.MkdirAll(handoffsDir, 0o755); err != nil {
+		t.Fatalf("recreate handoffs: %v", err)
+	}
+	foreignLetter := filepath.Join(t.TempDir(), "foreign-letter.md")
+	if err := os.WriteFile(foreignLetter, []byte("foreign words\n"), 0o644); err != nil {
+		t.Fatalf("write foreign letter: %v", err)
+	}
+	linkedLetter := filepath.Join(handoffsDir, "2099-01-01T00-00Z-keel.md")
+	if err := os.Symlink(foreignLetter, linkedLetter); err != nil {
+		t.Fatalf("symlink letter: %v", err)
+	}
+	newerLetter := filepath.Join(handoffsDir, "2100-01-01T00-00Z-keel.md")
+	if err := os.WriteFile(newerLetter, []byte("newer local words\n"), 0o644); err != nil {
+		t.Fatalf("write newer local letter: %v", err)
+	}
+
+	if _, err := d.crewPriming(member); err == nil {
+		t.Fatal("priming read a symlinked letter outside the member home")
+	} else {
+		for _, want := range []string{linkedLetter, handoffsDir, "symlink"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("refusal %q does not name %q", err, want)
+			}
+		}
+	}
+}
+
 // The slice's acceptance: a member files its letter and the day turns over in
 // one motion. The letter lands on disk as written, a fresh session takes over
 // the member's day, and the member is awake throughout.
@@ -393,7 +467,10 @@ func TestCrewHandoff_ARetryTurnsTheDayOverWithTheLetterAlreadyFiled(t *testing.T
 	}
 	// The letter the member actually wrote is what threads the new day — the
 	// retry must not have primed the successor off some other file.
-	_, block, bound := d.crewPrimeForSession(successor)
+	_, block, bound, err := d.crewPrimeForSession(successor)
+	if err != nil {
+		t.Fatalf("prime successor: %v", err)
+	}
 	if !bound || !strings.Contains(block, "The letter, written once.") {
 		t.Error("the successor was not primed by the letter that was already filed")
 	}
@@ -542,7 +619,10 @@ func TestCrewHandoff_TheSuccessorIsPrimedByTheLetterJustFiled(t *testing.T) {
 	}
 	successor := protocol.Deref(resp.CrewHandoffResult.SessionID)
 
-	member, block, bound := d.crewPrimeForSession(successor)
+	member, block, bound, err := d.crewPrimeForSession(successor)
+	if err != nil {
+		t.Fatalf("prime successor: %v", err)
+	}
 	if !bound {
 		t.Fatal("the successor is nobody")
 	}

--- a/internal/daemon/crew_paths.go
+++ b/internal/daemon/crew_paths.go
@@ -166,12 +166,11 @@ func (d *Daemon) resolveCrewWorkDir(dir string) (string, error) {
 }
 
 func (d *Daemon) resolveCrewWorkDirForHome(dir, userHome string) (string, error) {
-	resolved, err := resolveCrewDir(dir)
-	if err != nil || resolved == "" {
-		return resolved, err
+	original, err := absoluteCrewDir(dir)
+	if err != nil || original == "" {
+		return original, err
 	}
-	original := resolved
-	resolved, err = config.CanonicalRuntimePath(original)
+	resolved, err := config.CanonicalRuntimePath(original)
 	if err != nil {
 		return "", fmt.Errorf("resolve crew directory %q: %w", dir, err)
 	}
@@ -198,6 +197,16 @@ func (d *Daemon) resolveCrewWorkDirForHome(dir, userHome string) (string, error)
 		return "", fmt.Errorf("refusing crew directory %q: it resolves inside another profile's crew root %q; this daemon's crew root is %q", dir, foreignRoot, ownRoot)
 	}
 	return original, nil
+}
+
+// resolveCrewRecordedDir keeps the existing crew-set contract: new cwd and
+// awareness values must name directories that exist when they are recorded.
+func (d *Daemon) resolveCrewRecordedDir(dir string) (string, error) {
+	resolved, err := resolveCrewDir(dir)
+	if err != nil || resolved == "" {
+		return resolved, err
+	}
+	return d.resolveCrewWorkDir(resolved)
 }
 
 func (d *Daemon) validateCrewWorkDirs(member crew.Member) error {

--- a/internal/daemon/crew_paths.go
+++ b/internal/daemon/crew_paths.go
@@ -1,0 +1,238 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/victorarias/attn/internal/config"
+	"github.com/victorarias/attn/internal/crew"
+	"github.com/victorarias/attn/internal/docstore"
+)
+
+func pathWithin(root, target string) bool {
+	rel, err := filepath.Rel(root, target)
+	return err == nil && (rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))))
+}
+
+func (d *Daemon) resolvedCrewRoot() (string, error) {
+	root, err := config.CanonicalRuntimePath(filepath.Join(d.dataRoot, crew.HomesDirName))
+	if err != nil {
+		return "", fmt.Errorf("resolve this daemon's crew root: %w", err)
+	}
+	return root, nil
+}
+
+// validateCrewMemberPaths is the copied-database fence. A registry row may be
+// carried between profiles, but the absolute filesystem addresses inside it
+// never gain authority in the receiving daemon.
+func (d *Daemon) validateCrewMemberPaths(member crew.Member) error {
+	root, err := d.resolvedCrewRoot()
+	if err != nil {
+		return err
+	}
+	for _, candidate := range []struct{ label, stored string }{
+		{"home", member.HomeDir},
+		{"charter", member.CharterPath},
+	} {
+		label, stored := candidate.label, candidate.stored
+		resolved, err := config.CanonicalRuntimePath(stored)
+		if err != nil {
+			return fmt.Errorf("refusing crew member %s: resolve stored %s path %q: %w", crew.DisplayName(member.ID), label, stored, err)
+		}
+		if stored == "" || !filepath.IsAbs(stored) || !pathWithin(root, resolved) {
+			return fmt.Errorf("refusing crew member %s: stored %s path %q is outside this daemon's crew root %q; the likely cause is an attn.db copied from another profile", crew.DisplayName(member.ID), label, stored, root)
+		}
+	}
+	return nil
+}
+
+func (d *Daemon) validateCrewLetterPath(member crew.Member, stored string) error {
+	if err := d.validateCrewMemberPaths(member); err != nil {
+		return err
+	}
+	handoffsDir, err := d.validateCrewHandoffsDir(member)
+	if err != nil {
+		return err
+	}
+	expectedRoot, err := config.CanonicalRuntimePath(handoffsDir)
+	if err != nil {
+		return fmt.Errorf("resolve %s's handoffs root %q: %w", crew.DisplayName(member.ID), handoffsDir, err)
+	}
+	letter, err := config.CanonicalRuntimePath(stored)
+	if err != nil {
+		return fmt.Errorf("resolve %s's stored handoff path %q: %w", crew.DisplayName(member.ID), stored, err)
+	}
+	if stored == "" || !filepath.IsAbs(stored) || !pathWithin(expectedRoot, letter) {
+		return fmt.Errorf("refusing crew member %s: stored handoff path %q is outside this member's handoffs root %q; the likely cause is a copied attn.db or a symlink leaving the member home", crew.DisplayName(member.ID), stored, expectedRoot)
+	}
+	return nil
+}
+
+func (d *Daemon) validateCrewHandoffsDir(member crew.Member) (string, error) {
+	if err := d.validateCrewMemberPaths(member); err != nil {
+		return "", err
+	}
+	home, err := config.CanonicalRuntimePath(member.HomeDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s's home %q: %w", crew.DisplayName(member.ID), member.HomeDir, err)
+	}
+	stored := filepath.Join(member.HomeDir, crew.HandoffsDirName)
+	resolved, err := config.CanonicalRuntimePath(stored)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s's handoffs directory %q: %w", crew.DisplayName(member.ID), stored, err)
+	}
+	if !pathWithin(home, resolved) {
+		return "", fmt.Errorf("refusing crew member %s: handoffs directory %q resolves outside this member's home %q; the likely cause is a copied attn.db or a symlink leaving the member home", crew.DisplayName(member.ID), stored, home)
+	}
+	return stored, nil
+}
+
+func profileCrewRootContaining(userHome, target string) string {
+	if strings.TrimSpace(userHome) == "" || strings.TrimSpace(target) == "" {
+		return ""
+	}
+	home, err := filepath.Abs(userHome)
+	if err != nil {
+		return ""
+	}
+	target, err = filepath.Abs(target)
+	if err != nil {
+		return ""
+	}
+	home = filepath.Clean(home)
+	target = filepath.Clean(target)
+	rel, err := filepath.Rel(home, target)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		// The caller may already have canonicalized target while userHome still
+		// uses a platform alias such as /var. Compare both canonically as the
+		// fallback; the lexical pass above deliberately preserves a symlinked
+		// .attn-<profile> component long enough to identify it.
+		home, err = config.CanonicalRuntimePath(home)
+		if err != nil {
+			return ""
+		}
+		target, err = config.CanonicalRuntimePath(target)
+		if err != nil {
+			return ""
+		}
+		rel, err = filepath.Rel(home, target)
+	}
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return canonicalProfileCrewRootContaining(userHome, target)
+	}
+	parts := strings.Split(rel, string(filepath.Separator))
+	if len(parts) < 2 || parts[1] != crew.HomesDirName {
+		return canonicalProfileCrewRootContaining(userHome, target)
+	}
+	if parts[0] != ".attn" && !strings.HasPrefix(parts[0], ".attn-") {
+		return canonicalProfileCrewRootContaining(userHome, target)
+	}
+	return filepath.Join(home, parts[0], crew.HomesDirName)
+}
+
+func canonicalProfileCrewRootContaining(userHome, target string) string {
+	target, err := config.CanonicalRuntimePath(target)
+	if err != nil || target == "" {
+		return ""
+	}
+	entries, err := os.ReadDir(userHome)
+	if err != nil {
+		return ""
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if name != ".attn" && !strings.HasPrefix(name, ".attn-") {
+			continue
+		}
+		storedRoot := filepath.Join(userHome, name, crew.HomesDirName)
+		root, err := config.CanonicalRuntimePath(storedRoot)
+		if err == nil && pathWithin(root, target) {
+			return storedRoot
+		}
+	}
+	return ""
+}
+
+// resolveCrewWorkDir keeps ordinary project directories open while refusing a
+// cwd or awareness directory inside another profile's member homes.
+func (d *Daemon) resolveCrewWorkDir(dir string) (string, error) {
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve the user home while checking crew directory %q: %w", dir, err)
+	}
+	return d.resolveCrewWorkDirForHome(dir, userHome)
+}
+
+func (d *Daemon) resolveCrewWorkDirForHome(dir, userHome string) (string, error) {
+	resolved, err := resolveCrewDir(dir)
+	if err != nil || resolved == "" {
+		return resolved, err
+	}
+	original := resolved
+	resolved, err = config.CanonicalRuntimePath(original)
+	if err != nil {
+		return "", fmt.Errorf("resolve crew directory %q: %w", dir, err)
+	}
+	foreignRoot := profileCrewRootContaining(userHome, original)
+	if foreignRoot == "" {
+		foreignRoot = profileCrewRootContaining(userHome, resolved)
+	}
+	if foreignRoot == "" {
+		return original, nil
+	}
+	storedForeignRoot := foreignRoot
+	foreignRoot, err = config.CanonicalRuntimePath(storedForeignRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve foreign crew root %q: %w", storedForeignRoot, err)
+	}
+	ownRoot, err := d.resolvedCrewRoot()
+	if err != nil {
+		return "", err
+	}
+	if foreignRoot != ownRoot {
+		if storedForeignRoot != foreignRoot {
+			return "", fmt.Errorf("refusing crew directory %q: it is inside another profile's crew root %q, which resolves to %q; this daemon's crew root is %q", dir, storedForeignRoot, foreignRoot, ownRoot)
+		}
+		return "", fmt.Errorf("refusing crew directory %q: it resolves inside another profile's crew root %q; this daemon's crew root is %q", dir, foreignRoot, ownRoot)
+	}
+	return original, nil
+}
+
+func (d *Daemon) validateCrewWorkDirs(member crew.Member) error {
+	if _, err := d.resolveCrewWorkDir(member.CWD); err != nil {
+		return fmt.Errorf("%s's cwd: %w", crew.DisplayName(member.ID), err)
+	}
+	return d.validateCrewAwarenessDirs(member)
+}
+
+func (d *Daemon) validateCrewAwarenessDirs(member crew.Member) error {
+	for _, dir := range member.AwarenessDirs {
+		if _, err := d.resolveCrewWorkDir(dir); err != nil {
+			return fmt.Errorf("%s's awareness directory: %w", crew.DisplayName(member.ID), err)
+		}
+	}
+	return nil
+}
+
+func (d *Daemon) validateCrewBoundLaunchDir(sessionID, dir string) (string, error) {
+	members, _, err := d.readCrewMembers()
+	if docstore.IsUndeclaredCollection(err) {
+		return dir, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	for _, member := range members {
+		if member.BindingSession != sessionID {
+			continue
+		}
+		resolved, err := d.resolveCrewWorkDir(dir)
+		if err != nil {
+			return "", fmt.Errorf("%s's plugin launch directory: %w", crew.DisplayName(member.ID), err)
+		}
+		return resolved, nil
+	}
+	return dir, nil
+}

--- a/internal/daemon/crew_test.go
+++ b/internal/daemon/crew_test.go
@@ -6,11 +6,13 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/victorarias/attn/internal/crew"
 	"github.com/victorarias/attn/internal/enrollment"
 	"github.com/victorarias/attn/internal/garden"
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
 )
 
 // writeCrewHomes builds a copy of the real `~/.attn/crew` shape under a
@@ -270,6 +272,56 @@ func TestCrew_ReimportingHomesLeavesLiveRecordsAlone(t *testing.T) {
 	}
 	if len(crewList(t, d)) != 3 {
 		t.Fatal("re-import duplicated the roster")
+	}
+}
+
+func TestCrew_ImportRefusesAStoredHomeFromAnotherProfile(t *testing.T) {
+	d, _, readLog := newWakeableDaemon(t)
+	members, docs, err := d.readCrewMembers()
+	if err != nil {
+		t.Fatalf("read roster: %v", err)
+	}
+	member, ok := crew.Resolve("trellis", members)
+	if !ok {
+		t.Fatal("trellis is missing from the fixture roster")
+	}
+	foreignRoot := filepath.Join(t.TempDir(), "copied-default", crew.HomesDirName)
+	member.HomeDir = filepath.Join(foreignRoot, member.ID)
+	member.CharterPath = filepath.Join(member.HomeDir, crew.CharterFileName)
+	body, err := member.Encode()
+	if err != nil {
+		t.Fatalf("encode copied record: %v", err)
+	}
+	expected := docs[member.ID].Rev
+	schema, err := d.crewCollection()
+	if err != nil {
+		t.Fatalf("crew collection: %v", err)
+	}
+	fact := documentChangedFact(crew.Namespace, crew.CollectionMembers, member.ID, false)
+	if _, err := d.store.CommitDocumentWrite(store.DocumentWrite{
+		Schema: *schema, ID: member.ID, Body: body, Expected: &expected,
+	}, fact, time.Now()); err != nil {
+		t.Fatalf("seed copied registry record: %v", err)
+	}
+
+	d.importCrewHomes()
+	log := readLog()
+	for _, want := range []string{"import refused", member.HomeDir, filepath.Join(d.dataRoot, crew.HomesDirName), "attn.db copied from another profile"} {
+		if !strings.Contains(log, want) {
+			t.Errorf("import refusal does not name %q:\n%s", want, log)
+		}
+	}
+	if _, _, err := d.readCrewMembers(); err == nil {
+		t.Fatal("an operational roster read accepted the copied member record")
+	} else if !strings.Contains(err.Error(), member.HomeDir) {
+		t.Fatalf("read refusal %q does not name the foreign home", err)
+	}
+
+	addSession(t, d, "copied-db-wake")
+	if _, err := d.claimCrewBinding(member.ID, "copied-db-wake"); err == nil {
+		t.Fatal("a copied member record was writable")
+	} else if !strings.Contains(err.Error(), member.HomeDir) {
+		t.Fatalf("write refusal %q does not name the foreign home", err)
 	}
 }
 

--- a/internal/daemon/crew_wake.go
+++ b/internal/daemon/crew_wake.go
@@ -416,7 +416,7 @@ func (d *Daemon) handleCrewSet(conn net.Conn, msg *protocol.CrewSetMessage) {
 		return
 	}
 	if msg.Cwd != nil {
-		cwd, err := d.resolveCrewWorkDir(*msg.Cwd)
+		cwd, err := d.resolveCrewRecordedDir(*msg.Cwd)
 		if err != nil {
 			d.sendCrewError(conn, "set", err)
 			return
@@ -430,7 +430,7 @@ func (d *Daemon) handleCrewSet(conn net.Conn, msg *protocol.CrewSetMessage) {
 	} else if msg.AwarenessDirs != nil {
 		dirs := make([]string, 0, len(msg.AwarenessDirs))
 		for _, dir := range msg.AwarenessDirs {
-			resolved, err := d.resolveCrewWorkDir(dir)
+			resolved, err := d.resolveCrewRecordedDir(dir)
 			if err != nil {
 				d.sendCrewError(conn, "set", err)
 				return
@@ -452,10 +452,7 @@ func (d *Daemon) handleCrewSet(conn net.Conn, msg *protocol.CrewSetMessage) {
 	})
 }
 
-// resolveCrewDir makes a directory absolute and insists it exists. A recorded
-// cwd that is not there only fails at the next wake, which is the wrong end of
-// the day to learn about a typo. An empty value clears the field.
-func resolveCrewDir(dir string) (string, error) {
+func absoluteCrewDir(dir string) (string, error) {
 	dir = strings.TrimSpace(dir)
 	if dir == "" {
 		return "", nil
@@ -469,6 +466,17 @@ func resolveCrewDir(dir string) (string, error) {
 	absolute, err := filepath.Abs(dir)
 	if err != nil {
 		return "", fmt.Errorf("%s is not a usable path: %w", dir, err)
+	}
+	return absolute, nil
+}
+
+// resolveCrewDir makes a directory absolute and insists it exists. A recorded
+// cwd that is not there only fails at the next wake, which is the wrong end of
+// the day to learn about a typo. An empty value clears the field.
+func resolveCrewDir(dir string) (string, error) {
+	absolute, err := absoluteCrewDir(dir)
+	if err != nil || absolute == "" {
+		return absolute, err
 	}
 	info, err := os.Stat(absolute)
 	if err != nil {

--- a/internal/daemon/crew_wake.go
+++ b/internal/daemon/crew_wake.go
@@ -92,7 +92,13 @@ func (d *Daemon) crewMember(name string) (crew.Member, docstore.Document, error)
 // own home when nobody recorded one. The home always exists — it is what made
 // the member — so a wake never fails for want of a directory, and a cwd that
 // has since moved is named rather than silently swapped.
-func crewLaunchDir(member crew.Member) (string, error) {
+func (d *Daemon) crewLaunchDir(member crew.Member) (string, error) {
+	if err := d.validateCrewMemberPaths(member); err != nil {
+		return "", err
+	}
+	if err := d.validateCrewAwarenessDirs(member); err != nil {
+		return "", err
+	}
 	dir := strings.TrimSpace(member.CWD)
 	if dir == "" {
 		return member.HomeDir, nil
@@ -104,13 +110,23 @@ func crewLaunchDir(member crew.Member) (string, error) {
 	if !info.IsDir() {
 		return "", fmt.Errorf("%s launches in %s, which is not a directory; `attn crew set %s --cwd <dir>` moves it", crew.DisplayName(member.ID), dir, member.ID)
 	}
-	return dir, nil
+	resolved, err := d.resolveCrewWorkDir(dir)
+	if err != nil {
+		return "", fmt.Errorf("%s launches in %s: %w", crew.DisplayName(member.ID), dir, err)
+	}
+	return resolved, nil
 }
 
 // crewPriming composes what a member's launch injects, reading the prose off
 // the home each time: the files are canonical, so a charter edited between two
 // wakes takes effect at the next one with nothing to invalidate.
-func (d *Daemon) crewPriming(member crew.Member) crew.Priming {
+func (d *Daemon) crewPriming(member crew.Member) (crew.Priming, error) {
+	if err := d.validateCrewMemberPaths(member); err != nil {
+		return crew.Priming{}, err
+	}
+	if err := d.validateCrewWorkDirs(member); err != nil {
+		return crew.Priming{}, err
+	}
 	priming := crew.Priming{
 		Member:        member.ID,
 		HomeDir:       member.HomeDir,
@@ -124,13 +140,16 @@ func (d *Daemon) crewPriming(member crew.Member) crew.Priming {
 		d.logf("crew: reading %s's charter at %s: %v", crew.DisplayName(member.ID), member.CharterPath, err)
 	}
 
-	handoffsDir := filepath.Join(member.HomeDir, crew.HandoffsDirName)
+	handoffsDir, err := d.validateCrewHandoffsDir(member)
+	if err != nil {
+		return crew.Priming{}, err
+	}
 	entries, err := os.ReadDir(handoffsDir)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			d.logf("crew: reading %s's handoffs at %s: %v", crew.DisplayName(member.ID), handoffsDir, err)
 		}
-		return priming
+		return priming, nil
 	}
 	names := make([]string, 0, len(entries))
 	for _, entry := range entries {
@@ -141,16 +160,22 @@ func (d *Daemon) crewPriming(member crew.Member) crew.Priming {
 	}
 	crew.SortHandoffNames(names)
 	if len(names) == 0 {
-		return priming
+		return priming, nil
+	}
+	for _, name := range names {
+		if err := d.validateCrewLetterPath(member, filepath.Join(handoffsDir, name)); err != nil {
+			return crew.Priming{}, err
+		}
 	}
 	priming.HandoffName = names[0]
 	priming.OlderHandoffs = names[1:]
-	if letter, err := os.ReadFile(filepath.Join(handoffsDir, names[0])); err == nil {
+	letterPath := filepath.Join(handoffsDir, names[0])
+	if letter, err := os.ReadFile(letterPath); err == nil {
 		priming.Handoff = string(letter)
 	} else {
 		d.logf("crew: reading %s's freshest handoff %s: %v", crew.DisplayName(member.ID), names[0], err)
 	}
-	return priming
+	return priming, nil
 }
 
 // IPC handlers.
@@ -222,7 +247,7 @@ func (d *Daemon) crewWakeWithDelivery(name, agent string, autonomous bool, deliv
 			return nil, fmt.Errorf("agent %q is not available", agent)
 		}
 	}
-	directory, err := crewLaunchDir(member)
+	directory, err := d.crewLaunchDir(member)
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +351,11 @@ func (d *Daemon) handleCrewPrime(conn net.Conn, msg *protocol.CrewPrimeMessage) 
 		return
 	}
 	result := &protocol.CrewPrimeResult{AwarenessDirs: []string{}}
-	member, block, bound := d.crewPrimeForSession(sessionID)
+	member, block, bound, err := d.crewPrimeForSession(sessionID)
+	if err != nil {
+		d.sendCrewError(conn, "prime", err)
+		return
+	}
 	if bound {
 		result.Member = protocol.Ptr(member.ID)
 		result.Guidance = protocol.Ptr(block)
@@ -340,25 +369,28 @@ func (d *Daemon) handleCrewPrime(conn net.Conn, msg *protocol.CrewPrimeMessage) 
 // to be its member, and logs the size — the budget receipt the wake limit and
 // the heartbeat are waiting on. One line per injection, naming what each part
 // cost: grep `crew: priming`. Reports false for a session that is nobody.
-func (d *Daemon) crewPrimeForSession(sessionID string) (crew.Member, string, bool) {
+func (d *Daemon) crewPrimeForSession(sessionID string) (crew.Member, string, bool, error) {
 	if sessionID == "" || d.store == nil {
-		return crew.Member{}, "", false
+		return crew.Member{}, "", false, nil
 	}
 	if err := d.requireHome(crew.Surface); err != nil {
-		return crew.Member{}, "", false
+		return crew.Member{}, "", false, err
 	}
 	members, _, err := d.readCrewMembers()
 	if err != nil {
 		if !docstore.IsUndeclaredCollection(err) {
 			d.logf("crew: reading roster to prime %s: %v", sessionID, err)
 		}
-		return crew.Member{}, "", false
+		return crew.Member{}, "", false, err
 	}
 	for _, member := range members {
 		if member.BindingSession != sessionID {
 			continue
 		}
-		priming := d.crewPriming(member)
+		priming, err := d.crewPriming(member)
+		if err != nil {
+			return crew.Member{}, "", false, err
+		}
 		block := priming.Block()
 		handoff := priming.HandoffName
 		if handoff == "" {
@@ -367,9 +399,9 @@ func (d *Daemon) crewPrimeForSession(sessionID string) (crew.Member, string, boo
 		d.logf("crew: priming %s for session %s: %d bytes (charter %d, handoff %s %d, older %d)",
 			crew.DisplayName(member.ID), sessionID, len(block), len(priming.Charter),
 			handoff, len(priming.Handoff), len(priming.OlderHandoffs))
-		return member, block, true
+		return member, block, true, nil
 	}
-	return crew.Member{}, "", false
+	return crew.Member{}, "", false, nil
 }
 
 func (d *Daemon) handleCrewSet(conn net.Conn, msg *protocol.CrewSetMessage) {
@@ -384,7 +416,7 @@ func (d *Daemon) handleCrewSet(conn net.Conn, msg *protocol.CrewSetMessage) {
 		return
 	}
 	if msg.Cwd != nil {
-		cwd, err := resolveCrewDir(*msg.Cwd)
+		cwd, err := d.resolveCrewWorkDir(*msg.Cwd)
 		if err != nil {
 			d.sendCrewError(conn, "set", err)
 			return
@@ -398,7 +430,7 @@ func (d *Daemon) handleCrewSet(conn net.Conn, msg *protocol.CrewSetMessage) {
 	} else if msg.AwarenessDirs != nil {
 		dirs := make([]string, 0, len(msg.AwarenessDirs))
 		for _, dir := range msg.AwarenessDirs {
-			resolved, err := resolveCrewDir(dir)
+			resolved, err := d.resolveCrewWorkDir(dir)
 			if err != nil {
 				d.sendCrewError(conn, "set", err)
 				return

--- a/internal/daemon/crew_wake_test.go
+++ b/internal/daemon/crew_wake_test.go
@@ -454,6 +454,34 @@ func TestCrewSet_ADirectoryThatIsNotThereIsRefused(t *testing.T) {
 	}
 }
 
+func TestCrewPriming_StaleProjectPathsDoNotBlockPriming(t *testing.T) {
+	d, _, _ := newWakeableDaemon(t)
+	member, _, err := d.crewMember("keel")
+	if err != nil {
+		t.Fatalf("read member: %v", err)
+	}
+	missingRoot := t.TempDir()
+	member.CWD = filepath.Join(missingRoot, "moved-cwd")
+	member.AwarenessDirs = []string{filepath.Join(missingRoot, "moved-awareness")}
+
+	priming, err := d.crewPriming(member)
+	if err != nil {
+		t.Fatalf("stale project paths blocked priming: %v", err)
+	}
+	if priming.CWD != member.CWD {
+		t.Errorf("priming cwd = %q, want stale recorded path %q", priming.CWD, member.CWD)
+	}
+	if len(priming.AwarenessDirs) != 1 || priming.AwarenessDirs[0] != member.AwarenessDirs[0] {
+		t.Errorf("priming awareness = %v, want %v", priming.AwarenessDirs, member.AwarenessDirs)
+	}
+
+	if _, err := d.crewLaunchDir(member); err == nil {
+		t.Fatal("wake accepted a missing cwd")
+	} else if !strings.Contains(err.Error(), "not there") {
+		t.Fatalf("wake refusal = %q, want the existing missing-cwd explanation", err)
+	}
+}
+
 func TestCrewSet_ACwdInsideAnotherProfilesCrewIsRefused(t *testing.T) {
 	d, _, _ := newWakeableDaemon(t)
 	userHome := t.TempDir()
@@ -467,6 +495,26 @@ func TestCrewSet_ACwdInsideAnotherProfilesCrewIsRefused(t *testing.T) {
 		t.Fatal("a cwd inside another profile's crew homes was accepted")
 	}
 	for _, want := range []string{foreign, filepath.Join(userHome, ".attn-fixture", crew.HomesDirName), filepath.Join(d.dataRoot, crew.HomesDirName)} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal %q does not name %q", err, want)
+		}
+	}
+}
+
+func TestCrewSet_AMissingPathInsideAnotherProfilesCrewIsRefused(t *testing.T) {
+	d, _, _ := newWakeableDaemon(t)
+	userHome := t.TempDir()
+	foreignRoot := filepath.Join(userHome, ".attn-fixture", crew.HomesDirName)
+	if err := os.MkdirAll(foreignRoot, 0o755); err != nil {
+		t.Fatalf("create foreign crew root: %v", err)
+	}
+	missing := filepath.Join(foreignRoot, "quartz", "moved-project")
+
+	_, err := d.resolveCrewWorkDirForHome(missing, userHome)
+	if err == nil {
+		t.Fatal("a missing path inside another profile's crew homes was accepted")
+	}
+	for _, want := range []string{missing, foreignRoot, filepath.Join(d.dataRoot, crew.HomesDirName)} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("refusal %q does not name %q", err, want)
 		}

--- a/internal/daemon/crew_wake_test.go
+++ b/internal/daemon/crew_wake_test.go
@@ -316,7 +316,10 @@ func TestCrewPrime_ABoundSessionIsPrimedWithItsHomeAndTheSizeIsLogged(t *testing
 		t.Fatalf("wake: %v", err)
 	}
 
-	member, block, bound := d.crewPrimeForSession(result.SessionID)
+	member, block, bound, err := d.crewPrimeForSession(result.SessionID)
+	if err != nil {
+		t.Fatalf("prime: %v", err)
+	}
 	if !bound {
 		t.Fatal("the session a wake just bound was primed as nobody")
 	}
@@ -348,10 +351,10 @@ func TestCrewPrime_ABoundSessionIsPrimedWithItsHomeAndTheSizeIsLogged(t *testing
 func TestCrewPrime_AnUnboundSessionIsNobody(t *testing.T) {
 	d, _, _ := newWakeableDaemon(t)
 	addSession(t, d, "sess-worker")
-	if _, block, bound := d.crewPrimeForSession("sess-worker"); bound || block != "" {
+	if _, block, bound, err := d.crewPrimeForSession("sess-worker"); err != nil || bound || block != "" {
 		t.Fatalf("an unbound session was primed as somebody: %q", block)
 	}
-	if _, _, bound := d.crewPrimeForSession(""); bound {
+	if _, _, bound, err := d.crewPrimeForSession(""); err != nil || bound {
 		t.Fatal("a session with no id was primed")
 	}
 }
@@ -451,6 +454,57 @@ func TestCrewSet_ADirectoryThatIsNotThereIsRefused(t *testing.T) {
 	}
 }
 
+func TestCrewSet_ACwdInsideAnotherProfilesCrewIsRefused(t *testing.T) {
+	d, _, _ := newWakeableDaemon(t)
+	userHome := t.TempDir()
+	foreign := filepath.Join(userHome, ".attn-fixture", crew.HomesDirName, "ember", "project")
+	if err := os.MkdirAll(foreign, 0o755); err != nil {
+		t.Fatalf("create foreign crew cwd: %v", err)
+	}
+
+	_, err := d.resolveCrewWorkDirForHome(foreign, userHome)
+	if err == nil {
+		t.Fatal("a cwd inside another profile's crew homes was accepted")
+	}
+	for _, want := range []string{foreign, filepath.Join(userHome, ".attn-fixture", crew.HomesDirName), filepath.Join(d.dataRoot, crew.HomesDirName)} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal %q does not name %q", err, want)
+		}
+	}
+}
+
+func TestCrewSet_ASymlinkedForeignProfileRootIsRefused(t *testing.T) {
+	d, _, _ := newWakeableDaemon(t)
+	userHome := t.TempDir()
+	foreignTarget := filepath.Join(t.TempDir(), "foreign-profile")
+	foreign := filepath.Join(foreignTarget, crew.HomesDirName, "quartz", "project")
+	if err := os.MkdirAll(foreign, 0o755); err != nil {
+		t.Fatalf("create symlinked foreign crew cwd: %v", err)
+	}
+	profileLink := filepath.Join(userHome, ".attn-fixture")
+	if err := os.Symlink(foreignTarget, profileLink); err != nil {
+		t.Fatalf("symlink foreign profile: %v", err)
+	}
+	linkedCWD := filepath.Join(profileLink, crew.HomesDirName, "quartz", "project")
+
+	_, err := d.resolveCrewWorkDirForHome(linkedCWD, userHome)
+	if err == nil {
+		t.Fatal("a cwd under a symlinked foreign profile root was accepted")
+	}
+	for _, want := range []string{linkedCWD, filepath.Join(userHome, ".attn-fixture", crew.HomesDirName), filepath.Join(d.dataRoot, crew.HomesDirName)} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal %q does not name %q", err, want)
+		}
+	}
+	canonicalCWD, err := filepath.EvalSymlinks(linkedCWD)
+	if err != nil {
+		t.Fatalf("canonicalize linked cwd: %v", err)
+	}
+	if _, err := d.resolveCrewWorkDirForHome(canonicalCWD, userHome); err == nil {
+		t.Fatal("the canonical target of a symlinked foreign profile root was accepted")
+	}
+}
+
 // Every crew verb passes the fence. An outpost holds no part of the crew, so a
 // wake, a set and a prime all refuse there by name.
 func TestCrewWake_AnOutpostHoldsNoneOfIt(t *testing.T) {
@@ -477,7 +531,7 @@ func TestCrewWake_AnOutpostHoldsNoneOfIt(t *testing.T) {
 		t.Errorf("set refusal %q does not name the home", protocol.Deref(resp.Error))
 	}
 
-	if _, _, bound := d.crewPrimeForSession("sess-anything"); bound {
+	if _, _, bound, _ := d.crewPrimeForSession("sess-anything"); bound {
 		t.Fatal("an outpost primed a session as a crew member")
 	}
 }

--- a/internal/daemon/host_session.go
+++ b/internal/daemon/host_session.go
@@ -114,8 +114,10 @@ func (d *Daemon) spawnHostSession(opts ptybackend.SpawnOptions) error {
 	// PrepareLaunch wrote — so a machine without codex gave a delegated
 	// conversation agent repo guidance and no attn skill. Best-effort: a missing
 	// skill is a poorer agent, not a session that must refuse to start.
-	if err := agentdriver.EnsureAgentsSkillInstalled(); err != nil {
+	if synced, err := agentdriver.EnsureAgentsSkillInstalled(); err != nil {
 		d.logf("host spawn: failed to ensure the attn skill under ~/.agents: %v", err)
+	} else if !synced {
+		d.logf("host spawn: skipping user-global attn skill sync for profile %q", config.ProfileLabel())
 	}
 	// Daemon env, then login shell on top: credentials live in shell profiles and
 	// an app-launched host would otherwise fail its first prompt with "no API key".
@@ -149,6 +151,11 @@ func (d *Daemon) spawnHostSession(opts ptybackend.SpawnOptions) error {
 		hostEnv = append(hostEnv, "ATTN_NISSE_RESUME_FILE="+resume)
 	}
 	env = pty.MergeEnvironment(env, hostEnv)
+	routingEnv := opts.DaemonEnv
+	if len(routingEnv) == 0 {
+		routingEnv = d.spawnRoutingEnv()
+	}
+	env = pty.MergeEnvironment(env, routingEnv)
 	cwd := strings.TrimSpace(opts.ExternalCWD)
 	if cwd == "" {
 		cwd = opts.CWD
@@ -166,6 +173,7 @@ func (d *Daemon) spawnHostSession(opts ptybackend.SpawnOptions) error {
 
 // spawnSessionRuntime starts whichever runtime this session's agent asked for.
 func (d *Daemon) spawnSessionRuntime(req *spawnRequest, opts ptybackend.SpawnOptions) error {
+	opts.DaemonEnv = d.spawnRoutingEnv()
 	if req.hasPluginDriver && req.pluginDriver.Capabilities[pluginDriverConversationCapability] {
 		return d.spawnHostSession(opts)
 	}

--- a/internal/daemon/host_session_identity_test.go
+++ b/internal/daemon/host_session_identity_test.go
@@ -67,12 +67,14 @@ func TestConversationHostCarriesTheSessionIdentity(t *testing.T) {
 	socketPath := filepath.Join(t.TempDir(), "test.sock")
 	t.Setenv("ATTN_PROFILE", "fixture-lab")
 	t.Setenv("ATTN_SOCKET_PATH", socketPath)
+	t.Setenv("ATTN_WS_PORT", "25432")
 	d := NewForTesting(socketPath)
 	d.loginShellEnv = []string{
 		"ATTN_PROFILE=default",
 		"ATTN_DATA_DIR=/tmp/login-data",
 		"ATTN_DB_PATH=/tmp/login.db",
 		"ATTN_SOCKET_PATH=/tmp/login-shell.sock",
+		"ATTN_WS_PORT=19999",
 		"ATTN_CONFIG_PATH=/tmp/login-config.json",
 		"ATTN_PLUGIN_DIR=/tmp/login-plugins",
 		"PATH=" + os.Getenv("PATH"),
@@ -115,6 +117,7 @@ func TestConversationHostCarriesTheSessionIdentity(t *testing.T) {
 		"ATTN_DATA_DIR":       d.dataRoot,
 		"ATTN_DB_PATH":        config.DBPath(),
 		"ATTN_SOCKET_PATH":    socketPath,
+		"ATTN_WS_PORT":        config.WSPort(),
 		"ATTN_CONFIG_PATH":    config.ConfigPath(),
 		"ATTN_PLUGIN_DIR":     d.pluginDir,
 	} {

--- a/internal/daemon/host_session_identity_test.go
+++ b/internal/daemon/host_session_identity_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/protocol"
 )
 
@@ -63,7 +64,19 @@ func TestConversationHostCarriesTheSessionIdentity(t *testing.T) {
 	}
 	t.Setenv("ATTN_WRAPPER_PATH", activeAttn)
 
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	socketPath := filepath.Join(t.TempDir(), "test.sock")
+	t.Setenv("ATTN_PROFILE", "fixture-lab")
+	t.Setenv("ATTN_SOCKET_PATH", socketPath)
+	d := NewForTesting(socketPath)
+	d.loginShellEnv = []string{
+		"ATTN_PROFILE=default",
+		"ATTN_DATA_DIR=/tmp/login-data",
+		"ATTN_DB_PATH=/tmp/login.db",
+		"ATTN_SOCKET_PATH=/tmp/login-shell.sock",
+		"ATTN_CONFIG_PATH=/tmp/login-config.json",
+		"ATTN_PLUGIN_DIR=/tmp/login-plugins",
+		"PATH=" + os.Getenv("PATH"),
+	}
 	backend := &fakeSpawnBackend{}
 	workspaceID, _, cwd := setupDelegationSource(t, d, backend)
 	pipe, done := startPluginPipe(t, d, "pi-fixture-plugin", nil)
@@ -98,6 +111,12 @@ func TestConversationHostCarriesTheSessionIdentity(t *testing.T) {
 		"ATTN_AGENT":          "pi-fixture",
 		"ATTN_DAEMON_MANAGED": "1",
 		"ATTN_INSIDE_APP":     "1",
+		"ATTN_PROFILE":        "fixture-lab",
+		"ATTN_DATA_DIR":       d.dataRoot,
+		"ATTN_DB_PATH":        config.DBPath(),
+		"ATTN_SOCKET_PATH":    socketPath,
+		"ATTN_CONFIG_PATH":    config.ConfigPath(),
+		"ATTN_PLUGIN_DIR":     d.pluginDir,
 	} {
 		if env[name] != want {
 			t.Errorf("host env %s = %q, want %q — the agent's tools cannot report as this session", name, env[name], want)

--- a/internal/daemon/plugin_launch_instructions.go
+++ b/internal/daemon/plugin_launch_instructions.go
@@ -92,6 +92,10 @@ func (d *Daemon) gardenPrimeForLaunch(sessionID string) *hooks.GardenPrime {
 // a built-in driver's wrapper fetches over `crew_prime`. Empty for a session
 // that is nobody.
 func (d *Daemon) crewPrimeForLaunch(sessionID string) string {
-	_, block, _ := d.crewPrimeForSession(sessionID)
+	_, block, _, err := d.crewPrimeForSession(sessionID)
+	if err != nil {
+		d.logf("crew: refusing launch priming for session %s: %v", sessionID, err)
+		return ""
+	}
 	return block
 }

--- a/internal/daemon/reload.go
+++ b/internal/daemon/reload.go
@@ -249,6 +249,7 @@ func (d *Daemon) executePreparedSessionReload(sessionID string, opts ptybackend.
 		d.logf("reload: remove returned error for %s (continuing): %v", sessionID, removeErr)
 	}
 
+	opts.DaemonEnv = d.spawnRoutingEnv()
 	if spawnErr := d.ptyBackend.Spawn(ctx, opts); spawnErr != nil {
 		// Respawn failed and the old worker is already dead. Never leave a live-looking
 		// pane over a dead session: clear the flag and run normal exit finalization so
@@ -498,12 +499,20 @@ func (d *Daemon) preparePluginReload(session *protocol.Session, opts *ptybackend
 		prepared.abort()
 		return nil, err
 	}
+	externalCWD := strings.TrimSpace(result.CWD)
+	if externalCWD != "" {
+		externalCWD, err = d.validateCrewBoundLaunchDir(session.ID, externalCWD)
+		if err != nil {
+			prepared.abort()
+			return nil, err
+		}
+	}
 	opts.Agent = reg.Agent
 	opts.ResumeSessionID = ""
 	opts.LifecycleID = runID
 	opts.ExternalCommand = append([]string(nil), result.Argv...)
 	opts.ExternalEnv = commandEnv
-	opts.ExternalCWD = strings.TrimSpace(result.CWD)
+	opts.ExternalCWD = externalCWD
 	return prepared, nil
 }
 

--- a/internal/daemon/spawn_pipeline.go
+++ b/internal/daemon/spawn_pipeline.go
@@ -362,6 +362,15 @@ func (d *Daemon) executeSpawn(req *spawnRequest, plan *spawnPlan) *spawnOutcome 
 		plan.spawnOpts.ExternalCommand = append([]string(nil), result.Argv...)
 		plan.spawnOpts.ExternalEnv = commandEnv
 		plan.spawnOpts.ExternalCWD = strings.TrimSpace(result.CWD)
+		if plan.spawnOpts.ExternalCWD != "" {
+			resolved, err := d.validateCrewBoundLaunchDir(msg.ID, plan.spawnOpts.ExternalCWD)
+			if err != nil {
+				d.abortPluginSessionLaunch(msg.ID, "launch_failed")
+				plan.rollback(d, msg.ID)
+				return &spawnOutcome{err: err}
+			}
+			plan.spawnOpts.ExternalCWD = resolved
+		}
 	}
 
 	// Persist the complete launch intent before creating the worker. If the daemon

--- a/internal/daemon/spawn_routing.go
+++ b/internal/daemon/spawn_routing.go
@@ -11,6 +11,7 @@ func (d *Daemon) spawnRoutingEnv() []string {
 		"ATTN_DATA_DIR=" + d.dataRoot,
 		"ATTN_DB_PATH=" + config.DBPath(),
 		"ATTN_SOCKET_PATH=" + d.socketPath,
+		"ATTN_WS_PORT=" + config.WSPort(),
 		"ATTN_CONFIG_PATH=" + config.ConfigPath(),
 		"ATTN_PLUGIN_DIR=" + d.pluginDir,
 	}

--- a/internal/daemon/spawn_routing.go
+++ b/internal/daemon/spawn_routing.go
@@ -1,0 +1,17 @@
+package daemon
+
+import "github.com/victorarias/attn/internal/config"
+
+// spawnRoutingEnv is the daemon's exact filesystem and endpoint identity. It
+// is carried through both PTY runtimes and conversation hosts, then applied as
+// the final environment overlay in the child.
+func (d *Daemon) spawnRoutingEnv() []string {
+	return []string{
+		"ATTN_PROFILE=" + config.Profile(),
+		"ATTN_DATA_DIR=" + d.dataRoot,
+		"ATTN_DB_PATH=" + config.DBPath(),
+		"ATTN_SOCKET_PATH=" + d.socketPath,
+		"ATTN_CONFIG_PATH=" + config.ConfigPath(),
+		"ATTN_PLUGIN_DIR=" + d.pluginDir,
+	}
+}

--- a/internal/daemon/ws_settings.go
+++ b/internal/daemon/ws_settings.go
@@ -297,16 +297,22 @@ func (d *Daemon) settingsWithAgentAvailability() map[string]interface{} {
 		if available {
 			switch name {
 			case string(protocol.SessionAgentClaude):
-				if err := agentdriver.EnsureClaudeSkillInstalled(); err != nil {
+				if synced, err := agentdriver.EnsureClaudeSkillInstalled(); err != nil {
 					d.logf("failed to ensure Claude attn skill: %v", err)
+				} else if !synced {
+					d.logf("skipping user-global Claude attn skill sync for profile %q", config.ProfileLabel())
 				}
 			case string(protocol.SessionAgentCodex):
-				if err := agentdriver.EnsureAgentsSkillInstalled(); err != nil {
+				if synced, err := agentdriver.EnsureAgentsSkillInstalled(); err != nil {
 					d.logf("failed to ensure ~/.agents attn skill: %v", err)
+				} else if !synced {
+					d.logf("skipping user-global ~/.agents attn skill sync for profile %q", config.ProfileLabel())
 				}
 			case string(protocol.SessionAgentCopilot):
-				if err := agentdriver.EnsureCopilotSkillInstalled(); err != nil {
+				if synced, err := agentdriver.EnsureCopilotSkillInstalled(); err != nil {
 					d.logf("failed to ensure Copilot attn skill: %v", err)
+				} else if !synced {
+					d.logf("skipping user-global Copilot attn skill sync for profile %q", config.ProfileLabel())
 				}
 			}
 		}

--- a/internal/hub/bootstrap.go
+++ b/internal/hub/bootstrap.go
@@ -404,15 +404,11 @@ func (b *Bootstrapper) localVersion(ctx context.Context) (string, error) {
 }
 
 func (b *Bootstrapper) ensureLocalBinary(ctx context.Context, platform RemotePlatform, version string) (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
 	cacheKey, preferSourceBuild, err := b.localBinaryCacheKey(version)
 	if err != nil {
 		return "", err
 	}
-	cachePath := filepath.Join(home, ".attn", "remotes", "binaries", cacheKey, platform.ArtifactName)
+	cachePath := remoteBinaryCachePath(cacheKey, platform)
 	if info, err := os.Stat(cachePath); err == nil && info.Mode().IsRegular() {
 		return cachePath, nil
 	}
@@ -440,6 +436,10 @@ func (b *Bootstrapper) ensureLocalBinary(ctx context.Context, platform RemotePla
 		return "", err
 	}
 	return cachePath, nil
+}
+
+func remoteBinaryCachePath(key string, platform RemotePlatform) string {
+	return filepath.Join(config.DataDir(), "remotes", "binaries", key, platform.ArtifactName)
 }
 
 func (b *Bootstrapper) downloadReleaseArtifact(ctx context.Context, version, artifact, destDir string) error {
@@ -471,22 +471,17 @@ func (b *Bootstrapper) downloadReleaseArtifact(ctx context.Context, version, art
 // over this artifact is under a second: 0.13s to compile (bun embeds its
 // runtime rather than compiling it), 0.17s to hash locally, 0.38s to hash on the
 // far end. Measured on a 93,694,096-byte linux_arm64 host.
-func appRuntimeCacheDir(home, key string) string {
-	return filepath.Join(home, ".attn", "remotes", "app-runtime", key)
+func appRuntimeCacheDir(key string) string {
+	return filepath.Join(config.DataDir(), "remotes", "app-runtime", key)
 }
 
 // ensureLocalAppRuntime produces the app runtime host for the remote's platform
 // and returns its local path. Source build first, published artifact second —
 // the same order, and for the same reason, as the attn binary beside it.
 func (b *Bootstrapper) ensureLocalAppRuntime(ctx context.Context, platform RemotePlatform, version string) (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-
 	var reasons []string
 	if sourceCheckoutAvailable() {
-		stageDir := appRuntimeCacheDir(home, platform.GOOS+"_"+platform.GOARCH)
+		stageDir := appRuntimeCacheDir(platform.GOOS + "_" + platform.GOARCH)
 		if err := b.buildAppRuntimeFromSource(ctx, platform, stageDir); err == nil {
 			return filepath.Join(stageDir, apps.RuntimeHostBinaryName), nil
 		} else {
@@ -495,7 +490,7 @@ func (b *Bootstrapper) ensureLocalAppRuntime(ctx context.Context, platform Remot
 	}
 
 	if version != "" && version != "dev" {
-		cachePath := filepath.Join(appRuntimeCacheDir(home, version), platform.RuntimeArtifactName)
+		cachePath := filepath.Join(appRuntimeCacheDir(version), platform.RuntimeArtifactName)
 		if info, err := os.Stat(cachePath); err == nil && info.Mode().IsRegular() {
 			return cachePath, nil
 		}

--- a/internal/hub/bootstrap_test.go
+++ b/internal/hub/bootstrap_test.go
@@ -1,9 +1,28 @@
 package hub
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/victorarias/attn/internal/config"
 )
+
+func TestRemoteCachesStayInsideTheActiveProfileDataDir(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("ATTN_DATA_DIR", dataDir)
+	platform := RemotePlatform{GOOS: "linux", GOARCH: "arm64", ArtifactName: "attn-linux-arm64"}
+
+	if got, want := remoteBinaryCachePath("build-key", platform), filepath.Join(dataDir, "remotes", "binaries", "build-key", platform.ArtifactName); got != want {
+		t.Errorf("binary cache = %q, want %q", got, want)
+	}
+	if got, want := appRuntimeCacheDir("runtime-key"), filepath.Join(dataDir, "remotes", "app-runtime", "runtime-key"); got != want {
+		t.Errorf("app runtime cache = %q, want %q", got, want)
+	}
+	if got := config.DataDir(); got != dataDir {
+		t.Fatalf("test profile data dir = %q, want %q", got, dataDir)
+	}
+}
 
 func TestShouldInstallRemoteBinary(t *testing.T) {
 	tests := []struct {

--- a/internal/pty/manager.go
+++ b/internal/pty/manager.go
@@ -55,6 +55,7 @@ type SpawnOptions struct {
 	ExternalCommand   []string
 	ExternalEnv       []string
 	ExternalCWD       string
+	DaemonEnv         []string
 	LifecycleID       string
 
 	// LoginShellEnv, when non-nil, is a pre-computed login shell environment
@@ -738,7 +739,7 @@ func buildSpawnEnv(loginShell string, opts SpawnOptions, agent, wrapperPath stri
 	env = filterEnvKeys(env, launchKeys...)
 	env = MergeEnvironment(env, launchEnv)
 	// Don't leak worker-only configuration transport vars into spawned shells.
-	env = filterEnvKeys(env, "ATTN_PTY_WORKER", "ATTN_CACHED_SHELL_ENV", "ATTN_PTY_EXTERNAL_ENV")
+	env = filterEnvKeys(env, "ATTN_PTY_WORKER", "ATTN_CACHED_SHELL_ENV", "ATTN_PTY_EXTERNAL_ENV", "ATTN_PTY_DAEMON_ENV")
 
 	// Strip CLAUDECODE after all merges so spawned sessions don't think
 	// they're nested.  This var leaks into the daemon env when started
@@ -795,6 +796,13 @@ func buildSpawnEnv(loginShell string, opts SpawnOptions, agent, wrapperPath stri
 	if len(opts.ExternalEnv) > 0 {
 		env = MergeEnvironment(env, opts.ExternalEnv)
 	}
+	// External environments cross the worker boundary too, so scrub the
+	// transport envelope again after applying them.
+	env = filterEnvKeys(env, "ATTN_PTY_WORKER", "ATTN_CACHED_SHELL_ENV", "ATTN_PTY_EXTERNAL_ENV", "ATTN_PTY_DAEMON_ENV")
+	// Routing is the final overlay. Login-shell and plugin environments may add
+	// credentials and driver state; neither may redirect the session to another
+	// attn daemon.
+	env = MergeEnvironment(env, opts.DaemonEnv)
 	return env
 }
 

--- a/internal/pty/manager_test.go
+++ b/internal/pty/manager_test.go
@@ -204,6 +204,7 @@ func TestBuildSpawnEnv_DaemonRoutingOverridesLoginAndPluginEnvironment(t *testin
 	t.Setenv("ATTN_DATA_DIR", filepath.Join(t.TempDir(), "fixture-data"))
 	t.Setenv("ATTN_DB_PATH", filepath.Join(t.TempDir(), "fixture.db"))
 	t.Setenv("ATTN_SOCKET_PATH", socketPath)
+	t.Setenv("ATTN_WS_PORT", "25432")
 	t.Setenv("ATTN_CONFIG_PATH", filepath.Join(t.TempDir(), "fixture-config.json"))
 	t.Setenv("ATTN_PLUGIN_DIR", filepath.Join(t.TempDir(), "fixture-plugins"))
 
@@ -212,6 +213,7 @@ func TestBuildSpawnEnv_DaemonRoutingOverridesLoginAndPluginEnvironment(t *testin
 		"ATTN_DATA_DIR=" + config.DataDir(),
 		"ATTN_DB_PATH=" + config.DBPath(),
 		"ATTN_SOCKET_PATH=" + config.SocketPath(),
+		"ATTN_WS_PORT=" + config.WSPort(),
 		"ATTN_CONFIG_PATH=" + config.ConfigPath(),
 		"ATTN_PLUGIN_DIR=" + config.PluginDir(),
 	}
@@ -222,6 +224,7 @@ func TestBuildSpawnEnv_DaemonRoutingOverridesLoginAndPluginEnvironment(t *testin
 			"ATTN_DATA_DIR=/tmp/login-data",
 			"ATTN_DB_PATH=/tmp/login.db",
 			"ATTN_SOCKET_PATH=/tmp/login-shell.sock",
+			"ATTN_WS_PORT=19999",
 			"ATTN_CONFIG_PATH=/tmp/login-config.json",
 			"ATTN_PLUGIN_DIR=/tmp/login-plugins",
 		},
@@ -230,6 +233,7 @@ func TestBuildSpawnEnv_DaemonRoutingOverridesLoginAndPluginEnvironment(t *testin
 			"ATTN_DATA_DIR=/tmp/plugin-data",
 			"ATTN_DB_PATH=/tmp/plugin.db",
 			"ATTN_SOCKET_PATH=/tmp/plugin.sock",
+			"ATTN_WS_PORT=18888",
 			"ATTN_CONFIG_PATH=/tmp/plugin-config.json",
 			"ATTN_PLUGIN_DIR=/tmp/plugin-plugins",
 			"ATTN_PTY_DAEMON_ENV=internal-transport",
@@ -246,6 +250,7 @@ func TestBuildSpawnEnv_DaemonRoutingOverridesLoginAndPluginEnvironment(t *testin
 	for key, want := range map[string]string{
 		"ATTN_DATA_DIR":    config.DataDir(),
 		"ATTN_DB_PATH":     config.DBPath(),
+		"ATTN_WS_PORT":     config.WSPort(),
 		"ATTN_CONFIG_PATH": config.ConfigPath(),
 		"ATTN_PLUGIN_DIR":  config.PluginDir(),
 	} {

--- a/internal/pty/manager_test.go
+++ b/internal/pty/manager_test.go
@@ -198,6 +198,66 @@ func TestBuildSpawnEnv_SetsAttnPresence(t *testing.T) {
 	}
 }
 
+func TestBuildSpawnEnv_DaemonRoutingOverridesLoginAndPluginEnvironment(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "fixture.sock")
+	t.Setenv("ATTN_PROFILE", "fixture-lab")
+	t.Setenv("ATTN_DATA_DIR", filepath.Join(t.TempDir(), "fixture-data"))
+	t.Setenv("ATTN_DB_PATH", filepath.Join(t.TempDir(), "fixture.db"))
+	t.Setenv("ATTN_SOCKET_PATH", socketPath)
+	t.Setenv("ATTN_CONFIG_PATH", filepath.Join(t.TempDir(), "fixture-config.json"))
+	t.Setenv("ATTN_PLUGIN_DIR", filepath.Join(t.TempDir(), "fixture-plugins"))
+
+	routingEnv := []string{
+		"ATTN_PROFILE=" + config.Profile(),
+		"ATTN_DATA_DIR=" + config.DataDir(),
+		"ATTN_DB_PATH=" + config.DBPath(),
+		"ATTN_SOCKET_PATH=" + config.SocketPath(),
+		"ATTN_CONFIG_PATH=" + config.ConfigPath(),
+		"ATTN_PLUGIN_DIR=" + config.PluginDir(),
+	}
+	env := buildSpawnEnv("", SpawnOptions{
+		ID: "session-1",
+		LoginShellEnv: []string{
+			"ATTN_PROFILE=default",
+			"ATTN_DATA_DIR=/tmp/login-data",
+			"ATTN_DB_PATH=/tmp/login.db",
+			"ATTN_SOCKET_PATH=/tmp/login-shell.sock",
+			"ATTN_CONFIG_PATH=/tmp/login-config.json",
+			"ATTN_PLUGIN_DIR=/tmp/login-plugins",
+		},
+		ExternalEnv: []string{
+			"ATTN_PROFILE=plugin-profile",
+			"ATTN_DATA_DIR=/tmp/plugin-data",
+			"ATTN_DB_PATH=/tmp/plugin.db",
+			"ATTN_SOCKET_PATH=/tmp/plugin.sock",
+			"ATTN_CONFIG_PATH=/tmp/plugin-config.json",
+			"ATTN_PLUGIN_DIR=/tmp/plugin-plugins",
+			"ATTN_PTY_DAEMON_ENV=internal-transport",
+		},
+		DaemonEnv: routingEnv,
+	}, "codex", "/tmp/attn-wrapper", nil)
+
+	if got, _ := lookupEnv(env, "ATTN_PROFILE"); got != "fixture-lab" {
+		t.Fatalf("ATTN_PROFILE = %q, want daemon profile fixture-lab", got)
+	}
+	if got, _ := lookupEnv(env, "ATTN_SOCKET_PATH"); got != socketPath {
+		t.Fatalf("ATTN_SOCKET_PATH = %q, want daemon socket %q", got, socketPath)
+	}
+	for key, want := range map[string]string{
+		"ATTN_DATA_DIR":    config.DataDir(),
+		"ATTN_DB_PATH":     config.DBPath(),
+		"ATTN_CONFIG_PATH": config.ConfigPath(),
+		"ATTN_PLUGIN_DIR":  config.PluginDir(),
+	} {
+		if got, _ := lookupEnv(env, key); got != want {
+			t.Errorf("%s = %q, want daemon value %q", key, got, want)
+		}
+	}
+	if _, ok := lookupEnv(env, "ATTN_PTY_DAEMON_ENV"); ok {
+		t.Fatal("ATTN_PTY_DAEMON_ENV leaked into the spawned environment")
+	}
+}
+
 func TestBuildSpawnEnv_PutsActiveAttnFirstForAgentsAndShells(t *testing.T) {
 	profileDir := filepath.Join(t.TempDir(), "attn-profile")
 	wrapperPath := filepath.Join(profileDir, "attn")

--- a/internal/ptybackend/backend.go
+++ b/internal/ptybackend/backend.go
@@ -47,7 +47,10 @@ type SpawnOptions struct {
 	ExternalCommand   []string
 	ExternalEnv       []string
 	ExternalCWD       string
-	LifecycleID       string
+	// DaemonEnv is the daemon's exact routing contract. Every runtime reapplies
+	// it after login-shell and plugin environment.
+	DaemonEnv   []string
+	LifecycleID string
 
 	// ResumeConversationFile is an existing conversation file this session
 	// picks up from, chosen by the user in the new-session flow. Only a

--- a/internal/ptybackend/embedded.go
+++ b/internal/ptybackend/embedded.go
@@ -60,6 +60,7 @@ func embeddedSpawnOptions(opts SpawnOptions) pty.SpawnOptions {
 		ExternalCommand:   opts.ExternalCommand,
 		ExternalEnv:       opts.ExternalEnv,
 		ExternalCWD:       opts.ExternalCWD,
+		DaemonEnv:         opts.DaemonEnv,
 		LifecycleID:       opts.LifecycleID,
 		LoginShellEnv:     opts.LoginShellEnv,
 

--- a/internal/ptybackend/worker.go
+++ b/internal/ptybackend/worker.go
@@ -526,6 +526,7 @@ func (b *WorkerBackend) Spawn(ctx context.Context, opts SpawnOptions) error {
 		"ATTN_AUTO_COMPACT_WINDOW",
 		"ATTN_CACHED_SHELL_ENV",
 		"ATTN_PTY_EXTERNAL_ENV",
+		"ATTN_PTY_DAEMON_ENV",
 	)
 	workerEnv = append(workerEnv, "ATTN_PTY_WORKER=1")
 	if opts.WorkflowGuidanceEnabled {
@@ -557,6 +558,13 @@ func (b *WorkerBackend) Spawn(ctx context.Context, opts SpawnOptions) error {
 			return fmt.Errorf("encode external environment: %w", err)
 		}
 		workerEnv = append(workerEnv, "ATTN_PTY_EXTERNAL_ENV="+string(envJSON))
+	}
+	if len(opts.DaemonEnv) > 0 {
+		envJSON, err := json.Marshal(opts.DaemonEnv)
+		if err != nil {
+			return fmt.Errorf("encode daemon routing environment: %w", err)
+		}
+		workerEnv = append(workerEnv, "ATTN_PTY_DAEMON_ENV="+string(envJSON))
 	}
 	cmd.Env = workerEnv
 

--- a/internal/ptyworker/runtime.go
+++ b/internal/ptyworker/runtime.go
@@ -109,6 +109,7 @@ type Config struct {
 	ExternalCommand   []string
 	ExternalEnv       []string
 	ExternalCWD       string
+	DaemonEnv         []string
 	UnattendedLaunch  launchcontract.UnattendedLaunchSpec
 
 	RegistryPath   string
@@ -308,6 +309,7 @@ func (r *Runtime) run(ctx context.Context) error {
 		ExternalCommand:   r.cfg.ExternalCommand,
 		ExternalEnv:       r.cfg.ExternalEnv,
 		ExternalCWD:       r.cfg.ExternalCWD,
+		DaemonEnv:         r.cfg.DaemonEnv,
 		UnattendedLaunch:  r.cfg.UnattendedLaunch,
 	}); err != nil {
 		return fmt.Errorf("spawn PTY session: %w", err)


### PR DESCRIPTION
## TL;DR

Named-profile app bundles are now visibly labeled and remain authoritative over every daemon, session, crew-home, and cache path they own. A copied database or inherited shell environment can no longer make attn write into the default profile's crew homes. Verification profiles other than `dev` also cannot rewrite user-global agent skills; `dev` deliberately shares those skill directories with the default profile so attn's development loop uses the freshly bundled skill.

## Why

Profile data directories were already separate, but several runtime paths still depended on inherited environment or absolute paths stored in the database. The most confusing symptom was visual: a verification profile could look identical to production and could carry synthetic crew members named after real durable members. The more serious landmines were silent cross-profile routing and writes when a shell exported stale routing variables or a production database was copied into another profile.

These are guardrails against attn becoming a confused writer. They are not an authentication or OS-user security boundary.

## What changed

- Named bundles show a quiet, persistent `profile <name>` badge. The default bundle renders exactly as before.
- The Tauri shell clears all inherited routing and bundle-path overrides before applying its compiled profile, including data and plugin directories in production builds.
- Both PTY workers and conversation hosts receive the daemon's complete routing block after login-shell and plugin environment merges, including `ATTN_WS_PORT`. Internal worker transport variables are removed before the child starts.
- Crew member homes, charters, handoff directories, and handoff letters are revalidated under the active daemon's crew root at import and immediately before every read, write, or turnover launch. Refusals name the member, actual path, expected root, and copied-database cause.
- Project cwd and awareness paths remain unrestricted except when they resolve inside another profile's crew tree, including symlinked and currently missing descendants. Priming still tolerates stale project paths, while `crew set` preserves its existing existence check and wake preserves its existing missing-CWD refusal.
- Profiles other than the default and `dev` skip user-global agent skill synchronization with an explicit log entry. `dev` is the sole named-profile exception because it is the attn-on-attn development loop. Remote binary and app-runtime caches now live under the active profile's data root.
- Harness guidance reserves real crew names for production identities and requires synthetic members to pin `claude-haiku-4-5` unless a scenario documents why it needs more capability. Existing harness/profile builders contained no crew fixtures to rename.
- Crew and handoff CLI help now describes the active profile's crew directory instead of hardcoding the default path.

## Reviewer guide

1. Start with `internal/daemon/crew_paths.go`: it contains the two distinct fences—member-owned files must be inside this profile, while project paths are rejected only inside another profile's crew tree.
2. Follow `spawnRoutingEnv` through the PTY worker transport and host-session spawn to verify that exact daemon routing is the final environment overlay.
3. Review the Tauri scrub and Sidebar marker together: the compiled bundle profile owns both routing and legibility.
4. Check the skill-sync gate and remote cache helpers for the user-global/profile-local write split and the explicit `dev` exception.

## Manual verification

Built and launched a `fence-proof` app while deliberately supplying conflicting inherited profile, data, database, config, plugin, socket, and WebSocket values. Bundled preflight passed against the `fence-proof` daemon. The app displayed the `profile fence-proof` badge, and a fresh shell spawned from it reported `ATTN_PROFILE=fence-proof` plus only profile-local routing paths. The profile's sole crew member was the synthetic `Quartz`; none of the production member names appeared. The daemon log also recorded all three verification-profile skill-sync skips.

![attn-profile-fence-clean](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/ce0fc63b3b0137ac02f6b588a04c4bc01270fb30/delegate-profile-fence-a5ca981c/attn-profile-fence-clean.gif)

[Full-quality recording (mp4)](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/ce0fc63b3b0137ac02f6b588a04c4bc01270fb30/delegate-profile-fence-a5ca981c/attn-profile-fence-clean.mp4)

## Verification

- `make test-quick`
- Full frontend suite: 2,872 passed, 13 skipped
- Targeted regression coverage for daemon-owned `ATTN_WS_PORT`, stale priming paths, foreign crew descendants, and default/`dev` skill-sync ownership
- Rust profile tests and Linux amd64 build

## Out of scope

- No socket or WebSocket authentication.
- No crew lifecycle behavior changes.
