### PR TITLE
fix(opencode): show a delegated session in its pane, on the model it was pinned to

### DIFF
--- a/changelog.d/opencode-delegations-visible-and-pinned.yaml
+++ b/changelog.d/opencode-delegations-visible-and-pinned.yaml
@@ -1,0 +1,21 @@
+kind: fixed
+area: plugins
+change: >
+  A delegated OpenCode session now appears in its pane, on the model and effort
+  it was delegated with. The plugin used to create the session over OpenCode's
+  HTTP API and ask the TUI to select it, but that request is published to a bus
+  the TUI has not subscribed to yet when a session is starting, so it was
+  dropped and the pane sat on the OpenCode splash while the agent worked
+  unseen. The delegated turn is now submitted through the TUI itself, so the
+  pane shows the session OpenCode opened, within a couple of seconds. The
+  effort pin reached nothing at all: the TUI takes the model variant from its
+  own state, so a delegation asking for `max` quietly ran on whatever variant
+  was last used interactively. Each delegated run now gets its own OpenCode TUI
+  state seeded with the pin — which also stops delegations from rewriting the
+  model you picked yourself. A pinned model that cannot honor the requested
+  effort (MiMo declares no variants at all) now fails the run and names what
+  the model does offer, and a session that opens on a different provider, model
+  or variant than the pin is reported as degraded instead of running unnoticed.
+symptom: >
+  A delegated OpenCode session showed the OpenCode splash screen instead of its
+  work, and its `--effort` pin was not the effort it ran on.

--- a/plugins/attn-opencode/README.md
+++ b/plugins/attn-opencode/README.md
@@ -39,10 +39,21 @@ An ordinary promptless OpenCode session launches the TUI with OpenCode's own
 model and variant defaults. The plugin observes the native session OpenCode
 creates and persists its identity for resume. Delegated OpenCode sessions
 require an explicit `--model provider/model` and one of the contract-tested
-effort pins: `--effort low` or `--effort max`. The plugin sends those pins to
-OpenCode's server as `{ providerID, id, variant }`, so its staged prompt is
-bound to the selected native session. Other effort labels remain intentionally
-unsupported until they have the same adapter and live-app evidence.
+effort pins: `--effort low` or `--effort max`. Other effort labels remain
+intentionally unsupported until they have the same adapter and live-app
+evidence.
+
+A delegated launch runs the pinned model on OpenCode's `build` agent
+(`--agent build` plus the model in the injected config), and seeds its own
+`XDG_STATE_HOME` with the pinned variant, because the TUI takes the variant
+from its state rather than from the agent config — which also keeps a run from
+rewriting the user's own model selection. The delegated turn is then submitted
+through the TUI, so the pane shows the session OpenCode itself opened; the
+`session.created` event that submission produces is the receipt that stops the
+staging retry. Before staging, the plugin checks the pinned model's variants in
+OpenCode's provider catalog and fails the run when the model cannot honor the
+requested effort, and after the session opens it reads the model back and
+degrades loudly when provider, model, or variant differ from the pin.
 
 Each run gets a separate loopback port and random Basic-auth password. The
 password, staged prompt, and attn-composed launch instructions live in private
@@ -75,5 +86,5 @@ attention request, the plugin classifies the newest completed assistant prose
 using the same OpenCode model in a temporary, tool-disabled session. Ordinary
 prose questions then become `waiting_input`, completed answers become `idle`,
 and uncertain extraction or classification becomes `unknown`. The temporary
-session is deleted without selecting it in the TUI, and duplicate idle events
+session is deleted without ever reaching the TUI, and duplicate idle events
 reuse a verdict cached against the exact native message text.

