### PR TITLE
feat(garden): make seed documents live and answerable

### DIFF
--- a/app/src/annotations/useAnnotationSend.ts
+++ b/app/src/annotations/useAnnotationSend.ts
@@ -35,7 +35,7 @@ export function useAnnotationSend<T extends AnnotationSendResult>({
     sendRef.current = send;
   }, [send]);
 
-  const sendNow = useCallback(() => {
+  const runSend = useCallback((action: () => T | null | Promise<T | null>) => {
     if (sendingRef.current) {
       return;
     }
@@ -43,7 +43,7 @@ export function useAnnotationSend<T extends AnnotationSendResult>({
 
     let result: T | null | Promise<T | null>;
     try {
-      result = sendRef.current();
+      result = action();
     } catch (error) {
       sendingRef.current = false;
       setOutcome({
@@ -81,6 +81,12 @@ export function useAnnotationSend<T extends AnnotationSendResult>({
       });
   }, []);
 
+  const sendNow = useCallback(() => runSend(sendRef.current), [runSend]);
+  const sendAlternative = useCallback(
+    (alternative: () => T | null | Promise<T | null>) => runSend(alternative),
+    [runSend],
+  );
+
   useShortcut(shortcutId, sendNow, enabled);
 
   useEffect(() => {
@@ -92,5 +98,5 @@ export function useAnnotationSend<T extends AnnotationSendResult>({
   }, [outcome, sentClearMs]);
 
   const clearOutcome = useCallback(() => setOutcome(null), []);
-  return { outcome, send: sendNow, clearOutcome };
+  return { outcome, send: sendNow, sendAlternative, clearOutcome };
 }

--- a/app/src/components/GardenPanel.reader.test.tsx
+++ b/app/src/components/GardenPanel.reader.test.tsx
@@ -30,6 +30,7 @@ function seed(overrides: Partial<Seed> = {}): Seed {
 function seedDocument(root: Seed, noteBody: string): SeedDocument {
   return {
     seed: root,
+    tender_holds: Boolean(root.tender_session || root.tender_member),
     children: [],
     notes: noteBody ? [{
       id: `n-${noteBody}`,

--- a/app/src/components/GardenPanel.tsx
+++ b/app/src/components/GardenPanel.tsx
@@ -288,6 +288,7 @@ export function GardenPanel({
             const relations = expanded ? relationsOf(index, seed.id) : [];
             const localDocument: SeedDocument = {
               seed,
+              tender_holds: Boolean(seed.tender_session || seed.tender_member),
               children: seeds.filter((candidate) => crownOf(candidate) === seed.id),
               notes: [],
               notes_total: 0,

--- a/app/src/components/MarkdownReader/annotations/transport.ts
+++ b/app/src/components/MarkdownReader/annotations/transport.ts
@@ -15,16 +15,20 @@ import type { WireAnnotation } from './types';
 import type { MarkdownDocumentSource } from '../documentSource';
 
 /**
- * Submit result. `delivered`: typed into the session, drafts tombstone-cleared
- * (`generation` is the client's new floor; `error` may still report a failed
- * clear). `skipped_pending_approval`: nothing typed, drafts kept. An error
- * status rejects the promise instead.
+ * Submit result. `delivered` types into a session; `noted` appends to a seed.
+ * Both tombstone-clear drafts (`generation` is the client's new floor;
+ * `error` may still report a failed clear). `skipped_pending_approval` keeps
+ * the draft. An error status rejects the promise instead.
  */
 export interface MarkdownAnnotationsSubmitResult {
   status: string;
   generation?: number;
   error?: string;
 }
+
+export type MarkdownAnnotationsDestination =
+  | { kind: 'session'; sessionId: string }
+  | { kind: 'seed'; seedId: string };
 
 export interface MarkdownAnnotationsTransport {
   getMarkdownAnnotations(
@@ -40,12 +44,12 @@ export interface MarkdownAnnotationsTransport {
     generation: number,
   ): Promise<{ generation: number }>;
   /**
-   * Routed by target session. `orphanedIds` is client-derived and not
-   * persisted.
+   * Routed by the typed destination. `orphanedIds` is client-derived and not
+   * persisted; the document URI remains opaque identity.
    */
   submitMarkdownAnnotations(
     source: MarkdownDocumentSource,
-    targetSessionId: string,
+    destination: MarkdownAnnotationsDestination,
     orphanedIds: string[],
   ): Promise<MarkdownAnnotationsSubmitResult>;
 }

--- a/app/src/components/SeedDocumentView.test.tsx
+++ b/app/src/components/SeedDocumentView.test.tsx
@@ -45,6 +45,7 @@ function note(overrides: Partial<SeedDocumentNote> & { id: string }): SeedDocume
 function document(overrides: Partial<SeedDocument> = {}): SeedDocument {
   return {
     seed: seed(),
+    tender_holds: false,
     children: [],
     notes: [],
     notes_total: 0,

--- a/app/src/components/SeedDocumentView.tsx
+++ b/app/src/components/SeedDocumentView.tsx
@@ -12,6 +12,7 @@ import './SeedDocumentView.css';
 /** The one read model shared by the panel drill and the docked seed tile. */
 export interface SeedDocument {
   seed: Seed;
+  tender_holds: boolean;
   children: Seed[];
   /** Newest first, matching the garden log's wire order. */
   notes: SeedDocumentNote[];

--- a/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.css
+++ b/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.css
@@ -153,6 +153,54 @@
   cursor: default;
 }
 
+.workspace-dock-tile-seed-submit {
+  position: relative;
+  display: inline-flex;
+}
+
+.workspace-dock-tile-send-button--split-primary {
+  border-radius: 5px 0 0 5px;
+}
+
+.workspace-dock-tile-send-button--split-caret {
+  width: 24px;
+  padding: 2px 4px;
+  margin-left: -1px;
+  border-radius: 0 5px 5px 0;
+}
+
+.workspace-dock-tile-seed-submit-menu {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 132px;
+  padding: 4px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg-elevated, var(--color-bg-editor));
+  box-shadow: 0 8px 24px rgb(0 0 0 / 35%);
+}
+
+.workspace-dock-tile-seed-submit-menu button {
+  width: 100%;
+  padding: 6px 8px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-text-primary);
+  font-size: 11px;
+  text-align: left;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.workspace-dock-tile-seed-submit-menu button:hover,
+.workspace-dock-tile-seed-submit-menu button:focus-visible {
+  background: var(--color-bg-hover);
+  outline: none;
+}
+
 .workspace-dock-tile-actions {
   display: inline-flex;
   align-items: center;

--- a/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.test.tsx
@@ -15,6 +15,8 @@ import type {
   MarkdownAnnotationsTransport,
 } from '../MarkdownReader/annotations/transport';
 import type { WireAnnotation } from '../MarkdownReader/annotations/types';
+import { annotationToWire } from '../MarkdownReader/annotations/types';
+import { createAnchor, extractBlockTexts } from '../MarkdownReader/anchoring';
 import { DaemonApiProvider, type DaemonApi } from '../../contexts/DaemonApiContext';
 import type { Seed } from '../../types/generated';
 import type { SeedDocument } from '../SeedDocumentView';
@@ -609,6 +611,19 @@ function globalNote(id = 'g1'): WireAnnotation {
   return { id, type: 'global', text: 'whole-doc note', created_at: 1 };
 }
 
+function anchoredNote(content: string, needle: string): WireAnnotation {
+  const blocks = extractBlockTexts(content);
+  const block = blocks.find((candidate) => candidate.text.includes(needle))!;
+  const start = block.text.indexOf(needle);
+  return annotationToWire({
+    id: 'stored-1',
+    type: 'comment',
+    text: 'stay attached',
+    anchor: createAnchor(content, block.blockId, start, start + needle.length, blocks)!,
+    createdAt: 1,
+  });
+}
+
 function makeSendTransport(seed: WireAnnotation[] = [globalNote()]) {
   const getSpy = vi.fn(async () => ({ annotations: seed, generation: 5 }));
   const saveSpy = vi.fn(async () => ({ stale: false }));
@@ -751,7 +766,11 @@ describe('WorkspaceDockTile markdown send flow', () => {
     // …and a Send inside that window goes to the NEW target, never sess-a.
     fireEvent.click(sendButton());
     await waitFor(() => {
-      expect(submitSpy).toHaveBeenCalledWith(fileMarkdownSource('workspace-1', SEND_PATH), 'sess-b', []);
+      expect(submitSpy).toHaveBeenCalledWith(
+        fileMarkdownSource('workspace-1', SEND_PATH),
+        { kind: 'session', sessionId: 'sess-b' },
+        [],
+      );
     });
 
     // The echo landing simply confirms the pick.
@@ -816,7 +835,11 @@ describe('WorkspaceDockTile markdown send flow', () => {
     fireEvent.click(sendButton());
     expect(sendButton()).toHaveTextContent('Sending…');
     await waitFor(() => {
-      expect(submitSpy).toHaveBeenCalledWith(fileMarkdownSource('workspace-1', SEND_PATH), 'sess-a', []);
+      expect(submitSpy).toHaveBeenCalledWith(
+        fileMarkdownSource('workspace-1', SEND_PATH),
+        { kind: 'session', sessionId: 'sess-a' },
+        [],
+      );
     });
 
     await act(async () => {
@@ -931,7 +954,11 @@ describe('WorkspaceDockTile markdown send flow', () => {
     const event = pressCmdEnter();
     expect(event.defaultPrevented).toBe(true); // dispatcher consumed it
     await waitFor(() => {
-      expect(submitSpy).toHaveBeenCalledWith(fileMarkdownSource('workspace-1', SEND_PATH), 'sess-a', []);
+      expect(submitSpy).toHaveBeenCalledWith(
+        fileMarkdownSource('workspace-1', SEND_PATH),
+        { kind: 'session', sessionId: 'sess-a' },
+        [],
+      );
     });
   });
 
@@ -1001,6 +1028,7 @@ function seedFixture(overrides: Partial<Seed> = {}): Seed {
 function seedDocumentFixture(body = '# Seed body\n\nAnnotate this plan.'): SeedDocument {
   return {
     seed: seedFixture({ body }),
+    tender_holds: true,
     children: [seedFixture({ id: 's-child1', title: 'Reader child', body: '', status: 'harvested' })],
     notes: [{
       id: 'n-live11',
@@ -1022,7 +1050,10 @@ describe('WorkspaceDockTile seed reader', () => {
 
   it('loads the seed document, renders its ledger, annotates by seed URI, and refetches on a garden push', async () => {
     const first = seedDocumentFixture();
-    const second = seedDocumentFixture('# Updated seed body');
+    const second = {
+      ...seedDocumentFixture('# Updated seed body'),
+      seed: seedFixture({ body: '# Updated seed body', rev: 2 }),
+    };
     const sendSeedDocumentGet = vi.fn()
       .mockResolvedValueOnce(first)
       .mockResolvedValueOnce(second);
@@ -1055,7 +1086,9 @@ describe('WorkspaceDockTile seed reader', () => {
     expect(await screen.findByRole('heading', { name: 'Seed body' })).toBeInTheDocument();
     expect(screen.getByText('Reader child')).toBeInTheDocument();
     expect(screen.getByText('Live ledger note')).toBeInTheDocument();
-    expect(screen.getByText('Seed reader plan', { selector: '.workspace-dock-tile-title' })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Seed reader plan', { selector: '.workspace-dock-tile-title' })).toBeInTheDocument();
+    });
     expect(view.container.querySelector('.md-reader--annotating')).toBeInTheDocument();
     expect(onRequestContent).not.toHaveBeenCalled();
     expect(getSpy).toHaveBeenCalledWith(seedMarkdownSource('s-plan11'));
@@ -1063,12 +1096,196 @@ describe('WorkspaceDockTile seed reader', () => {
     await waitFor(() => expect(sendButton()).toHaveTextContent('Send 1'));
     fireEvent.click(sendButton());
     await waitFor(() => {
-      expect(submitSpy).toHaveBeenCalledWith(seedMarkdownSource('s-plan11'), 'sess-a', []);
+      expect(submitSpy).toHaveBeenCalledWith(
+        seedMarkdownSource('s-plan11'),
+        { kind: 'session', sessionId: 'sess-a' },
+        [],
+      );
     });
 
-    view.rerender(<WorkspaceDockTile {...props} gardenSeeds={[{ ...first.seed }]} />);
+    view.rerender(<WorkspaceDockTile {...props} gardenSeeds={[second.seed]} />);
     expect(await screen.findByRole('heading', { name: 'Updated seed body' })).toBeInTheDocument();
     expect(sendSeedDocumentGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the tended seed primary bound to its live tender and offers Note on seed in the caret menu', async () => {
+    const detail = seedDocumentFixture();
+    const daemonApi = {
+      sendSeedDocumentGet: vi.fn().mockResolvedValue(detail),
+      sendOpenMarkdown: vi.fn(),
+    } as unknown as DaemonApi;
+    const { transport, submitSpy } = makeSendTransport();
+    submitSpy.mockResolvedValue({ status: 'noted', generation: 8 });
+    setMarkdownAnnotationsTransport(transport);
+    render(
+      <WorkspaceDockTile
+        tile={{
+          type: 'tile', tileId: 'tile-seed-s-plan11', tileKind: 'seed',
+          tileParams: 's-plan11', tileSessionId: 'sess-b',
+        }}
+        workspaceId="workspace-1"
+        dragging={false}
+        workspaceSessions={SEND_SESSIONS}
+        gardenSeeds={[detail.seed]}
+        onClose={vi.fn()}
+        onHeaderPointerDown={vi.fn()}
+        onRequestContent={vi.fn()}
+      />,
+      { wrapper: ({ children }) => <SeedTileTestWrapper api={daemonApi}>{children}</SeedTileTestWrapper> },
+    );
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Send 1' })).toBeEnabled());
+    expect(screen.queryByRole('combobox', { name: 'Send annotations to session' })).toBeNull();
+    const caret = screen.getByRole('button', { name: 'More annotation destinations' });
+    expect(caret).toHaveAttribute('aria-haspopup', 'menu');
+    fireEvent.click(caret);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Note on seed' }));
+
+    await waitFor(() => {
+      expect(submitSpy).toHaveBeenCalledWith(
+        seedMarkdownSource('s-plan11'),
+        { kind: 'seed', seedId: 's-plan11' },
+        [],
+      );
+    });
+    expect(await screen.findByRole('status')).toHaveTextContent('Noted ✓');
+  });
+
+  it('makes Note on seed the unsplit primary when nobody tends the seed', async () => {
+    const detail = {
+      ...seedDocumentFixture(),
+      seed: seedFixture({ tender_session: '', tender_member: '' }),
+      tender_holds: false,
+    };
+    const daemonApi = {
+      sendSeedDocumentGet: vi.fn().mockResolvedValue(detail),
+      sendOpenMarkdown: vi.fn(),
+    } as unknown as DaemonApi;
+    const { transport, submitSpy } = makeSendTransport();
+    submitSpy.mockResolvedValue({ status: 'noted', generation: 8 });
+    setMarkdownAnnotationsTransport(transport);
+    render(
+      <WorkspaceDockTile
+        tile={{ type: 'tile', tileId: 'tile-seed-s-plan11', tileKind: 'seed', tileParams: 's-plan11' }}
+        workspaceId="workspace-1"
+        dragging={false}
+        workspaceSessions={SEND_SESSIONS}
+        gardenSeeds={[detail.seed]}
+        onClose={vi.fn()}
+        onHeaderPointerDown={vi.fn()}
+        onRequestContent={vi.fn()}
+      />,
+      { wrapper: ({ children }) => <SeedTileTestWrapper api={daemonApi}>{children}</SeedTileTestWrapper> },
+    );
+
+    const primary = await screen.findByRole('button', { name: 'Note on seed 1' });
+    expect(primary).toBeEnabled();
+    expect(screen.queryByRole('button', { name: 'More annotation destinations' })).toBeNull();
+    fireEvent.click(primary);
+    await waitFor(() => {
+      expect(submitSpy).toHaveBeenCalledWith(
+        seedMarkdownSource('s-plan11'),
+        { kind: 'seed', seedId: 's-plan11' },
+        [],
+      );
+    });
+  });
+
+  it('flips the primary live across park and claim pushes without waiting for detail reads', async () => {
+    const first = seedDocumentFixture();
+    const never = new Promise<SeedDocument>(() => {});
+    const sendSeedDocumentGet = vi.fn()
+      .mockResolvedValueOnce(first)
+      .mockImplementation(() => never);
+    const daemonApi = { sendSeedDocumentGet, sendOpenMarkdown: vi.fn() } as unknown as DaemonApi;
+    const { transport, submitSpy } = makeSendTransport();
+    setMarkdownAnnotationsTransport(transport);
+    const props = {
+      tile: { type: 'tile' as const, tileId: 'tile-seed-s-plan11', tileKind: 'seed' as const, tileParams: 's-plan11' },
+      workspaceId: 'workspace-1',
+      dragging: false,
+      workspaceSessions: SEND_SESSIONS,
+      onClose: vi.fn(),
+      onHeaderPointerDown: vi.fn(),
+      onRequestContent: vi.fn(),
+    };
+    const view = render(
+      <WorkspaceDockTile {...props} gardenSeeds={[first.seed]} />,
+      { wrapper: ({ children }) => <SeedTileTestWrapper api={daemonApi}>{children}</SeedTileTestWrapper> },
+    );
+    await screen.findByRole('button', { name: 'Send 1' });
+
+    const parked = seedFixture({ tender_session: '', tender_member: '', rev: 2 });
+    view.rerender(<WorkspaceDockTile {...props} gardenSeeds={[parked]} />);
+    expect(screen.getByRole('button', { name: 'Note on seed 1' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'More annotation destinations' })).toBeNull();
+
+    const claimed = seedFixture({ tender_session: 'sess-b', tender_member: 'trellis', rev: 3 });
+    view.rerender(<WorkspaceDockTile {...props} gardenSeeds={[claimed]} />);
+    const primary = screen.getByRole('button', { name: 'Send 1' });
+    expect(screen.getByRole('button', { name: 'More annotation destinations' })).toBeInTheDocument();
+    fireEvent.click(primary);
+    await waitFor(() => {
+      expect(submitSpy).toHaveBeenCalledWith(
+        seedMarkdownSource('s-plan11'),
+        { kind: 'session', sessionId: 'sess-b' },
+        [],
+      );
+    });
+  });
+
+  it('re-anchors a persisted highlight from the pushed body without remounting or accepting a stale detail body', async () => {
+    const oldBody = 'First paragraph with target words inside it.\n';
+    const newBody = '# New introduction\n\n' + oldBody;
+    const first = {
+      ...seedDocumentFixture(oldBody),
+      seed: seedFixture({ body: oldBody }),
+    };
+    let resolveDetail: (document: SeedDocument) => void = () => {};
+    const detailPending = new Promise<SeedDocument>((resolve) => { resolveDetail = resolve; });
+    const sendSeedDocumentGet = vi.fn()
+      .mockResolvedValueOnce(first)
+      .mockReturnValueOnce(detailPending);
+    const daemonApi = { sendSeedDocumentGet, sendOpenMarkdown: vi.fn() } as unknown as DaemonApi;
+    const { transport } = makeSendTransport([anchoredNote(oldBody, 'target words')]);
+    setMarkdownAnnotationsTransport(transport);
+    const props = {
+      tile: { type: 'tile' as const, tileId: 'tile-seed-s-plan11', tileKind: 'seed' as const, tileParams: 's-plan11' },
+      workspaceId: 'workspace-1',
+      dragging: false,
+      gardenSeeds: [first.seed],
+      onClose: vi.fn(),
+      onHeaderPointerDown: vi.fn(),
+      onRequestContent: vi.fn(),
+    };
+    const view = render(
+      <WorkspaceDockTile {...props} />,
+      { wrapper: ({ children }) => <SeedTileTestWrapper api={daemonApi}>{children}</SeedTileTestWrapper> },
+    );
+    await waitFor(() => {
+      expect(view.container.querySelector('[data-md-mark="stored-1"]')).not.toBeNull();
+    });
+    const oldMark = view.container.querySelector('[data-md-mark="stored-1"]');
+    expect(oldMark).toHaveTextContent('target words');
+    const scrollNode = view.container.querySelector<HTMLElement>('.md-reader-doc')!;
+    scrollNode.scrollTop = 137;
+
+    const pushed = seedFixture({ body: newBody, rev: 2 });
+    view.rerender(<WorkspaceDockTile {...props} gardenSeeds={[pushed]} />);
+    expect(screen.getByRole('heading', { name: 'New introduction' })).toBeInTheDocument();
+    expect(view.container.querySelector('.md-reader-doc')).toBe(scrollNode);
+    expect(scrollNode.scrollTop).toBe(137);
+    await waitFor(() => {
+      expect(view.container.querySelector('[data-md-mark="stored-1"]')).toHaveTextContent('target words');
+    });
+    expect(view.container.querySelector('.md-card-orphan-badge')).toBeNull();
+    expect(screen.queryByText('⚠ moved')).toBeNull();
+    expect(sendSeedDocumentGet).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      resolveDetail({ ...first, notes_total: 2 });
+    });
+    expect(screen.getByRole('heading', { name: 'New introduction' })).toBeInTheDocument();
   });
 
   it('names an unknown seed read failure in the tile', async () => {

--- a/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.test.tsx
@@ -66,16 +66,24 @@ const testSurfaceValue: NotebookSurfaceContextValue = {
   connectionGeneration: 0,
 };
 
-function NotebookSurfaceTestWrapper({ children }: { children: ReactNode }) {
-  return <NotebookSurfaceProvider value={testSurfaceValue}>{children}</NotebookSurfaceProvider>;
+const defaultDaemonApi = {} as DaemonApi;
+
+function NotebookSurfaceTestWrapper({
+  api = defaultDaemonApi,
+  children,
+}: {
+  api?: DaemonApi;
+  children: ReactNode;
+}) {
+  return (
+    <DaemonApiProvider api={api}>
+      <NotebookSurfaceProvider value={testSurfaceValue}>{children}</NotebookSurfaceProvider>
+    </DaemonApiProvider>
+  );
 }
 
 function SeedTileTestWrapper({ api, children }: { api: DaemonApi; children: ReactNode }) {
-  return (
-    <DaemonApiProvider api={api}>
-      <NotebookSurfaceTestWrapper>{children}</NotebookSurfaceTestWrapper>
-    </DaemonApiProvider>
-  );
+  return <NotebookSurfaceTestWrapper api={api}>{children}</NotebookSurfaceTestWrapper>;
 }
 
 const opener = vi.hoisted(() => ({

--- a/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.tsx
+++ b/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.tsx
@@ -793,7 +793,7 @@ function SeedTileBody({
     return () => {
       ignore = true;
     };
-  }, [gardenSeeds, liveSeed, seedId, sendSeedDocumentGet]);
+  }, [gardenSeeds, liveSeed, onDocument, seedId, sendSeedDocumentGet]);
 
   useEffect(() => {
     onDocument(displayedDocument);

--- a/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.tsx
+++ b/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.tsx
@@ -27,7 +27,7 @@ import { useNotebookSurfaceContext } from '../../contexts/NotebookSurfaceContext
 import { NotebookTile } from '../notebook/NotebookTile';
 import type { NotebookSurfaceHandle } from '../NotebookSurface';
 import { SeedDocumentView, type SeedDocument } from '../SeedDocumentView';
-import { useDaemonApi } from '../../contexts/DaemonApiContext';
+import { useDaemonApi, useOptionalDaemonApi } from '../../contexts/DaemonApiContext';
 import type { Seed } from '../../hooks/useDaemonSocket';
 import './WorkspaceDockTile.css';
 
@@ -731,7 +731,9 @@ function MarkdownBody({
 }
 
 function useLiveSeedDocument(seedId: string, gardenSeeds: Seed[], enabled: boolean) {
-  const { sendSeedDocumentGet } = useDaemonApi();
+  // Ordinary tiles are also rendered in lightweight workspace surfaces that
+  // do not need daemon commands. Only require the API when this is a seed.
+  const sendSeedDocumentGet = useOptionalDaemonApi()?.sendSeedDocumentGet;
   const [document, setDocument] = useState<SeedDocument | null>(null);
   const [error, setError] = useState<string | null>(null);
   const liveSeed = useMemo(
@@ -759,6 +761,11 @@ function useLiveSeedDocument(seedId: string, gardenSeeds: Seed[], enabled: boole
     if (!seedId) {
       setDocument(null);
       setError('No seed is associated with this tile.');
+      return;
+    }
+    if (!sendSeedDocumentGet) {
+      setDocument(null);
+      setError('The daemon API is unavailable.');
       return;
     }
     let ignore = false;

--- a/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.tsx
+++ b/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.tsx
@@ -148,7 +148,10 @@ export function WorkspaceDockTile({
   const isMarkdown = tile.tileKind === 'markdown';
   const isSeed = tile.tileKind === 'seed';
   const isAnnotatedDocument = isMarkdown || isSeed;
-  const [seedDocument, setSeedDocument] = useState<SeedDocument | null>(null);
+  const {
+    document: seedDocument,
+    error: seedDocumentError,
+  } = useLiveSeedDocument(path, gardenSeeds, isSeed);
   const title = isSeed ? (seedDocument?.seed.title || path || baseTitle) : baseTitle;
   const documentSource = useMemo(
     () => (isSeed ? seedMarkdownSource(path) : fileMarkdownSource(workspaceId, path)),
@@ -646,9 +649,8 @@ export function WorkspaceDockTile({
           />
         ) : tile.tileKind === 'seed' ? (
           <SeedTileBody
-            seedId={path}
-            gardenSeeds={gardenSeeds}
-            onDocument={setSeedDocument}
+            document={seedDocument}
+            error={seedDocumentError}
             onAnnotationsCountChange={setAnnotationCount}
             annotationsSendRef={annotationsSendRef}
           />
@@ -724,20 +726,8 @@ function MarkdownBody({
   );
 }
 
-function SeedTileBody({
-  seedId,
-  gardenSeeds,
-  onDocument,
-  onAnnotationsCountChange,
-  annotationsSendRef,
-}: {
-  seedId: string;
-  gardenSeeds: Seed[];
-  onDocument: (document: SeedDocument | null) => void;
-  onAnnotationsCountChange: (count: number) => void;
-  annotationsSendRef: RefObject<MarkdownAnnotationsSendHandle | null>;
-}) {
-  const { sendSeedDocumentGet, sendOpenMarkdown } = useDaemonApi();
+function useLiveSeedDocument(seedId: string, gardenSeeds: Seed[], enabled: boolean) {
+  const { sendSeedDocumentGet } = useDaemonApi();
   const [document, setDocument] = useState<SeedDocument | null>(null);
   const [error, setError] = useState<string | null>(null);
   const liveSeed = useMemo(
@@ -761,9 +751,9 @@ function SeedTileBody({
   // not necessarily touch this seed's own revision, so the array identity is
   // the live invalidation signal for the complete reader document.
   useEffect(() => {
+    if (!enabled) return;
     if (!seedId) {
       setDocument(null);
-      onDocument(null);
       setError('No seed is associated with this tile.');
       return;
     }
@@ -793,15 +783,25 @@ function SeedTileBody({
     return () => {
       ignore = true;
     };
-  }, [gardenSeeds, liveSeed, onDocument, seedId, sendSeedDocumentGet]);
+  }, [enabled, gardenSeeds, liveSeed, seedId, sendSeedDocumentGet]);
 
-  useEffect(() => {
-    onDocument(displayedDocument);
-  }, [displayedDocument, onDocument]);
+  return { document: displayedDocument, error };
+}
 
-  useEffect(() => () => onDocument(null), [onDocument]);
+function SeedTileBody({
+  document,
+  error,
+  onAnnotationsCountChange,
+  annotationsSendRef,
+}: {
+  document: SeedDocument | null;
+  error: string | null;
+  onAnnotationsCountChange: (count: number) => void;
+  annotationsSendRef: RefObject<MarkdownAnnotationsSendHandle | null>;
+}) {
+  const { sendOpenMarkdown } = useDaemonApi();
 
-  if (!displayedDocument) {
+  if (!document) {
     return (
       <div className={`workspace-dock-tile-message${error ? ' workspace-dock-tile-error' : ''}`}>
         {error || 'Loading seed…'}
@@ -811,7 +811,7 @@ function SeedTileBody({
 
   return (
     <SeedDocumentView
-      document={displayedDocument}
+      document={document}
       annotationsEnabled
       onAnnotationsCountChange={onAnnotationsCountChange}
       annotationsSendRef={annotationsSendRef}

--- a/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.tsx
+++ b/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.tsx
@@ -20,7 +20,9 @@ import {
   type MarkdownDocumentSource,
 } from '../MarkdownReader/documentSource';
 import { getMarkdownAnnotationsTransport } from '../MarkdownReader/annotations/transport';
+import type { MarkdownAnnotationsDestination } from '../MarkdownReader/annotations/transport';
 import { useAnnotationSend } from '../../annotations/useAnnotationSend';
+import { useEscapeStack } from '../../hooks/useEscapeStack';
 import { useNotebookSurfaceContext } from '../../contexts/NotebookSurfaceContext';
 import { NotebookTile } from '../notebook/NotebookTile';
 import type { NotebookSurfaceHandle } from '../NotebookSurface';
@@ -86,12 +88,12 @@ interface WorkspaceDockTileProps {
   bodyRef?: Ref<HTMLDivElement>;
 }
 
-/** Header send state for a markdown tile. `sent` auto-clears after ~4s;
+/** Header send state for an annotated document tile. `sent` auto-clears after ~4s;
     `skipped`/`warning`/`error` persist until the next action. `warning`
-    covers delivered-but-draft-clear-failed: the payload reached the session
+    covers accepted-but-draft-clear-failed: the payload reached its destination
     but the daemon still holds the draft, so local state is kept to match. */
 type MarkdownSendResult =
-  | { kind: 'sent' }
+  | { kind: 'sent'; destination: 'session' | 'seed' }
   | { kind: 'skipped' }
   | { kind: 'warning'; message: string }
   | { kind: 'error'; message: string };
@@ -184,12 +186,26 @@ export function WorkspaceDockTile({
     : boundInWorkspace
       ? boundSessionId
       : '';
+  const seedTenderSessionId = seedDocument?.tender_holds
+    ? seedDocument.seed.tender_session.trim()
+    : '';
+  const primaryDestination = useMemo<MarkdownAnnotationsDestination | null>(() => {
+    if (isSeed) {
+      if (!seedDocument || !path) return null;
+      return seedTenderSessionId
+        ? { kind: 'session', sessionId: seedTenderSessionId }
+        : { kind: 'seed', seedId: path };
+    }
+    return targetSessionId ? { kind: 'session', sessionId: targetSessionId } : null;
+  }, [isSeed, path, seedDocument, seedTenderSessionId, targetSessionId]);
   const transportAvailable = getMarkdownAnnotationsTransport() !== null;
 
-  const performAnnotationSend = useCallback((): MarkdownSendResult | null | Promise<MarkdownSendResult> => {
+  const performAnnotationSend = useCallback((
+    destination: MarkdownAnnotationsDestination | null,
+  ): MarkdownSendResult | null | Promise<MarkdownSendResult> => {
     const handle = annotationsSendRef.current;
     const transport = getMarkdownAnnotationsTransport();
-    if (annotationCount === 0 || !targetSessionId || !handle || !transport || !path) {
+    if (annotationCount === 0 || !destination || !handle || !transport || !path) {
       return null;
     }
     if (!handle.isHydrated()) {
@@ -204,37 +220,38 @@ export function WorkspaceDockTile({
       await handle.flushPendingSave();
       const result = await transport.submitMarkdownAnnotations(
         documentSource,
-        targetSessionId,
+        destination,
         handle.getOrphanedIds(),
       );
-      if (result.status === 'delivered' && result.error) {
-        // The daemon delivered the payload but kept its draft; local state
+      if ((result.status === 'delivered' || result.status === 'noted') && result.error) {
+        // The daemon accepted the payload but kept its draft; local state
         // stays with that surviving source of truth.
         return { kind: 'warning', message: result.error };
       }
-      if (result.status === 'delivered') {
+      if (result.status === 'delivered' || result.status === 'noted') {
         handle.applyDeliveredClear(result.generation ?? 0);
-        return { kind: 'sent' };
+        return { kind: 'sent', destination: result.status === 'noted' ? 'seed' : 'session' };
       }
       if (result.status === 'skipped_pending_approval') {
         return { kind: 'skipped' };
       }
       return { kind: 'error', message: result.error || 'Send failed' };
     })();
-  }, [annotationCount, documentSource, path, targetSessionId]);
+  }, [annotationCount, documentSource, path]);
 
   const sendEnabled = isAnnotatedDocument
       && visible
       && hasFocusWithin
       && annotationCount > 0
-      && !!targetSessionId
+      && !!primaryDestination
       && transportAvailable;
   const {
     outcome: sendOutcome,
     send: sendNow,
+    sendAlternative,
     clearOutcome: clearSendOutcome,
   } = useAnnotationSend<MarkdownSendResult>({
-    send: performAnnotationSend,
+    send: () => performAnnotationSend(primaryDestination),
     shortcutId: 'markdown.sendAnnotations',
     enabled: sendEnabled,
     sentClearMs: SEND_SENT_CLEAR_MS,
@@ -252,7 +269,32 @@ export function WorkspaceDockTile({
   }, []);
 
   const sending = sendStatus.kind === 'sending';
-  const sendDisabled = sending || annotationCount === 0 || !targetSessionId || !transportAvailable;
+  const sendDisabled = sending || annotationCount === 0 || !primaryDestination || !transportAvailable;
+  const [seedDestinationMenuOpen, setSeedDestinationMenuOpen] = useState(false);
+  const seedDestinationGroupRef = useRef<HTMLDivElement>(null);
+  const seedDestinationCaretRef = useRef<HTMLButtonElement>(null);
+  const seedDestinationItemRef = useRef<HTMLButtonElement>(null);
+  const closeSeedDestinationMenu = useCallback((restoreFocus = false) => {
+    setSeedDestinationMenuOpen(false);
+    if (restoreFocus) {
+      window.requestAnimationFrame(() => seedDestinationCaretRef.current?.focus());
+    }
+  }, []);
+  useEscapeStack(() => closeSeedDestinationMenu(true), seedDestinationMenuOpen);
+  useEffect(() => {
+    if (!seedDestinationMenuOpen) return;
+    seedDestinationItemRef.current?.focus();
+    const handleMouseDown = (event: MouseEvent) => {
+      if (!seedDestinationGroupRef.current?.contains(event.target as Node)) {
+        closeSeedDestinationMenu();
+      }
+    };
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [closeSeedDestinationMenu, seedDestinationMenuOpen]);
+  useEffect(() => {
+    if (!seedTenderSessionId) setSeedDestinationMenuOpen(false);
+  }, [seedTenderSessionId]);
 
   useEffect(() => {
     setBrowserAddress(tile.tileParams || '');
@@ -440,7 +482,7 @@ export function WorkspaceDockTile({
               <span className="workspace-dock-tile-send-status" role="status">Sending…</span>
             ) : sendStatus.kind === 'sent' ? (
               <span className="workspace-dock-tile-send-status workspace-dock-tile-send-status--ok" role="status">
-                Sent ✓
+                {sendStatus.destination === 'seed' ? 'Noted ✓' : 'Sent ✓'}
               </span>
             ) : sendStatus.kind === 'skipped' ? (
               <span className="workspace-dock-tile-send-status workspace-dock-tile-send-status--warn" role="status">
@@ -463,47 +505,105 @@ export function WorkspaceDockTile({
                 {sendStatus.message}
               </span>
             ) : null}
-            <select
-              className="workspace-dock-tile-session-picker"
-              aria-label="Send annotations to session"
-              value={targetSessionId}
-              onChange={(event) => {
-                const sessionId = event.target.value;
-                if (!sessionId || sessionId === targetSessionId) {
-                  return;
-                }
-                // Optimistic: the pick takes effect immediately (picker value
-                // AND Send target); the daemon echo confirms it later. On a
-                // failed retarget request, roll back to the persisted binding.
-                setPendingTargetSessionId(sessionId);
-                clearSendOutcome();
-                void Promise.resolve(onRetargetTile?.(sessionId)).catch((error) => {
-                  console.warn('[WorkspaceDockTile] Failed to retarget tile session:', error);
-                  setPendingTargetSessionId((prev) => (prev === sessionId ? null : prev));
-                });
-              }}
-            >
-              {!targetSessionId && (
-                <option value="" disabled>
-                  No session
-                </option>
-              )}
-              {workspaceSessions.map((session) => (
-                <option key={session.sessionId} value={session.sessionId}>
-                  {session.label}
-                  {session.state === 'pending_approval' ? ' ⏸ approval' : ''}
-                </option>
-              ))}
-            </select>
-            <button
-              type="button"
-              className="workspace-dock-tile-send-button"
-              disabled={sendDisabled}
-              title="Send annotations to the selected session (⌘Enter)"
-              onClick={sendNow}
-            >
-              {sending ? 'Sending…' : `Send ${annotationCount}`}
-            </button>
+            {isSeed ? (
+              <div
+                ref={seedDestinationGroupRef}
+                className="workspace-dock-tile-seed-submit"
+                role="group"
+                aria-label="Submit seed annotations"
+              >
+                <button
+                  type="button"
+                  className={`workspace-dock-tile-send-button${seedTenderSessionId ? ' workspace-dock-tile-send-button--split-primary' : ''}`}
+                  disabled={sendDisabled}
+                  title={seedTenderSessionId
+                    ? 'Send annotations to the tending session (⌘Enter)'
+                    : 'Leave annotations as a note on the seed (⌘Enter)'}
+                  onClick={sendNow}
+                >
+                  {sending
+                    ? (seedTenderSessionId ? 'Sending…' : 'Noting…')
+                    : seedTenderSessionId
+                      ? `Send ${annotationCount}`
+                      : `Note on seed ${annotationCount}`}
+                </button>
+                {seedTenderSessionId ? (
+                  <>
+                    <button
+                      ref={seedDestinationCaretRef}
+                      type="button"
+                      className="workspace-dock-tile-send-button workspace-dock-tile-send-button--split-caret"
+                      aria-label="More annotation destinations"
+                      aria-haspopup="menu"
+                      aria-expanded={seedDestinationMenuOpen}
+                      disabled={sendDisabled}
+                      onClick={() => setSeedDestinationMenuOpen((open) => !open)}
+                    >
+                      ▾
+                    </button>
+                    {seedDestinationMenuOpen ? (
+                      <div className="workspace-dock-tile-seed-submit-menu" role="menu">
+                        <button
+                          ref={seedDestinationItemRef}
+                          type="button"
+                          role="menuitem"
+                          onClick={() => {
+                            closeSeedDestinationMenu();
+                            sendAlternative(() => performAnnotationSend({ kind: 'seed', seedId: path }));
+                          }}
+                        >
+                          Note on seed
+                        </button>
+                      </div>
+                    ) : null}
+                  </>
+                ) : null}
+              </div>
+            ) : (
+              <>
+                <select
+                  className="workspace-dock-tile-session-picker"
+                  aria-label="Send annotations to session"
+                  value={targetSessionId}
+                  onChange={(event) => {
+                    const sessionId = event.target.value;
+                    if (!sessionId || sessionId === targetSessionId) {
+                      return;
+                    }
+                    // Optimistic: the pick takes effect immediately (picker value
+                    // AND Send target); the daemon echo confirms it later. On a
+                    // failed retarget request, roll back to the persisted binding.
+                    setPendingTargetSessionId(sessionId);
+                    clearSendOutcome();
+                    void Promise.resolve(onRetargetTile?.(sessionId)).catch((error) => {
+                      console.warn('[WorkspaceDockTile] Failed to retarget tile session:', error);
+                      setPendingTargetSessionId((prev) => (prev === sessionId ? null : prev));
+                    });
+                  }}
+                >
+                  {!targetSessionId && (
+                    <option value="" disabled>
+                      No session
+                    </option>
+                  )}
+                  {workspaceSessions.map((session) => (
+                    <option key={session.sessionId} value={session.sessionId}>
+                      {session.label}
+                      {session.state === 'pending_approval' ? ' ⏸ approval' : ''}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  className="workspace-dock-tile-send-button"
+                  disabled={sendDisabled}
+                  title="Send annotations to the selected session (⌘Enter)"
+                  onClick={sendNow}
+                >
+                  {sending ? 'Sending…' : `Send ${annotationCount}`}
+                </button>
+              </>
+            )}
           </div>
         ) : null}
         <div className="workspace-dock-tile-actions">
@@ -640,6 +740,22 @@ function SeedTileBody({
   const { sendSeedDocumentGet, sendOpenMarkdown } = useDaemonApi();
   const [document, setDocument] = useState<SeedDocument | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const liveSeed = useMemo(
+    () => gardenSeeds.find((seed) => seed.id === seedId) ?? null,
+    [gardenSeeds, seedId],
+  );
+  const displayedDocument = useMemo(() => {
+    if (!document || !liveSeed || liveSeed.rev < document.seed.rev) return document;
+    const tenderChanged = liveSeed.tender_session !== document.seed.tender_session
+      || liveSeed.tender_member !== document.seed.tender_member;
+    return {
+      ...document,
+      seed: liveSeed,
+      tender_holds: tenderChanged
+        ? Boolean(liveSeed.tender_session || liveSeed.tender_member)
+        : document.tender_holds,
+    };
+  }, [document, liveSeed]);
 
   // Every garden fact re-pushes the seeds snapshot. Notes and child changes do
   // not necessarily touch this seed's own revision, so the array identity is
@@ -656,8 +772,19 @@ function SeedTileBody({
     void sendSeedDocumentGet(seedId)
       .then((next) => {
         if (ignore) return;
-        setDocument(next);
-        onDocument(next);
+        if (liveSeed && liveSeed.rev >= next.seed.rev) {
+          const tenderChanged = liveSeed.tender_session !== next.seed.tender_session
+            || liveSeed.tender_member !== next.seed.tender_member;
+          setDocument({
+            ...next,
+            seed: liveSeed,
+            tender_holds: tenderChanged
+              ? Boolean(liveSeed.tender_session || liveSeed.tender_member)
+              : next.tender_holds,
+          });
+        } else {
+          setDocument(next);
+        }
       })
       .catch((readError) => {
         if (ignore) return;
@@ -666,11 +793,15 @@ function SeedTileBody({
     return () => {
       ignore = true;
     };
-  }, [gardenSeeds, onDocument, seedId, sendSeedDocumentGet]);
+  }, [gardenSeeds, liveSeed, seedId, sendSeedDocumentGet]);
+
+  useEffect(() => {
+    onDocument(displayedDocument);
+  }, [displayedDocument, onDocument]);
 
   useEffect(() => () => onDocument(null), [onDocument]);
 
-  if (!document) {
+  if (!displayedDocument) {
     return (
       <div className={`workspace-dock-tile-message${error ? ' workspace-dock-tile-error' : ''}`}>
         {error || 'Loading seed…'}
@@ -680,7 +811,7 @@ function SeedTileBody({
 
   return (
     <SeedDocumentView
-      document={document}
+      document={displayedDocument}
       annotationsEnabled
       onAnnotationsCountChange={onAnnotationsCountChange}
       annotationsSendRef={annotationsSendRef}

--- a/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.tsx
+++ b/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.tsx
@@ -273,12 +273,17 @@ export function WorkspaceDockTile({
 
   const sending = sendStatus.kind === 'sending';
   const sendDisabled = sending || annotationCount === 0 || !primaryDestination || !transportAvailable;
-  const [seedDestinationMenuOpen, setSeedDestinationMenuOpen] = useState(false);
+  const seedDestinationMenuKey = seedTenderSessionId && seedDocument
+    ? `${seedTenderSessionId}:${seedDocument.seed.rev}`
+    : null;
+  const [openSeedDestinationMenuKey, setOpenSeedDestinationMenuKey] = useState<string | null>(null);
+  const seedDestinationMenuOpen = seedDestinationMenuKey !== null
+    && openSeedDestinationMenuKey === seedDestinationMenuKey;
   const seedDestinationGroupRef = useRef<HTMLDivElement>(null);
   const seedDestinationCaretRef = useRef<HTMLButtonElement>(null);
   const seedDestinationItemRef = useRef<HTMLButtonElement>(null);
   const closeSeedDestinationMenu = useCallback((restoreFocus = false) => {
-    setSeedDestinationMenuOpen(false);
+    setOpenSeedDestinationMenuKey(null);
     if (restoreFocus) {
       window.requestAnimationFrame(() => seedDestinationCaretRef.current?.focus());
     }
@@ -295,9 +300,6 @@ export function WorkspaceDockTile({
     document.addEventListener('mousedown', handleMouseDown);
     return () => document.removeEventListener('mousedown', handleMouseDown);
   }, [closeSeedDestinationMenu, seedDestinationMenuOpen]);
-  useEffect(() => {
-    if (!seedTenderSessionId) setSeedDestinationMenuOpen(false);
-  }, [seedTenderSessionId]);
 
   useEffect(() => {
     setBrowserAddress(tile.tileParams || '');
@@ -540,7 +542,9 @@ export function WorkspaceDockTile({
                       aria-haspopup="menu"
                       aria-expanded={seedDestinationMenuOpen}
                       disabled={sendDisabled}
-                      onClick={() => setSeedDestinationMenuOpen((open) => !open)}
+                      onClick={() => setOpenSeedDestinationMenuKey((openKey) => (
+                        openKey === seedDestinationMenuKey ? null : seedDestinationMenuKey
+                      ))}
                     >
                       ▾
                     </button>

--- a/app/src/contexts/DaemonApiContext.tsx
+++ b/app/src/contexts/DaemonApiContext.tsx
@@ -21,8 +21,12 @@ export function DaemonApiProvider({ api, children }: { api: DaemonApi; children:
   return <DaemonApiContext.Provider value={api}>{children}</DaemonApiContext.Provider>;
 }
 
+export function useOptionalDaemonApi(): DaemonApi | null {
+  return useContext(DaemonApiContext);
+}
+
 export function useDaemonApi(): DaemonApi {
-  const api = useContext(DaemonApiContext);
+  const api = useOptionalDaemonApi();
   if (!api) {
     throw new Error('useDaemonApi must be used within DaemonApiProvider');
   }

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -3602,6 +3602,60 @@ describe('useDaemonSocket notebook and annotation events', () => {
     unmount();
   });
 
+  it('serializes exactly one typed markdown annotation destination', async () => {
+    const { result, unmount, ws } = await renderAndOpen();
+
+    const fileSource = fileMarkdownSource('ws-1', '/tmp/doc.md');
+    const delivered = result.current.submitMarkdownAnnotations(
+      fileSource,
+      { kind: 'session', sessionId: 'sess-a' },
+      ['moved-1'],
+    );
+    await Promise.resolve();
+    const sessionSent = lastSent(ws);
+    expect(sessionSent).toMatchObject({
+      cmd: 'markdown_annotations_submit',
+      document_uri: fileSource.uri,
+      target_session_id: 'sess-a',
+      orphaned_ids: ['moved-1'],
+    });
+    expect(sessionSent.target_seed_id).toBeUndefined();
+    ws.emit({
+      event: 'markdown_annotations_submit_result',
+      request_id: sessionSent.request_id,
+      document_uri: fileSource.uri,
+      success: true,
+      status: 'delivered',
+    });
+    await expect(delivered).resolves.toMatchObject({ status: 'delivered' });
+
+    const seedSource = seedMarkdownSource('s-7k3f9m');
+    const noted = result.current.submitMarkdownAnnotations(
+      seedSource,
+      { kind: 'seed', seedId: 's-7k3f9m' },
+      [],
+    );
+    await Promise.resolve();
+    const seedSent = lastSent(ws);
+    expect(seedSent).toMatchObject({
+      cmd: 'markdown_annotations_submit',
+      document_uri: seedSource.uri,
+      source_kind: 'seed',
+      seed_id: 's-7k3f9m',
+      target_seed_id: 's-7k3f9m',
+    });
+    expect(seedSent.target_session_id).toBeUndefined();
+    ws.emit({
+      event: 'markdown_annotations_submit_result',
+      request_id: seedSent.request_id,
+      document_uri: seedSource.uri,
+      success: true,
+      status: 'noted',
+    });
+    await expect(noted).resolves.toMatchObject({ status: 'noted' });
+    unmount();
+  });
+
   it('treats a stale save as a resolved outcome, not an error', async () => {
     const { result, unmount, ws } = await renderAndOpen();
 
@@ -3713,6 +3767,7 @@ describe('useDaemonSocket notebook and annotation events', () => {
     expect(sent).toMatchObject({ cmd: 'seed_document_get', seed_id: 's-7k3f9m' });
     const document = {
       seed: { id: 's-7k3f9m', title: 'Garden era', body: '# Plan' },
+      tender_holds: false,
       children: [],
       notes: [],
       notes_total: 0,

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -84,6 +84,7 @@ import {
   markdownAnnotationKey,
 } from './daemonMarkdownAnnotationEvents';
 import type { MarkdownDocumentSource } from '../components/MarkdownReader/documentSource';
+import type { MarkdownAnnotationsDestination } from '../components/MarkdownReader/annotations/transport';
 import {
   pendingRequestKey,
   sendKeyedRequest as sendLastWriterWinsRequest,
@@ -133,6 +134,7 @@ export type TicketRow = GeneratedTicketRow;
 export type Seed = GeneratedSeed;
 export interface SeedDocument {
   seed: Seed;
+  tender_holds: boolean;
   children: Seed[];
   notes: GeneratedSeedNote[];
   notes_total: number;
@@ -4114,19 +4116,22 @@ export function useDaemonSocket({
       'clear', source, { generation },
     ), [sendMarkdownAnnotationsCommand]);
 
-  // PR6 send flow: format the persisted draft and type it into the target
-  // session's PTY. Pending key `submit:<path>` — a second Send for the same
-  // path supersedes the first; the doorbell is one PTY write, so the shared
-  // 10s timeout is ample. Resolves `{status, generation?, error?}` for both
-  // `delivered` and `skipped_pending_approval`; rejects on `status:"error"`.
+  // Format the persisted draft and submit it to one typed destination. Pending
+  // key `submit:<uri>` keeps this last-writer-wins per document. Resolves the
+  // accepted/skipped status and rejects on `status:"error"`.
   const submitMarkdownAnnotations = useCallback((
     source: MarkdownDocumentSource,
-    targetSessionId: string,
+    destination: MarkdownAnnotationsDestination,
     orphanedIds: string[],
-  ) =>
+  ) => {
+    const destinationFields = destination.kind === 'session'
+      ? { target_session_id: destination.sessionId }
+      : { target_seed_id: destination.seedId };
+    return (
     sendMarkdownAnnotationsCommand<{ status: string; generation?: number; error?: string }>(
-      'submit', source, { target_session_id: targetSessionId, orphaned_ids: orphanedIds },
-    ), [sendMarkdownAnnotationsCommand]);
+      'submit', source, { ...destinationFields, orphaned_ids: orphanedIds },
+    ));
+  }, [sendMarkdownAnnotationsCommand]);
 
   // Mute a PR with optimistic update
   const sendMutePR = useCallback((prId: string) => {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentMsgMessage, AgentMsgResult, AgentMsgStatus, AgentPeekMessage, AgentPeekResult, AgentPeekScreen, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, AppApplyMessage, AppApplyResult, AppConsumerInfo, AppInvocationInfo, AppListMessage, AppListResult, AppLogsMessage, AppLogsResult, AppRemoveMessage, AppRemoveResult, AppRollbackMessage, AppRollbackResult, AppRuntimeInfo, AppRuntimeRestartMessage, AppRuntimeRestartResult, AppRuntimeStatusMessage, AppRuntimeStatusResult, AppSetEnabledMessage, AppSetEnabledResult, AppStallInfo, AppStatusMessage, AppStatusResult, AppSummary, AppVersionInfo, AppWatchMessage, AppWatchResult, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, BusConsumerStatus, BusHealthEntry, BusProducerStatus, BusSetConsumerEnabledMessage, BusSetConsumerEnabledResultMessage, BusStatusGetMessage, BusStatusResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, CrewDayClose, CrewHandoffMessage, CrewHandoffResult, CrewListMessage, CrewListResult, CrewMember, CrewPrimeMessage, CrewPrimeResult, CrewSetMessage, CrewSetResult, CrewSleepMessage, CrewSleepResult, CrewSleepResultMessage, CrewUpdatedMessage, CrewWakeMessage, CrewWakeResult, CrewWakeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocUndefineMessage, DocUndefineResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GardenSeedsUpdatedMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, OpenSeedMessage, OpenSeedResultMessage, OpenSentFilesMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyInputProbeResultMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Seed, SeedArtifactReference, SeedDocument, SeedDocumentGetMessage, SeedDocumentGetResultMessage, SeedEdge, SeedLinkMessage, SeedLinkResult, SeedListMessage, SeedListResult, SeedNote, SeedNoteMessage, SeedNoteResult, SeedNotesMessage, SeedNotesResult, SeedPlantMessage, SeedPlantResult, SeedPlotChild, SeedPlotMessage, SeedPlotProgress, SeedPlotResult, SeedReadyMessage, SeedReadyResult, SeedRelation, SeedShowMessage, SeedShowResult, SeedTransitionMessage, SeedTransitionResult, SeedVar, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessageWindowStatus, SessionMessagesChangedMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketRow, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentMsgMessage, AgentMsgResult, AgentMsgStatus, AgentPeekMessage, AgentPeekResult, AgentPeekScreen, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, AppApplyMessage, AppApplyResult, AppConsumerInfo, AppInvocationInfo, AppListMessage, AppListResult, AppLogsMessage, AppLogsResult, AppRemoveMessage, AppRemoveResult, AppRollbackMessage, AppRollbackResult, AppRuntimeInfo, AppRuntimeRestartMessage, AppRuntimeRestartResult, AppRuntimeStatusMessage, AppRuntimeStatusResult, AppSetEnabledMessage, AppSetEnabledResult, AppStallInfo, AppStatusMessage, AppStatusResult, AppSummary, AppVersionInfo, AppWatchMessage, AppWatchResult, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, BusConsumerStatus, BusHealthEntry, BusProducerStatus, BusSetConsumerEnabledMessage, BusSetConsumerEnabledResultMessage, BusStatusGetMessage, BusStatusResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, CrewDayClose, CrewHandoffMessage, CrewHandoffResult, CrewListMessage, CrewListResult, CrewMember, CrewPrimeMessage, CrewPrimeResult, CrewSetMessage, CrewSetResult, CrewSleepMessage, CrewSleepResult, CrewSleepResultMessage, CrewUpdatedMessage, CrewWakeMessage, CrewWakeResult, CrewWakeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocUndefineMessage, DocUndefineResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GardenSeedsUpdatedMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, OpenSeedMessage, OpenSeedResultMessage, OpenSentFilesMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyInputProbeResultMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Seed, SeedArtifactReference, SeedDocument, SeedDocumentGetMessage, SeedDocumentGetResultMessage, SeedEdge, SeedEditMessage, SeedEditResult, SeedLinkMessage, SeedLinkResult, SeedListMessage, SeedListResult, SeedNote, SeedNoteMessage, SeedNoteResult, SeedNotesMessage, SeedNotesResult, SeedPlantMessage, SeedPlantResult, SeedPlotChild, SeedPlotMessage, SeedPlotProgress, SeedPlotResult, SeedReadyMessage, SeedReadyResult, SeedRelation, SeedShowMessage, SeedShowResult, SeedTransitionMessage, SeedTransitionResult, SeedVar, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessageWindowStatus, SessionMessagesChangedMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketRow, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const activityStatusMessage = Convert.toActivityStatusMessage(json);
 //   const activityStatusResult = Convert.toActivityStatusResult(json);
@@ -365,6 +365,8 @@
 //   const seedDocumentGetMessage = Convert.toSeedDocumentGetMessage(json);
 //   const seedDocumentGetResultMessage = Convert.toSeedDocumentGetResultMessage(json);
 //   const seedEdge = Convert.toSeedEdge(json);
+//   const seedEditMessage = Convert.toSeedEditMessage(json);
+//   const seedEditResult = Convert.toSeedEditResult(json);
 //   const seedLinkMessage = Convert.toSeedLinkMessage(json);
 //   const seedLinkResult = Convert.toSeedLinkResult(json);
 //   const seedListMessage = Convert.toSeedListMessage(json);
@@ -4183,15 +4185,16 @@ export enum MarkdownAnnotationsSaveResultMessageEvent {
 }
 
 export interface MarkdownAnnotationsSubmitMessage {
-    cmd:               MarkdownAnnotationsSubmitMessageCmd;
-    document_uri:      string;
-    orphaned_ids?:     string[];
-    path?:             string;
-    request_id:        string;
-    seed_id?:          string;
-    source_kind:       string;
-    target_session_id: string;
-    workspace_id?:     string;
+    cmd:                MarkdownAnnotationsSubmitMessageCmd;
+    document_uri:       string;
+    orphaned_ids?:      string[];
+    path?:              string;
+    request_id:         string;
+    seed_id?:           string;
+    source_kind:        string;
+    target_seed_id?:    string;
+    target_session_id?: string;
+    workspace_id?:      string;
     [property: string]: any;
 }
 
@@ -4200,18 +4203,19 @@ export enum MarkdownAnnotationsSubmitMessageCmd {
 }
 
 export interface MarkdownAnnotationsSubmitResultMessage {
-    document_uri:      string;
-    error?:            string;
-    event:             MarkdownAnnotationsSubmitResultMessageEvent;
-    generation?:       number;
-    path?:             string;
-    request_id:        string;
-    seed_id?:          string;
-    source_kind:       string;
-    status:            string;
-    success:           boolean;
-    target_session_id: string;
-    workspace_id?:     string;
+    document_uri:       string;
+    error?:             string;
+    event:              MarkdownAnnotationsSubmitResultMessageEvent;
+    generation?:        number;
+    path?:              string;
+    request_id:         string;
+    seed_id?:           string;
+    source_kind:        string;
+    status:             string;
+    success:            boolean;
+    target_seed_id?:    string;
+    target_session_id?: string;
+    workspace_id?:      string;
     [property: string]: any;
 }
 
@@ -5456,6 +5460,7 @@ export interface Response {
     present_open_result?:                  PresentOpenResultObject;
     prs?:                                  PRElement[];
     repos?:                                RepoElement[];
+    seed_edit_result?:                     SeedEditResultObject;
     seed_link_result?:                     SeedLinkResultObject;
     seed_list_result?:                     SeedListResultObject;
     seed_note_result?:                     SeedNoteResultObject;
@@ -5750,6 +5755,11 @@ export interface PresentOpenResultObject {
     seq:             number;
     title:           string;
     warnings?:       string[];
+    [property: string]: any;
+}
+
+export interface SeedEditResultObject {
+    seed: SeedElement;
     [property: string]: any;
 }
 
@@ -6138,10 +6148,11 @@ export interface SeedArtifactReference {
 }
 
 export interface SeedDocument {
-    children:    SeedElement[];
-    notes:       Note[];
-    notes_total: number;
-    seed:        SeedElement;
+    children:     SeedElement[];
+    notes:        Note[];
+    notes_total:  number;
+    seed:         SeedElement;
+    tender_holds: boolean;
     [property: string]: any;
 }
 
@@ -6166,10 +6177,11 @@ export interface SeedDocumentGetResultMessage {
 }
 
 export interface SeedDocumentGetResultMessageDocument {
-    children:    SeedElement[];
-    notes:       Note[];
-    notes_total: number;
-    seed:        SeedElement;
+    children:     SeedElement[];
+    notes:        Note[];
+    notes_total:  number;
+    seed:         SeedElement;
+    tender_holds: boolean;
     [property: string]: any;
 }
 
@@ -6180,6 +6192,22 @@ export enum SeedDocumentGetResultMessageEvent {
 export interface SeedEdge {
     kind: string;
     to:   string;
+    [property: string]: any;
+}
+
+export interface SeedEditMessage {
+    body:    string;
+    cmd:     SeedEditMessageCmd;
+    seed_id: string;
+    [property: string]: any;
+}
+
+export enum SeedEditMessageCmd {
+    SeedEdit = "seed_edit",
+}
+
+export interface SeedEditResult {
+    seed: SeedElement;
     [property: string]: any;
 }
 
@@ -11243,6 +11271,22 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SeedEdge")), null, 2);
     }
 
+    public static toSeedEditMessage(json: string): SeedEditMessage {
+        return cast(JSON.parse(json), r("SeedEditMessage"));
+    }
+
+    public static seedEditMessageToJson(value: SeedEditMessage): string {
+        return JSON.stringify(uncast(value, r("SeedEditMessage")), null, 2);
+    }
+
+    public static toSeedEditResult(json: string): SeedEditResult {
+        return cast(JSON.parse(json), r("SeedEditResult"));
+    }
+
+    public static seedEditResultToJson(value: SeedEditResult): string {
+        return JSON.stringify(uncast(value, r("SeedEditResult")), null, 2);
+    }
+
     public static toSeedLinkMessage(json: string): SeedLinkMessage {
         return cast(JSON.parse(json), r("SeedLinkMessage"));
     }
@@ -15103,7 +15147,8 @@ const typeMap: any = {
         { json: "request_id", js: "request_id", typ: "" },
         { json: "seed_id", js: "seed_id", typ: u(undefined, "") },
         { json: "source_kind", js: "source_kind", typ: "" },
-        { json: "target_session_id", js: "target_session_id", typ: "" },
+        { json: "target_seed_id", js: "target_seed_id", typ: u(undefined, "") },
+        { json: "target_session_id", js: "target_session_id", typ: u(undefined, "") },
         { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
     ], "any"),
     "MarkdownAnnotationsSubmitResultMessage": o([
@@ -15117,7 +15162,8 @@ const typeMap: any = {
         { json: "source_kind", js: "source_kind", typ: "" },
         { json: "status", js: "status", typ: "" },
         { json: "success", js: "success", typ: true },
-        { json: "target_session_id", js: "target_session_id", typ: "" },
+        { json: "target_seed_id", js: "target_seed_id", typ: u(undefined, "") },
+        { json: "target_session_id", js: "target_session_id", typ: u(undefined, "") },
         { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
     ], "any"),
     "MergePRMessage": o([
@@ -15863,6 +15909,7 @@ const typeMap: any = {
         { json: "present_open_result", js: "present_open_result", typ: u(undefined, r("PresentOpenResultObject")) },
         { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
         { json: "repos", js: "repos", typ: u(undefined, a(r("RepoElement"))) },
+        { json: "seed_edit_result", js: "seed_edit_result", typ: u(undefined, r("SeedEditResultObject")) },
         { json: "seed_link_result", js: "seed_link_result", typ: u(undefined, r("SeedLinkResultObject")) },
         { json: "seed_list_result", js: "seed_list_result", typ: u(undefined, r("SeedListResultObject")) },
         { json: "seed_note_result", js: "seed_note_result", typ: u(undefined, r("SeedNoteResultObject")) },
@@ -16091,6 +16138,9 @@ const typeMap: any = {
         { json: "seq", js: "seq", typ: 0 },
         { json: "title", js: "title", typ: "" },
         { json: "warnings", js: "warnings", typ: u(undefined, a("")) },
+    ], "any"),
+    "SeedEditResultObject": o([
+        { json: "seed", js: "seed", typ: r("SeedElement") },
     ], "any"),
     "SeedLinkResultObject": o([
         { json: "changed", js: "changed", typ: true },
@@ -16377,6 +16427,7 @@ const typeMap: any = {
         { json: "notes", js: "notes", typ: a(r("Note")) },
         { json: "notes_total", js: "notes_total", typ: 0 },
         { json: "seed", js: "seed", typ: r("SeedElement") },
+        { json: "tender_holds", js: "tender_holds", typ: true },
     ], "any"),
     "SeedDocumentGetMessage": o([
         { json: "cmd", js: "cmd", typ: r("SeedDocumentGetMessageCmd") },
@@ -16395,10 +16446,19 @@ const typeMap: any = {
         { json: "notes", js: "notes", typ: a(r("Note")) },
         { json: "notes_total", js: "notes_total", typ: 0 },
         { json: "seed", js: "seed", typ: r("SeedElement") },
+        { json: "tender_holds", js: "tender_holds", typ: true },
     ], "any"),
     "SeedEdge": o([
         { json: "kind", js: "kind", typ: "" },
         { json: "to", js: "to", typ: "" },
+    ], "any"),
+    "SeedEditMessage": o([
+        { json: "body", js: "body", typ: "" },
+        { json: "cmd", js: "cmd", typ: r("SeedEditMessageCmd") },
+        { json: "seed_id", js: "seed_id", typ: "" },
+    ], "any"),
+    "SeedEditResult": o([
+        { json: "seed", js: "seed", typ: r("SeedElement") },
     ], "any"),
     "SeedLinkMessage": o([
         { json: "cmd", js: "cmd", typ: r("SeedLinkMessageCmd") },
@@ -18511,6 +18571,9 @@ const typeMap: any = {
     ],
     "SeedDocumentGetResultMessageEvent": [
         "seed_document_get_result",
+    ],
+    "SeedEditMessageCmd": [
+        "seed_edit",
     ],
     "SeedLinkMessageCmd": [
         "seed_link",

--- a/changelog.d/delegate-garden-bcd-living-seeds.yaml
+++ b/changelog.d/delegate-garden-bcd-living-seeds.yaml
@@ -1,0 +1,6 @@
+kind: added
+area: garden
+change: >
+  Open seed documents now re-anchor annotations as their body changes, send
+  feedback to a live tender by default, and keep unattended feedback as a note
+  in the seed ledger.

--- a/cmd/attn/seed.go
+++ b/cmd/attn/seed.go
@@ -42,6 +42,8 @@ func runSeed() {
 		runSeedList(args)
 	case "show":
 		runSeedShow(args)
+	case "edit":
+		runSeedEdit(args)
 	case "export":
 		runSeedExport(args)
 	case "tend", "park", "harvest", "wither", "replant":
@@ -109,6 +111,10 @@ commands:
         one seed: the freshest handoff left on it, its state, who tends it,
         every edge that touches it in both directions, its body, and the newest
         notes on its log.
+
+  edit <id> -m <body>
+        replace the seed's markdown body without moving its state or claim.
+        - reads stdin; an explicit empty -m clears the body.
 
   tend <id> [--member <name>]
         claim the seed and start growing it. One tender at a time: tending a
@@ -288,6 +294,16 @@ func (f *seedFlags) sessionID() string {
 		return id
 	}
 	return strings.TrimSpace(os.Getenv("ATTN_SESSION_ID"))
+}
+
+func (f *seedFlags) wasSet(name string) bool {
+	set := false
+	f.fs.Visit(func(flag *flag.Flag) {
+		if flag.Name == name {
+			set = true
+		}
+	})
+	return set
 }
 
 // staleWindowSeconds reads --window, refusing a value that is not a duration.
@@ -517,6 +533,26 @@ func runSeedShow(args []string) {
 		return
 	}
 	fprintSeedShow(os.Stdout, result)
+}
+
+func runSeedEdit(args []string) {
+	f := newSeedFlags("edit")
+	positionals := f.parse("edit", args)
+	if len(positionals) != 1 {
+		seedFail("edit", fmt.Errorf("needs exactly one seed id, got %d: attn seed edit s-7k3f9m -m -", len(positionals)))
+	}
+	if !f.wasSet("m") {
+		seedFail("edit", fmt.Errorf("needs -m <body>; use -m - to read markdown from stdin, or -m '' to clear it"))
+	}
+	result, err := seedClient().SeedEdit(positionals[0], f.text("edit"))
+	if err != nil {
+		seedFail("edit", err)
+	}
+	if *f.json {
+		writeJSON(result.Seed)
+		return
+	}
+	fmt.Printf("updated %s at revision %d\n", result.Seed.ID, result.Seed.Rev)
 }
 
 // fprintSeedShow renders one seed for a reader. The handoff comes before the

--- a/docs/plans/2026-08-14-garden-era-epic.md
+++ b/docs/plans/2026-08-14-garden-era-epic.md
@@ -168,8 +168,8 @@ events.
       panel read-only drill (ruling A).
 - [x] `attn://seed/<id>` URI, draft-key generalization, typed
       daemon fields (ruling B).
-- [ ] Live re-anchor on body edits (ruling C).
-- [ ] Split-button submit with the untended flip (ruling D).
+- [x] Live re-anchor on body edits (ruling C).
+- [x] Split-button submit with the untended flip (ruling D).
 - [ ] Delegation reporting on seeds: bind at dispatch, log-note status,
       typed `attach`/`detach` with the artifact projection, agent-msg
       steering — the weight transfer.

--- a/internal/client/garden.go
+++ b/internal/client/garden.go
@@ -72,6 +72,19 @@ func (c *Client) SeedShow(seedID string) (*protocol.SeedShowResult, error) {
 	return resp.SeedShowResult, nil
 }
 
+// SeedEdit replaces one seed's markdown body without moving its lifecycle or
+// claim. An empty body is deliberate and clears the document.
+func (c *Client) SeedEdit(seedID, body string) (*protocol.SeedEditResult, error) {
+	resp, err := c.send(protocol.SeedEditMessage{Cmd: protocol.CmdSeedEdit, SeedID: seedID, Body: body})
+	if err != nil {
+		return nil, err
+	}
+	if resp.SeedEditResult == nil {
+		return nil, fmt.Errorf("the daemon accepted the edit but returned no seed")
+	}
+	return resp.SeedEditResult, nil
+}
+
 // SeedTransition moves a seed through its life. The daemon decides whether the
 // move is legal from the state the seed is in and refuses by name; nothing here
 // pre-judges it, so the CLI and the app cannot disagree about the rules.

--- a/internal/daemon/bus.go
+++ b/internal/daemon/bus.go
@@ -203,6 +203,10 @@ const (
 	// after the write it describes has committed, so a consumer that reads it
 	// always finds the seed.
 	FactGardenPlanted = "garden.planted"
+	// FactGardenBodyEdited: a seed's living markdown document changed. The
+	// garden snapshot carries the new body and revision so open readers can
+	// re-anchor immediately without waiting on a detail refetch.
+	FactGardenBodyEdited = "garden.body_edited"
 	// One fact per lifecycle move, rather than one `garden.changed`: the subject
 	// says which seed and the name says what happened to it, which is what a
 	// change feed and a future nudge both read. All of them project the same way
@@ -354,7 +358,12 @@ func buildWireProjections() []projection {
 		},
 		{
 			filter: bus.Filter{FactSessionUnregistered},
-			apply:  func(d *Daemon, ev bus.Event) { d.projectSessionUnregistered(ev) },
+			apply: func(d *Daemon, ev bus.Event) {
+				d.projectSessionUnregistered(ev)
+				// Session liveness is part of garden truth: it decides whether a
+				// stored tender still holds and therefore where feedback routes.
+				d.projectGardenSeeds()
+			},
 		},
 		{
 			filter: bus.Filter{FactSessionRespawned},

--- a/internal/daemon/bus.go
+++ b/internal/daemon/bus.go
@@ -314,6 +314,8 @@ func buildWireProjections() []projection {
 			filter: bus.Filter{FactSessionRegistered},
 			apply: func(d *Daemon, ev bus.Event) {
 				d.projectSessionEvent(protocol.EventSessionRegistered, ev.Subject)
+				// A new session can reactivate a stored tender with the same id.
+				d.projectGardenSeeds()
 			},
 		},
 		{
@@ -372,6 +374,8 @@ func buildWireProjections() []projection {
 					Event: protocol.EventRuntimeRespawned,
 					ID:    protocol.Ptr(ev.Subject),
 				})
+				// Keep the computed tender hold in lockstep with session rebirth.
+				d.projectGardenSeeds()
 			},
 		},
 		{

--- a/internal/daemon/bus_wire_join_test.go
+++ b/internal/daemon/bus_wire_join_test.go
@@ -55,7 +55,7 @@ var wireFixtures = map[string]wireFixture{
 		subject: (*wireWorld).session,
 	},
 	FactSessionRegistered: {
-		events:  []string{protocol.EventSessionRegistered},
+		events:  []string{protocol.EventSessionRegistered, protocol.EventGardenSeedsUpdated},
 		subject: (*wireWorld).session,
 	},
 	FactSessionReregistered: {
@@ -107,7 +107,7 @@ var wireFixtures = map[string]wireFixture{
 		payload: func(w *wireWorld) any { return w.d.sessionForBroadcast(w.d.store.Get(w.sessionID)) },
 	},
 	FactSessionRespawned: {
-		events:  []string{protocol.EventRuntimeRespawned},
+		events:  []string{protocol.EventRuntimeRespawned, protocol.EventGardenSeedsUpdated},
 		subject: (*wireWorld).session,
 	},
 	FactSessionPTYResized: {

--- a/internal/daemon/bus_wire_join_test.go
+++ b/internal/daemon/bus_wire_join_test.go
@@ -102,7 +102,7 @@ var wireFixtures = map[string]wireFixture{
 	},
 	FactSessionUnregistered: {
 		// The session is gone by then, so it rides in the payload.
-		events:  []string{protocol.EventSessionUnregistered},
+		events:  []string{protocol.EventSessionUnregistered, protocol.EventGardenSeedsUpdated},
 		subject: (*wireWorld).session,
 		payload: func(w *wireWorld) any { return w.d.sessionForBroadcast(w.d.store.Get(w.sessionID)) },
 	},
@@ -205,6 +205,7 @@ var wireFixtures = map[string]wireFixture{
 	FactTicketAttached:      {events: []string{protocol.EventTicketsUpdated}},
 	FactTicketChanged:       {events: []string{protocol.EventTicketsUpdated}},
 	FactGardenPlanted:       {events: []string{protocol.EventGardenSeedsUpdated}},
+	FactGardenBodyEdited:    {events: []string{protocol.EventGardenSeedsUpdated}},
 	FactGardenTended:        {events: []string{protocol.EventGardenSeedsUpdated}},
 	FactGardenParked:        {events: []string{protocol.EventGardenSeedsUpdated}},
 	FactGardenHarvested:     {events: []string{protocol.EventGardenSeedsUpdated}},

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -48,6 +48,7 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdSeedPlot:                   commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdSeedList:                   commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdSeedShow:                   commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdSeedEdit:                   commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdSeedTransition:             commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdSeedNote:                   commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdSeedNotes:                  commandMetadata(ScopeHubLocal, false, true),

--- a/internal/daemon/command_meta_test.go
+++ b/internal/daemon/command_meta_test.go
@@ -25,6 +25,9 @@ func TestCommandMetaExamples(t *testing.T) {
 	if meta := CommandMeta[protocol.CmdOpenSeed]; meta.Scope != ScopeHubLocal {
 		t.Fatalf("open_seed scope = %v, want %v", meta.Scope, ScopeHubLocal)
 	}
+	if meta := CommandMeta[protocol.CmdSeedEdit]; meta.Scope != ScopeHubLocal {
+		t.Fatalf("seed_edit scope = %v, want %v", meta.Scope, ScopeHubLocal)
+	}
 	if !blocksDuringRecovery(protocol.CmdPtyInput) {
 		t.Fatal("pty_input should block during recovery")
 	}
@@ -109,8 +112,16 @@ func TestRemoteCommandSessionID(t *testing.T) {
 			// its own local store.
 			name: "markdown_annotations_submit",
 			cmd:  protocol.CmdMarkdownAnnotationsSubmit,
-			msg:  &protocol.MarkdownAnnotationsSubmitMessage{Path: protocol.Ptr("/tmp/notes.md"), TargetSessionID: "sess-md-submit"},
+			msg:  &protocol.MarkdownAnnotationsSubmitMessage{Path: protocol.Ptr("/tmp/notes.md"), TargetSessionID: protocol.Ptr("sess-md-submit")},
 			want: "sess-md-submit",
+		},
+		{
+			name: "markdown_annotations_note_on_seed stays home local",
+			cmd:  protocol.CmdMarkdownAnnotationsSubmit,
+			msg: &protocol.MarkdownAnnotationsSubmitMessage{
+				SeedID: protocol.Ptr("s-abc123"), TargetSeedID: protocol.Ptr("s-abc123"),
+			},
+			want: "",
 		},
 		{
 			// Hub→remote regression: a turn's stamps are written by the daemon

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2813,6 +2813,8 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleSeedList(conn, msg.(*protocol.SeedListMessage))
 	case protocol.CmdSeedShow: // wire: seed_show
 		d.handleSeedShow(conn, msg.(*protocol.SeedShowMessage))
+	case protocol.CmdSeedEdit: // wire: seed_edit
+		d.handleSeedEdit(conn, msg.(*protocol.SeedEditMessage))
 	case protocol.CmdSeedTransition: // wire: seed_transition
 		d.handleSeedTransition(conn, msg.(*protocol.SeedTransitionMessage))
 	case protocol.CmdSeedNote: // wire: seed_note

--- a/internal/daemon/garden.go
+++ b/internal/daemon/garden.go
@@ -705,9 +705,57 @@ func (d *Daemon) handleSeedShow(conn net.Conn, msg *protocol.SeedShowMessage) {
 	})
 }
 
+func (d *Daemon) handleSeedEdit(conn net.Conn, msg *protocol.SeedEditMessage) {
+	if err := d.requireHome(garden.Surface); err != nil {
+		d.sendGardenError(conn, "edit", err)
+		return
+	}
+	if err := garden.ValidateBody(msg.Body); err != nil {
+		d.sendGardenError(conn, "edit", err)
+		return
+	}
+	seed, doc, err := d.applySeedBodyEdit(msg.SeedID, msg.Body)
+	if err != nil {
+		d.sendGardenError(conn, "edit", err)
+		return
+	}
+	d.sendGardenResponse(conn, protocol.Response{
+		Ok:             true,
+		SeedEditResult: &protocol.SeedEditResult{Seed: seedToProtocol(seed, doc, d.gardenReady()[seed.ID])},
+	})
+}
+
+// applySeedBodyEdit changes only the living markdown body. Re-reading on a
+// conflict preserves lifecycle, tender and edge changes that landed while the
+// editor was writing.
+func (d *Daemon) applySeedBodyEdit(id, body string) (garden.Seed, docstore.Document, error) {
+	schema, err := d.seedsCollection()
+	if err != nil {
+		return garden.Seed{}, docstore.Document{}, err
+	}
+	const attempts = 3
+	for range attempts {
+		seed, doc, err := d.readSeed(id)
+		if err != nil {
+			return garden.Seed{}, docstore.Document{}, err
+		}
+		seed.Body = body
+		written, err := d.writeSeed(*schema, seed, doc.Rev, FactGardenBodyEdited)
+		if err == nil {
+			return seed, written, nil
+		}
+		if !docstore.IsConflict(err) {
+			return garden.Seed{}, docstore.Document{}, err
+		}
+	}
+	return garden.Seed{}, docstore.Document{}, fmt.Errorf(
+		"%s was rewritten under all %d attempts to edit it; read it again with `attn seed show %s` and retry",
+		id, attempts, id)
+}
+
 // handleSeedDocumentGet returns the complete reading surface for one seed.
-// Garden mutation snapshots are the invalidation signal; clients refetch this
-// one-shot document after each snapshot instead of holding a second watcher.
+// Garden snapshots carry the live seed itself; clients use this detail read
+// for the ledger and as a fallback when a bounded snapshot omits the open seed.
 func (d *Daemon) handleSeedDocumentGet(client *wsClient, msg *protocol.SeedDocumentGetMessage) {
 	result := protocol.SeedDocumentGetResultMessage{
 		Event:     protocol.EventSeedDocumentGetResult,
@@ -750,10 +798,11 @@ func (d *Daemon) handleSeedDocumentGet(client *wsClient, msg *protocol.SeedDocum
 		wireSeed.PlotProgress = progress
 	}
 	result.Document = &protocol.SeedDocument{
-		Seed:       wireSeed,
-		Children:   read.wire(children),
-		Notes:      notes,
-		NotesTotal: notesTotal,
+		Seed:        wireSeed,
+		TenderHolds: seed.Tender().Holds(d.sessionExists),
+		Children:    read.wire(children),
+		Notes:       notes,
+		NotesTotal:  notesTotal,
 	}
 	result.Success = true
 	d.sendToClient(client, result)
@@ -1179,44 +1228,56 @@ func (d *Daemon) handleSeedNote(conn net.Conn, msg *protocol.SeedNoteMessage) {
 		d.sendGardenError(conn, "note", err)
 		return
 	}
-	if err := garden.ValidateNote(msg.Body); err != nil {
-		d.sendGardenError(conn, "note", err)
-		return
-	}
-	kind, err := garden.ParseNoteKind(protocol.Deref(msg.Kind))
-	if err != nil {
-		d.sendGardenError(conn, "note", err)
-		return
-	}
-	// A note on a seed that is not planted is refused by name rather than
-	// written into a log nobody will ever read.
-	seed, _, err := d.readSeed(msg.SeedID)
-	if err != nil {
-		d.sendGardenError(conn, "note", err)
-		return
-	}
-	schema, err := d.notesCollection()
-	if err != nil {
-		d.sendGardenError(conn, "note", err)
-		return
-	}
 	authorSession := strings.TrimSpace(protocol.Deref(msg.SourceSessionID))
-	note := garden.Note{
-		Seed:          seed.ID,
-		Kind:          kind,
-		Body:          msg.Body,
-		AuthorSession: authorSession,
-		AuthorMember:  d.resolveTenderMember(protocol.Deref(msg.Member), authorSession),
-	}
-	written, doc, err := d.mintAndWriteNote(*schema, note)
+	note, err := d.appendSeedNote(
+		msg.SeedID,
+		msg.Body,
+		authorSession,
+		protocol.Deref(msg.Member),
+		protocol.Deref(msg.Kind),
+	)
 	if err != nil {
 		d.sendGardenError(conn, "note", err)
 		return
 	}
 	d.sendGardenResponse(conn, protocol.Response{
 		Ok:             true,
-		SeedNoteResult: &protocol.SeedNoteResult{Note: noteToProtocol(written, doc)},
+		SeedNoteResult: &protocol.SeedNoteResult{Note: note},
 	})
+}
+
+// appendSeedNote is the one log-write path shared by the CLI and the seed
+// annotation destination. It validates the typed seed before minting so no
+// note can land in a log nobody can read.
+func (d *Daemon) appendSeedNote(seedID, body, authorSession, member, kindName string) (protocol.SeedNote, error) {
+	if err := garden.ValidateNote(body); err != nil {
+		return protocol.SeedNote{}, err
+	}
+	kind, err := garden.ParseNoteKind(kindName)
+	if err != nil {
+		return protocol.SeedNote{}, err
+	}
+	seed, _, err := d.readSeed(seedID)
+	if err != nil {
+		return protocol.SeedNote{}, err
+	}
+	schema, err := d.notesCollection()
+	if err != nil {
+		return protocol.SeedNote{}, err
+	}
+	authorSession = strings.TrimSpace(authorSession)
+	note := garden.Note{
+		Seed:          seed.ID,
+		Kind:          kind,
+		Body:          body,
+		AuthorSession: authorSession,
+		AuthorMember:  d.resolveTenderMember(member, authorSession),
+	}
+	written, doc, err := d.mintAndWriteNote(*schema, note)
+	if err != nil {
+		return protocol.SeedNote{}, err
+	}
+	return noteToProtocol(written, doc), nil
 }
 
 // mintAndWriteNote writes one log entry, minting again on a taken id for the

--- a/internal/daemon/garden_test.go
+++ b/internal/daemon/garden_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -63,6 +64,17 @@ func plant(t *testing.T, d *Daemon, msg protocol.SeedPlantMessage) protocol.Seed
 		t.Fatalf("plant %q: %v", msg.Title, protocol.Deref(resp.Error))
 	}
 	return resp.SeedPlantResult.Seed
+}
+
+func editSeed(t *testing.T, d *Daemon, seedID, body string) protocol.Seed {
+	t.Helper()
+	resp := gardenCall(t, func(c net.Conn) {
+		d.handleSeedEdit(c, &protocol.SeedEditMessage{Cmd: protocol.CmdSeedEdit, SeedID: seedID, Body: body})
+	})
+	if !resp.Ok {
+		t.Fatalf("edit %s: %v", seedID, protocol.Deref(resp.Error))
+	}
+	return resp.SeedEditResult.Seed
 }
 
 // addGardenSession puts a second real session in the workspace, the way the app
@@ -194,6 +206,7 @@ func TestGarden_ASecondSessionCannotTakeALiveClaim(t *testing.T) {
 	seed := plant(t, d, protocol.SeedPlantMessage{SourceSessionID: protocol.Ptr("sess-a"), Title: "contended"})
 
 	move(t, d, "sess-a", seed.ID, garden.VerbTend, "", "trellis")
+	editSeed(t, d, seed.ID, "edited body")
 
 	refused := transition(t, d, "sess-b", seed.ID, garden.VerbTend, "", "alder")
 	if refused.Ok {
@@ -358,6 +371,7 @@ func TestGarden_EveryMovePublishesItsOwnFact(t *testing.T) {
 	defer unsubscribe()
 
 	move(t, d, "sess-a", seed.ID, garden.VerbTend, "", "trellis")
+	editSeed(t, d, seed.ID, "edited while tended")
 	note(t, d, "sess-a", seed.ID, "on the log", "trellis")
 	move(t, d, "sess-a", seed.ID, garden.VerbPark, "", "trellis")
 	move(t, d, "sess-a", seed.ID, garden.VerbHarvest, "done", "trellis")
@@ -365,11 +379,55 @@ func TestGarden_EveryMovePublishesItsOwnFact(t *testing.T) {
 	move(t, d, "sess-a", seed.ID, garden.VerbWither, "", "trellis")
 
 	want := []string{
-		FactGardenTended, FactGardenNoted, FactGardenParked,
+		FactGardenTended, FactGardenBodyEdited, FactGardenNoted, FactGardenParked,
 		FactGardenHarvested, FactGardenReplanted, FactGardenWithered,
 	}
 	if !slices.Equal(seen, want) {
 		t.Fatalf("the bus saw %v, want %v", seen, want)
+	}
+}
+
+func TestGarden_EditChangesOnlyTheLivingBody(t *testing.T) {
+	d := newGardenDaemon(t)
+	crown := plant(t, d, protocol.SeedPlantMessage{Title: "Crown"})
+	seed := plant(t, d, protocol.SeedPlantMessage{
+		SourceSessionID: protocol.Ptr("sess-a"), Title: "Editable", Body: protocol.Ptr("old body"), PartOf: protocol.Ptr(crown.ID),
+	})
+	before := move(t, d, "sess-a", seed.ID, garden.VerbTend, "", "trellis")
+
+	after := editSeed(t, d, seed.ID, "# New body\n\nStill the same seed.")
+
+	if after.Body != "# New body\n\nStill the same seed." || after.Rev != before.Rev+1 {
+		t.Fatalf("edited body/revision = %q/%d, want new body/rev %d", after.Body, after.Rev, before.Rev+1)
+	}
+	if after.ID != before.ID || after.Title != before.Title || after.Status != before.Status ||
+		after.TenderSession != before.TenderSession || after.TenderMember != before.TenderMember ||
+		!reflect.DeepEqual(after.Edges, before.Edges) || !reflect.DeepEqual(after.Vars, before.Vars) {
+		t.Fatalf("edit changed seed identity/lifecycle: before=%+v after=%+v", before, after)
+	}
+
+	cleared := editSeed(t, d, seed.ID, "")
+	if cleared.Body != "" {
+		t.Fatalf("explicit empty edit left body %q", cleared.Body)
+	}
+}
+
+func TestGarden_EditRejectsUnknownSeedAndOversizedBody(t *testing.T) {
+	d := newGardenDaemon(t)
+	unknown := gardenCall(t, func(c net.Conn) {
+		d.handleSeedEdit(c, &protocol.SeedEditMessage{Cmd: protocol.CmdSeedEdit, SeedID: "s-ffffff", Body: "words"})
+	})
+	if unknown.Ok || !strings.Contains(protocol.Deref(unknown.Error), "s-ffffff") {
+		t.Fatalf("unknown edit = %+v, want named seed refusal", unknown)
+	}
+	seed := plant(t, d, protocol.SeedPlantMessage{Title: "Bounded"})
+	oversized := gardenCall(t, func(c net.Conn) {
+		d.handleSeedEdit(c, &protocol.SeedEditMessage{
+			Cmd: protocol.CmdSeedEdit, SeedID: seed.ID, Body: strings.Repeat("x", garden.MaxBodyBytes+1),
+		})
+	})
+	if oversized.Ok || !strings.Contains(protocol.Deref(oversized.Error), "max_body_bytes") {
+		t.Fatalf("oversized edit = %+v, want named body limit", oversized)
 	}
 }
 

--- a/internal/daemon/seed_reader_test.go
+++ b/internal/daemon/seed_reader_test.go
@@ -62,6 +62,32 @@ func TestSeedDocumentGetNamesUnknownID(t *testing.T) {
 	}
 }
 
+func TestSeedDocumentGetReportsWhetherTheStoredTenderStillHolds(t *testing.T) {
+	d := newGardenDaemon(t)
+	seed := plant(t, d, protocol.SeedPlantMessage{Title: "Held only while live"})
+	move(t, d, "sess-a", seed.ID, garden.VerbTend, "", "trellis")
+
+	read := func(requestID string) protocol.SeedDocumentGetResultMessage {
+		client := newWorkspaceProtocolTestClient()
+		d.handleSeedDocumentGet(client, &protocol.SeedDocumentGetMessage{
+			Cmd: protocol.CmdSeedDocumentGet, SeedID: seed.ID, RequestID: requestID,
+		})
+		return readSeedDocumentResult(t, client)
+	}
+	if result := read("live"); !result.Success || result.Document == nil || !result.Document.TenderHolds {
+		t.Fatalf("live tender document = %+v, want tender_holds", result)
+	}
+
+	d.store.Remove("sess-a")
+	result := read("gone")
+	if !result.Success || result.Document == nil || result.Document.TenderHolds {
+		t.Fatalf("ended tender document = %+v, want stored identity without a live hold", result)
+	}
+	if result.Document.Seed.TenderSession != "sess-a" {
+		t.Fatalf("read model erased stored tender identity: %+v", result.Document.Seed)
+	}
+}
+
 func TestOpenSeedUsesPlacementPaneAndTenderBinding(t *testing.T) {
 	d := newGardenDaemon(t)
 	_, _, workspaceID := setupMarkdownWorkspaceOn(t, d)

--- a/internal/daemon/testdata/wire/flow.golden
+++ b/internal/daemon/testdata/wire/flow.golden
@@ -60,7 +60,13 @@
     "workspace_id": "workspace-1"
   }
 }
---- 05 workspace_layout
+--- 05 garden_seeds_updated
+{
+  "event": "garden_seeds_updated",
+  "seeds": null,
+  "total": 0
+}
+--- 06 workspace_layout
 {
   "event": "workspace_layout",
   "workspace_layout": {
@@ -81,7 +87,7 @@
     "workspace_id": "workspace-1"
   }
 }
---- 06 session_todos_updated
+--- 07 session_todos_updated
 {
   "event": "session_todos_updated",
   "session": {
@@ -99,7 +105,7 @@
     "workspace_id": "workspace-1"
   }
 }
---- 07 session_state_changed
+--- 08 session_state_changed
 {
   "event": "session_state_changed",
   "session": {
@@ -117,7 +123,7 @@
     "workspace_id": "workspace-1"
   }
 }
---- 08 workspace_state_changed
+--- 09 workspace_state_changed
 {
   "event": "workspace_state_changed",
   "workspace": {
@@ -130,7 +136,7 @@
     "title": "Renamed"
   }
 }
---- 09 workspace_state_changed
+--- 10 workspace_state_changed
 {
   "event": "workspace_state_changed",
   "workspace": {
@@ -143,7 +149,7 @@
     "title": "Renamed"
   }
 }
---- 10 session_unregistered
+--- 11 session_unregistered
 {
   "event": "session_unregistered",
   "session": {
@@ -162,13 +168,13 @@
     "workspace_muted": true
   }
 }
---- 11 garden_seeds_updated
+--- 12 garden_seeds_updated
 {
   "event": "garden_seeds_updated",
   "seeds": null,
   "total": 0
 }
---- 12 workspace_unregistered
+--- 13 workspace_unregistered
 {
   "event": "workspace_unregistered",
   "workspace": {
@@ -181,7 +187,7 @@
     "title": "Renamed"
   }
 }
---- 13 sessions_updated
+--- 14 sessions_updated
 {
   "event": "sessions_updated"
 }

--- a/internal/daemon/testdata/wire/flow.golden
+++ b/internal/daemon/testdata/wire/flow.golden
@@ -162,7 +162,13 @@
     "workspace_muted": true
   }
 }
---- 11 workspace_unregistered
+--- 11 garden_seeds_updated
+{
+  "event": "garden_seeds_updated",
+  "seeds": null,
+  "total": 0
+}
+--- 12 workspace_unregistered
 {
   "event": "workspace_unregistered",
   "workspace": {
@@ -175,7 +181,7 @@
     "title": "Renamed"
   }
 }
---- 12 sessions_updated
+--- 13 sessions_updated
 {
   "event": "sessions_updated"
 }

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -1534,7 +1534,7 @@ func remoteCommandSessionID(cmd string, msg interface{}) string {
 		}
 	case protocol.CmdMarkdownAnnotationsSubmit: // wire: markdown_annotations_submit
 		if typed, ok := msg.(*protocol.MarkdownAnnotationsSubmitMessage); ok {
-			return typed.TargetSessionID
+			return protocol.Deref(typed.TargetSessionID)
 		}
 	case protocol.CmdSettleTurn: // wire: settle_turn
 		// The turn's stamps live in the store of the daemon that owns the

--- a/internal/daemon/ws_annotation_drafts.go
+++ b/internal/daemon/ws_annotation_drafts.go
@@ -14,6 +14,7 @@ import (
 // Submit statuses on the wire (plain strings in the protocol).
 const (
 	annotationSubmitStatusDelivered = "delivered"
+	annotationSubmitStatusNoted     = "noted"
 	annotationSubmitStatusSkipped   = "skipped_pending_approval"
 	annotationSubmitStatusError     = "error"
 )

--- a/internal/daemon/ws_markdown_annotations_submit.go
+++ b/internal/daemon/ws_markdown_annotations_submit.go
@@ -9,8 +9,8 @@ import (
 )
 
 // handleMarkdownAnnotationsSubmit formats the persisted annotation draft for
-// a path into the feedback payload and delivers it into the target session's
-// PTY via typeDoorbell (bracketed paste, then Enter, both under doorbellMu).
+// a document and delivers it to exactly one typed destination: a session via
+// typeDoorbell, or the source seed's own log as a note.
 //
 // Drafts are tombstone-cleared ONLY after a successful delivery; every other
 // outcome (validation error, unknown session, pending_approval skip, PTY
@@ -22,19 +22,25 @@ import (
 // single-writer, and the client flushes its debounced save before submitting
 // — accepted.
 func (d *Daemon) handleMarkdownAnnotationsSubmit(client *wsClient, msg *protocol.MarkdownAnnotationsSubmitMessage) {
-	target := strings.TrimSpace(msg.TargetSessionID)
+	targetSession := strings.TrimSpace(protocol.Deref(msg.TargetSessionID))
+	targetSeed := strings.TrimSpace(protocol.Deref(msg.TargetSeedID))
 	source, sourceErr := d.resolveAnnotationDocumentSource(msg.DocumentUri, msg.SourceKind, msg.WorkspaceID, msg.Path, msg.SeedID)
 	workspaceID, path, seedID := annotationSourcePointers(source)
 	result := protocol.MarkdownAnnotationsSubmitResultMessage{
-		Event:           protocol.EventMarkdownAnnotationsSubmitResult,
-		RequestID:       msg.RequestID,
-		DocumentUri:     source.documentURI,
-		SourceKind:      source.kind,
-		WorkspaceID:     workspaceID,
-		Path:            path,
-		SeedID:          seedID,
-		TargetSessionID: target,
-		Status:          annotationSubmitStatusError,
+		Event:       protocol.EventMarkdownAnnotationsSubmitResult,
+		RequestID:   msg.RequestID,
+		DocumentUri: source.documentURI,
+		SourceKind:  source.kind,
+		WorkspaceID: workspaceID,
+		Path:        path,
+		SeedID:      seedID,
+		Status:      annotationSubmitStatusError,
+	}
+	if targetSession != "" {
+		result.TargetSessionID = protocol.Ptr(targetSession)
+	}
+	if targetSeed != "" {
+		result.TargetSeedID = protocol.Ptr(targetSeed)
 	}
 	fail := func(errText string) {
 		result.Error = protocol.Ptr(errText)
@@ -44,8 +50,12 @@ func (d *Daemon) handleMarkdownAnnotationsSubmit(client *wsClient, msg *protocol
 		fail("markdown_annotations_submit: " + sourceErr.Error())
 		return
 	}
-	if target == "" {
-		fail("markdown_annotations_submit: target_session_id is required")
+	if (targetSession == "") == (targetSeed == "") {
+		fail("markdown_annotations_submit: exactly one of target_session_id or target_seed_id is required")
+		return
+	}
+	if targetSeed != "" && (source.kind != annotationSourceSeed || targetSeed != source.seedID) {
+		fail("markdown_annotations_submit: target_seed_id must match the seed document source")
 		return
 	}
 	draft, err := d.store.GetMarkdownAnnotationDraft(source.draftKey)
@@ -64,43 +74,52 @@ func (d *Daemon) handleMarkdownAnnotationsSubmit(client *wsClient, msg *protocol
 		fail("no annotations to send")
 		return
 	}
-	session := d.store.Get(target)
-	if session == nil {
-		fail("session not found: " + target)
-		return
-	}
-	// UX pre-check; typeDoorbell re-checks the state under doorbellMu — that
-	// in-lock check is the fence, this one just avoids formatting for nothing.
-	if !isNudgeDeliveryAllowed(string(session.State)) {
-		result.Status = annotationSubmitStatusSkipped
-		d.sendToClient(client, result)
-		return
-	}
 	orphaned := make(map[string]bool, len(msg.OrphanedIds))
 	for _, id := range msg.OrphanedIds {
 		orphaned[id] = true
 	}
 	payload := formatMarkdownAnnotationPayload(source, annotations, orphaned)
-	if err := d.typeDoorbell(target, payload); err != nil {
-		if errors.Is(err, errDoorbellBlockedByApproval) {
+	if targetSession != "" {
+		session := d.store.Get(targetSession)
+		if session == nil {
+			fail("session not found: " + targetSession)
+			return
+		}
+		// UX pre-check; typeDoorbell re-checks under doorbellMu — that in-lock
+		// check is the fence, this one only avoids formatting for nothing.
+		if !isNudgeDeliveryAllowed(string(session.State)) {
 			result.Status = annotationSubmitStatusSkipped
 			d.sendToClient(client, result)
 			return
 		}
-		d.logf("markdown_annotations_submit: %s -> %s: delivery failed: %v", source.draftKey, target, err)
-		fail(err.Error())
-		return
+		if err := d.typeDoorbell(targetSession, payload); err != nil {
+			if errors.Is(err, errDoorbellBlockedByApproval) {
+				result.Status = annotationSubmitStatusSkipped
+				d.sendToClient(client, result)
+				return
+			}
+			d.logf("markdown_annotations_submit: %s -> %s: delivery failed: %v", source.draftKey, targetSession, err)
+			fail(err.Error())
+			return
+		}
+		result.Status = annotationSubmitStatusDelivered
+	} else {
+		if _, err := d.appendSeedNote(targetSeed, payload, "", "", ""); err != nil {
+			d.logf("markdown_annotations_submit: %s -> seed %s: note failed: %v", source.draftKey, targetSeed, err)
+			fail(err.Error())
+			return
+		}
+		result.Status = annotationSubmitStatusNoted
 	}
-	// Delivered. Tombstone the draft at the generation we read so any
+	// Delivered or noted. Tombstone the draft at the generation we read so any
 	// straggling debounced save with generation <= floor is rejected (the
-	// PR5 resurrection guard). A clear failure after successful delivery
-	// still reports delivered — never risk a re-delivery — but carries an
-	// error so the UI can re-hydrate instead of assuming an empty draft.
+	// PR5 resurrection guard). A clear failure after the destination accepted
+	// the payload still reports success — never risk duplicate delivery.
 	result.Success = true
-	result.Status = annotationSubmitStatusDelivered
 	if err := d.store.ClearMarkdownAnnotationDraft(source.draftKey, draft.Generation, time.Now()); err != nil {
-		d.logf("markdown_annotations_submit: %s: delivered but clearing drafts failed: %v", source.draftKey, err)
-		result.Error = protocol.Ptr("delivered; failed to clear drafts: " + err.Error())
+		verb := result.Status
+		d.logf("markdown_annotations_submit: %s: %s but clearing drafts failed: %v", source.draftKey, verb, err)
+		result.Error = protocol.Ptr(verb + "; failed to clear drafts: " + err.Error())
 		d.sendToClient(client, result)
 		return
 	}

--- a/internal/daemon/ws_markdown_annotations_submit_test.go
+++ b/internal/daemon/ws_markdown_annotations_submit_test.go
@@ -46,7 +46,7 @@ func sendSubmit(t *testing.T, d *Daemon, target string, orphaned []string) proto
 		SourceKind:      annotationSourceFile,
 		WorkspaceID:     protocol.Ptr("workspace-test"),
 		Path:            protocol.Ptr(submitTestPath),
-		TargetSessionID: target,
+		TargetSessionID: protocol.Ptr(target),
 		OrphanedIds:     orphaned,
 		RequestID:       "req-1",
 	})
@@ -55,6 +55,34 @@ func sendSubmit(t *testing.T, d *Daemon, target string, orphaned []string) proto
 	if res.Event != protocol.EventMarkdownAnnotationsSubmitResult || res.RequestID != "req-1" {
 		t.Fatalf("unexpected result envelope: %+v", res)
 	}
+	return res
+}
+
+func seedSeedSubmitDraft(t *testing.T, d *Daemon, seedID string, generation int) {
+	t.Helper()
+	blob, err := json.Marshal(submitTestAnnotations())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := d.store.SaveMarkdownAnnotationDraft(seedDocumentURI(seedID), string(blob), generation, time.Now()); err != nil {
+		t.Fatalf("seed seed draft: %v", err)
+	}
+}
+
+func sendSeedSubmit(t *testing.T, d *Daemon, sourceSeed string, targetSession, targetSeed *string) protocol.MarkdownAnnotationsSubmitResultMessage {
+	t.Helper()
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleMarkdownAnnotationsSubmit(client, &protocol.MarkdownAnnotationsSubmitMessage{
+		Cmd:             protocol.CmdMarkdownAnnotationsSubmit,
+		DocumentUri:     seedDocumentURI(sourceSeed),
+		SourceKind:      annotationSourceSeed,
+		SeedID:          protocol.Ptr(sourceSeed),
+		TargetSessionID: targetSession,
+		TargetSeedID:    targetSeed,
+		RequestID:       "req-seed",
+	})
+	var res protocol.MarkdownAnnotationsSubmitResultMessage
+	readNotebookWSEvent(t, client.send, &res)
 	return res
 }
 
@@ -127,6 +155,120 @@ func TestMarkdownAnnotationsSubmitCarriesOrphanedIds(t *testing.T) {
 	if len(inputs) != 2 || !strings.Contains(inputs[0], "(~line 3, moved)") {
 		t.Fatalf("payload should label orphaned c1, got %q", inputs)
 	}
+}
+
+func TestMarkdownAnnotationsSubmitNotesOnTypedSourceSeed(t *testing.T) {
+	d := newGardenDaemon(t)
+	seed := plant(t, d, protocol.SeedPlantMessage{Title: "Review target"})
+	seedSeedSubmitDraft(t, d, seed.ID, 4)
+
+	res := sendSeedSubmit(t, d, seed.ID, nil, protocol.Ptr(seed.ID))
+
+	if !res.Success || res.Status != annotationSubmitStatusNoted || res.Error != nil {
+		t.Fatalf("result = %+v, want noted", res)
+	}
+	if protocol.Deref(res.TargetSeedID) != seed.ID || res.TargetSessionID != nil {
+		t.Fatalf("typed destination = seed %v session %v", res.TargetSeedID, res.TargetSessionID)
+	}
+	shown := show(t, d, seed.ID)
+	if shown.NotesTotal != 1 || len(shown.Notes) != 1 {
+		t.Fatalf("seed log = %+v total=%d, want one annotation note", shown.Notes, shown.NotesTotal)
+	}
+	want := formatMarkdownAnnotationPayload(annotationDocumentSource{
+		kind: annotationSourceSeed, seedID: seed.ID, seedTitle: seed.Title,
+	}, submitTestAnnotations(), map[string]bool{})
+	if shown.Notes[0].Body != want || shown.Notes[0].Kind != "note" {
+		t.Fatalf("note = %+v, want formatted annotation payload %q", shown.Notes[0], want)
+	}
+	if n := storedSeedSubmitDraftCount(t, d, seed.ID); n != 0 {
+		t.Fatalf("draft not cleared after note: %d annotations remain", n)
+	}
+}
+
+func TestMarkdownAnnotationsSubmitRequiresExactlyOneMatchingTypedDestination(t *testing.T) {
+	d := newGardenDaemon(t)
+	seed := plant(t, d, protocol.SeedPlantMessage{Title: "Typed routing"})
+	seedSeedSubmitDraft(t, d, seed.ID, 2)
+
+	for _, tc := range []struct {
+		name       string
+		session    *string
+		targetSeed *string
+		wantError  string
+	}{
+		{name: "neither", wantError: "exactly one"},
+		{name: "both", session: protocol.Ptr("sess-a"), targetSeed: protocol.Ptr(seed.ID), wantError: "exactly one"},
+		{name: "different seed", targetSeed: protocol.Ptr("s-ffffff"), wantError: "must match"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res := sendSeedSubmit(t, d, seed.ID, tc.session, tc.targetSeed)
+			if res.Success || res.Error == nil || !strings.Contains(*res.Error, tc.wantError) {
+				t.Fatalf("result = %+v, want error containing %q", res, tc.wantError)
+			}
+		})
+	}
+	if n := storedSeedSubmitDraftCount(t, d, seed.ID); n != 1 {
+		t.Fatalf("invalid routing changed draft: got %d annotations", n)
+	}
+}
+
+func TestMarkdownAnnotationsSubmitDoesNotRouteAFileDocumentToASeed(t *testing.T) {
+	d := newSubmitDaemon(t)
+	seedSubmitDraft(t, d, 2, submitTestAnnotations())
+	client := &wsClient{send: make(chan outboundMessage, 1)}
+	d.handleMarkdownAnnotationsSubmit(client, &protocol.MarkdownAnnotationsSubmitMessage{
+		Cmd:          protocol.CmdMarkdownAnnotationsSubmit,
+		DocumentUri:  fileDocumentURI("workspace-test", submitTestPath),
+		SourceKind:   annotationSourceFile,
+		WorkspaceID:  protocol.Ptr("workspace-test"),
+		Path:         protocol.Ptr(submitTestPath),
+		TargetSeedID: protocol.Ptr("s-ffffff"),
+		RequestID:    "file-to-seed",
+	})
+	var res protocol.MarkdownAnnotationsSubmitResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if res.Success || res.Error == nil || !strings.Contains(*res.Error, "must match the seed document source") {
+		t.Fatalf("result = %+v, want file-to-seed routing refusal", res)
+	}
+	if n := storedSubmitDraftCount(t, d); n != 1 {
+		t.Fatalf("routing refusal changed file draft: got %d annotations", n)
+	}
+}
+
+func TestMarkdownAnnotationsSubmitNoteClearFailureStillReportsNoted(t *testing.T) {
+	d := newGardenDaemon(t)
+	seed := plant(t, d, protocol.SeedPlantMessage{Title: "Keep one note"})
+	seedSeedSubmitDraft(t, d, seed.ID, 2)
+	d.gardenBroadcastHook = func([]protocol.Seed, int) {
+		if err := d.store.Close(); err != nil {
+			t.Errorf("closing store after note: %v", err)
+		}
+	}
+
+	res := sendSeedSubmit(t, d, seed.ID, nil, protocol.Ptr(seed.ID))
+
+	if !res.Success || res.Status != annotationSubmitStatusNoted {
+		t.Fatalf("result = %+v, want noted despite clear failure", res)
+	}
+	if res.Error == nil || !strings.Contains(*res.Error, "noted; failed to clear drafts") {
+		t.Fatalf("error = %v, want noted-but-not-cleared marker", res.Error)
+	}
+	if res.Generation != nil {
+		t.Fatalf("generation should be absent when the clear failed, got %v", res.Generation)
+	}
+}
+
+func storedSeedSubmitDraftCount(t *testing.T, d *Daemon, seedID string) int {
+	t.Helper()
+	draft, err := d.store.GetMarkdownAnnotationDraft(seedDocumentURI(seedID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	anns, err := decodeMarkdownAnnotations(draft.Annotations)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return len(anns)
 }
 
 // pending_approval target: nothing is typed, drafts stay intact, and the

--- a/internal/garden/garden.go
+++ b/internal/garden/garden.go
@@ -256,8 +256,14 @@ func ValidatePlant(title, body string) error {
 	if n := len([]rune(trimmed)); n > MaxTitleChars {
 		return fmt.Errorf("that title is %d characters and the limit is %d; a title names the work in a line — the detail goes in the body (`-m`, or `-m -` to read stdin)", n, MaxTitleChars)
 	}
+	return ValidateBody(body)
+}
+
+// ValidateBody applies the same measured body tripwire to planting and later
+// edits, so a seed cannot grow past the limit through a different door.
+func ValidateBody(body string) error {
 	if n := len(body); n > MaxBodyBytes {
-		return fmt.Errorf("that body is %d bytes and the limit is %d; a seed's body is a plan, not an archive", n, MaxBodyBytes)
+		return fmt.Errorf("max_body_bytes=%d, asked for %d; a seed's body is a plan, not an archive", MaxBodyBytes, n)
 	}
 	return nil
 }

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -190,6 +190,7 @@ const (
 	CmdSeedList                              = "seed_list"
 	CmdSeedShow                              = "seed_show"
 	CmdSeedDocumentGet                       = "seed_document_get"
+	CmdSeedEdit                              = "seed_edit"
 	CmdSeedTransition                        = "seed_transition"
 	CmdSeedNote                              = "seed_note"
 	CmdSeedNotes                             = "seed_notes"
@@ -1269,6 +1270,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdSeedDocumentGet:
 		var msg SeedDocumentGetMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdSeedEdit:
+		var msg SeedEditMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -3982,8 +3982,11 @@ type MarkdownAnnotationsSubmitMessage struct {
 	// SourceKind corresponds to the JSON schema field "source_kind".
 	SourceKind string `json:"source_kind"`
 
+	// TargetSeedID corresponds to the JSON schema field "target_seed_id".
+	TargetSeedID *string `json:"target_seed_id,omitempty,omitzero"`
+
 	// TargetSessionID corresponds to the JSON schema field "target_session_id".
-	TargetSessionID string `json:"target_session_id"`
+	TargetSessionID *string `json:"target_session_id,omitempty,omitzero"`
 
 	// WorkspaceID corresponds to the JSON schema field "workspace_id".
 	WorkspaceID *string `json:"workspace_id,omitempty,omitzero"`
@@ -4020,8 +4023,11 @@ type MarkdownAnnotationsSubmitResultMessage struct {
 	// Success corresponds to the JSON schema field "success".
 	Success bool `json:"success"`
 
+	// TargetSeedID corresponds to the JSON schema field "target_seed_id".
+	TargetSeedID *string `json:"target_seed_id,omitempty,omitzero"`
+
 	// TargetSessionID corresponds to the JSON schema field "target_session_id".
-	TargetSessionID string `json:"target_session_id"`
+	TargetSessionID *string `json:"target_session_id,omitempty,omitzero"`
 
 	// WorkspaceID corresponds to the JSON schema field "workspace_id".
 	WorkspaceID *string `json:"workspace_id,omitempty,omitzero"`
@@ -5645,6 +5651,9 @@ type Response struct {
 	// Repos corresponds to the JSON schema field "repos".
 	Repos []RepoState `json:"repos,omitempty,omitzero"`
 
+	// SeedEditResult corresponds to the JSON schema field "seed_edit_result".
+	SeedEditResult *SeedEditResult `json:"seed_edit_result,omitempty,omitzero"`
+
 	// SeedLinkResult corresponds to the JSON schema field "seed_link_result".
 	SeedLinkResult *SeedLinkResult `json:"seed_link_result,omitempty,omitzero"`
 
@@ -5866,6 +5875,9 @@ type SeedDocument struct {
 
 	// Seed corresponds to the JSON schema field "seed".
 	Seed Seed `json:"seed"`
+
+	// TenderHolds corresponds to the JSON schema field "tender_holds".
+	TenderHolds bool `json:"tender_holds"`
 }
 
 type SeedDocumentGetMessage struct {
@@ -5902,6 +5914,22 @@ type SeedEdge struct {
 
 	// To corresponds to the JSON schema field "to".
 	To string `json:"to"`
+}
+
+type SeedEditMessage struct {
+	// Body corresponds to the JSON schema field "body".
+	Body string `json:"body"`
+
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// SeedID corresponds to the JSON schema field "seed_id".
+	SeedID string `json:"seed_id"`
+}
+
+type SeedEditResult struct {
+	// Seed corresponds to the JSON schema field "seed".
+	Seed Seed `json:"seed"`
 }
 
 type SeedLinkMessage struct {

--- a/internal/protocol/parse_test.go
+++ b/internal/protocol/parse_test.go
@@ -429,6 +429,16 @@ func TestParseSeedReaderMessages(t *testing.T) {
 			t.Fatalf("parsed (%q, %T, %+v)", cmd, data, msg)
 		}
 	})
+	t.Run("edit seed body", func(t *testing.T) {
+		cmd, data, err := ParseMessage([]byte(`{"cmd":"seed_edit","seed_id":"s-abc123","body":"# revised"}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		msg, ok := data.(*SeedEditMessage)
+		if cmd != CmdSeedEdit || !ok || msg.SeedID != "s-abc123" || msg.Body != "# revised" {
+			t.Fatalf("parsed (%q, %T, %+v)", cmd, data, msg)
+		}
+	})
 }
 
 func TestParseBrowserMessages(t *testing.T) {

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -2866,9 +2866,9 @@ model MarkdownAnnotationsClearResultMessage {
   generation: int32;
 }
 
-// Format the persisted annotation draft for `path` into the feedback payload
-// and deliver it into target_session_id's PTY (bracketed paste + Enter).
-// Drafts are tombstone-cleared ONLY on successful delivery.
+// Format the persisted annotation draft into feedback for one typed
+// destination: a session PTY (bracketed paste + Enter) or the source seed's
+// log. Drafts are tombstone-cleared only after the destination accepts it.
 model MarkdownAnnotationsSubmitMessage {
   cmd: "markdown_annotations_submit";
   document_uri: string;
@@ -2876,7 +2876,10 @@ model MarkdownAnnotationsSubmitMessage {
   workspace_id?: string;
   path?: string;
   seed_id?: string;
-  target_session_id: string;
+  // Exactly one typed destination. A seed destination appends the formatted
+  // feedback to its log; a session destination delivers it to the agent.
+  target_session_id?: string;
+  target_seed_id?: string;
   // Annotation ids the client currently shows as orphaned (anchor no longer
   // resolves). Orphanhood is a client-derived, non-persisted property; the
   // formatter labels these "(~line N, moved)".
@@ -2886,11 +2889,12 @@ model MarkdownAnnotationsSubmitMessage {
 
 // Result of markdown_annotations_submit.
 // status: "delivered" — payload typed into the session; drafts cleared.
+//         "noted" — payload appended to the source seed's log; drafts cleared.
 //         "skipped_pending_approval" — target is waiting on an approval
 //           prompt; nothing was typed, drafts kept.
 //         "error" — see error; drafts kept.
-// generation: new generation floor after the clear (delivered only) so the
-// client can seed its counter without a round-trip.
+// generation: new generation floor after a delivered/noted clear so the client
+// can seed its counter without a round-trip.
 model MarkdownAnnotationsSubmitResultMessage {
   event: "markdown_annotations_submit_result";
   request_id: string;
@@ -2899,7 +2903,8 @@ model MarkdownAnnotationsSubmitResultMessage {
   workspace_id?: string;
   path?: string;
   seed_id?: string;
-  target_session_id: string;
+  target_session_id?: string;
+  target_seed_id?: string;
   success: boolean;
   status: string;
   error?: string;
@@ -4486,9 +4491,22 @@ model SeedShowResult {
   "handoff"?: SeedNote;
 }
 
+// Replace one seed's markdown body without moving its lifecycle or claim.
+// The daemon re-reads on a revision conflict so a concurrent tend/park is
+// preserved rather than overwritten by the editor's older snapshot.
+model SeedEditMessage {
+  "cmd": "seed_edit";
+  "seed_id": string;
+  "body": string;
+}
+
+model SeedEditResult {
+  "seed": Seed;
+}
+
 // One-shot reader payload shared by the seed tile and GardenPanel drill. The
-// existing garden_seeds_updated event is its invalidation: clients re-read an
-// open document when any garden fact moves rather than holding another watcher.
+// garden_seeds_updated carries the live seed for immediate body/tender updates;
+// clients also re-read this model for the ledger and bounded-snapshot fallback.
 model SeedDocumentGetMessage {
   "cmd": "seed_document_get";
   "seed_id": string;
@@ -4497,6 +4515,10 @@ model SeedDocumentGetMessage {
 
 model SeedDocument {
   "seed": Seed;
+  // Whether the stored tender currently holds this seed. A tender session may
+  // remain in the document after that session exits, so the ids alone cannot
+  // answer where feedback can be delivered.
+  "tender_holds": boolean;
   "children": Seed[];
   "notes": SeedNote[];
   "notes_total": int32;
@@ -5042,6 +5064,7 @@ model Response {
   seed_plot_result?: SeedPlotResult;
   seed_list_result?: SeedListResult;
   seed_show_result?: SeedShowResult;
+  seed_edit_result?: SeedEditResult;
   seed_transition_result?: SeedTransitionResult;
   seed_note_result?: SeedNoteResult;
   seed_notes_result?: SeedNotesResult;


### PR DESCRIPTION
## TL;DR

Seed documents now react to live body and tender changes, and their annotation composer routes feedback to exactly one typed destination: the current tender session or the seed ledger when nobody is tending. The existing file-document annotation path is unchanged.

## What changed

`attn seed edit <id> -m <markdown>` changes only the seed body, preserving concurrent lifecycle, claim, edge, and variable changes through revision-aware retries. The daemon publishes a named `garden.body_edited` fact after the write.

The existing `garden_seeds_updated` payload already carries each seed's full body and revision. When the open seed is present, the tile now applies that payload immediately to the mounted reader, which drives the existing anchor resolver without a reload or a second annotation stack. It still performs the detail read for ledger changes and as a fallback when the bounded garden snapshot omits an older open seed; a stale detail response cannot overwrite a newer pushed body.

The composer derives its shape from daemon-owned tender truth:

| Seed state | Primary action | Secondary action |
|---|---|---|
| Live tender session | `Send N` to that session | `Note on seed` in the caret menu |
| No live tender session | `Note on seed N` | none |

`SeedDocument.tender_holds` distinguishes a live holder from stale stored tender IDs. Claim/park garden pushes update the shape immediately, and session disappearance republishes garden truth so the detail model can drop a dead holder.

Annotation submission now carries an explicit session or seed destination. The daemon requires exactly one, refuses file-to-seed or mismatched seed routing, appends seed feedback through the normal log-note path, and only clears the persisted draft after the destination accepts it.

## Review path

1. `internal/protocol/schema/main.tsp` and `internal/daemon/ws_markdown_annotations_submit.go` define and enforce the typed routing contract.
2. `internal/daemon/garden.go` and `internal/daemon/bus.go` own body editing, holder truth, and live garden projection.
3. `WorkspaceDockTile.tsx` applies pushed seed revisions and renders the two composer shapes while leaving the file branch intact.
4. The daemon and workspace-tile tests pin destination validation, live claim/park changes, stale-detail races, highlight re-anchoring, node identity, and scroll retention.

## Manual verification

In a packaged throwaway profile, I planted and opened a seed, persisted a highlight, then inserted text above it with the CLI. The mounted reader updated immediately; the highlight stayed on the same phrase without orphaning or a scroll jump.

![Live seed re-anchor](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/0ac84b9c47039d55e9f8cca066070b2ab854f601/delegate-garden-bcd-63dc3858/garden-bcd-reanchor.gif)

[Full-quality re-anchor recording (mp4)](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/0ac84b9c47039d55e9f8cca066070b2ab854f601/delegate-garden-bcd-63dc3858/garden-bcd-reanchor.mp4)

I sent that annotation and saw the formatted feedback arrive in the tending terminal. After parking the seed, the composer flipped to the unsplit note action; submitting another annotation cleared the draft and persisted the formatted note in the visible ledger.

![Tender routing and seed note](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/0ac84b9c47039d55e9f8cca066070b2ab854f601/delegate-garden-bcd-63dc3858/garden-bcd-routing.gif)

[Full-quality routing recording (mp4)](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/0ac84b9c47039d55e9f8cca066070b2ab854f601/delegate-garden-bcd-63dc3858/garden-bcd-routing.mp4)

## Out of scope

File-document behavior and payloads are unchanged. Delegation reporting, attach/detach verbs, ticket retirement, signposts, conversion, and the dormant artifact projection remain later garden steps.
