### PR TITLE
fix(terminal): name the format a snapshot was written in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -579,6 +579,17 @@ Design and gate decisions:
   fallback — a snapshot-less attach keeps whatever the client has and dedups the
   live stream against `last_seq`. See
   [docs/plans/2026-08-16-snapshot-restore.md](docs/plans/2026-08-16-snapshot-restore.md).
+- A snapshot names the format it was written in
+  (`attach_result.snapshot.format`, derived at build time by
+  `scripts/snapshot-format.sh` from the two ghostty locks). A pty-worker
+  outlives an install, so an upgraded app is routinely offered bytes an older
+  encoder wrote; the client compares that tag against its own decoder and
+  treats anything else — a foreign tag or no tag — as no snapshot, which is
+  already a supported attach. Never decode a snapshot on the strength of the
+  field being present, and never route a decode failure to model-fault
+  recovery: the model is fine, the payload is not, and a new epoch reattaches
+  straight back into the same bytes. See
+  [docs/plans/2026-08-16-snapshot-format-skew.md](docs/plans/2026-08-16-snapshot-format-skew.md).
 - Encoding fails outright when the worker's parser sits mid-sequence and
   continuation tracking was off, so the worker enables it at construction, not at
   snapshot time.

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ VERSION ?= $(shell bash ./scripts/version.sh)
 BUILD_TIME ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 SOURCE_FINGERPRINT ?= $(shell bash ./scripts/source-fingerprint.sh --field fingerprint)
 GIT_COMMIT ?= $(shell bash ./scripts/source-fingerprint.sh --field commit)
+# Identity of the terminal-snapshot wire format. The frontend computes it from
+# the same script, so a bundle's worker and app agree by construction.
+SNAPSHOT_FORMAT ?= $(shell bash ./scripts/snapshot-format.sh)
 OUTPUT ?= $(BINARY_NAME)
 # Guards the macOS-only branches below (code signing, the lsof port check). It
 # was used by three recipes and defined by none, so `$(UNAME_S)` expanded to
@@ -40,7 +43,7 @@ OUTPUT ?= $(BINARY_NAME)
 # ad-hoc linker signature inside a properly signed bundle, and macOS answered
 # `daemon ensure` with Killed: 9.
 UNAME_S := $(shell uname -s)
-GO_LDFLAGS = -X github.com/victorarias/attn/internal/buildinfo.Version=$(VERSION) -X github.com/victorarias/attn/internal/buildinfo.BuildTime=$(BUILD_TIME) -X github.com/victorarias/attn/internal/buildinfo.SourceFingerprint=$(SOURCE_FINGERPRINT) -X github.com/victorarias/attn/internal/buildinfo.GitCommit=$(GIT_COMMIT)
+GO_LDFLAGS = -X github.com/victorarias/attn/internal/buildinfo.Version=$(VERSION) -X github.com/victorarias/attn/internal/buildinfo.BuildTime=$(BUILD_TIME) -X github.com/victorarias/attn/internal/buildinfo.SourceFingerprint=$(SOURCE_FINGERPRINT) -X github.com/victorarias/attn/internal/buildinfo.GitCommit=$(GIT_COMMIT) -X github.com/victorarias/attn/internal/buildinfo.SnapshotFormat=$(SNAPSHOT_FORMAT)
 # Honor the repository's .tool-versions even when an older standalone Zig is
 # earlier on PATH (the app's WASM builder follows the same order).
 ZIG ?= $(shell if command -v asdf >/dev/null 2>&1; then asdf which zig 2>/dev/null || command -v zig; else command -v zig; fi)

--- a/app/src/components/GhosttyTerminal.snapshotDecode.test.tsx
+++ b/app/src/components/GhosttyTerminal.snapshotDecode.test.tsx
@@ -1,0 +1,150 @@
+import { render, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const createTerminalCalls: unknown[][] = [];
+  const noteModelFaultCalls: unknown[][] = [];
+  const recordUiDiagCalls: Array<Record<string, unknown>> = [];
+  const writes: string[] = [];
+
+  const createTerminal = () => {
+    createTerminalCalls.push([]);
+    const terminal = {
+      cols: 80,
+      rows: 24,
+      write: (data: string | Uint8Array) => {
+        writes.push(typeof data === 'string' ? data : new TextDecoder().decode(data));
+      },
+      resize(cols: number, rows: number) {
+        terminal.cols = cols;
+        terminal.rows = rows;
+      },
+      adoptSnapshot: () => {
+        throw new Error('ghostty_snapshot_decoder_ready failed');
+      },
+      getMode: () => false,
+      getScrollbackLength: () => 0,
+      getViewport: () => [],
+      getScrollbackLine: () => [],
+      getGraphemeString: () => '',
+      getScrollbackGraphemeString: () => '',
+      free: () => undefined,
+      isAlternateScreen: () => false,
+      hasMouseTracking: () => false,
+    };
+    return terminal;
+  };
+
+  class MockRenderer {
+    readonly cellWidth = 8;
+    readonly cellHeight = 16;
+    fitDimensions() { return { cols: 80, rows: 24 }; }
+    resize() {}
+    render() {
+      return {
+        quads: 0,
+        cellsArrayLen: 0,
+        printableSkippedNull: 0,
+        printableSkippedZeroWidth: 0,
+      };
+    }
+    invalidateGlyphCache() {}
+    setFontSize() {}
+    dispose() {}
+  }
+
+  return {
+    MockRenderer,
+    createTerminal,
+    createTerminalCalls,
+    noteModelFault: (...args: unknown[]) => { noteModelFaultCalls.push(args); },
+    noteModelFaultCalls,
+    recordUiDiag: (event: Record<string, unknown>) => { recordUiDiagCalls.push(event); },
+    recordUiDiagCalls,
+    writes,
+  };
+});
+
+vi.mock('ghostty-web', () => ({
+  CellFlags: {},
+  Ghostty: {
+    load: async () => ({ createTerminal: mocks.createTerminal }),
+  },
+  InputHandler: class {
+    dispose() {}
+  },
+}));
+
+vi.mock('../ghostty/wasm', () => ({ loadGhostty: async () => ({ createTerminal: mocks.createTerminal }) }));
+vi.mock('./GhosttyWebGlRenderer', () => ({ WebGlTerminalRenderer: mocks.MockRenderer }));
+vi.mock('../utils/terminalIconFont', () => ({
+  ensureTerminalIconFont: () => new Promise<void>(() => undefined),
+}));
+vi.mock('../utils/terminalDiagnosticsLog', () => ({
+  TERMINAL_DIAGNOSTICS_FILE: 'terminal-diagnostics.jsonl',
+  disposePaneDiagnostics: () => undefined,
+  noteModelFault: mocks.noteModelFault,
+  noteRecovery: () => undefined,
+  noteResize: () => undefined,
+  recordDiag: () => undefined,
+  recordPaint: () => undefined,
+  registerRenderProbe: () => undefined,
+}));
+vi.mock('../utils/uiDiagnosticsLog', () => ({
+  captureUiSnapshot: () => ({}),
+  recordUiDiag: mocks.recordUiDiag,
+  UI_DIAGNOSTICS_FILE: 'diagnostics.jsonl',
+}));
+vi.mock('../utils/terminalPerf', () => ({
+  registerTerminalPerfGetter: () => () => undefined,
+}));
+
+import { GhosttyTerminal } from './GhosttyTerminal';
+
+// Bytes a worker of another build encoded reach a decoder that rejects them.
+// Treating that as a model fault replaced the model, remounted the pane,
+// reattached, and was served the same bytes — 421 faults in six seconds on the
+// build that shipped it. See docs/plans/2026-08-16-snapshot-format-skew.md.
+describe('GhosttyTerminal snapshot decode', () => {
+  it('records an undecodable snapshot without faulting the model', async () => {
+    const originalResizeObserver = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+
+    const onReady = vi.fn();
+    try {
+      render(
+        <GhosttyTerminal
+          fontSize={14}
+          debugName="snapshot-decode-test"
+          onInput={vi.fn()}
+          onReady={onReady}
+          onResize={vi.fn()}
+        />,
+      );
+
+      await waitFor(() => expect(onReady).toHaveBeenCalledTimes(1));
+      const handle = onReady.mock.calls[0][0] as {
+        restoreSnapshot: (bytes: Uint8Array) => Promise<void>;
+        write: (data: string) => Promise<void>;
+      };
+
+      await handle.restoreSnapshot(new Uint8Array([1, 2, 3, 4]));
+
+      const rejected = mocks.recordUiDiagCalls.filter((event) => event.kind === 'snapshot_decode_rejected');
+      expect(rejected).toHaveLength(1);
+      expect(rejected[0].bytes).toBe(4);
+      expect(rejected[0].error).toBe('ghostty_snapshot_decoder_ready failed');
+      expect(mocks.noteModelFaultCalls).toHaveLength(0);
+      // No new epoch: one model built, and it still takes writes.
+      expect(mocks.createTerminalCalls).toHaveLength(1);
+      await handle.write('live output after the refused restore');
+      expect(mocks.writes.join('')).toContain('live output after the refused restore');
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver;
+    }
+  });
+});

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from 'react';
 import { InputHandler } from 'ghostty-web';