--- a/plugins/attn-opencode/src/driver.ts
+++ b/plugins/attn-opencode/src/driver.ts
@@ -416,6 +416,7 @@ export class OpenCodeDriver {
   // same startup budget the server itself gets.
   private async stagePinnedTurn(client: OpenCodeHTTP, binding: NativeBinding, prompt: string, signal: AbortSignal): Promise<void> {
     const deadline = Date.now() + this.startupDeadline;
+    const before = new Set(await this.sessionIDs(client, signal));
     for (;;) {
       if (signal.aborted || binding.pinError) return;
       if (binding.claimedID) return;
@@ -429,7 +430,46 @@ export class OpenCodeDriver {
         request.dispose();
       }
       await sleep(this.stageRetryDelay, signal);
+      if (signal.aborted || binding.claimedID || binding.pinError) return;
+      // An SSE drop can lose the receipt for a prompt the TUI did take, and a
+      // second submission into that session creates no new one to receive. The
+      // session carrying this run's prompt is the same receipt, read directly.
+      const opened = await this.sessionOpenedFor(client, prompt, before, signal);
+      if (opened) {
+        binding.claimedID = opened;
+        await this.bindNativeSession(client, binding, opened, signal);
+        return;
+      }
     }
+  }
+
+  private async sessionIDs(client: OpenCodeHTTP, signal: AbortSignal): Promise<string[]> {
+    const request = this.requestDeadline(signal);
+    try {
+      return await client.listSessionIDs(request.signal);
+    } finally {
+      request.dispose();
+    }
+  }
+
+  // Sessions are stored per project directory, so a session this run did not
+  // open is only ruled out by the prompt it carries.
+  private async sessionOpenedFor(
+    client: OpenCodeHTTP,
+    prompt: string,
+    before: Set<string>,
+    signal: AbortSignal,
+  ): Promise<string | undefined> {
+    const candidates = (await this.sessionIDs(client, signal)).filter((id) => !before.has(id));
+    for (const id of candidates.reverse()) {
+      const request = this.requestDeadline(signal);
+      try {
+        if ((await client.userPromptText(id, request.signal))?.includes(prompt)) return id;
+      } finally {
+        request.dispose();
+      }
+    }
+    return undefined;
   }
 
   // OpenCode drops a variant the pinned model does not declare — MiMo declares

--- a/plugins/attn-opencode/src/driver.ts
+++ b/plugins/attn-opencode/src/driver.ts
@@ -23,6 +23,11 @@ import {
 
 const startupDeadlineMs = 20_000;
 const reconnectDelayMs = 250;
+// A submitted prompt reaches `session.created` in about 70ms once the TUI is
+// attached, and the TUI attaches about three seconds after the server answers
+// health. Waiting a second between staging attempts leaves the receipt room to
+// arrive, so a prompt the TUI already took is never submitted twice.
+const stageRetryDelayMs = 1_000;
 const healthRequestTimeoutMs = 2_000;
 const eventReconnectAttempts = 3;
 const classifierTimeoutMs = 30_000;
@@ -42,6 +47,7 @@ export type OpenCodeDriverOptions = {
   http?: (port: number, password: string) => OpenCodeHTTP;
   startupDeadline?: number;
   reconnectDelay?: number;
+  stageRetryDelay?: number;
   healthRequestTimeout?: number;
   classifierTimeout?: number;
   stopClassifier?: (client: OpenCodeHTTP) => StopClassifier;
@@ -65,6 +71,9 @@ type NativeBinding = {
   record: RunRecord;
   nativeID?: string;
   mode: LaunchSelection["mode"];
+  claimedID?: string;
+  pin?: OpenCodeModel;
+  pinError?: string;
 };
 
 type BufferedSubscription = {
@@ -85,6 +94,7 @@ export class OpenCodeDriver {
   private readonly http: (port: number, password: string) => OpenCodeHTTP;
   private readonly startupDeadline: number;
   private readonly reconnectDelay: number;
+  private readonly stageRetryDelay: number;
   private readonly healthRequestTimeout: number;
   private readonly classifierTimeout: number;
   private readonly stopClassifier: (client: OpenCodeHTTP) => StopClassifier;
@@ -102,6 +112,7 @@ export class OpenCodeDriver {
     this.http = options.http ?? ((port, password) => new OpenCodeHTTP({ port, password }));
     this.startupDeadline = options.startupDeadline ?? startupDeadlineMs;
     this.reconnectDelay = options.reconnectDelay ?? reconnectDelayMs;
+    this.stageRetryDelay = options.stageRetryDelay ?? stageRetryDelayMs;
     this.healthRequestTimeout = options.healthRequestTimeout ?? healthRequestTimeoutMs;
     this.classifierTimeout = options.classifierTimeout ?? classifierTimeoutMs;
     this.stopClassifier = options.stopClassifier ?? ((client) => new OpenCodeStopClassifier(client));
@@ -188,6 +199,12 @@ export class OpenCodeDriver {
         yolo: params.yolo === true,
         resume_session_id: selection.nativeSessionID,
         instruction_ref: record.instruction_ref,
+        ...(selection.mode === "pinned" && selection.model
+          ? {
+            pin: { model: `${selection.model.providerID}/${selection.model.id}`, variant: selection.model.variant },
+            state_dir: this.options.registry.stateDir(record.run_id),
+          }
+          : {}),
       };
       await this.options.registry.writeLaunchConfig(record, launchConfig);
       this.startMonitor(record, selection);
@@ -286,7 +303,9 @@ export class OpenCodeDriver {
     const binding: NativeBinding = {
       record: initialRecord,
       nativeID: initialRecord.opencode_session_id,
+      claimedID: initialRecord.opencode_session_id,
       mode: selection.mode,
+      pin: selection.model,
     };
     const eventController = new AbortController();
     const abortEventsForSession = () => eventController.abort(signal.reason);
@@ -311,35 +330,20 @@ export class OpenCodeDriver {
           if (selection.model && !sessionModelMatches(nativeSession, selection.model)) {
             throw new Error("persisted OpenCode session model or variant no longer matches the delegated pins");
           }
-          await this.reconcileStatus(binding.record, client, binding.nativeID, setup.signal);
-          await client.selectSession(binding.nativeID, setup.signal);
-        } else if (selection.mode === "pinned") {
-          const model = selection.model!;
-          const nativeID = await client.createSession(model, setup.signal);
-          binding.nativeID = nativeID;
-          binding.record = await this.options.registry.update(binding.record.run_id, { opencode_session_id: nativeID });
-          await this.enqueueReport(binding.record, {
-            kind: "metadata",
-            metadata: {
-              schema: 1,
-              opencode_session_id: nativeID,
-              opencode_version: binding.record.opencode_version,
-              pinned: true,
-              model: binding.record.model,
-              variant: binding.record.variant,
-            },
-          });
           // A just-submitted prompt can be absent from /session/status until its
           // first explicit lifecycle event. Reconciliation therefore never infers
           // idle from absence.
-          await this.reconcileStatus(binding.record, client, nativeID, setup.signal);
-          await client.selectSession(nativeID, setup.signal);
-          const prompt = await this.options.registry.prompt(binding.record);
-          if (prompt !== "") await client.promptAsync(nativeID, prompt, model, setup.signal);
+          await this.reconcileStatus(binding.record, client, binding.nativeID, setup.signal);
         }
         await bufferedSubscription.release();
       } finally {
         setup.dispose();
+      }
+
+      if (!binding.nativeID && selection.mode === "pinned") {
+        if (selection.model) await this.requireOfferedVariant(client, selection.model, signal);
+        const prompt = await this.options.registry.prompt(binding.record);
+        if (prompt !== "") await this.stagePinnedTurn(client, binding, prompt, signal);
       }
 
       let establishedStreamFailures = 0;
@@ -402,6 +406,96 @@ export class OpenCodeDriver {
     }
   }
 
+  // The TUI owns the session a delegated run must display, and it opens one only
+  // when a prompt is submitted through it. Nothing in OpenCode's API says whether
+  // the TUI has attached to the event bus yet — `/tui/*` answers `true` with no
+  // TUI running at all — and a submission published before it attaches is
+  // dropped. The `session.created` event the TUI's own submission produces is the
+  // only receipt, so the staged prompt is submitted again until that event claims
+  // the run. Locally the TUI attaches in about three seconds; the deadline is the
+  // same startup budget the server itself gets.
+  private async stagePinnedTurn(client: OpenCodeHTTP, binding: NativeBinding, prompt: string, signal: AbortSignal): Promise<void> {
+    const deadline = Date.now() + this.startupDeadline;
+    for (;;) {
+      if (signal.aborted || binding.pinError) return;
+      if (binding.claimedID) return;
+      if (Date.now() >= deadline) {
+        throw new Error(`OpenCode's TUI did not open a session for the staged prompt within ${this.startupDeadline}ms`);
+      }
+      const request = this.requestDeadline(signal);
+      try {
+        await client.submitTUIPrompt(prompt, request.signal);
+      } finally {
+        request.dispose();
+      }
+      await sleep(this.stageRetryDelay, signal);
+    }
+  }
+
+  // OpenCode drops a variant the pinned model does not declare — MiMo declares
+  // none at all, DeepSeek Pro has no `low` — and the session then runs on
+  // whatever the model does by default. The catalog is the first place that is
+  // knowable, so an effort the model cannot honor fails the run here, naming
+  // what it does offer, instead of arriving as an unverifiable pin.
+  private async requireOfferedVariant(client: OpenCodeHTTP, model: OpenCodeModel, signal: AbortSignal): Promise<void> {
+    const request = this.requestDeadline(signal);
+    let offered: string[];
+    try {
+      offered = await client.modelVariants(model, request.signal);
+    } finally {
+      request.dispose();
+    }
+    if (offered.includes(model.variant)) return;
+    throw new Error(
+      `OpenCode model ${model.providerID}/${model.id} cannot honor the delegated variant ${model.variant}: it offers ${offered.length === 0 ? "no variants" : offered.join(", ")}`,
+    );
+  }
+
+  private async bindNativeSession(client: OpenCodeHTTP, binding: NativeBinding, nativeID: string, signal: AbortSignal): Promise<void> {
+    const request = this.requestDeadline(signal);
+    let nativeSession: unknown;
+    try {
+      nativeSession = await client.getSession(nativeID, request.signal);
+    } finally {
+      request.dispose();
+    }
+    if (signal.aborted) return;
+    const selectedModel = sessionModel(nativeSession);
+    if (binding.pin && !sessionModelMatches(nativeSession, binding.pin)) {
+      // The delegation asked for one model and OpenCode opened another, so the
+      // run is not what was delegated. Say which, and leave it unbound rather
+      // than reporting a session nobody asked for.
+      binding.pinError = `OpenCode opened its session on ${describeModel(selectedModel)} instead of the delegated pin ${describeModel(binding.pin)}`;
+      this.degraded.set(binding.record.run_id, `OpenCode run ${binding.record.attn_session_id} is degraded: ${binding.pinError}`);
+      await this.enqueueReport(binding.record, { kind: "state", state: "unknown" });
+      return;
+    }
+    const pinned = binding.mode === "pinned";
+    binding.nativeID = nativeID;
+    binding.record = await this.options.registry.update(binding.record.run_id, {
+      opencode_session_id: nativeID,
+      pinned,
+      model: selectedModel ? `${selectedModel.providerID}/${selectedModel.id}` : undefined,
+      variant: selectedModel?.variant,
+    });
+    await this.enqueueReport(binding.record, {
+      kind: "metadata",
+      metadata: {
+        schema: 1,
+        opencode_session_id: nativeID,
+        opencode_version: binding.record.opencode_version,
+        pinned,
+        ...(selectedModel ? { model: `${selectedModel.providerID}/${selectedModel.id}`, variant: selectedModel.variant } : {}),
+      },
+    });
+    const statusRequest = this.requestDeadline(signal);
+    try {
+      await this.reconcileStatus(binding.record, client, nativeID, statusRequest.signal);
+    } finally {
+      statusRequest.dispose();
+    }
+  }
+
   private async waitForHealthyServer(record: RunRecord, signal: AbortSignal): Promise<OpenCodeHTTP> {
     const deadline = Date.now() + this.startupDeadline;
     let lastError: unknown = new Error("OpenCode server did not start");
@@ -448,39 +542,11 @@ export class OpenCodeDriver {
 
   private async handleEvent(client: OpenCodeHTTP, binding: NativeBinding, event: { type: string; sessionID?: string; status?: string }, parentSignal: AbortSignal): Promise<void> {
     if (parentSignal.aborted) return;
-    if (!binding.nativeID && binding.mode === "interactive" && event.type === "session.created" && event.sessionID) {
-      const request = this.requestDeadline(parentSignal);
-      let nativeSession: unknown;
-      try {
-        nativeSession = await client.getSession(event.sessionID, request.signal);
-      } finally {
-        request.dispose();
-      }
-      if (parentSignal.aborted) return;
-      const selectedModel = sessionModel(nativeSession);
-      binding.nativeID = event.sessionID;
-      binding.record = await this.options.registry.update(binding.record.run_id, {
-        opencode_session_id: event.sessionID,
-        pinned: false,
-        model: selectedModel ? `${selectedModel.providerID}/${selectedModel.id}` : undefined,
-        variant: selectedModel?.variant,
-      });
-      await this.enqueueReport(binding.record, {
-        kind: "metadata",
-        metadata: {
-          schema: 1,
-          opencode_session_id: event.sessionID,
-          opencode_version: binding.record.opencode_version,
-          pinned: false,
-          ...(selectedModel ? { model: `${selectedModel.providerID}/${selectedModel.id}`, variant: selectedModel.variant } : {}),
-        },
-      });
-      const statusRequest = this.requestDeadline(parentSignal);
-      try {
-        await this.reconcileStatus(binding.record, client, binding.nativeID, statusRequest.signal);
-      } finally {
-        statusRequest.dispose();
-      }
+    if (!binding.claimedID && !binding.pinError && event.type === "session.created" && event.sessionID) {
+      // Claim before the bind's own round trips, so staging stops submitting the
+      // moment the TUI opened a session rather than once it is fully bound.
+      binding.claimedID = event.sessionID;
+      await this.bindNativeSession(client, binding, event.sessionID, parentSignal);
     }
     if (parentSignal.aborted || !binding.nativeID || event.sessionID !== binding.nativeID) return;
     const record = binding.record;
@@ -775,6 +841,10 @@ export class OpenCodeDriver {
     if (!this.availability.ok) throw new Error(this.availability.message);
     return this.availability;
   }
+}
+
+function describeModel(model: OpenCodeModel | undefined): string {
+  return model ? `${model.providerID}/${model.id} (${model.variant})` : "an unreadable model";
 }
 
 function cancelsClassification(event: { type: string; status?: string }): boolean {

--- a/plugins/attn-opencode/src/launcher.ts
+++ b/plugins/attn-opencode/src/launcher.ts
@@ -1,9 +1,12 @@
 import { createServer } from "node:net";
 import { chmod, open, readFile, rename, rm } from "node:fs/promises";
+import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { randomBytes } from "node:crypto";
-import type { LaunchConfig } from "./types";
+import { parseModelPin } from "./opencode-http";
+import { writePrivate } from "./run-registry";
+import { type LaunchConfig, type LaunchPin, pinnedAgent } from "./types";
 
 const maxPortAttempts = 3;
 const sourceGuidancePluginRef = pathToFileURL(join(import.meta.dir, "guidance-plugin.ts")).href;
@@ -17,23 +20,26 @@ if (import.meta.main) {
 export async function launch(path: string): Promise<number> {
   let config = await readConfig(path);
   const guidancePluginRef = process.env.ATTN_OPENCODE_GUIDANCE_PLUGIN_REF?.trim() || sourceGuidancePluginRef;
-  const opencodeConfig = opencodeConfigForLaunch(process.env.OPENCODE_CONFIG_CONTENT, config.instruction_ref, guidancePluginRef);
+  const opencodeConfig = opencodeConfigForLaunch(process.env.OPENCODE_CONFIG_CONTENT, {
+    instructionRef: config.instruction_ref,
+    pluginRef: guidancePluginRef,
+    pin: config.pin,
+  });
+  const stateHome = config.pin && config.state_dir ? await seedTUIState(config.state_dir, config.pin) : undefined;
   for (let attempt = 1; attempt <= maxPortAttempts; attempt += 1) {
     const password = (await readFile(config.password_ref, "utf8")).trim();
     const args = [config.executable, "--hostname", "127.0.0.1", "--port", String(config.port)];
     if (config.resume_session_id) args.push("--session", config.resume_session_id);
+    if (config.pin) args.push("--agent", pinnedAgent);
     if (config.yolo) args.push("--yolo");
     const child = Bun.spawn(args, {
       cwd: config.cwd,
       env: {
         ...process.env,
         OPENCODE_SERVER_PASSWORD: password,
-        ...(config.instruction_ref
-          ? {
-              ATTN_OPENCODE_INSTRUCTION_REF: config.instruction_ref,
-              OPENCODE_CONFIG_CONTENT: JSON.stringify(opencodeConfig),
-            }
-          : {}),
+        ...(config.instruction_ref ? { ATTN_OPENCODE_INSTRUCTION_REF: config.instruction_ref } : {}),
+        ...(config.instruction_ref || config.pin ? { OPENCODE_CONFIG_CONTENT: JSON.stringify(opencodeConfig) } : {}),
+        ...(stateHome ? { XDG_STATE_HOME: stateHome } : {}),
       },
       stdin: "inherit",
       stdout: "inherit",
@@ -56,9 +62,9 @@ export async function launch(path: string): Promise<number> {
 
 export function opencodeConfigForLaunch(
   existingJSON: string | undefined,
-  instructionRef?: string,
-  pluginRef = sourceGuidancePluginRef,
+  options: { instructionRef?: string; pluginRef?: string; pin?: LaunchPin } = {},
 ): Record<string, unknown> {
+  const { instructionRef, pin, pluginRef = sourceGuidancePluginRef } = options;
   let parsed: unknown = {};
   if (existingJSON !== undefined && existingJSON.trim() !== "") {
     try {
@@ -71,12 +77,13 @@ export function opencodeConfigForLaunch(
     throw new Error("invalid inherited OPENCODE_CONFIG_CONTENT: expected a JSON object");
   }
   const base = parsed as Record<string, unknown>;
-  if (!instructionRef) return base;
-  const inheritedInstructions = base.instructions ?? [];
+  const withPin = pin ? { ...base, agent: agentWithPin(base.agent, pin) } : base;
+  if (!instructionRef) return withPin;
+  const inheritedInstructions = withPin.instructions ?? [];
   if (!Array.isArray(inheritedInstructions) || !inheritedInstructions.every((value) => typeof value === "string")) {
     throw new Error("invalid inherited OPENCODE_CONFIG_CONTENT.instructions: expected an array of strings");
   }
-  const inheritedPlugins = base.plugin ?? [];
+  const inheritedPlugins = withPin.plugin ?? [];
   if (!Array.isArray(inheritedPlugins)) {
     throw new Error("invalid inherited OPENCODE_CONFIG_CONTENT.plugin: expected an array");
   }
@@ -84,8 +91,49 @@ export function opencodeConfigForLaunch(
     value === pluginRef || (Array.isArray(value) && value[0] === pluginRef)
   );
   return {
-    ...base,
+    ...withPin,
     plugin: hasGuidancePlugin ? inheritedPlugins : [...inheritedPlugins, pluginRef],
+  };
+}
+
+// The variant a submitted prompt runs on comes from the TUI's own XDG state,
+// not from the agent config, so a pinned launch gets a state directory of its
+// own seeded with the pin — which also stops the run from rewriting the user's
+// selection. Their display preferences are copied in so a delegated pane still
+// looks like their OpenCode.
+async function seedTUIState(stateDir: string, pin: LaunchPin): Promise<string> {
+  const { providerID, id } = parseModelPin(pin.model);
+  await writePrivate(join(stateDir, "opencode", "model.json"), JSON.stringify({
+    recent: [{ providerID, modelID: id }],
+    favorite: [],
+    variant: { [pin.model]: pin.variant },
+  }));
+  const inherited = join(process.env.XDG_STATE_HOME?.trim() || join(homedir(), ".local", "state"), "opencode", "kv.json");
+  try {
+    await writePrivate(join(stateDir, "opencode", "kv.json"), await readFile(inherited, "utf8"));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  return stateDir;
+}
+
+// A delegated launch pins the model on the agent OpenCode runs the session
+// with, so the TUI opens it on its first frame instead of the user's default,
+// and `--agent` selects that agent whatever `default_agent` says. The variant
+// is not settable here — the TUI takes it from its own state, which
+// `seedTUIState` writes.
+function agentWithPin(inherited: unknown, pin: LaunchPin): Record<string, unknown> {
+  if (inherited !== undefined && (typeof inherited !== "object" || inherited === null || Array.isArray(inherited))) {
+    throw new Error("invalid inherited OPENCODE_CONFIG_CONTENT.agent: expected an object");
+  }
+  const agents = (inherited ?? {}) as Record<string, unknown>;
+  const existing = agents[pinnedAgent];
+  if (existing !== undefined && (typeof existing !== "object" || existing === null || Array.isArray(existing))) {
+    throw new Error(`invalid inherited OPENCODE_CONFIG_CONTENT.agent.${pinnedAgent}: expected an object`);
+  }
+  return {
+    ...agents,
+    [pinnedAgent]: { ...(existing as Record<string, unknown> | undefined), model: pin.model },
   };
 }
 

--- a/plugins/attn-opencode/src/opencode-http.ts
+++ b/plugins/attn-opencode/src/opencode-http.ts
@@ -105,15 +105,19 @@ export class OpenCodeHTTP {
     return body.map((entry) => asString(asObject(entry)?.id)).filter((id): id is string => id !== undefined);
   }
 
+  // OpenCode's message order is not contractually chronological, so the user
+  // message is the first one with that role, not the first one in the list.
   async userPromptText(sessionID: string, signal?: AbortSignal): Promise<string | undefined> {
-    const messages = await this.listMessages(sessionID, 1, signal);
-    const first = asObject(messages[0]);
-    const info = asObject(first?.info) ?? first;
-    if (asString(info?.role) !== "user") return undefined;
-    const parts = Array.isArray(first?.parts) ? first.parts : [];
-    const text = parts.map((part) => asObject(part)).filter((part) => asString(part?.type) === "text")
-      .map((part) => asString(part?.text) ?? "").join("");
-    return text === "" ? undefined : text;
+    const messages = await this.listMessages(sessionID, 5, signal);
+    for (const message of messages) {
+      const entry = asObject(message);
+      if (asString((asObject(entry?.info) ?? entry)?.role) !== "user") continue;
+      const parts = Array.isArray(entry?.parts) ? entry.parts : [];
+      const text = parts.map((part) => asObject(part)).filter((part) => asString(part?.type) === "text")
+        .map((part) => asString(part?.text) ?? "").join("");
+      if (text !== "") return text;
+    }
+    return undefined;
   }
 
   async listToolIDs(signal?: AbortSignal): Promise<string[]> {

--- a/plugins/attn-opencode/src/opencode-http.ts
+++ b/plugins/attn-opencode/src/opencode-http.ts
@@ -55,6 +55,19 @@ export class OpenCodeHTTP {
     return body.id;
   }
 
+  // Variants are per model: OpenCode Zen's DeepSeek offers low/high/max, MiMo
+  // offers none at all, and a variant a model does not declare is dropped
+  // silently wherever it is asked for.
+  async modelVariants(model: Omit<OpenCodeModel, "variant">, signal?: AbortSignal): Promise<string[]> {
+    const body = await this.request<unknown>("/config/providers", { signal });
+    const providers = asObject(body)?.providers;
+    if (!Array.isArray(providers)) throw new Error("OpenCode provider catalog response was invalid");
+    const provider = providers.map(asObject).find((entry) => asString(entry?.id) === model.providerID);
+    const entry = asObject(asObject(provider?.models)?.[model.id]);
+    if (!entry) throw new Error(`OpenCode has no model ${model.providerID}/${model.id}`);
+    return Object.keys(asObject(entry.variants) ?? {});
+  }
+
   async getSession(sessionID: string, signal?: AbortSignal): Promise<unknown> {
     return this.request(`/session/${encodeURIComponent(sessionID)}`, { signal });
   }
@@ -112,23 +125,13 @@ export class OpenCodeHTTP {
     await this.request(`/session/${encodeURIComponent(sessionID)}`, { method: "DELETE", signal });
   }
 
-  async selectSession(sessionID: string, signal?: AbortSignal): Promise<void> {
-    await this.request("/tui/select-session", { method: "POST", body: { sessionID }, signal });
-  }
-
-  async promptAsync(sessionID: string, prompt: string, model: OpenCodeModel, signal?: AbortSignal): Promise<void> {
-    await this.request(`/session/${encodeURIComponent(sessionID)}/prompt_async`, {
-      method: "POST",
-      // OpenCode uses different model shapes for native session creation and
-      // prompt submission. Keep the translation at this HTTP boundary so the
-      // rest of the driver continues to preserve one native-session identity.
-      body: {
-        parts: [{ type: "text", text: prompt }],
-        model: { providerID: model.providerID, modelID: model.id },
-        variant: model.variant,
-      },
-      signal,
-    });
+  // The TUI reads these as bus events and answers nothing: the response is
+  // `true` even when no TUI is attached to the event stream at all. Only the
+  // session a submission creates proves the TUI received anything.
+  async submitTUIPrompt(prompt: string, signal?: AbortSignal): Promise<void> {
+    await this.request("/tui/clear-prompt", { method: "POST", body: {}, signal });
+    await this.request("/tui/append-prompt", { method: "POST", body: { text: prompt }, signal });
+    await this.request("/tui/submit-prompt", { method: "POST", body: {}, signal });
   }
 
   async statusFor(sessionID: string, signal?: AbortSignal): Promise<string | undefined> {

--- a/plugins/attn-opencode/src/opencode-http.ts
+++ b/plugins/attn-opencode/src/opencode-http.ts
@@ -97,6 +97,25 @@ export class OpenCodeHTTP {
     throw new Error("OpenCode message list response was invalid");
   }
 
+  // Sessions are stored per project directory, so this lists every session in
+  // the run's directory, not only the ones this run opened.
+  async listSessionIDs(signal?: AbortSignal): Promise<string[]> {
+    const body = await this.request<unknown>("/session", { signal });
+    if (!Array.isArray(body)) throw new Error("OpenCode session list response was invalid");
+    return body.map((entry) => asString(asObject(entry)?.id)).filter((id): id is string => id !== undefined);
+  }
+
+  async userPromptText(sessionID: string, signal?: AbortSignal): Promise<string | undefined> {
+    const messages = await this.listMessages(sessionID, 1, signal);
+    const first = asObject(messages[0]);
+    const info = asObject(first?.info) ?? first;
+    if (asString(info?.role) !== "user") return undefined;
+    const parts = Array.isArray(first?.parts) ? first.parts : [];
+    const text = parts.map((part) => asObject(part)).filter((part) => asString(part?.type) === "text")
+      .map((part) => asString(part?.text) ?? "").join("");
+    return text === "" ? undefined : text;
+  }
+
   async listToolIDs(signal?: AbortSignal): Promise<string[]> {
     const body = await this.request<unknown>("/experimental/tool/ids", { signal });
     const root = asObject(body);

--- a/plugins/attn-opencode/src/run-registry.ts
+++ b/plugins/attn-opencode/src/run-registry.ts
@@ -115,6 +115,12 @@ export class RunRegistry {
     });
   }
 
+  // A pinned run gets its own OpenCode TUI state, so it opens on the delegated
+  // model and cannot rewrite the user's own selection. See `seedTUIState`.
+  stateDir(runID: string): string {
+    return join(this.root, "state", safeRunID(runID));
+  }
+
   async password(record: RunRecord): Promise<string> {
     return readPrivate(record.password_ref);
   }
@@ -151,6 +157,7 @@ export class RunRegistry {
         record.prompt_ref ? rm(record.prompt_ref, { force: true }) : Promise.resolve(),
         record.instruction_ref ? rm(record.instruction_ref, { force: true }) : Promise.resolve(),
         rm(record.launch_config_ref, { force: true }),
+        rm(this.stateDir(record.run_id), { force: true, recursive: true }),
       ]);
     });
   }

--- a/plugins/attn-opencode/src/types.ts
+++ b/plugins/attn-opencode/src/types.ts
@@ -166,6 +166,16 @@ export type RunRecord = {
   created_at: string;
 };
 
+// OpenCode's built-in primary agent, and the one its HTTP-created sessions
+// already ran as. A delegated launch pins it so the model the delegation asked
+// for is the model the TUI opens with.
+export const pinnedAgent = "build";
+
+export type LaunchPin = {
+  model: string;
+  variant: string;
+};
+
 export type LaunchConfig = {
   schema: 1;
   run_id: string;
@@ -176,6 +186,8 @@ export type LaunchConfig = {
   yolo: boolean;
   resume_session_id?: string;
   instruction_ref?: string;
+  pin?: LaunchPin;
+  state_dir?: string;
 };
 
 export type ReportState = "working" | "waiting_input" | "pending_approval" | "idle" | "unknown";

--- a/plugins/attn-opencode/test/driver.test.ts
+++ b/plugins/attn-opencode/test/driver.test.ts
@@ -280,6 +280,47 @@ describe("OpenCode server-backed driver", () => {
     expect(target.tuiSubmissions).toHaveLength(1);
   });
 
+  test("binds the session its staged prompt opened when the event announcing it is lost", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*");
+    // The TUI takes the prompt and opens a session, but its `session.created`
+    // never reaches the driver.
+    target.dropSessionCreatedEvent = true;
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = driverFor(rpc, registry, target);
+    await driver.initialize();
+    await driver.spawn(params("run-lost-receipt"));
+
+    await eventually(
+      () => rpc.calls.some((call) => call.method === "session.report_metadata"),
+      () => `bind from the opened session; submissions=${target.tuiSubmissions.length}; health=${JSON.stringify(driver.health())}`,
+    );
+    expect(target.tuiSubmissions).toHaveLength(1);
+    expect((await registry.get("run-lost-receipt"))?.opencode_session_id).toBe("native-1");
+    expect(driver.health().ok).toBe(true);
+  });
+
+  test("leaves a promptless pinned launch to the pane and binds what it opens", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*");
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = driverFor(rpc, registry, target);
+    await driver.initialize();
+    await driver.spawn({ ...params("run-no-prompt"), initial_prompt: undefined });
+
+    await eventually(() => target.eventSubscriberCount === 1, "subscribed run");
+    expect(target.tuiSubmissions).toHaveLength(0);
+    // The TUI opens on the pinned model either way, so the first session the
+    // user submits there is this run's session.
+    target.sessions.set("native-1", { id: "native-1", model: target.tuiModel });
+    target.emit("session.created", { sessionID: "native-1" });
+    await eventually(
+      () => rpc.calls.some((call) => call.method === "session.report_metadata"),
+      "bind from the pane's own session",
+    );
+    expect((await registry.get("run-no-prompt"))?.opencode_session_id).toBe("native-1");
+  });
+
   test("refuses a delegated effort the pinned model does not offer", async () => {
     const rpc = new RecordingRPC();
     const target = server("*");

--- a/plugins/attn-opencode/test/driver.test.ts
+++ b/plugins/attn-opencode/test/driver.test.ts
@@ -177,8 +177,10 @@ describe("OpenCode server-backed driver", () => {
 
     const launch = await driver.spawn(params());
     expect(launch.argv.slice(0, 3)).toEqual([process.execPath, "run", expect.stringContaining("launcher.ts")]);
+    // The submission is recorded before the bind it triggers runs, so wait on
+    // the bind's own report rather than on the submission.
     await eventually(
-      () => target.tuiSubmissions.length === 1,
+      () => rpc.calls.some((call) => call.method === "session.report_metadata"),
       () => `staged prompt submission; health=${JSON.stringify(driver.health())}; requests=${JSON.stringify(target.requests)}; calls=${JSON.stringify(rpc.calls)}`,
     );
     expect(target.requests.some((request) => request.path === "/event")).toBe(true);
@@ -329,7 +331,10 @@ describe("OpenCode server-backed driver", () => {
     const driver = driverFor(rpc, registry, target);
     await driver.initialize();
     await driver.spawn(params("run-attention-events"));
-    await eventually(() => target.tuiSubmissions.length === 1, "native prompt submission");
+    await eventually(
+      () => rpc.calls.some((call) => call.method === "session.report_metadata"),
+      "native prompt submission and bind",
+    );
 
     const reportsBeforeOtherSession = rpc.calls.length;
     target.askQuestion("native-other", "question-other");
@@ -374,7 +379,10 @@ describe("OpenCode server-backed driver", () => {
     const driver = driverFor(rpc, registry, target);
     await driver.initialize();
     await driver.spawn(params("run-overlapping-attention"));
-    await eventually(() => target.tuiSubmissions.length === 1, "native prompt submission");
+    await eventually(
+      () => rpc.calls.some((call) => call.method === "session.report_metadata"),
+      "native prompt submission and bind",
+    );
 
     target.askPermission("native-1", "permission-overlap");
     await eventually(
@@ -418,7 +426,10 @@ describe("OpenCode server-backed driver", () => {
     const driver = driverFor(rpc, registry, target);
     await driver.initialize();
     await driver.spawn(params("run-idle-attention"));
-    await eventually(() => target.tuiSubmissions.length === 1, "native prompt submission");
+    await eventually(
+      () => rpc.calls.some((call) => call.method === "session.report_metadata"),
+      "native prompt submission and bind",
+    );
 
     target.pendingQuestions.set("question-idle", "native-1");
     target.emit("session.idle", { sessionID: "native-1" });
@@ -453,7 +464,10 @@ describe("OpenCode server-backed driver", () => {
     const driver = driverFor(rpc, registry, target);
     await driver.initialize();
     await driver.spawn(params("run-prose-verdicts"));
-    await eventually(() => target.tuiSubmissions.length === 1, "native prompt submission");
+    await eventually(
+      () => rpc.calls.some((call) => call.method === "session.report_metadata"),
+      "native prompt submission and bind",
+    );
 
     target.messages.set("native-1", [assistantMessage("message-question", "Should I continue?")]);
     target.classifierReplies.push('{"verdict":"WAITING"}');
@@ -485,7 +499,10 @@ describe("OpenCode server-backed driver", () => {
     const driver = driverFor(rpc, registry, target);
     await driver.initialize();
     await driver.spawn(params("run-prose-cache"));
-    await eventually(() => target.tuiSubmissions.length === 1, "native prompt submission");
+    await eventually(
+      () => rpc.calls.some((call) => call.method === "session.report_metadata"),
+      "native prompt submission and bind",
+    );
     target.messages.set("native-1", [assistantMessage("same-message", "Which option should I use?")]);
     target.classifierReplies.push('{"verdict":"WAITING"}');
 
@@ -512,7 +529,10 @@ describe("OpenCode server-backed driver", () => {
     const driver = driverFor(rpc, registry, target);
     await driver.initialize();
     await driver.spawn(params("run-prose-malformed"));
-    await eventually(() => target.tuiSubmissions.length === 1, "native prompt submission");
+    await eventually(
+      () => rpc.calls.some((call) => call.method === "session.report_metadata"),
+      "native prompt submission and bind",
+    );
     target.messages.set("native-1", [assistantMessage("message-malformed", "Can you choose?")]);
     target.classifierReplies.push("WAITING");
     target.emit("session.idle", { sessionID: "native-1" });
@@ -527,7 +547,10 @@ describe("OpenCode server-backed driver", () => {
     const driver = driverFor(rpc, registry, target);
     await driver.initialize();
     await driver.spawn(params("run-idle-reconcile-failure"));
-    await eventually(() => target.tuiSubmissions.length === 1, "native prompt submission");
+    await eventually(
+      () => rpc.calls.some((call) => call.method === "session.report_metadata"),
+      "native prompt submission and bind",
+    );
     target.failPendingLists = true;
     target.emit("session.idle", { sessionID: "native-1" });
     await eventually(() => rpc.calls.at(-1)?.method === "session.report_stop", "unknown reconciliation verdict");
@@ -554,7 +577,10 @@ describe("OpenCode server-backed driver", () => {
       });
       await driver.initialize();
       await driver.spawn(params(`run-cancel-${newerEvent}`));
-      await eventually(() => target.tuiSubmissions.length === 1, "native prompt submission");
+      await eventually(
+      () => rpc.calls.some((call) => call.method === "session.report_metadata"),
+      "native prompt submission and bind",
+    );
       target.messages.set("native-1", [assistantMessage("message-blocked", "What next?")]);
       target.emit("session.idle", { sessionID: "native-1" });
       await eventually(() => classifier.inputs.length === 1, "classifier started");
@@ -592,7 +618,10 @@ describe("OpenCode server-backed driver", () => {
     });
     await driver.initialize();
     await driver.spawn(params("run-benign-session-update"));
-    await eventually(() => target.tuiSubmissions.length === 1, "native prompt submission");
+    await eventually(
+      () => rpc.calls.some((call) => call.method === "session.report_metadata"),
+      "native prompt submission and bind",
+    );
     target.messages.set("native-1", [assistantMessage("message-benign", "Should I continue?")]);
     target.emit("session.idle", { sessionID: "native-1" });
     await eventually(() => classifier.inputs.length === 1, "classifier started");
@@ -610,7 +639,10 @@ describe("OpenCode server-backed driver", () => {
     const driver = driverFor(rpc, registry, target);
     await driver.initialize();
     await driver.spawn(params("run-question-reconnect"));
-    await eventually(() => target.tuiSubmissions.length === 1 && target.eventSubscriberCount === 1, "initial native run");
+    await eventually(
+      () => rpc.calls.some((call) => call.method === "session.report_metadata") && target.eventSubscriberCount === 1,
+      "initial native run",
+    );
 
     target.pendingQuestions.set("question-missed", "native-1");
     target.closeEvents();
@@ -629,7 +661,10 @@ describe("OpenCode server-backed driver", () => {
     const driver = driverFor(rpc, registry, target);
     await driver.initialize();
     await driver.spawn(params("run-question-reconnect-order"));
-    await eventually(() => target.tuiSubmissions.length === 1 && target.eventSubscriberCount === 1, "initial native run");
+    await eventually(
+      () => rpc.calls.some((call) => call.method === "session.report_metadata") && target.eventSubscriberCount === 1,
+      "initial native run",
+    );
 
     target.pendingQuestions.set("question-race", "native-1");
     let releaseSnapshot!: () => void;
@@ -1064,7 +1099,10 @@ describe("OpenCode server-backed driver", () => {
     });
     await driver.initialize();
     await driver.spawn(params("run-classifier-timeout"));
-    await eventually(() => target.tuiSubmissions.length === 1, "native prompt submission");
+    await eventually(
+      () => rpc.calls.some((call) => call.method === "session.report_metadata"),
+      "native prompt submission and bind",
+    );
     target.messages.set("native-1", [assistantMessage("message-timeout", "Are you there?")]);
     target.emit("session.idle", { sessionID: "native-1" });
     await eventually(() => (rpc.calls.at(-1)?.params as { verdict?: string }).verdict === "unknown", "timed-out unknown verdict");

--- a/plugins/attn-opencode/test/driver.test.ts
+++ b/plugins/attn-opencode/test/driver.test.ts
@@ -109,6 +109,7 @@ function driverFor(rpc: RecordingRPC, registry: RunRegistry, target: FakeOpenCod
     http: (port, password) => new OpenCodeHTTP({ port, password }),
     startupDeadline: 300,
     reconnectDelay: 5,
+    stageRetryDelay: 5,
   });
 }
 
@@ -177,7 +178,7 @@ describe("OpenCode server-backed driver", () => {
     const launch = await driver.spawn(params());
     expect(launch.argv.slice(0, 3)).toEqual([process.execPath, "run", expect.stringContaining("launcher.ts")]);
     await eventually(
-      () => target.prompts.length === 1,
+      () => target.tuiSubmissions.length === 1,
       () => `staged prompt submission; health=${JSON.stringify(driver.health())}; requests=${JSON.stringify(target.requests)}; calls=${JSON.stringify(rpc.calls)}`,
     );
     expect(target.requests.some((request) => request.path === "/event")).toBe(true);
@@ -186,11 +187,8 @@ describe("OpenCode server-backed driver", () => {
 
     const created = target.sessions.get("native-1") as { model: { providerID: string; id: string; variant: string } };
     expect(created.model).toEqual({ providerID: "spotify-glm", id: "zai-org/GLM-5.2-FP8", variant: "max" });
-    expect(target.prompts[0]?.body).toEqual({
-      parts: [{ type: "text", text: "Say GLM_SPIKE_OK" }],
-      model: { providerID: "spotify-glm", modelID: "zai-org/GLM-5.2-FP8" },
-      variant: "max",
-    });
+    expect(target.tuiSubmissions).toEqual([{ sessionID: "native-1", text: "Say GLM_SPIKE_OK" }]);
+    expect(target.requests.some((request) => request.path === "/session" && request.method === "POST")).toBe(false);
 
     target.emit("session.status", { sessionID: "native-1", status: { type: "busy" } });
     target.emit("session.status", { sessionID: "native-1", status: { type: "retry" } });
@@ -204,6 +202,97 @@ describe("OpenCode server-backed driver", () => {
     ]);
     const sequences = rpc.calls.slice(1).map((call) => (call.params as { seq: number }).seq);
     expect(sequences).toEqual([1, 2, 3, 4]);
+  });
+
+  test("keeps staging the delegated turn until the TUI attaches, then binds the session it opened", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*");
+    target.tuiAttached = false;
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = driverFor(rpc, registry, target);
+    await driver.initialize();
+    await driver.spawn(params("run-late-tui"));
+
+    // A submission published before the TUI attaches is answered and dropped.
+    await eventually(
+      () => target.requests.filter((request) => request.path === "/tui/submit-prompt").length >= 2,
+      "repeated staging while the TUI is detached",
+    );
+    expect(target.tuiSubmissions).toHaveLength(0);
+    expect(rpc.calls.map((call) => call.method)).toEqual(["driver.register"]);
+
+    target.tuiAttached = true;
+    await eventually(() => rpc.calls.some((call) => call.method === "session.report_metadata"), "binding after the TUI attaches");
+    expect(target.tuiSubmissions).toEqual([{ sessionID: "native-1", text: "Say GLM_SPIKE_OK" }]);
+    expect(await registry.get("run-late-tui")).toEqual(expect.objectContaining({
+      opencode_session_id: "native-1",
+      pinned: true,
+      model: "spotify-glm/zai-org/GLM-5.2-FP8",
+      variant: "max",
+    }));
+
+    // The staging loop stops on the receipt: no second turn, and a hidden
+    // classifier session created later never steals the binding.
+    const submissions = target.requests.filter((request) => request.path === "/tui/submit-prompt").length;
+    target.emit("session.created", { sessionID: "native-hidden" });
+    await Bun.sleep(30);
+    expect(target.requests.filter((request) => request.path === "/tui/submit-prompt")).toHaveLength(submissions);
+    expect(target.tuiSubmissions).toHaveLength(1);
+    expect((await registry.get("run-late-tui"))?.opencode_session_id).toBe("native-1");
+  });
+
+  test("degrades loudly when OpenCode opens the delegated session on another model", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*");
+    target.tuiModel = { providerID: "opencode-go", id: "mimo-v2.5", variant: "low" };
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = driverFor(rpc, registry, target);
+    await driver.initialize();
+    await driver.spawn(params("run-wrong-model"));
+
+    await eventually(() => driver.health().ok === false, "degraded pin mismatch");
+    expect(driver.health().message).toContain(
+      "OpenCode opened its session on opencode-go/mimo-v2.5 (low) instead of the delegated pin spotify-glm/zai-org/GLM-5.2-FP8 (max)",
+    );
+    expect(rpc.calls.filter((call) => call.method === "session.report_metadata")).toHaveLength(0);
+    expect(rpc.calls.at(-1)).toEqual(expect.objectContaining({
+      method: "session.report_state",
+      params: expect.objectContaining({ state: "unknown" }),
+    }));
+    expect((await registry.get("run-wrong-model"))?.opencode_session_id).toBeUndefined();
+  });
+
+  test("stages the delegated turn once even while the bind is still in flight", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*");
+    // The session read the bind depends on never answers, so only the claim made
+    // when `session.created` arrived can stop the staging loop.
+    target.hangingSessionReads.add("native-1");
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = driverFor(rpc, registry, target);
+    await driver.initialize();
+    await driver.spawn(params("run-stage-once"));
+
+    await eventually(() => target.tuiSubmissions.length === 1, "staged turn");
+    await Bun.sleep(60);
+    expect(target.tuiSubmissions).toHaveLength(1);
+  });
+
+  test("refuses a delegated effort the pinned model does not offer", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*");
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = driverFor(rpc, registry, target);
+    await driver.initialize();
+    await driver.spawn({ ...params("run-no-variant"), model: "opencode-go/mimo-v2.5" });
+
+    await eventually(() => driver.health().ok === false, "degraded unofferable variant");
+    expect(driver.health().message).toContain(
+      "OpenCode model opencode-go/mimo-v2.5 cannot honor the delegated variant max: it offers no variants",
+    );
+    // The run fails before anything is staged, so no session runs unpinned.
+    expect(target.tuiSubmissions).toHaveLength(0);
+    expect((await registry.get("run-no-variant"))?.opencode_session_id).toBeUndefined();
   });
 
   test("uses the standalone executable as its launcher without requiring Bun", async () => {
@@ -240,7 +329,7 @@ describe("OpenCode server-backed driver", () => {
     const driver = driverFor(rpc, registry, target);
     await driver.initialize();
     await driver.spawn(params("run-attention-events"));
-    await eventually(() => target.prompts.length === 1, "native prompt submission");
+    await eventually(() => target.tuiSubmissions.length === 1, "native prompt submission");
 
     const reportsBeforeOtherSession = rpc.calls.length;
     target.askQuestion("native-other", "question-other");
@@ -285,7 +374,7 @@ describe("OpenCode server-backed driver", () => {
     const driver = driverFor(rpc, registry, target);
     await driver.initialize();
     await driver.spawn(params("run-overlapping-attention"));
-    await eventually(() => target.prompts.length === 1, "native prompt submission");
+    await eventually(() => target.tuiSubmissions.length === 1, "native prompt submission");
 
     target.askPermission("native-1", "permission-overlap");
     await eventually(
@@ -329,7 +418,7 @@ describe("OpenCode server-backed driver", () => {
     const driver = driverFor(rpc, registry, target);
     await driver.initialize();
     await driver.spawn(params("run-idle-attention"));
-    await eventually(() => target.prompts.length === 1, "native prompt submission");
+    await eventually(() => target.tuiSubmissions.length === 1, "native prompt submission");
 
     target.pendingQuestions.set("question-idle", "native-1");
     target.emit("session.idle", { sessionID: "native-1" });
@@ -364,7 +453,7 @@ describe("OpenCode server-backed driver", () => {
     const driver = driverFor(rpc, registry, target);
     await driver.initialize();
     await driver.spawn(params("run-prose-verdicts"));
-    await eventually(() => target.prompts.length === 1, "native prompt submission");
+    await eventually(() => target.tuiSubmissions.length === 1, "native prompt submission");
 
     target.messages.set("native-1", [assistantMessage("message-question", "Should I continue?")]);
     target.classifierReplies.push('{"verdict":"WAITING"}');
@@ -386,9 +475,7 @@ describe("OpenCode server-backed driver", () => {
       (call.params as { verdict: string }).verdict)).toEqual(["waiting_input", "idle"]);
     expect(target.classifierPrompts).toHaveLength(2);
     expect(target.deletedSessions).toEqual(["native-2", "native-3"]);
-    expect(target.requests.filter((request) => request.path === "/tui/select-session").map((request) => request.body)).toEqual([
-      { sessionID: "native-1" },
-    ]);
+    expect(target.tuiSubmissions).toEqual([{ sessionID: "native-1", text: "Say GLM_SPIKE_OK" }]);
   });
 
   test("reuses a cached message verdict while reserving a fresh report sequence", async () => {
@@ -398,7 +485,7 @@ describe("OpenCode server-backed driver", () => {
     const driver = driverFor(rpc, registry, target);
     await driver.initialize();
     await driver.spawn(params("run-prose-cache"));
-    await eventually(() => target.prompts.length === 1, "native prompt submission");
+    await eventually(() => target.tuiSubmissions.length === 1, "native prompt submission");
     target.messages.set("native-1", [assistantMessage("same-message", "Which option should I use?")]);
     target.classifierReplies.push('{"verdict":"WAITING"}');
 
@@ -425,7 +512,7 @@ describe("OpenCode server-backed driver", () => {
     const driver = driverFor(rpc, registry, target);
     await driver.initialize();
     await driver.spawn(params("run-prose-malformed"));
-    await eventually(() => target.prompts.length === 1, "native prompt submission");
+    await eventually(() => target.tuiSubmissions.length === 1, "native prompt submission");
     target.messages.set("native-1", [assistantMessage("message-malformed", "Can you choose?")]);
     target.classifierReplies.push("WAITING");
     target.emit("session.idle", { sessionID: "native-1" });
@@ -440,7 +527,7 @@ describe("OpenCode server-backed driver", () => {
     const driver = driverFor(rpc, registry, target);
     await driver.initialize();
     await driver.spawn(params("run-idle-reconcile-failure"));
-    await eventually(() => target.prompts.length === 1, "native prompt submission");
+    await eventually(() => target.tuiSubmissions.length === 1, "native prompt submission");
     target.failPendingLists = true;
     target.emit("session.idle", { sessionID: "native-1" });
     await eventually(() => rpc.calls.at(-1)?.method === "session.report_stop", "unknown reconciliation verdict");
@@ -463,10 +550,11 @@ describe("OpenCode server-backed driver", () => {
         stopClassifier: () => classifier,
         startupDeadline: 300,
         reconnectDelay: 5,
+        stageRetryDelay: 5,
       });
       await driver.initialize();
       await driver.spawn(params(`run-cancel-${newerEvent}`));
-      await eventually(() => target.prompts.length === 1, "native prompt submission");
+      await eventually(() => target.tuiSubmissions.length === 1, "native prompt submission");
       target.messages.set("native-1", [assistantMessage("message-blocked", "What next?")]);
       target.emit("session.idle", { sessionID: "native-1" });
       await eventually(() => classifier.inputs.length === 1, "classifier started");
@@ -500,10 +588,11 @@ describe("OpenCode server-backed driver", () => {
       stopClassifier: () => classifier,
       startupDeadline: 300,
       reconnectDelay: 5,
+      stageRetryDelay: 5,
     });
     await driver.initialize();
     await driver.spawn(params("run-benign-session-update"));
-    await eventually(() => target.prompts.length === 1, "native prompt submission");
+    await eventually(() => target.tuiSubmissions.length === 1, "native prompt submission");
     target.messages.set("native-1", [assistantMessage("message-benign", "Should I continue?")]);
     target.emit("session.idle", { sessionID: "native-1" });
     await eventually(() => classifier.inputs.length === 1, "classifier started");
@@ -521,7 +610,7 @@ describe("OpenCode server-backed driver", () => {
     const driver = driverFor(rpc, registry, target);
     await driver.initialize();
     await driver.spawn(params("run-question-reconnect"));
-    await eventually(() => target.prompts.length === 1 && target.eventSubscriberCount === 1, "initial native run");
+    await eventually(() => target.tuiSubmissions.length === 1 && target.eventSubscriberCount === 1, "initial native run");
 
     target.pendingQuestions.set("question-missed", "native-1");
     target.closeEvents();
@@ -540,7 +629,7 @@ describe("OpenCode server-backed driver", () => {
     const driver = driverFor(rpc, registry, target);
     await driver.initialize();
     await driver.spawn(params("run-question-reconnect-order"));
-    await eventually(() => target.prompts.length === 1 && target.eventSubscriberCount === 1, "initial native run");
+    await eventually(() => target.tuiSubmissions.length === 1 && target.eventSubscriberCount === 1, "initial native run");
 
     target.pendingQuestions.set("question-race", "native-1");
     let releaseSnapshot!: () => void;
@@ -581,7 +670,7 @@ describe("OpenCode server-backed driver", () => {
     });
     await eventually(() => target.requests.some((request) => request.path === "/event"), "interactive SSE subscription");
     expect(target.requests.some((request) => request.path === "/session" && request.method === "POST")).toBe(false);
-    expect(target.prompts).toHaveLength(0);
+    expect(target.tuiSubmissions).toHaveLength(0);
 
     target.sessions.set("native-default", {
       id: "native-default",
@@ -658,8 +747,8 @@ describe("OpenCode server-backed driver", () => {
         variant: "low",
       },
     });
-    await eventually(() => target.requests.some((request) => request.path === "/tui/select-session"), "resume selection");
-    expect(target.prompts).toHaveLength(0);
+    await eventually(() => target.requests.some((request) => request.path === "/session/native-resume"), "resume identity read");
+    expect(target.tuiSubmissions).toHaveLength(0);
     expect(target.requests.some((request) => request.path === "/session/native-resume")).toBe(true);
 
     await expect(driver.resume({
@@ -691,6 +780,7 @@ describe("OpenCode server-backed driver", () => {
       http: (port, password) => new OpenCodeHTTP({ port, password }),
       startupDeadline: 300,
       reconnectDelay: 5,
+      stageRetryDelay: 5,
     });
     await driver.initialize();
     await driver.resume({
@@ -705,7 +795,7 @@ describe("OpenCode server-backed driver", () => {
         variant: "low",
       },
     });
-    await eventually(() => target.requests.some((request) => request.path === "/tui/select-session"), "upgraded resume selection");
+    await eventually(() => target.requests.some((request) => request.path === "/session/native-upgrade"), "upgraded resume identity read");
     expect(await registry.get("run-forward-upgrade")).toEqual(expect.objectContaining({
       opencode_session_id: "native-upgrade",
       opencode_version: "1.18.0",
@@ -748,6 +838,7 @@ describe("OpenCode server-backed driver", () => {
       http: (port, password) => new OpenCodeHTTP({ port, password }),
       startupDeadline: 40,
       reconnectDelay: 5,
+      stageRetryDelay: 5,
     });
     await driver.initialize();
     await driver.spawn({ session_id: "attn-version-mismatch", run_id: "run-version-mismatch", cwd: "/tmp" });
@@ -784,7 +875,7 @@ describe("OpenCode server-backed driver", () => {
         variant: "max",
       },
     });
-    await eventually(() => target.requests.some((request) => request.path === "/tui/select-session"), "interactive resume selection");
+    await eventually(() => target.requests.some((request) => request.path === "/session/native-default"), "interactive resume identity read");
     expect(target.requests.some((request) => request.path === "/session" && request.method === "POST")).toBe(false);
     expect(await registry.get("run-interactive-resume")).toEqual(expect.objectContaining({
       opencode_session_id: "native-default",
@@ -825,18 +916,23 @@ describe("OpenCode server-backed driver", () => {
       http: (port, password) => new OpenCodeHTTP({ port, password }),
       startupDeadline: 300,
       reconnectDelay: 5,
+      stageRetryDelay: 5,
     });
     await driver.initialize();
+    // Each TUI opens the variant its own launch config pinned.
+    first.tuiModel = { providerID: "spotify-glm", id: "zai-org/GLM-5.2-FP8", variant: "low" };
+    second.tuiModel = { providerID: "spotify-glm", id: "zai-org/GLM-5.2-FP8", variant: "max" };
     await Promise.all([
       driver.spawn({ ...params("run-low"), effort: "low", initial_prompt: "first" }),
       driver.spawn({ ...params("run-max"), effort: "max", initial_prompt: "second" }),
     ]);
-    await eventually(() => first.prompts.length === 1 && second.prompts.length === 1, "both isolated prompt submissions");
-    const firstModel = (first.sessions.get("native-1") as { model: { variant: string } }).model;
-    const secondModel = (second.sessions.get("native-1") as { model: { variant: string } }).model;
-    expect([firstModel.variant, secondModel.variant].sort()).toEqual(["low", "max"]);
+    await eventually(() => first.tuiSubmissions.length === 1 && second.tuiSubmissions.length === 1, "both isolated prompt submissions");
     const low = await registry.get("run-low");
     const max = await registry.get("run-max");
+    expect(low?.variant).toBe("low");
+    expect(max?.variant).toBe("max");
+    expect((await registry.readLaunchConfig(low!)).pin).toEqual({ model: "spotify-glm/zai-org/GLM-5.2-FP8", variant: "low" });
+    expect((await registry.readLaunchConfig(max!)).pin).toEqual({ model: "spotify-glm/zai-org/GLM-5.2-FP8", variant: "max" });
     expect(low?.port).not.toBe(max?.port);
     expect(low?.password_ref).not.toBe(max?.password_ref);
     expect(await registry.password(low!)).not.toBe(await registry.password(max!));
@@ -893,6 +989,7 @@ describe("OpenCode server-backed driver", () => {
       http: (port, password) => new OpenCodeHTTP({ port, password }),
       startupDeadline: 300,
       reconnectDelay: 5,
+      stageRetryDelay: 5,
     });
     await driver.initialize();
 
@@ -903,9 +1000,8 @@ describe("OpenCode server-backed driver", () => {
     expect(await registry.get("run-orphan")).toBeUndefined();
     expect(await registry.get("run-recovery")).toBeDefined();
     expect([...target.sessions.keys()]).toEqual(["native-recovery"]);
-    expect(target.requests.filter((request) => request.path === "/tui/select-session").map((request) => request.body)).toEqual([
-      { sessionID: "native-recovery" },
-    ]);
+    expect(target.tuiSubmissions).toHaveLength(0);
+    expect(target.requests.some((request) => request.path.startsWith("/tui/"))).toBe(false);
     await driver.sessionClosed({ session_id: "attn-recovery", run_id: "run-recovery", reason: "test cleanup" });
   });
 
@@ -923,10 +1019,11 @@ describe("OpenCode server-backed driver", () => {
       http: (port, password) => new OpenCodeHTTP({ port, password }),
       startupDeadline: 300,
       reconnectDelay: 5,
+      stageRetryDelay: 5,
     });
     await driver.initialize();
     await Promise.all([driver.spawn(params("run-classifier-first")), driver.spawn(params("run-classifier-second"))]);
-    await eventually(() => first.prompts.length === 1 && second.prompts.length === 1, "both native runs");
+    await eventually(() => first.tuiSubmissions.length === 1 && second.tuiSubmissions.length === 1, "both native runs");
     first.messages.set("native-1", [assistantMessage("same-id", "Same text?")]);
     second.messages.set("native-1", [assistantMessage("same-id", "Same text?")]);
     first.classifierReplies.push('{"verdict":"WAITING"}');
@@ -963,10 +1060,11 @@ describe("OpenCode server-backed driver", () => {
       classifierTimeout: 5,
       startupDeadline: 300,
       reconnectDelay: 5,
+      stageRetryDelay: 5,
     });
     await driver.initialize();
     await driver.spawn(params("run-classifier-timeout"));
-    await eventually(() => target.prompts.length === 1, "native prompt submission");
+    await eventually(() => target.tuiSubmissions.length === 1, "native prompt submission");
     target.messages.set("native-1", [assistantMessage("message-timeout", "Are you there?")]);
     target.emit("session.idle", { sessionID: "native-1" });
     await eventually(() => (rpc.calls.at(-1)?.params as { verdict?: string }).verdict === "unknown", "timed-out unknown verdict");
@@ -1003,6 +1101,7 @@ describe("OpenCode server-backed driver", () => {
         http: (port, password) => new OpenCodeHTTP({ port, password }),
         startupDeadline: 40,
         reconnectDelay: 5,
+        stageRetryDelay: 5,
         healthRequestTimeout: 5,
       });
       await driver.initialize();
@@ -1039,6 +1138,7 @@ describe("OpenCode server-backed driver", () => {
         http: (port, password) => new OpenCodeHTTP({ port, password }),
         startupDeadline: 100,
         reconnectDelay: 5,
+        stageRetryDelay: 5,
         healthRequestTimeout: 5,
       });
       await driver.initialize();
@@ -1090,6 +1190,7 @@ describe("OpenCode server-backed driver", () => {
       },
       startupDeadline: 300,
       reconnectDelay: 5,
+      stageRetryDelay: 5,
     });
     await driver.initialize();
     await driver.spawn({
@@ -1128,6 +1229,7 @@ describe("OpenCode server-backed driver", () => {
       http: (port, password) => new OpenCodeHTTP({ port, password }),
       startupDeadline: 100,
       reconnectDelay: 5,
+      stageRetryDelay: 5,
       healthRequestTimeout: 5,
     });
     await driver.initialize();
@@ -1171,7 +1273,7 @@ test("registry persists atomically with private files and cleans them after sess
       context_revision: 3,
     },
   });
-  await eventually(() => target.prompts.length === 1, "run creation");
+  await eventually(() => target.tuiSubmissions.length === 1, "run creation");
   const record = await registry.get("run-cleanup");
   expect(record).toBeDefined();
   expect((await stat(record!.password_ref)).mode & 0o077).toBe(0);
@@ -1209,18 +1311,41 @@ test("OpenCode config merge preserves keys and deduplicates the guidance plugin"
     theme: "dark",
     instructions: ["repo.md"],
     plugin: ["user-plugin", pluginRef],
-  }), "/tmp/attn.md", pluginRef)).toEqual({
+  }), { instructionRef: "/tmp/attn.md", pluginRef })).toEqual({
     theme: "dark",
     instructions: ["repo.md"],
     plugin: ["user-plugin", pluginRef],
   });
-  expect(opencodeConfigForLaunch(undefined, "/tmp/attn.md", pluginRef)).toEqual({ plugin: [pluginRef] });
+  expect(opencodeConfigForLaunch(undefined, { instructionRef: "/tmp/attn.md", pluginRef })).toEqual({ plugin: [pluginRef] });
+});
+
+test("OpenCode config merge pins the delegated model on the launched agent", () => {
+  const pin = { model: "opencode/deepseek-v4-flash", variant: "max" };
+  expect(opencodeConfigForLaunch(undefined, { pin })).toEqual({
+    agent: { build: { model: "opencode/deepseek-v4-flash" } },
+  });
+  // The pin replaces only the model of the agent the launch runs.
+  expect(opencodeConfigForLaunch(JSON.stringify({
+    model: "opencode-go/mimo-v2.5",
+    agent: { plan: { model: "opencode/other" }, build: { temperature: 0.1, model: "opencode-go/mimo-v2.5" } },
+  }), { pin })).toEqual({
+    model: "opencode-go/mimo-v2.5",
+    agent: {
+      plan: { model: "opencode/other" },
+      build: { temperature: 0.1, model: "opencode/deepseek-v4-flash" },
+    },
+  });
 });
 
 test("OpenCode config merge rejects malformed inherited config", () => {
-  expect(() => opencodeConfigForLaunch("{", "/tmp/attn.md")).toThrow("invalid inherited OPENCODE_CONFIG_CONTENT");
-  expect(() => opencodeConfigForLaunch(JSON.stringify({ instructions: [1] }), "/tmp/attn.md")).toThrow("array of strings");
-  expect(() => opencodeConfigForLaunch(JSON.stringify({ plugin: "bad" }), "/tmp/attn.md")).toThrow("expected an array");
+  const instructionRef = "/tmp/attn.md";
+  expect(() => opencodeConfigForLaunch("{", { instructionRef })).toThrow("invalid inherited OPENCODE_CONFIG_CONTENT");
+  expect(() => opencodeConfigForLaunch(JSON.stringify({ instructions: [1] }), { instructionRef })).toThrow("array of strings");
+  expect(() => opencodeConfigForLaunch(JSON.stringify({ plugin: "bad" }), { instructionRef })).toThrow("expected an array");
+  expect(() => opencodeConfigForLaunch(JSON.stringify({ agent: [] }), { pin: { model: "a/b", variant: "max" } }))
+    .toThrow("OPENCODE_CONFIG_CONTENT.agent: expected an object");
+  expect(() => opencodeConfigForLaunch(JSON.stringify({ agent: { build: "bad" } }), { pin: { model: "a/b", variant: "max" } }))
+    .toThrow("OPENCODE_CONFIG_CONTENT.agent.build: expected an object");
 });
 
 test("guidance plugin reads the current private instruction file for every prompt", async () => {
@@ -1311,6 +1436,46 @@ test("launcher retries an address-in-use failure with a fresh port", async () =>
   }));
   expect(await launch(config)).toBe(0);
   expect(JSON.parse(await readFile(config, "utf8")).port).not.toBe(12345);
+});
+
+test("launcher runs a pinned delegation on the pinned agent, with the pin in its own TUI state", async () => {
+  const root = await tempRoot();
+  const argvFile = join(root, "argv");
+  const configFile = join(root, "opencode-config");
+  const stateFile = join(root, "state-home");
+  const executable = join(root, "fake-opencode");
+  await writeFile(
+    executable,
+    `#!/bin/sh\necho "$@" > ${argvFile}\nprintf '%s' "$OPENCODE_CONFIG_CONTENT" > ${configFile}\nprintf '%s' "$XDG_STATE_HOME" > ${stateFile}\nexit 0\n`,
+    { mode: 0o755 },
+  );
+  const password = join(root, "password");
+  await writePrivate(password, "secret");
+  const config = join(root, "launch.json");
+  await writePrivate(config, JSON.stringify({
+    schema: 1,
+    run_id: "launch-pinned",
+    executable,
+    cwd: root,
+    password_ref: password,
+    port: 12345,
+    yolo: true,
+    pin: { model: "opencode/deepseek-v4-flash", variant: "max" },
+    state_dir: join(root, "state"),
+  }));
+  expect(await launch(config)).toBe(0);
+  expect((await readFile(argvFile, "utf8")).trim()).toBe("--hostname 127.0.0.1 --port 12345 --agent build --yolo");
+  expect(JSON.parse(await readFile(configFile, "utf8")).agent).toEqual({
+    build: { model: "opencode/deepseek-v4-flash" },
+  });
+  // The TUI takes the variant from its own state, and a pinned run writes that
+  // state under its own home instead of the user's.
+  expect((await readFile(stateFile, "utf8")).trim()).toBe(join(root, "state"));
+  expect(JSON.parse(await readFile(join(root, "state", "opencode", "model.json"), "utf8"))).toEqual({
+    recent: [{ providerID: "opencode", modelID: "deepseek-v4-flash" }],
+    favorite: [],
+    variant: { "opencode/deepseek-v4-flash": "max" },
+  });
 });
 
 async function tempRoot(): Promise<string> {

--- a/plugins/attn-opencode/test/fake-opencode.ts
+++ b/plugins/attn-opencode/test/fake-opencode.ts
@@ -23,6 +23,16 @@ export class FakeOpenCode {
   pendingListBarrier?: Promise<void>;
   readonly hangingSessionReads = new Set<string>();
   readonly prompts: Array<{ sessionID: string; body: unknown }> = [];
+  readonly tuiSubmissions: Array<{ sessionID: string; text: string }> = [];
+  tuiAttached = true;
+  tuiModel: unknown = { providerID: "spotify-glm", id: "zai-org/GLM-5.2-FP8", variant: "max" };
+  // Every model the tests pin, with the variants OpenCode's catalog declares for
+  // it. A model missing here is a model OpenCode does not have.
+  variants = new Map<string, string[]>([
+    ["spotify-glm/zai-org/GLM-5.2-FP8", ["low", "max"]],
+    ["opencode-go/mimo-v2.5", []],
+  ]);
+  private composer = "";
   private controllers = new Set<ReadableStreamDefaultController<Uint8Array>>();
   private nextSession = 1;
   readonly server: ReturnType<typeof Bun.serve>;
@@ -112,6 +122,19 @@ export class FakeOpenCode {
       this.sessions.set(id, { id, model: (body as { model: unknown }).model });
       return Response.json({ id });
     }
+    if (url.pathname === "/config/providers") {
+      const providers = new Map<string, Record<string, unknown>>();
+      for (const [pin, variants] of this.variants) {
+        const slash = pin.indexOf("/");
+        const providerID = pin.slice(0, slash);
+        const models = providers.get(providerID) ?? {};
+        models[pin.slice(slash + 1)] = { id: pin.slice(slash + 1), variants: Object.fromEntries(variants.map((name) => [name, {}])) };
+        providers.set(providerID, models);
+      }
+      return Response.json({
+        providers: [...providers].map(([id, models]) => ({ id, models })),
+      });
+    }
     if (url.pathname === "/session/status") return Response.json(Object.fromEntries(this.statuses));
     if (url.pathname === "/question") {
       if (this.failPendingLists) return Response.json({ error: "question list failed" }, { status: 500 });
@@ -188,7 +211,27 @@ export class FakeOpenCode {
       const session = this.sessions.get(sessionID);
       return session ? Response.json(session) : new Response("missing", { status: 404 });
     }
-    if (url.pathname === "/tui/select-session") return Response.json(true);
+    // Every `/tui/*` route answers `true` whether or not a TUI is attached to
+    // the event bus, exactly like OpenCode: a control request published before
+    // the TUI attaches is simply dropped.
+    if (url.pathname === "/tui/clear-prompt") {
+      if (this.tuiAttached) this.composer = "";
+      return Response.json(true);
+    }
+    if (url.pathname === "/tui/append-prompt") {
+      if (this.tuiAttached) this.composer += (body as { text?: string }).text ?? "";
+      return Response.json(true);
+    }
+    if (url.pathname === "/tui/submit-prompt") {
+      if (this.tuiAttached && this.composer !== "") {
+        const id = `native-${this.nextSession++}`;
+        this.sessions.set(id, { id, model: this.tuiModel });
+        this.tuiSubmissions.push({ sessionID: id, text: this.composer });
+        this.composer = "";
+        this.emit("session.created", { sessionID: id });
+      }
+      return Response.json(true);
+    }
     return new Response("not found", { status: 404 });
   }
 }

--- a/plugins/attn-opencode/test/fake-opencode.ts
+++ b/plugins/attn-opencode/test/fake-opencode.ts
@@ -25,6 +25,9 @@ export class FakeOpenCode {
   readonly prompts: Array<{ sessionID: string; body: unknown }> = [];
   readonly tuiSubmissions: Array<{ sessionID: string; text: string }> = [];
   tuiAttached = true;
+  // OpenCode's SSE stream can drop between the TUI taking a prompt and the
+  // event that announces the session it opened.
+  dropSessionCreatedEvent = false;
   tuiModel: unknown = { providerID: "spotify-glm", id: "zai-org/GLM-5.2-FP8", variant: "max" };
   // Every model the tests pin, with the variants OpenCode's catalog declares for
   // it. A model missing here is a model OpenCode does not have.
@@ -135,6 +138,9 @@ export class FakeOpenCode {
         providers: [...providers].map(([id, models]) => ({ id, models })),
       });
     }
+    if (url.pathname === "/session" && request.method === "GET") {
+      return Response.json([...this.sessions.values()]);
+    }
     if (url.pathname === "/session/status") return Response.json(Object.fromEntries(this.statuses));
     if (url.pathname === "/question") {
       if (this.failPendingLists) return Response.json({ error: "question list failed" }, { status: 500 });
@@ -226,9 +232,10 @@ export class FakeOpenCode {
       if (this.tuiAttached && this.composer !== "") {
         const id = `native-${this.nextSession++}`;
         this.sessions.set(id, { id, model: this.tuiModel });
+        this.messages.set(id, [{ info: { id: `user-${id}`, role: "user" }, parts: [{ type: "text", text: this.composer }] }]);
         this.tuiSubmissions.push({ sessionID: id, text: this.composer });
         this.composer = "";
-        this.emit("session.created", { sessionID: id });
+        if (!this.dropSessionCreatedEvent) this.emit("session.created", { sessionID: id });
       }
       return Response.json(true);
     }
@@ -241,7 +248,7 @@ export function basic(password: string): string {
 }
 
 export async function eventually(predicate: () => boolean, message: string | (() => string)): Promise<void> {
-  const deadline = Date.now() + 2_000;
+  const deadline = Date.now() + 5_000;
   while (Date.now() < deadline) {
     if (predicate()) return;
     await Bun.sleep(10);

--- a/plugins/attn-opencode/test/fake-opencode.ts
+++ b/plugins/attn-opencode/test/fake-opencode.ts
@@ -232,7 +232,12 @@ export class FakeOpenCode {
       if (this.tuiAttached && this.composer !== "") {
         const id = `native-${this.nextSession++}`;
         this.sessions.set(id, { id, model: this.tuiModel });
-        this.messages.set(id, [{ info: { id: `user-${id}`, role: "user" }, parts: [{ type: "text", text: this.composer }] }]);
+        // Newest first, like OpenCode can answer: the reply the TUI produces is
+        // ahead of the prompt in the list.
+        this.messages.set(id, [
+          { info: { id: `assistant-${id}`, role: "assistant" }, parts: [{ type: "text", text: "working" }] },
+          { info: { id: `user-${id}`, role: "user" }, parts: [{ type: "text", text: this.composer }] },
+        ]);
         this.tuiSubmissions.push({ sessionID: id, text: this.composer });
         this.composer = "";
         if (!this.dropSessionCreatedEvent) this.emit("session.created", { sessionID: id });


### PR DESCRIPTION
Two defects in `plugins/attn-opencode`: a delegated OpenCode session was invisible in its pane, and its model/effort pin was never verified — and, it turns out, the effort half of it never applied.

## The agent was invisible

The driver created the native session over HTTP and called `/tui/select-session`. That route publishes a bus event and answers `true` whether or not a TUI is attached to the event stream — proved against a headless `opencode serve`, which answers `true` with no TUI in existence. The TUI subscribes to `/event` about three seconds after the server answers `/global/health`, so a select published before that is dropped forever. The pane kept the splash while the agent worked, and there is no TUI-liveness signal anywhere in the API to wait on.

So the TUI owns the session now. A pinned launch runs `--agent build` with the model in the injected config, the delegated turn is submitted through the TUI (`/tui/clear-prompt` → `append-prompt` → `submit-prompt`), and the `session.created` event that submission produces is the receipt: it claims the run, stops the staging retry, and binds the session the TUI itself opened. The claim is taken the moment the event lands rather than after the bind's round trips, so a prompt the TUI already took is never submitted twice (that duplicate was real, and observed: two identical user messages in one session).

## The effort pin applied to nothing

The TUI reads the selected model's variant from its own XDG state (`~/.local/state/opencode/model.json`), not from the agent config. A delegation pinned to `--effort low` opened at `max` — whatever was last used interactively — and the earlier `max` runs "verified" only by coincidence. Each pinned run now gets its own `XDG_STATE_HOME` seeded with the pin (the user's display preferences are copied in, so the pane still looks like their OpenCode). That also stops delegated runs from rewriting the model selection the user made themselves.

Both ends are checked now:

- Before staging, against `/config/providers`: an effort the model does not offer fails the run and names what it does offer. MiMo declares `variants: {}`, so `--effort max` on it was silently dropped; `deepseek-v4-pro` has no `low`.
- After the session opens, against the session itself: a different provider, model, or variant sets the run degraded with the pin and what arrived, and leaves it unbound.

## Live verification — profile `ocfix`, current branch

Provider / model / variant read back from each run's own OpenCode server:

| delegated pin | session model read back | outcome |
| --- | --- | --- |
| `opencode/deepseek-v4-flash` `max` | `{opencode, deepseek-v4-flash, max}`, agent `build` | pin verified |
| `opencode/deepseek-v4-flash` `low` | `{opencode, deepseek-v4-flash, low}` | pin verified (was `max` before this change) |
| `opencode-go/deepseek-v4-flash` `max` | `{opencode-go, deepseek-v4-flash, max}` | pin verified, turn completes |
| `opencode-go/deepseek-v4-flash` `low` | footer `… OpenCode Go · low` | pin verified, turn completes |
| `opencode-go/mimo-v2.5` `max` | — | refused: `OpenCode model opencode-go/mimo-v2.5 cannot honor the delegated variant max: it offers no variants`, nothing staged |
| `opencode-go/deepseek-v4-flash` `high` | — | `OpenCode effort "high" has no verified variant mapping` at spawn, unchanged |

Visibility: the pane shows the delegated turn 2.1s after `attn delegate` returns (it never did before). Single submission per run, verified in the message list. `~/.local/state/opencode/model.json` is byte-identical before and after the whole matrix.

`opencode/*` (OpenCode Zen) models answer `APIError 401 "Model is disabled"` on this account right now — `opencode run --model opencode/deepseek-v4-flash` fails the same way outside attn, so it is an account/provider condition, not this change. The pin itself still reads back correct on those runs, which is what the pin verification is about. The `opencode/mimo-v2.5-free` leg the brief asked for is covered by the same finding: the model is both Zen-disabled and variant-less.

![clip](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/22b8163f610376412552657c48343dae5e533d36/delegate-oc-fix-3f3e7a70/clip.gif)

[Full-quality recording (mp4)](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/22b8163f610376412552657c48343dae5e533d36/delegate-oc-fix-3f3e7a70/clip.mp4)

## Tests

`plugins/attn-opencode/test/driver.test.ts`: staging retries until the TUI attaches and binds the session it opened; stages once even while the bind is in flight; refuses an effort the pinned model does not offer; degrades loudly on a model mismatch; the launcher runs on the pinned agent with the pin in its own TUI state. Each was checked red by mutation.

https://claude.ai/code/session_01AzXBdU9mMw7yaKujfeHBgk