-import { CellFlags, type GhosttyCell, type GhosttyTerminal as GhosttyModel } from '../ghostty';
+import { CellFlags, type GhosttyCell, type GhosttyTerminal as GhosttyModel, type SnapshotHistory } from '../ghostty';
 import { loadGhostty } from '../ghostty/wasm';
 import { openPath, openUrl } from '@tauri-apps/plugin-opener';
 import { exists } from '@tauri-apps/plugin-fs';
@@ -1800,7 +1800,25 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         const terminal = terminalRef.current;
         if (!terminal) return;
         modelOpRingRef.current.noteRestoreChunk(snapshot, terminal.cols, terminal.rows);
-        const history = terminal.adoptSnapshot(snapshot);
+        let history: SnapshotHistory;
+        try {
+          history = terminal.adoptSnapshot(snapshot);
+        } catch (reason) {
+          // Bytes this decoder cannot read are a payload fault, not a model
+          // fault: replacing the model would remount the pane, reattach, and be
+          // served the same bytes forever. adoptSnapshot throws before it swaps
+          // the handle, so the model it declined to replace is still usable and
+          // the live stream keeps painting on it.
+          recordUiDiag({
+            kind: 'snapshot_decode_rejected',
+            diagnosticFile: UI_DIAGNOSTICS_FILE,
+            pane: diagKeyRef.current,
+            session: runtimeMetaRef.current?.sessionId ?? undefined,
+            bytes: snapshot.length,
+            error: reason instanceof Error ? reason.message : String(reason),
+          });
+          return;
+        }
         // The decoded terminal carries the worker's modes, and the worker never
         // asserted the app's grapheme clustering.
         graphemeResetCarryRef.current = false;

--- a/app/src/ghostty/index.ts
+++ b/app/src/ghostty/index.ts
@@ -9,6 +9,7 @@ export type {
   RGB,
   RenderStateColors,
   RenderStateCursor,
+  SnapshotHistory,
 } from './terminal';
 export { DIRTY_FALSE, DIRTY_FULL, DIRTY_PARTIAL } from './abi';
 

--- a/app/src/ghostty/terminal.snapshot.test.ts
+++ b/app/src/ghostty/terminal.snapshot.test.ts
@@ -106,6 +106,22 @@ describe('adoptSnapshot', () => {
     terminal.free();
   });
 
+  it('rejects bytes it cannot decode without touching the terminal', () => {
+    // The containment in GhosttyTerminal.restoreSnapshot rests on this: a
+    // refused decode must leave the model it declined to replace intact, so a
+    // snapshot written by another build costs the restore and nothing else.
+    const terminal = ghostty.createTerminal(80, 24, {});
+    terminal.write('content that survives a refused restore\r\n');
+
+    expect(() => terminal.adoptSnapshot(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]))).toThrow();
+
+    expect([terminal.cols, terminal.rows]).toEqual([80, 24]);
+    expect(viewportRows(terminal)[0]).toBe('content that survives a refused restore');
+    terminal.write('and still takes input');
+    expect(viewportRows(terminal)[1]).toBe('and still takes input');
+    terminal.free();
+  });
+
   it('keeps the terminal usable for live input', () => {
     const { terminal, history } = adopted();
     while (history.next() !== null) { /* drain */ }

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { invoke, isTauri } from '@tauri-apps/api/core';
 import { ptyAttach, ptyDetach, ptyKill, ptyReload, ptySpawn } from '../pty/bridge';
+import { LOCAL_SNAPSHOT_FORMAT } from '../pty/attachPlanning';
 import { AutomationActionTimeoutError, PROTOCOL_VERSION, retryTransientAttachRequest, useDaemonSocket } from './useDaemonSocket';
 import { useWorkflowRunsStore } from '../store/workflowRuns';
 import { useAutomationsStore } from '../store/automations';
@@ -2138,6 +2139,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
           cols: 56,
           rows: 35,
           snapshot_b64: btoa('fresh-daemon-frame'),
+          format: LOCAL_SNAPSHOT_FORMAT,
         },
         last_seq: 29376,
         running: true,

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -258,7 +258,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '252';
+export const PROTOCOL_VERSION = '253';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a

--- a/app/src/pty/attachPlanning.test.ts
+++ b/app/src/pty/attachPlanning.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  LOCAL_SNAPSHOT_FORMAT,
   classifyAttachRestore,
   createAttachRequestContext,
   enqueuePendingAttachOutput,
@@ -14,7 +15,7 @@ describe('attachPlanning', () => {
       const plan = classifyAttachRestore({
         cols: 80,
         rows: 24,
-        snapshot: { cols: 80, rows: 24, snapshot_b64: 'ZHVtcA==' },
+        snapshot: { cols: 80, rows: 24, snapshot_b64: 'ZHVtcA==', format: LOCAL_SNAPSHOT_FORMAT },
       }, createAttachRequestContext({ cols: 80, rows: 24 }, 'relaunch_restore'));
 
       expect(plan.hasSnapshot).toBe(true);
@@ -28,7 +29,7 @@ describe('attachPlanning', () => {
       const plan = classifyAttachRestore({
         cols: 100,
         rows: 40,
-        snapshot: { cols: 100, rows: 40, snapshot_b64: 'ZHVtcA==' },
+        snapshot: { cols: 100, rows: 40, snapshot_b64: 'ZHVtcA==', format: LOCAL_SNAPSHOT_FORMAT },
       }, createAttachRequestContext({ cols: 58, rows: 46 }, 'same_app_remount'));
 
       expect(plan.hasSnapshot).toBe(true);
@@ -42,23 +43,75 @@ describe('attachPlanning', () => {
       const plan = classifyAttachRestore({
         cols: 80,
         rows: 24,
-        snapshot: { cols: 80, rows: 24, snapshot_b64: '' },
+        snapshot: { cols: 80, rows: 24, snapshot_b64: '', format: LOCAL_SNAPSHOT_FORMAT },
       }, createAttachRequestContext({ cols: 80, rows: 24 }, 'relaunch_restore'));
 
       expect(plan.hasSnapshot).toBe(false);
+    });
+
+    it('declines a snapshot written in a different build format', () => {
+      // A pty-worker outlives an install, so an upgraded app is offered bytes
+      // its decoder has never seen. Decoding them faults the restore; declining
+      // them costs the scrollback and nothing else.
+      const plan = classifyAttachRestore({
+        cols: 80,
+        rows: 24,
+        snapshot: { cols: 80, rows: 24, snapshot_b64: 'ZHVtcA==', format: 'deadbeef1234' },
+      }, createAttachRequestContext({ cols: 80, rows: 24 }, 'same_app_remount'));
+
+      expect(plan.hasSnapshot).toBe(false);
+      // Geometry falls back to the daemon's reported PTY size, not the
+      // snapshot's grid: nothing is being restored at that grid.
+      expect(plan.restoreCols).toBe(80);
+    });
+
+    it('declines a snapshot that names no format', () => {
+      // Every worker running when this shipped omits the field. An unnamed
+      // format is one nobody speaks.
+      const plan = classifyAttachRestore({
+        cols: 80,
+        rows: 24,
+        snapshot: { cols: 80, rows: 24, snapshot_b64: 'ZHVtcA==' },
+      }, createAttachRequestContext({ cols: 80, rows: 24 }, 'same_app_remount'));
+
+      expect(plan.hasSnapshot).toBe(false);
+    });
+
+    it('leaves a foreign-format attach unreset, on the client watermark', () => {
+      // The whole point of declining: an attach that restores nothing must not
+      // clear the pane, and must not adopt a watermark for output it never
+      // rendered.
+      const restorePlan = classifyAttachRestore({
+        cols: 80,
+        rows: 24,
+        snapshot: { cols: 80, rows: 24, snapshot_b64: 'ZHVtcA==', format: 'deadbeef1234' },
+      }, createAttachRequestContext({ cols: 80, rows: 24 }, 'same_app_remount'));
+
+      const effects = planAttachResultEffects({
+        attachResult: {
+          last_seq: 7,
+          snapshot: { cols: 80, rows: 24, snapshot_b64: 'ZHVtcA==', format: 'deadbeef1234' },
+        },
+        restorePlan,
+        previousSeq: 6,
+      });
+
+      expect(effects.shouldReset).toBe(false);
+      expect(effects.restoreAction).toEqual({ kind: 'none' });
+      expect(effects.nextSeq).toBe(6);
     });
 
     it('plans a snapshot_restore reset and emits the vt dump as the restore action', () => {
       const restorePlan = classifyAttachRestore({
         cols: 80,
         rows: 24,
-        snapshot: { cols: 80, rows: 24, snapshot_b64: 'ZHVtcA==' },
+        snapshot: { cols: 80, rows: 24, snapshot_b64: 'ZHVtcA==', format: LOCAL_SNAPSHOT_FORMAT },
       }, createAttachRequestContext({ cols: 80, rows: 24 }, 'relaunch_restore'));
 
       const effects = planAttachResultEffects({
         attachResult: {
           last_seq: 7,
-          snapshot: { cols: 80, rows: 24, snapshot_b64: 'ZHVtcA==' },
+          snapshot: { cols: 80, rows: 24, snapshot_b64: 'ZHVtcA==', format: LOCAL_SNAPSHOT_FORMAT },
         },
         restorePlan,
         previousSeq: 6,
@@ -81,7 +134,7 @@ describe('attachPlanning', () => {
       }, {
         cols: 80,
         rows: 24,
-        snapshot: { cols: 80, rows: 24, snapshot_b64: 'ZHVtcA==' },
+        snapshot: { cols: 80, rows: 24, snapshot_b64: 'ZHVtcA==', format: LOCAL_SNAPSHOT_FORMAT },
       }, {
         attachPolicy: 'same_app_remount',
         attachContext,
@@ -247,13 +300,13 @@ describe('attachPlanning', () => {
       const restorePlan = classifyAttachRestore({
         cols: 58,
         rows: 46,
-        snapshot: { cols: 58, rows: 46, snapshot_b64: 'ZHVtcA==' },
+        snapshot: { cols: 58, rows: 46, snapshot_b64: 'ZHVtcA==', format: LOCAL_SNAPSHOT_FORMAT },
       }, createAttachRequestContext({ cols: 58, rows: 46 }, 'relaunch_restore'));
 
       const effects = planAttachResultEffects({
         attachResult: {
           last_seq: 10,
-          snapshot: { cols: 58, rows: 46, snapshot_b64: 'ZHVtcA==' },
+          snapshot: { cols: 58, rows: 46, snapshot_b64: 'ZHVtcA==', format: LOCAL_SNAPSHOT_FORMAT },
         },
         restorePlan,
         queuedOutputs: [

--- a/app/src/pty/attachPlanning.ts
+++ b/app/src/pty/attachPlanning.ts
@@ -12,7 +12,27 @@ export interface AttachGhosttySnapshot {
   cols: number;
   rows: number;
   snapshot_b64: string;
+  format?: string;
   scrollback_truncated?: boolean;
+}
+
+// The snapshot wire format this build decodes. A pty-worker outlives an
+// install, so an upgraded app is routinely offered bytes an older worker
+// encoded; only the client knows what its own decoder reads, which is why the
+// comparison lives here and not in the daemon.
+// See docs/plans/2026-08-16-snapshot-format-skew.md.
+export const LOCAL_SNAPSHOT_FORMAT = __ATTN_SNAPSHOT_FORMAT__;
+
+// A snapshot is decodable when it names this build's format. An unnamed format
+// — a worker from before the field existed — is one nobody speaks, which is
+// exactly the case that produced the incident this guards.
+export function snapshotIsDecodable(
+  snapshot: Pick<AttachGhosttySnapshot, 'format'> | null | undefined,
+  localFormat: string = LOCAL_SNAPSHOT_FORMAT,
+): boolean {
+  if (!snapshot) return false;
+  const format = typeof snapshot.format === 'string' ? snapshot.format.trim() : '';
+  return format !== '' && format === localFormat;
 }
 
 export interface AttachRestoreData {
@@ -90,8 +110,16 @@ function normalizeAttachAgent(agent?: string | null, shell?: boolean): string | 
 export function classifyAttachRestore(
   data: AttachRestoreData,
   context?: AttachRequestContext,
+  localFormat: string = LOCAL_SNAPSHOT_FORMAT,
 ) {
-  const ghosttySnapshot = data.snapshot && data.snapshot.snapshot_b64 ? data.snapshot : null;
+  // A snapshot this build cannot decode is no snapshot: everything downstream
+  // of hasSnapshot already handles that case — no reset, the client's own
+  // watermark as the dedup baseline, the live stream painting on.
+  const ghosttySnapshot = data.snapshot
+    && data.snapshot.snapshot_b64
+    && snapshotIsDecodable(data.snapshot, localFormat)
+    ? data.snapshot
+    : null;
   const hasSnapshot = ghosttySnapshot !== null;
   const attachedCols = typeof data.cols === 'number' ? data.cols : null;
   const attachedRows = typeof data.rows === 'number' ? data.rows : null;

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1105,6 +1105,7 @@ export enum AttachResultMessageEvent {
 export interface Snapshot {
     blocks?:              BlockElement[];
     cols:                 number;
+    format?:              string;
     placements?:          PlacementElement[];
     rows:                 number;
     scrollback_truncated: boolean;
@@ -1168,6 +1169,7 @@ export enum AttachSessionMessageCmd {
 export interface AttachSnapshot {
     blocks?:              BlockElement[];
     cols:                 number;
+    format?:              string;
     placements?:          PlacementElement[];
     rows:                 number;
     scrollback_truncated: boolean;
@@ -13068,6 +13070,7 @@ const typeMap: any = {
     "Snapshot": o([
         { json: "blocks", js: "blocks", typ: u(undefined, a(r("BlockElement"))) },
         { json: "cols", js: "cols", typ: 0 },
+        { json: "format", js: "format", typ: u(undefined, "") },
         { json: "placements", js: "placements", typ: u(undefined, a(r("PlacementElement"))) },
         { json: "rows", js: "rows", typ: 0 },
         { json: "scrollback_truncated", js: "scrollback_truncated", typ: true },
@@ -13112,6 +13115,7 @@ const typeMap: any = {
     "AttachSnapshot": o([
         { json: "blocks", js: "blocks", typ: u(undefined, a(r("BlockElement"))) },
         { json: "cols", js: "cols", typ: 0 },
+        { json: "format", js: "format", typ: u(undefined, "") },
         { json: "placements", js: "placements", typ: u(undefined, a(r("PlacementElement"))) },
         { json: "rows", js: "rows", typ: 0 },
         { json: "scrollback_truncated", js: "scrollback_truncated", typ: true },

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -16,3 +16,6 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+// The snapshot wire format this bundle decodes, defined by vite.config.ts.
+declare const __ATTN_SNAPSHOT_FORMAT__: string;

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,7 +1,20 @@
 /// <reference types="vitest" />
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { execFileSync } from "child_process";
 import { resolve } from "path";
+
+// The terminal-snapshot wire format this bundle decodes. Computed here, from
+// the same script the Makefile feeds into buildinfo.SnapshotFormat, so a
+// bundle's worker and app agree by construction rather than by a build script
+// remembering to export an env var. A failure to derive it fails the build:
+// guessing would silently cost every session its restore.
+// See docs/plans/2026-08-16-snapshot-format-skew.md.
+const snapshotFormat = execFileSync(
+  "bash",
+  [resolve(__dirname, "../scripts/snapshot-format.sh")],
+  { encoding: "utf8" },
+).trim();
 
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
@@ -9,6 +22,9 @@ const host = process.env.TAURI_DEV_HOST;
 // https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [react()],
+  define: {
+    __ATTN_SNAPSHOT_FORMAT__: JSON.stringify(snapshotFormat),
+  },
   // Multi-page app configuration for test harness
   build: {
     rollupOptions: {

--- a/changelog.d/snapshot-format-skew.yaml
+++ b/changelog.d/snapshot-format-skew.yaml
@@ -1,0 +1,21 @@
+kind: fixed
+area: terminal
+change: >
+  Sessions that were already running when you update attn now reopen
+  normally. A session's terminal process keeps running across an update, so
+  it can hand the new app a terminal snapshot the new app cannot read — and
+  the app treated that as a broken terminal, rebuilt it, was handed the same
+  snapshot again, and looped there behind an error banner. A snapshot now
+  says which build wrote it, and one the app cannot read is skipped: the
+  session comes back without its earlier scrollback and keeps running,
+  filling in as the agent prints. Restart the session to get full history
+  back.
+notes: >
+  docs/plans/2026-08-16-snapshot-format-skew.md. The tag is derived at build
+  time from the native and wasm ghostty locks, so republishing either moves
+  it without anyone remembering to; a snapshot that names no format at all —
+  every worker running today — reads as unreadable, which is what makes this
+  reach the sessions the incident left behind. Beside it, a decode failure
+  is no longer routed to model-fault recovery: the model it declined to
+  replace is intact, so an unforeseen skew costs one restore instead of a
+  hot loop.

--- a/docs/plans/2026-08-16-snapshot-format-skew.md
+++ b/docs/plans/2026-08-16-snapshot-format-skew.md
@@ -1,0 +1,144 @@
+# A snapshot that outlives the build that wrote it
+
+Written 2026-08-16, after
+[2026-08-16-snapshot-restore.md](2026-08-16-snapshot-restore.md) shipped and
+broke every session that was open when it was installed.
+
+## What happened
+
+attn was installed over a running production app at 00:26. The two sessions
+whose pty-workers had been spawned at 00:16 and 00:22 kept running — that is
+the point of the worker being its own process — and opening either one
+produced a red banner and a hot loop:
+
+```
+PTY attach result: policy=same_app_remount ghostty_snapshot_bytes=17386
+                   replay_decision=use_ghostty_snapshot
+→ ghostty_model_fault operation=restoreSnapshot
+                      error="ghostty_snapshot_decoder_ready failed"
+```
+
+421 faults in six seconds, 421 attach round-trips behind them, each writing a
+DOM snapshot into `ui-diagnostics.jsonl`. Sessions spawned after the install
+were fine.
+
+## Why
+
+`AttachResult.GhosttySnapshot` is the same worker-RPC field it has always
+been. What changed in #923 is what the bytes *mean*: the carried patch's VT
+dump became ghostty's snapshot record stream. The field did not move, the
+worker RPC minor did not move, and `IsCompatibleVersion` reports major 1 /
+minor 1 on both sides — so a pre-install worker answers `attach` with a VT
+dump, the new daemon labels it `use_ghostty_snapshot`, and the new wasm
+decoder is handed bytes in a format it has never seen.
+
+The loop is a second defect standing behind the first. `restoreSnapshot`
+routes any throw to `recoverFromModelFault`, which bumps `rendererEpoch` to
+replace the wasm model — the correct response to a broken model, and the wrong
+one here. The model is fine; the payload is wrong. The new epoch remounts the
+pane, the pane reattaches, the daemon serves the identical bytes, and it
+throws again.
+
+Neither is a one-off. The worker surviving an upgrade is a feature, and every
+future release that moves the encoder does this again to every session a user
+had open.
+
+## The rule
+
+**A snapshot names the format it was written in, and a decoder that does not
+speak that format does not decode it.** Absence of a name is a format nobody
+speaks — which is what makes the fix reach the workers already running out
+there, this incident's included.
+
+## Design
+
+### The tag is derived, never typed
+
+The identity is a 12-hex tag computed by `scripts/snapshot-format.sh` from the
+files that decide the wire format:
+
+- `ghostty-vt-native.lock` — the encoder's archive, keyed by pin.
+- `ghostty-vt-wasm.lock` — the decoder's module, pinned by sha256.
+- a salt constant in the script, for a change to attn's own encode/decode glue
+  that moves neither artifact.
+
+The pin alone would not have caught this incident: #923 changed the native
+lock's `key=` (it dropped the carried patch) while `ghostty-vt.pin` stayed at
+`d760ee96`. The locks are what move when the format moves.
+
+The Makefile passes the tag to Go through `buildinfo.SnapshotFormat`, the same
+ldflags path `SourceFingerprint` already uses; `vite.config.ts` runs the same
+script and defines it for the frontend. One implementation, two consumers, so
+a same-build worker and app always agree by construction — and a divergence
+would show up as `scenario-snapshot-scrollback-restore` losing its scrollback.
+
+Deriving from the locks rather than from `SourceFingerprint` is deliberate: a
+tag that moved on every commit would cost every live session its scrollback on
+every upgrade, for a format that did not change.
+
+### The app decides, because the app owns the decoder
+
+The tag rides with the payload — worker RPC → `AttachInfo` → the wire's
+`AttachSnapshot.format` — and `classifyAttachRestore` treats a snapshot whose
+format is not this build's as no snapshot at all.
+
+That is one comparison, in the one place that owns the decoder, and it is
+correct for a relayed remote attach without touching the hub: the chain
+worker → remote daemon → local daemon → app can skew at any link, and only the
+last link knows what it can read. Everything downstream of `hasSnapshot` is
+already written for the snapshot-less case — no reset, the client's own
+watermark as the dedup baseline, the live stream painting on — so the fallback
+costs nothing new.
+
+A daemon-side filter would additionally save shipping ~17 KB that the app
+discards. Not worth a second comparison that can disagree with the first.
+
+### A decode failure is not a model fault
+
+`restoreSnapshot` catches a throw from `adoptSnapshot`, records it once, and
+leaves the model alone. `adoptSnapshot` releases and throws before it swaps the
+handle, on both failure paths, so the model it declines to replace is intact —
+that ordering is what makes containment safe, and it is now load-bearing.
+
+This is the net under any skew the tag fails to predict: a corrupt payload, a
+truncated frame, a bug in the tag itself. The cost of a failure becomes one
+missing restore rather than an unusable session.
+
+The pane's `reset` is emitted before the restore, so a decode that fails after
+the tag matched leaves the pane blank until the session next prints. That is
+the residual, and it is bounded: the tag is what keeps the predictable skew
+from reaching it.
+
+## What the user gets
+
+An upgrade with sessions open: those sessions keep running, attach without
+their scrollback, and repopulate as the agent prints. Nothing faults, nothing
+loops, no banner. Restarting a session restores the full behavior, because its
+new worker is this build's.
+
+No notice is shown. A session that comes back thin is quieter than a banner
+about a format tag, and the condition ends by itself.
+
+## Surfaces
+
+- **Worker RPC** — `AttachResult.GhosttySnapshotFormat`, additive and
+  skew-safe like the fields around it. Absent from an old worker; absent reads
+  as incompatible.
+- **Protocol** — `AttachSnapshot.format`, `ProtocolVersion` 252 → 253.
+- **Backends** — the worker backend passes the tag through; the embedded
+  backend is the daemon's own process and stamps `buildinfo.SnapshotFormat`.
+- **Linux** — the tag is build plumbing, not cgo; the pure-Go stub emits no
+  snapshot and reaches none of this.
+- **CLI** — nothing. No command reads a snapshot.
+- **Docs** — a line in AGENTS.md under the terminal contracts, and a changelog
+  fragment.
+
+## Verification
+
+- `scenario-snapshot-scrollback-restore` still restores scrollback: the proof
+  the two tag computations agree in a real bundle.
+- A skewed attach degrades instead of faulting, driven by serving a snapshot
+  under a foreign tag.
+- Unit: `classifyAttachRestore` drops a foreign-tag and an absent-tag
+  snapshot; `restoreSnapshot` on undecodable bytes records the rejection,
+  raises no model fault, and leaves the model usable.

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -5,4 +5,9 @@ var (
 	BuildTime         = "unknown"
 	SourceFingerprint = "unknown"
 	GitCommit         = "unknown"
+	// SnapshotFormat identifies the terminal-snapshot wire format this build
+	// encodes, so a client that cannot decode it can say so instead of trying.
+	// scripts/snapshot-format.sh derives it; "unknown" (a build that skipped
+	// the ldflag) never matches a client and costs restore, never correctness.
+	SnapshotFormat = "unknown"
 )

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2038,11 +2038,12 @@ func TestDaemon_HandleAttachSession_ServesGhosttySnapshotWhenAvailable(t *testin
 	backend := &fakeAttachBackend{}
 	snapshot := []byte("\x1b[H\x1b[2JOpenAI Codex\r\n\r\nRun /review on my current changes")
 	backend.SetAttachInfo(ptybackend.AttachInfo{
-		Running:         true,
-		LastSeq:         12,
-		Cols:            58,
-		Rows:            46,
-		GhosttySnapshot: snapshot,
+		Running:               true,
+		LastSeq:               12,
+		Cols:                  58,
+		Rows:                  46,
+		GhosttySnapshot:       snapshot,
+		GhosttySnapshotFormat: "cafef00d1234",
 	})
 	d.ptyBackend = backend
 
@@ -2080,6 +2081,13 @@ func TestDaemon_HandleAttachSession_ServesGhosttySnapshotWhenAvailable(t *testin
 		}
 		if protocol.Deref(result.LastSeq) != 12 {
 			t.Fatalf("last_seq = %d, want 12", protocol.Deref(result.LastSeq))
+		}
+		// The format the worker encoded in travels with the bytes: the client
+		// owns the decoder, so it is the only participant that can tell whether
+		// these bytes are readable. A worker outlives an install, so this is
+		// routinely not the client's own format.
+		if got := protocol.Deref(result.Snapshot.Format); got != "cafef00d1234" {
+			t.Fatalf("snapshot format = %q, want %q", got, "cafef00d1234")
 		}
 	case <-time.After(1 * time.Second):
 		t.Fatal("timed out waiting for attach_result")

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -82,8 +82,12 @@ type attachReplayPayload struct {
 	// its model and replays it. Empty when the policy omits restore or no
 	// server-authoritative terminal is available (ghostty absent).
 	ghosttySnapshot []byte
-	ghosttyCols     uint16
-	ghosttyRows     uint16
+	// ghosttySnapshotFormat travels with the bytes so the client — the only
+	// participant that owns a decoder — can decline a format it cannot read.
+	// Empty from a worker that predates the field, which reads the same way.
+	ghosttySnapshotFormat string
+	ghosttyCols           uint16
+	ghosttyRows           uint16
 	// ghosttyBlocks are the worker's OSC 133 command blocks resolved atomically
 	// with ghosttySnapshot (Phase 3a). Carried only alongside a snapshot.
 	ghosttyBlocks []pty.AttachBlockData
@@ -119,13 +123,14 @@ func buildAttachReplayPayload(info ptybackend.AttachInfo, policy protocol.Attach
 		return attachReplayPayload{decision: "no_snapshot"}
 	}
 	return attachReplayPayload{
-		ghosttySnapshot:     info.GhosttySnapshot,
-		ghosttyCols:         info.Cols,
-		ghosttyRows:         info.Rows,
-		ghosttyBlocks:       info.GhosttyBlocks,
-		ghosttyPlacements:   info.GhosttyPlacements,
-		scrollbackTruncated: info.GhosttyScrollbackTruncated,
-		decision:            "use_ghostty_snapshot",
+		ghosttySnapshot:       info.GhosttySnapshot,
+		ghosttySnapshotFormat: info.GhosttySnapshotFormat,
+		ghosttyCols:           info.Cols,
+		ghosttyRows:           info.Rows,
+		ghosttyBlocks:         info.GhosttyBlocks,
+		ghosttyPlacements:     info.GhosttyPlacements,
+		scrollbackTruncated:   info.GhosttyScrollbackTruncated,
+		decision:              "use_ghostty_snapshot",
 	}
 }
 
@@ -391,12 +396,13 @@ func (d *Daemon) handleAttachSession(client *wsClient, msg *protocol.AttachSessi
 	}
 	replay := buildAttachReplayPayload(info, protocol.Deref(msg.AttachPolicy))
 	d.logf(
-		"PTY attach result: id=%s policy=%s running=%v last_seq=%d ghostty_snapshot_bytes=%d scrollback_truncated=%v replay_decision=%s size=%dx%d",
+		"PTY attach result: id=%s policy=%s running=%v last_seq=%d ghostty_snapshot_bytes=%d snapshot_format=%s scrollback_truncated=%v replay_decision=%s size=%dx%d",
 		msg.ID,
 		protocol.Deref(msg.AttachPolicy),
 		info.Running,
 		info.LastSeq,
 		len(replay.ghosttySnapshot),
+		replay.ghosttySnapshotFormat,
 		replay.scrollbackTruncated,
 		replay.decision,
 		info.Cols,
@@ -430,6 +436,7 @@ func (d *Daemon) handleAttachSession(client *wsClient, msg *protocol.AttachSessi
 			Cols:                int(replay.ghosttyCols),
 			Rows:                int(replay.ghosttyRows),
 			SnapshotB64:         base64.StdEncoding.EncodeToString(replay.ghosttySnapshot),
+			Format:              protocol.Ptr(replay.ghosttySnapshotFormat),
 			Blocks:              attachBlocksToProtocol(replay.ghosttyBlocks),
 			Placements:          placementsToProtocol(replay.ghosttyPlacements),
 			ScrollbackTruncated: replay.scrollbackTruncated,

--- a/internal/hub/bootstrap.go
+++ b/internal/hub/bootstrap.go
@@ -716,6 +716,12 @@ func (b *Bootstrapper) buildBinaryFromSource(ctx context.Context, platform Remot
 	if gc := buildinfo.GitCommit; gc != "" && gc != "unknown" {
 		ldflags += " -X github.com/victorarias/attn/internal/buildinfo.GitCommit=" + gc
 	}
+	// The remote daemon's workers encode snapshots this app decodes, so the
+	// build it gets must carry the same format tag; without it every remote
+	// session attaches without its scrollback.
+	if sf := buildinfo.SnapshotFormat; sf != "" && sf != "unknown" {
+		ldflags += " -X github.com/victorarias/attn/internal/buildinfo.SnapshotFormat=" + sf
+	}
 	// The worker's server-authoritative terminal links libghostty-vt via cgo on
 	// Linux too (internal/ghosttyvt), so the cross-compile needs that target's
 	// native archive present. It is download-first (no zig for the archive

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "252"
+const ProtocolVersion = "253"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -710,6 +710,9 @@ type AttachSnapshot struct {
 	// Cols corresponds to the JSON schema field "cols".
 	Cols int `json:"cols"`
 
+	// Format corresponds to the JSON schema field "format".
+	Format *string `json:"format,omitempty,omitzero"`
+
 	// Placements corresponds to the JSON schema field "placements".
 	Placements []KittyPlacement `json:"placements,omitempty,omitzero"`
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -3758,6 +3758,13 @@ model AttachSnapshot {
   cols: int32;
   rows: int32;
   snapshot_b64: string;          // base64 ghostty snapshot record stream
+  // The wire format snapshot_b64 is written in. A pty-worker outlives an
+  // install, so these bytes can be encoded by a build the client's decoder does
+  // not match; the client compares this against its own and falls back to a
+  // snapshot-less attach rather than decoding a format it cannot read. Absent
+  // from a worker that predates the field, which is also a format nobody
+  // speaks. See docs/plans/2026-08-16-snapshot-format-skew.md.
+  format?: string;
   blocks?: AttachBlock[];        // OSC 133 command blocks, empty/absent if none
   // Kitty placements on the screen the snapshot carries, captured in the same
   // hold. Absent when the session holds no images. Pixels are not inlined; the

--- a/internal/pty/manager.go
+++ b/internal/pty/manager.go
@@ -114,6 +114,12 @@ type AttachInfo struct {
 	// terminal (primary + alt screens, scrollback, cursor) from libghostty-vt.
 	// Snapshot geometry is Cols/Rows. nil when the ghostty terminal is absent.
 	GhosttySnapshot []byte
+	// GhosttySnapshotFormat names the wire format GhosttySnapshot is written in
+	// (buildinfo.SnapshotFormat), stamped where the bytes are produced. A
+	// pty-worker outlives an install, so a snapshot can reach a client built
+	// against a different libghostty-vt; carrying the format is what lets that
+	// client decline it. Empty when there is no snapshot.
+	GhosttySnapshotFormat string
 	// GhosttyBlocks are the worker's OSC 133 command blocks resolved to
 	// SCREEN-space rows of GhosttySnapshot, captured under the same lock hold
 	// (atomic with the dump and LastSeq). nil when ghostty is absent.

--- a/internal/pty/session.go
+++ b/internal/pty/session.go
@@ -15,6 +15,7 @@ import (
 
 	creackpty "github.com/creack/pty"
 
+	"github.com/victorarias/attn/internal/buildinfo"
 	"github.com/victorarias/attn/internal/ghosttyvt"
 )
 
@@ -663,10 +664,20 @@ func (s *Session) info() AttachInfo {
 		ExitCode:                   exitCode,
 		ExitSignal:                 exitSignal,
 		GhosttySnapshot:            ghosttySnapshot,
+		GhosttySnapshotFormat:      snapshotFormat(ghosttySnapshot),
 		GhosttyBlocks:              ghosttyBlocks,
 		GhosttyPlacements:          ghosttyPlacements,
 		GhosttyScrollbackTruncated: ghosttyTruncated,
 	}
+}
+
+// snapshotFormat names the format of bytes this build just encoded. Nothing to
+// name when there are no bytes.
+func snapshotFormat(snapshot []byte) string {
+	if len(snapshot) == 0 {
+		return ""
+	}
+	return buildinfo.SnapshotFormat
 }
 
 // kittyImage copies one stored image out of the session's terminal. Under

--- a/internal/pty/snapshot_format_test.go
+++ b/internal/pty/snapshot_format_test.go
@@ -1,0 +1,51 @@
+package pty
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/buildinfo"
+	"github.com/victorarias/attn/internal/ghosttyvt"
+)
+
+// A snapshot names the build that encoded it, because a pty-worker outlives an
+// install and its bytes can reach a client whose decoder is a different build.
+// See docs/plans/2026-08-16-snapshot-format-skew.md.
+func TestInfoStampsSnapshotFormat(t *testing.T) {
+	newSession := func() *Session {
+		return &Session{
+			id:          "snapshot-format",
+			cols:        80,
+			rows:        24,
+			cmd:         &exec.Cmd{},
+			subscribers: make(map[string]*sessionSubscriber),
+			running:     true,
+			exited:      make(chan struct{}),
+			startedAt:   time.Now(),
+		}
+	}
+
+	gt, err := ghosttyvt.New(80, 24, ghosttyvt.Options{})
+	if err != nil {
+		t.Skipf("ghostty terminal unavailable on this platform: %v", err)
+	}
+	t.Cleanup(gt.Close)
+
+	s := newSession()
+	s.ghostty = gt
+	info := s.info()
+	if len(info.GhosttySnapshot) == 0 {
+		t.Fatal("expected a snapshot from a session with a ghostty terminal")
+	}
+	if info.GhosttySnapshotFormat != buildinfo.SnapshotFormat {
+		t.Fatalf("snapshot format = %q, want %q", info.GhosttySnapshotFormat, buildinfo.SnapshotFormat)
+	}
+
+	// Nothing encoded, nothing to name: an empty format beside empty bytes is
+	// how a stub build and a failed construction already read.
+	bare := newSession()
+	if got := bare.info().GhosttySnapshotFormat; got != "" {
+		t.Fatalf("snapshot format without a terminal = %q, want empty", got)
+	}
+}

--- a/internal/ptybackend/backend.go
+++ b/internal/ptybackend/backend.go
@@ -136,6 +136,9 @@ type AttachInfo struct {
 	// GhosttySnapshot is the server-authoritative VT serialization of the whole
 	// terminal (geometry Cols/Rows); nil when absent.
 	GhosttySnapshot []byte
+	// GhosttySnapshotFormat names the wire format GhosttySnapshot is written
+	// in; empty when absent, and from an old worker that does not send it.
+	GhosttySnapshotFormat string
 	// GhosttyBlocks are OSC 133 command blocks resolved to SCREEN-space rows of
 	// GhosttySnapshot, captured atomically with it and LastSeq; nil when absent.
 	GhosttyBlocks []pty.AttachBlockData

--- a/internal/ptybackend/embedded.go
+++ b/internal/ptybackend/embedded.go
@@ -119,6 +119,7 @@ func (b *EmbeddedBackend) Attach(_ context.Context, sessionID, subscriberID stri
 		ExitCode:                   info.ExitCode,
 		ExitSignal:                 info.ExitSignal,
 		GhosttySnapshot:            info.GhosttySnapshot,
+		GhosttySnapshotFormat:      info.GhosttySnapshotFormat,
 		GhosttyBlocks:              info.GhosttyBlocks,
 		GhosttyPlacements:          info.GhosttyPlacements,
 		GhosttyScrollbackTruncated: info.GhosttyScrollbackTruncated,

--- a/internal/ptybackend/worker.go
+++ b/internal/ptybackend/worker.go
@@ -703,6 +703,7 @@ func (b *WorkerBackend) Attach(ctx context.Context, sessionID, subscriberID stri
 				ExitCode:                   attachResult.ExitCode,
 				ExitSignal:                 attachResult.ExitSignal,
 				GhosttySnapshot:            attachResult.GhosttySnapshot,
+				GhosttySnapshotFormat:      attachResult.GhosttySnapshotFormat,
 				GhosttyBlocks:              attachBlocksFromWire(attachResult.GhosttyBlocks),
 				GhosttyPlacements:          ptyworker.PlacementsFromWire(attachResult.GhosttyPlacements),
 				GhosttyScrollbackTruncated: attachResult.GhosttyScrollbackTruncated,

--- a/internal/ptyworker/protocol.go
+++ b/internal/ptyworker/protocol.go
@@ -268,6 +268,13 @@ type AttachResult struct {
 	// GhosttySnapshot is the server-authoritative VT serialization of the whole
 	// terminal from libghostty-vt (geometry is Cols/Rows). Omitted when absent.
 	GhosttySnapshot []byte `json:"ghostty_snapshot,omitempty"`
+	// GhosttySnapshotFormat identifies the wire format GhosttySnapshot is
+	// written in (buildinfo.SnapshotFormat). A worker outlives an install, so
+	// these bytes can reach a client built against a different libghostty-vt;
+	// the client compares this against its own decoder and skips a restore it
+	// cannot read. Additive: an old worker omits it, and an unnamed format is
+	// one nobody speaks.
+	GhosttySnapshotFormat string `json:"ghostty_snapshot_format,omitempty"`
 	// GhosttyBlocks are the worker's OSC 133 command blocks resolved to
 	// SCREEN-space rows of GhosttySnapshot, captured atomically with it and
 	// LastSeq (Phase 3a). Mirrors pty.AttachBlockData. Omitted when absent;

--- a/internal/ptyworker/protocol_test.go
+++ b/internal/ptyworker/protocol_test.go
@@ -128,3 +128,31 @@ func mustRawJSON(t *testing.T, v any) json.RawMessage {
 	}
 	return payload
 }
+
+func TestAttachResultCarriesSnapshotFormat(t *testing.T) {
+	payload, err := json.Marshal(AttachResult{
+		GhosttySnapshot:       []byte("snapshot bytes"),
+		GhosttySnapshotFormat: "cafef00d1234",
+	})
+	if err != nil {
+		t.Fatalf("marshal attach result: %v", err)
+	}
+	var decoded AttachResult
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("unmarshal attach result: %v", err)
+	}
+	if decoded.GhosttySnapshotFormat != "cafef00d1234" {
+		t.Fatalf("snapshot format = %q, want %q", decoded.GhosttySnapshotFormat, "cafef00d1234")
+	}
+
+	// A worker that predates the field is exactly the case this exists for: it
+	// answers attach with bytes and no format, and empty must survive the
+	// decode so the client can refuse them.
+	var old AttachResult
+	if err := json.Unmarshal([]byte(`{"ghostty_snapshot":"c25hcHNob3Q="}`), &old); err != nil {
+		t.Fatalf("unmarshal legacy attach result: %v", err)
+	}
+	if old.GhosttySnapshotFormat != "" {
+		t.Fatalf("legacy snapshot format = %q, want empty", old.GhosttySnapshotFormat)
+	}
+}

--- a/internal/ptyworker/runtime.go
+++ b/internal/ptyworker/runtime.go
@@ -947,6 +947,7 @@ func (c *connCtx) handleRequest(req RequestEnvelope) {
 			ExitCode:                   info.ExitCode,
 			ExitSignal:                 info.ExitSignal,
 			GhosttySnapshot:            info.GhosttySnapshot,
+			GhosttySnapshotFormat:      info.GhosttySnapshotFormat,
 			GhosttyBlocks:              attachBlocksToWire(info.GhosttyBlocks),
 			GhosttyPlacements:          placementsToWire(info.GhosttyPlacements),
 			GhosttyScrollbackTruncated: info.GhosttyScrollbackTruncated,

--- a/scripts/snapshot-format.sh
+++ b/scripts/snapshot-format.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Prints the snapshot format tag: the identity of the terminal-snapshot wire
+# format this build encodes and decodes.
+#
+# A pty-worker outlives an install, so a session opened after an upgrade can be
+# served a snapshot the running app cannot read. The tag is what lets the app
+# recognize that and fall back to a snapshot-less attach instead of decoding
+# garbage. See docs/plans/2026-08-16-snapshot-format-skew.md.
+#
+# Derived, never typed: the inputs are the two artifacts that decide the format
+# — the native encoder's archive and the browser decoder's module — so
+# republishing either moves the tag with no discipline required. The pin alone
+# is not enough: the native lock key changed for the snapshot API while
+# ghostty-vt.pin stayed put, which is the skew that produced the incident.
+#
+# Bump SALT when attn's own encode/decode changes the bytes without moving
+# either lock.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SALT=1
+
+hash_stdin() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 | awk '{print $1}'
+    return
+  fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+    return
+  fi
+  if command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 | awk '{print $NF}'
+    return
+  fi
+  echo "No SHA-256 implementation found (tried shasum, sha256sum, openssl)" >&2
+  exit 1
+}
+
+inputs=("${ROOT_DIR}/ghostty-vt-native.lock" "${ROOT_DIR}/ghostty-vt-wasm.lock")
+for path in "${inputs[@]}"; do
+  if [[ ! -f "${path}" ]]; then
+    echo "snapshot-format: missing ${path#"${ROOT_DIR}/"} — the tag cannot be derived from an incomplete checkout" >&2
+    exit 1
+  fi
+done
+
+digest="$({ printf 'salt=%s\n' "${SALT}"; cat "${inputs[@]}"; } | hash_stdin)"
+printf '%s\n' "${digest:0:12}"


### PR DESCRIPTION
A pty-worker outlives an install. A session that was running when attn updated
is therefore served a snapshot encoded by the build it started under, and
nothing on the path could tell: the worker RPC field carrying those bytes never
changed name and the RPC minor never moved, so `IsCompatibleVersion` reports
major 1 / minor 1 on both sides while the bytes underneath went from a VT dump
to ghostty's snapshot record stream.

The client took them and threw, and the throw was routed to model-fault
recovery — a new epoch, a remount, a reattach, the same bytes. Measured on the
production install that shipped it: 421 faults in six seconds on two sessions,
421 attach round-trips behind them, each writing a DOM snapshot to
`ui-diagnostics.jsonl`, all behind a red banner.

```
PTY attach result: policy=same_app_remount ghostty_snapshot_bytes=17386
                   replay_decision=use_ghostty_snapshot
→ ghostty_model_fault operation=restoreSnapshot
                      error="ghostty_snapshot_decoder_ready failed"
```

## The upgrade path

A snapshot now names its format (`attach_result.snapshot.format`), and the
client compares that against its own decoder before decoding anything. A
foreign tag — or no tag, which is every worker running today — is treated as no
snapshot, which is already a supported attach: no reset, the client's own
watermark as the dedup baseline, the live stream painting on. The session comes
back without its earlier scrollback and keeps working; restarting it restores
full behavior. Nothing is shown to the user: a session that comes back thin is
quieter than a banner about a format tag, and the condition ends by itself.

The comparison lives in the client because the client owns the decoder. The
chain worker → remote daemon → local daemon → app can skew at any link, and
only the last link knows what it can read — so this covers a relayed remote
attach with no hub plumbing.

## The tag is derived, never typed

`scripts/snapshot-format.sh` hashes the two artifacts that decide the format —
`ghostty-vt-native.lock` (the encoder's archive) and `ghostty-vt-wasm.lock`
(the decoder's module) — plus a salt for a change to attn's own encode/decode
glue that moves neither. The Makefile feeds it to `buildinfo.SnapshotFormat`;
`vite.config.ts` calls the same script for the frontend. One implementation,
two consumers, so a bundle's worker and app agree by construction.

The pin alone would not have caught this incident: #923 changed the native
lock's `key=` (it dropped the carried patch) while `ghostty-vt.pin` stayed at
`d760ee96`. Deriving from the locks rather than from `SourceFingerprint` is
also deliberate — a tag that moved on every commit would cost every live
session its scrollback on every upgrade, for a format that did not change.

## A decode failure is not a model fault

Independent of the tag: `restoreSnapshot` now catches the throw, records it
once, and leaves the model alone. `adoptSnapshot` releases and throws before it
swaps the handle on both failure paths, so the model it declined to replace is
intact — that ordering is now load-bearing and has its own test. This is the
net under any skew the tag fails to predict, and it turns the cost of a bad
payload from an unusable session into one missing restore.

Residual, stated plainly: the pane's `reset` is emitted before the restore, so
a decode that fails *after* the tag matched leaves the pane blank until the
session next prints. The tag is what keeps the predictable skew away from it.

## Verification

Live, on a throwaway profile, simulating a real format change across an
install:

- Seeded a session, bumped the format, ran `make install PROFILE=fmtskew`. The
  worker survived the install — the incident's exact shape.
- The daemon served `snapshot_format=199ae0429d61` to a decoder built at
  `08b9b91b6b6c`.
- The pane attached, restored no history (expected), **took live input**, and
  `ghostty_model_fault` went 0 → 0.

Same-build restore is unchanged: `scenario-snapshot-scrollback-restore` still
recovers 2000 rows across a relaunch, which is what proves the Go and vite tag
computations agree in a real bundle.

Unit: `classifyAttachRestore` drops a foreign-tag and an absent-tag snapshot and
leaves the attach unreset on the client watermark; `restoreSnapshot` on
undecodable bytes records the rejection, raises no model fault, and leaves the
model taking writes; `adoptSnapshot` rejects garbage without touching the
terminal; the worker RPC round-trips the tag and decodes a legacy result to
empty; the daemon puts it on the wire. Full Go suite and 2881 frontend tests
green.

No evidence recording: the visible change here is the absence of a banner, and
a clip of a session opening normally shows nothing without a before. The fault
counts and daemon log lines above are the evidence.

## Surfaces

- **Protocol** — `AttachSnapshot.format`, `ProtocolVersion` 252 → 253
  (`generated.go`, `generated.ts`, `useDaemonSocket.ts`).
- **Worker RPC** — `AttachResult.GhosttySnapshotFormat`, additive and skew-safe;
  absent from an old worker, which reads as incompatible.
- **Backends** — worker passes it through, embedded stamps its own process's.
- **Hub** — a remote daemon built from source carries the tag in its ldflags,
  or every remote session would attach without scrollback.
- **Linux** — build plumbing, not cgo; the pure-Go stub emits no snapshot.
- **CLI** — nothing reads a snapshot.
- **Docs** — plan doc, an AGENTS.md contract line, changelog fragment.

Plan: `docs/plans/2026-08-16-snapshot-format-skew.md`.

https://claude.ai/code/session_011GhcqUUDfASUjH6YMfo4ws