### PR TITLE
feat(daemon): gate the WebSocket port with a per-profile client token

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -482,6 +482,16 @@ settles it; `turn_owed` is derived at broadcast from the persisted
 IPC: `~/.attn/attn.sock`. WebSocket clients buffer 256 messages; sustained
 over-send may drop messages or disconnect slow clients.
 
+Every WebSocket client presents the profile's **client token** in
+`client_hello` — the socket has file permissions, the port had nothing. The
+daemon mints `<data-dir>/client-token` at startup; clients read it through one
+path per language (`config.ClientToken()`, `get_client_token`,
+`harnessClientHello()`). A new client that dials the daemon must send it, or
+the hello is refused by name. Nothing is pushed before that hello: hub
+registration and `initial_state` both happen in `admitClient`, so an
+unauthorized connection sees no broadcast at all, not merely refused commands.
+See `docs/glossary.md`.
+
 ## Cross-cutting contracts
 
 ### Protocol

--- a/app/e2e/binary-pty-output-realpty.spec.ts
+++ b/app/e2e/binary-pty-output-realpty.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from './fixtures';
+import { E2E_CLIENT_TOKEN } from './profileEnv';
 
 const realPtyEnabled = process.env.VITE_FORCE_REAL_PTY === '1';
 
@@ -37,7 +38,7 @@ test.describe('Binary PTY output transport', () => {
     // Mirror the app's spawn flow: identify (client_hello), register the
     // owning workspace, then spawn the session runtime into it.
     const spawnResult = await page.evaluate(
-      ({ wsUrl, id }) =>
+      ({ wsUrl, id, clientToken }) =>
         new Promise<{ success?: boolean; error?: string }>((resolve, reject) => {
           const workspaceId = `workspace-${id}`;
           const ws = new WebSocket(wsUrl);
@@ -77,6 +78,7 @@ test.describe('Binary PTY output transport', () => {
               client_kind: 'e2e-test',
               version: 'e2e',
               capabilities: ['workspace_sessions'],
+              client_token: clientToken,
             }));
             ws.send(JSON.stringify({
               cmd: 'register_workspace',
@@ -96,7 +98,7 @@ test.describe('Binary PTY output transport', () => {
             }));
           };
         }),
-      { wsUrl: daemonInfo.wsUrl, id: sessionId }
+      { wsUrl: daemonInfo.wsUrl, id: sessionId, clientToken: E2E_CLIENT_TOKEN }
     );
     expect(spawnResult.success, JSON.stringify(spawnResult)).toBe(true);
 

--- a/app/e2e/fixtures.ts
+++ b/app/e2e/fixtures.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as net from 'net';
-import { e2ePorts, resolveAttnBinaryPath } from './profileEnv';
+import { E2E_CLIENT_TOKEN, e2ePorts, resolveAttnBinaryPath } from './profileEnv';
 import { waitForDaemonSocket } from './daemonReadiness';
 import { WHATS_NEW_ID, WHATS_NEW_STORAGE_KEY } from '../src/hooks/useWhatsNew';
 
@@ -184,6 +184,7 @@ async function startDaemon(ghUrl: string): Promise<{ proc: ChildProcess; socketP
       ...process.env,
       PATH: `${stubs.binDir}${path.delimiter}${process.env.PATH}`,
       ATTN_DATA_DIR: tempDir,
+      ATTN_CLIENT_TOKEN: E2E_CLIENT_TOKEN,
       ATTN_WS_PORT: TEST_DAEMON_PORT, // Use test port to avoid conflicts with production daemon
       ATTN_SOCKET_PATH: socketPath, // Test isolation: separate socket
       ATTN_DB_PATH: dbPath, // Test isolation: separate database
@@ -274,6 +275,7 @@ function createManagedDaemon(ghUrl: string): ManagedDaemon {
         ...process.env,
         PATH: `${stubs.binDir}${path.delimiter}${process.env.PATH}`,
         ATTN_DATA_DIR: tempDir,
+        ATTN_CLIENT_TOKEN: E2E_CLIENT_TOKEN,
         ATTN_WS_PORT: TEST_DAEMON_PORT,
         ATTN_SOCKET_PATH: socketPath,
         ATTN_DB_PATH: dbPath,

--- a/app/e2e/profileEnv.ts
+++ b/app/e2e/profileEnv.ts
@@ -25,6 +25,12 @@ export function resolveAttnBinaryPath(): string {
   );
 }
 
+// The client token the throwaway daemon and the bundle under test share. The
+// daemon takes it from ATTN_CLIENT_TOKEN instead of minting one, and Vite hands
+// the same value to the browser, which cannot read the daemon's temp data dir.
+// A fixed string is fine: this daemon lives for one run on a per-profile port.
+export const E2E_CLIENT_TOKEN = 'e2e-client-token';
+
 export interface E2EPorts {
   profile: string;
   daemonPort: string;

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from '@playwright/test';
-import { e2ePorts } from './e2e/profileEnv';
+import { E2E_CLIENT_TOKEN, e2ePorts } from './e2e/profileEnv';
 
 // Ports for the active ATTN_PROFILE. Default profile keeps the historical
 // 19849 (daemon) / 1421 (Vite); a named profile gets disjoint per-profile bands
@@ -25,6 +25,7 @@ export default defineConfig({
     timeout: 30000,
     env: {
       VITE_DAEMON_PORT: TEST_DAEMON_PORT,
+      VITE_CLIENT_TOKEN: E2E_CLIENT_TOKEN,
       VITE_MOCK_PTY: process.env.VITE_MOCK_PTY ?? '1',
       VITE_FORCE_REAL_PTY: process.env.VITE_FORCE_REAL_PTY ?? '0',
     },

--- a/app/scripts/real-app-harness/common.mjs
+++ b/app/scripts/real-app-harness/common.mjs
@@ -6,6 +6,7 @@ import { waitForFirstWorkspacePane, waitForPaneVisible } from './scenarioAsserti
 import {
   assertProductionRunAllowed,
   currentHarnessProfile,
+  harnessClientHello,
   defaultAppPathForProfile,
   defaultWSURLForProfile,
   deepLinkSchemeForProfile,
@@ -321,10 +322,7 @@ async function writeDaemonSettings(entries, { wsUrl = defaultWSURLForProfile(), 
         // The daemon refuses commands from a client that has not claimed
         // workspace_sessions, and says so on the way out.
         ws.send(JSON.stringify({
-          cmd: 'client_hello',
-          client_kind: 'harness-observer',
-          version: 'real-app-harness',
-          capabilities: ['workspace_sessions'],
+          ...harnessClientHello('harness-observer'),
         }));
         for (const { key, value } of entries) {
           ws.send(JSON.stringify({ cmd: 'set_setting', key, value }));

--- a/app/scripts/real-app-harness/daemonObserver.mjs
+++ b/app/scripts/real-app-harness/daemonObserver.mjs
@@ -1,5 +1,5 @@
 import WebSocket from 'ws';
-import { assertProductionRunAllowed, defaultWSURLForProfile } from './harnessProfile.mjs';
+import { assertProductionRunAllowed, defaultWSURLForProfile, harnessClientHello } from './harnessProfile.mjs';
 
 function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -12,10 +12,7 @@ function workspacePaneIds(workspace) {
 function sendClientHello(ws) {
   ws.send(
     JSON.stringify({
-      cmd: 'client_hello',
-      client_kind: 'harness-observer',
-      version: 'real-app-harness',
-      capabilities: ['workspace_sessions'],
+      ...harnessClientHello('harness-observer'),
     }),
   );
 }

--- a/app/scripts/real-app-harness/harnessProfile.mjs
+++ b/app/scripts/real-app-harness/harnessProfile.mjs
@@ -177,6 +177,31 @@ export function dataDirForProfile(profile = currentHarnessProfile()) {
   return resolveHarnessResources(profile).dataDir;
 }
 
+// The credential the daemon requires in client_hello, minted into the profile's
+// data dir at daemon startup. Every harness socket sends it; without it the
+// daemon refuses the hello and names this file.
+export function clientTokenForProfile(profile = currentHarnessProfile()) {
+  const fromEnv = (process.env.ATTN_CLIENT_TOKEN ?? '').trim();
+  if (fromEnv) return fromEnv;
+  try {
+    return fs.readFileSync(path.join(dataDirForProfile(profile), 'client-token'), 'utf8').trim();
+  } catch {
+    return '';
+  }
+}
+
+// The hello every harness websocket opens with. One place, so a new field on
+// the message reaches all of them.
+export function harnessClientHello(clientKind, { version = 'real-app-harness', capabilities = ['workspace_sessions'] } = {}) {
+  return {
+    cmd: 'client_hello',
+    client_kind: clientKind,
+    version,
+    capabilities,
+    client_token: clientTokenForProfile(),
+  };
+}
+
 // Unix socket the `attn` CLI talks to for the active profile. Pass this as
 // ATTN_SOCKET_PATH when driving the CLI (e.g. `attn open`) against the daemon.
 export function socketPathForProfile(profile = currentHarnessProfile()) {

--- a/app/scripts/real-app-harness/presentDaemon.mjs
+++ b/app/scripts/real-app-harness/presentDaemon.mjs
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import WebSocket from 'ws';
-import { defaultDaemonPortForProfile } from './harnessProfile.mjs';
+import { defaultDaemonPortForProfile, harnessClientHello } from './harnessProfile.mjs';
 
 const HARNESS_DIR = path.dirname(fileURLToPath(import.meta.url));
 const DAEMON_SOCKET_HOOK_PATH = path.resolve(HARNESS_DIR, '../../src/hooks/useDaemonSocket.ts');
@@ -68,10 +68,9 @@ export async function withDaemonSocket(fn, { port = defaultDaemonPortForProfile(
     // so daemon-side diagnostics can tell harness connections apart.
     await sendAndWait(
       {
-        cmd: 'client_hello',
-        client_kind: 'harness-present-daemon',
-        version: `protocol-${readFrontendProtocolVersion()}`,
-        capabilities: ['workspace_sessions'],
+        ...harnessClientHello('harness-present-daemon', {
+          version: `protocol-${readFrontendProtocolVersion()}`,
+        }),
       },
       'initial_state',
     );

--- a/app/scripts/real-app-harness/scenario-automation-lifecycle.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-lifecycle.mjs
@@ -52,7 +52,7 @@ import { fileURLToPath } from 'node:url';
 import WebSocket from 'ws';
 import { parseCommonArgs, printCommonHelp, launchFreshAppAndConnect } from './common.mjs';
 import { createScenarioRunner } from './scenarioRunner.mjs';
-import { currentHarnessProfile, dataDirForProfile, resolveHarnessResources } from './harnessProfile.mjs';
+import { currentHarnessProfile, dataDirForProfile, harnessClientHello, resolveHarnessResources } from './harnessProfile.mjs';
 import { UiAutomationClient } from './uiAutomationClient.mjs';
 import { DaemonObserver } from './daemonObserver.mjs';
 import { captureFrontWindowScreenshot } from './nativeWindowCapture.mjs';
@@ -317,10 +317,9 @@ async function wsRequest(wsURL, message, event, timeoutMs = 30_000) {
     const timer = setTimeout(() => { ws.close(); reject(new Error(`timed out waiting for ${event}`)); }, timeoutMs);
     let ready = false;
     ws.once('open', () => ws.send(JSON.stringify({
-      cmd: 'client_hello',
-      client_kind: 'harness-automation-lifecycle',
-      version: `protocol-${readFrontendProtocolVersion()}`,
-      capabilities: ['workspace_sessions'],
+      ...harnessClientHello('harness-automation-lifecycle', {
+        version: `protocol-${readFrontendProtocolVersion()}`,
+      }),
     })));
     ws.on('message', (raw) => {
       const value = JSON.parse(raw.toString());

--- a/app/scripts/real-app-harness/scenario-automation-pr-continuity.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-pr-continuity.mjs
@@ -15,6 +15,7 @@ import { readFrontendProtocolVersion } from './presentDaemon.mjs';
 import {
   currentHarnessProfile,
   dataDirForProfile,
+  harnessClientHello,
   resolveHarnessResources,
 } from './harnessProfile.mjs';
 
@@ -148,10 +149,9 @@ async function wsRequest(wsURL, message, event, timeoutMs = 30_000) {
     const timer = setTimeout(() => { ws.close(); reject(new Error(`timed out waiting for ${event}`)); }, timeoutMs);
     let ready = false;
     ws.once('open', () => ws.send(JSON.stringify({
-      cmd: 'client_hello',
-      client_kind: 'harness-automation-continuity',
-      version: `protocol-${readFrontendProtocolVersion()}`,
-      capabilities: ['workspace_sessions'],
+      ...harnessClientHello('harness-automation-continuity', {
+        version: `protocol-${readFrontendProtocolVersion()}`,
+      }),
     })));
     ws.on('message', (raw) => {
       const value = JSON.parse(raw.toString());

--- a/app/scripts/real-app-harness/scenario-terminal-annotations.mjs
+++ b/app/scripts/real-app-harness/scenario-terminal-annotations.mjs
@@ -32,6 +32,7 @@ import {
   waitForFirstWorkspacePane,
 } from './scenarioAssertions.mjs';
 import { ensureCodexPromptReadyViaPty } from './scenarioAgents.mjs';
+import { harnessClientHello } from './harnessProfile.mjs';
 import { createScenarioRunner } from './scenarioRunner.mjs';
 
 // Generous on purpose: how long a live agent takes to stop says nothing about
@@ -181,10 +182,7 @@ function daemonAnnotations(wsUrl, sessionId, timeoutMs = 8_000) {
     }, timeoutMs);
     ws.once('open', () => {
       ws.send(JSON.stringify({
-        cmd: 'client_hello',
-        client_kind: 'harness-observer',
-        version: 'real-app-harness',
-        capabilities: ['workspace_sessions'],
+        ...harnessClientHello('harness-observer'),
       }));
       ws.send(JSON.stringify({ cmd: 'session_annotations_get', session_id: sessionId, request_id: requestId }));
     });

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -479,6 +479,11 @@ fn get_browser_host_token(_caller: browser_host::TrustedMainWebview) -> Result<S
 }
 
 #[tauri::command]
+fn get_client_token() -> Result<String, String> {
+    profile::read_client_token()
+}
+
+#[tauri::command]
 fn ensure_daemon(_app: tauri::AppHandle) -> Result<(), String> {
     let _guard = ENSURE_DAEMON_LOCK
         .lock()
@@ -1128,6 +1133,7 @@ Object.defineProperty(window, "__ATTN_NATIVE_DIALOGS", {
             open_safe_markdown_target,
             get_build_profile,
             get_browser_host_token,
+            get_client_token,
             open_presentation_window,
             browser_host::browser_host_mount,
             browser_host::browser_host_update,

--- a/app/src-tauri/src/profile.rs
+++ b/app/src-tauri/src/profile.rs
@@ -97,6 +97,23 @@ fn data_dir() -> Result<PathBuf, String> {
     Ok(home.join(name))
 }
 
+/// Reads the per-profile credential every WebSocket client presents in
+/// client_hello. The daemon mints it at startup — the app only reads it, so a
+/// missing file means the daemon has not started yet and the empty string lets
+/// the daemon answer with the path it expected.
+pub fn read_client_token() -> Result<String, String> {
+    if let Ok(token) = env::var("ATTN_CLIENT_TOKEN") {
+        let token = token.trim().to_string();
+        if !token.is_empty() {
+            return Ok(token);
+        }
+    }
+    let path = data_dir()?.join("client-token");
+    Ok(fs::read_to_string(&path)
+        .map(|token| token.trim().to_string())
+        .unwrap_or_default())
+}
+
 /// Returns the stable per-profile secret used to authenticate the trusted main
 /// webview as the daemon's browser host. The token is persisted with owner-only
 /// permissions so app restarts can reconnect to a daemon that stayed alive.

--- a/app/src/hooks/useDaemonSocket.clientToken.test.tsx
+++ b/app/src/hooks/useDaemonSocket.clientToken.test.tsx
@@ -1,0 +1,131 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { invoke, isTauri } from '@tauri-apps/api/core';
+import { useDaemonSocket } from './useDaemonSocket';
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static instances: FakeWebSocket[] = [];
+
+  readonly url: string;
+  readyState = FakeWebSocket.CONNECTING;
+  binaryType = 'blob';
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  sent: string[] = [];
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+    queueMicrotask(() => {
+      this.readyState = FakeWebSocket.OPEN;
+      this.onopen?.(new Event('open'));
+    });
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.(new CloseEvent('close'));
+  }
+
+  emit(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+  }
+}
+
+async function waitForOpenSocket(): Promise<FakeWebSocket> {
+  await waitFor(() => {
+    expect(FakeWebSocket.instances.length).toBeGreaterThan(0);
+  });
+  const ws = FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+  await waitFor(() => {
+    expect(ws.readyState).toBe(FakeWebSocket.OPEN);
+  });
+  return ws;
+}
+
+function renderSocket() {
+  return renderHook(() =>
+    useDaemonSocket({
+      onSessionsUpdate: vi.fn(),
+      onWorkspacesUpdate: vi.fn(),
+      onPRsUpdate: vi.fn(),
+      onReposUpdate: vi.fn(),
+      onAuthorsUpdate: vi.fn(),
+      wsUrl: 'ws://localhost:9999/ws',
+    }),
+  );
+}
+
+// The daemon's WebSocket port carries no file permissions, so the app proves
+// itself with the profile's client token. Two halves matter to the user: the
+// hello carries it, and a refusal ends the reconnect loop showing what the
+// daemon said — which names the file to read — instead of blinking forever.
+describe('useDaemonSocket client token', () => {
+  let originalWebSocket: typeof WebSocket;
+
+  beforeEach(() => {
+    originalWebSocket = globalThis.WebSocket;
+    FakeWebSocket.instances = [];
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+    vi.mocked(isTauri).mockReturnValue(true);
+    vi.mocked(invoke).mockImplementation(async (cmd: string) =>
+      cmd === 'get_client_token' ? 'profile-token' : '',
+    );
+  });
+
+  afterEach(() => {
+    globalThis.WebSocket = originalWebSocket;
+    vi.restoreAllMocks();
+  });
+
+  it('presents the profile token in client_hello', async () => {
+    const { unmount } = renderSocket();
+    const ws = await waitForOpenSocket();
+
+    await waitFor(() => {
+      const hello = ws.sent.map((entry) => JSON.parse(entry)).find((entry) => entry.cmd === 'client_hello');
+      expect(hello?.client_token).toBe('profile-token');
+    });
+
+    unmount();
+  });
+
+  it('stops reconnecting and surfaces the daemon message when the token is refused', async () => {
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { result, unmount } = renderSocket();
+    const ws = await waitForOpenSocket();
+
+    act(() => {
+      ws.emit({
+        event: 'command_error',
+        cmd: 'client_hello',
+        success: false,
+        error_code: 'unauthorized_client',
+        error: 'client_hello refused: read /tmp/.attn-dev/client-token',
+      });
+      ws.close();
+    });
+
+    await waitFor(() => {
+      expect(result.current.connectionError).toContain('/tmp/.attn-dev/client-token');
+    });
+    // Retrying cannot help until someone changes the token, and a reconnect loop
+    // would bury the message that says how. The close handler decides this
+    // synchronously and says so — asserting on the socket count instead would
+    // pass on its own, since the backoff has not elapsed by here either way.
+    expect(errors.mock.calls.flat().join(' ')).toContain('Circuit open, not retrying');
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    unmount();
+  });
+});

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -263,7 +263,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '256';
+export const PROTOCOL_VERSION = '257';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a
@@ -1357,11 +1357,22 @@ export function useDaemonSocket({
     }
 
     let browserHostToken = '';
+    // The per-profile credential the daemon requires in client_hello. In the app
+    // it comes from the profile's token file through Tauri; in a plain browser
+    // (dev:vite, Playwright) Vite hands it over, because nothing there can read
+    // a file. Empty means the hello is refused, and the daemon says where to
+    // look.
+    let clientToken = import.meta.env.VITE_CLIENT_TOKEN ?? '';
     if (isTauri()) {
       try {
         browserHostToken = await invoke<string>('get_browser_host_token');
       } catch (error) {
         console.warn('[Daemon] Browser host authentication is unavailable:', error);
+      }
+      try {
+        clientToken = await invoke<string>('get_client_token');
+      } catch (error) {
+        console.warn('[Daemon] Client token is unavailable:', error);
       }
     }
 
@@ -1411,8 +1422,9 @@ export function useDaemonSocket({
         circuitResetTimeoutRef.current = null;
       }
 
-      // Identify ourselves first thing. Sending hello is useful for
-      // daemon-side diagnostics (client kind/version in logs).
+      // Identify ourselves first thing, and prove we may be here: the daemon
+      // withholds initial_state and every broadcast until this hello passes,
+      // so nothing else can be sent before it.
       ws.send(
         JSON.stringify({
           cmd: 'client_hello',
@@ -1425,6 +1437,7 @@ export function useDaemonSocket({
             KITTY_IMAGES_CAPABILITY,
             ...(browserHostToken ? [BROWSER_HOST_CAPABILITY] : []),
           ],
+          client_token: clientToken || undefined,
           browser_host_token: browserHostToken || undefined,
         }),
       );
@@ -3015,6 +3028,15 @@ export function useDaemonSocket({
           }
 
           case 'command_error':
+            if (data.error_code === 'unauthorized_client') {
+              // The daemon hangs up right after this. Reconnecting cannot help —
+              // the token is wrong until someone changes it — so open the circuit
+              // and show what the daemon said, which names the file to read.
+              console.error('[Daemon] Client token refused:', data.error);
+              setConnectionError(data.error || 'The daemon refused this client.');
+              circuitOpenRef.current = true;
+              break;
+            }
             if (data.error === 'daemon_recovering') {
               console.debug('[Daemon] Command deferred while daemon recovers:', data.cmd);
               rejectPendingForCommand(data.cmd, 'Daemon is recovering. Please retry in a moment.');

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -2125,6 +2125,7 @@ export interface ClientHelloMessage {
     capabilities:        string[];
     client_id?:          string;
     client_kind:         string;
+    client_token?:       string;
     cmd:                 ClientHelloMessageCmd;
     version:             string;
     [property: string]: any;
@@ -7761,6 +7762,7 @@ export interface WebSocketEvent {
     directory?:                string;
     dirty?:                    boolean;
     error?:                    string;
+    error_code?:               string;
     event:                     string;
     exit_code?:                number;
     found?:                    boolean;
@@ -14089,6 +14091,7 @@ const typeMap: any = {
         { json: "capabilities", js: "capabilities", typ: a("") },
         { json: "client_id", js: "client_id", typ: u(undefined, "") },
         { json: "client_kind", js: "client_kind", typ: "" },
+        { json: "client_token", js: "client_token", typ: u(undefined, "") },
         { json: "cmd", js: "cmd", typ: r("ClientHelloMessageCmd") },
         { json: "version", js: "version", typ: "" },
     ], "any"),
@@ -17541,6 +17544,7 @@ const typeMap: any = {
         { json: "directory", js: "directory", typ: u(undefined, "") },
         { json: "dirty", js: "dirty", typ: u(undefined, true) },
         { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "error_code", js: "error_code", typ: u(undefined, "") },
         { json: "event", js: "event", typ: "" },
         { json: "exit_code", js: "exit_code", typ: u(undefined, 0) },
         { json: "found", js: "found", typ: u(undefined, true) },

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -11,6 +11,9 @@ interface ImportMetaEnv {
   readonly VITE_ATTN_SOURCE_FINGERPRINT?: string;
   readonly VITE_ATTN_GIT_COMMIT?: string;
   readonly VITE_ATTN_BUILD_TIME?: string;
+  // Only for a bundle running outside Tauri, which cannot read the profile's
+  // client-token file. vite.config.ts fills it in from that file.
+  readonly VITE_CLIENT_TOKEN?: string;
 }
 
 interface ImportMeta {

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -2,6 +2,8 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { execFileSync } from "child_process";
+import { readFileSync } from "fs";
+import { homedir } from "os";
 import { resolve } from "path";
 
 // The terminal-snapshot wire format this bundle decodes. Computed here, from
@@ -19,11 +21,40 @@ const snapshotFormat = execFileSync(
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
 
+// A bundle served outside Tauri — `dev:vite` — has no way to read the profile's
+// client-token file, and the daemon refuses a client_hello without it. Read it
+// here, where node can, so the browser dev loop needs no setup.
+//
+// Serve only. A built bundle must never carry this: the same bundle ships to
+// every profile and to whoever installs a release, and the token is per-profile
+// and secret. Inside the app it is unused anyway — Tauri reads the file itself.
+// An explicit VITE_CLIENT_TOKEN (Playwright sets one) wins: this define
+// replaces the expression outright, so it has to reproduce what vite's own
+// VITE_-prefix injection would have put there.
+function clientTokenFromProfile(): string {
+  // @ts-expect-error process is a nodejs global
+  const env = process.env as Record<string, string | undefined>;
+  const explicit = (env.VITE_CLIENT_TOKEN ?? env.ATTN_CLIENT_TOKEN ?? "").trim();
+  if (explicit) return explicit;
+  const profile = (env.ATTN_PROFILE ?? "").trim();
+  const dataDir =
+    (env.ATTN_DATA_DIR ?? "").trim() ||
+    resolve(homedir(), profile ? `.attn-${profile}` : ".attn");
+  try {
+    return readFileSync(resolve(dataDir, "client-token"), "utf8").trim();
+  } catch {
+    return "";
+  }
+}
+
 // https://vite.dev/config/
-export default defineConfig(async () => ({
+export default defineConfig(async ({ command }) => ({
   plugins: [react()],
   define: {
     __ATTN_SNAPSHOT_FORMAT__: JSON.stringify(snapshotFormat),
+    ...(command === "serve"
+      ? { "import.meta.env.VITE_CLIENT_TOKEN": JSON.stringify(clientTokenFromProfile()) }
+      : {}),
   },
   // Multi-page app configuration for test harness
   build: {

--- a/changelog.d/ws-client-token.yaml
+++ b/changelog.d/ws-client-token.yaml
@@ -1,0 +1,14 @@
+kind: changed
+area: daemon
+change: >
+  The daemon's local WebSocket port now requires a credential. Until now any
+  process on the machine that knew the port could speak the whole protocol —
+  read every session, spawn agents, write files — and one profile's app could
+  drive another profile's daemon. The daemon mints a token into its profile's
+  data directory (`~/.attn[-profile]/client-token`, owner-only) on first
+  startup and reuses it afterwards, and every client presents it when it
+  connects. A connection that has not presented it is handed nothing at all —
+  no state, no updates — rather than merely being refused commands. Nothing to
+  set up: the app, the CLI and the harness all read the same file. A client
+  that presents the wrong one is told so, with the path to read, instead of
+  being hung up on.

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -196,6 +196,8 @@ func main() {
 		runDaemonCommand()
 	case "ws-relay":
 		runWSRelay()
+	case "client-token":
+		runClientToken()
 	case "pty-worker":
 		runPTYWorker()
 	case "workflow":
@@ -588,6 +590,18 @@ func runDaemonStop() {
 		return
 	}
 	fmt.Printf("daemon %s\n", result.Note)
+}
+
+// runClientToken prints this profile's client token — what a WebSocket client
+// must present in client_hello. Silent on stdout beyond the token itself: the
+// hub reads it over SSH to authenticate against a remote daemon.
+func runClientToken() {
+	token := config.ClientToken()
+	if token == "" {
+		fmt.Fprintf(os.Stderr, "no client token at %s — the daemon mints it at startup; start it first\n", config.ClientTokenPath())
+		os.Exit(1)
+	}
+	fmt.Println(token)
 }
 
 func runWSRelay() {

--- a/cmd/attn/plugin.go
+++ b/cmd/attn/plugin.go
@@ -206,17 +206,20 @@ func pluginDaemonRequest(payload map[string]any, expectedEvent, expectedAction s
 	}
 	conn.SetReadLimit(16 << 20)
 	defer conn.Close(websocket.StatusNormalClosure, "")
-	if _, _, err := conn.Read(ctx); err != nil {
-		return nil, fmt.Errorf("read daemon state: %w", err)
-	}
 	hello := map[string]any{
 		"cmd":          protocol.CmdClientHello,
 		"client_kind":  "attn-cli",
 		"version":      "protocol-" + protocol.ProtocolVersion,
 		"capabilities": []string{protocol.CapabilityWorkspaceSessions},
+		"client_token": config.ClientToken(),
 	}
+	// Hello first: the daemon sends nothing at all — initial_state included —
+	// until it passes.
 	if err := writePluginDaemonMessage(ctx, conn, hello); err != nil {
 		return nil, err
+	}
+	if _, _, err := conn.Read(ctx); err != nil {
+		return nil, fmt.Errorf("read daemon state: %w", err)
 	}
 	if err := writePluginDaemonMessage(ctx, conn, payload); err != nil {
 		return nil, err

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -614,6 +614,30 @@ written by whoever tends it; a **crew handoff** is the member's day-line.
 Plan:
 [docs/plans/2026-08-11-the-crew-primitive.md](plans/2026-08-11-the-crew-primitive.md).
 
+## Client token
+
+The credential a client presents in `client_hello` to speak the daemon's
+protocol at all. The daemon mints it at first startup into its own profile's
+data directory as `client-token`, owner-only, and reuses it forever after so a
+restart never strands a client.
+
+It exists because the daemon's two front doors are gated differently: the unix
+socket has file permissions, and the loopback WebSocket port has nothing. The
+token gives the port the same gate. Per-profile is the point — the same binary
+serves every profile, so one profile's app cannot drive another's daemon.
+
+Distinct from the two tokens that already existed. The **browser host token**
+says *which* client is the trusted Tauri main webview, once it is already
+inside; `ATTN_WS_AUTH_TOKEN` is an operator-set HTTP bearer for a WS port
+deliberately exposed beyond loopback. The client token answers the earlier
+question: may this process speak here? — and a connection that already cleared
+the bearer is exempt from it, because that is the same question answered at the
+layer that fits a browser.
+
+`attn client-token` prints it. A refused hello names the file and the profile,
+so the fix is readable off the error. Plan:
+[docs/plans/2026-08-16-local-ws-client-token.md](plans/2026-08-16-local-ws-client-token.md).
+
 ## Home daemon
 
 A daemon that is **its own home** — standalone, complete, owning its garden,

--- a/docs/plans/2026-08-16-local-ws-client-token.md
+++ b/docs/plans/2026-08-16-local-ws-client-token.md
@@ -1,0 +1,130 @@
+# Local WS client token
+
+The daemon listens on two things: a unix socket, gated by file permissions, and
+a loopback WebSocket port, gated by nothing. Any local process that knows the
+port speaks the full protocol today — read every session, spawn agents, write
+files through `fs_write`. PR #922 fenced profiles at the filesystem and spawn
+level, but the wire carries no credential, so one profile's client can drive
+another profile's daemon.
+
+This closes it with a per-profile runtime token the daemon mints and every
+local client presents in `client_hello`.
+
+## The credential
+
+`<data-dir>/client-token` — 32 bytes from `crypto/rand`, hex, written 0600.
+Minted by the daemon at `Start()` and reused on later startups so a restart
+does not strand a client. `ATTN_CLIENT_TOKEN` overrides the file for harnesses
+that spawn a daemon and a client together and want to hand both the same value.
+
+Per-profile is the point: the same binary serves every profile, so the secret
+has to live in profile data. Nothing is baked at build time — a released binary
+would ship a public secret.
+
+Three token-shaped things now exist; they do different jobs:
+
+| | what it proves | where |
+| --- | --- | --- |
+| `client-token` | this process may speak the protocol at all | hello, every local client |
+| `browser-host-token` | this client is the trusted Tauri main webview | hello, app only |
+| `ATTN_WS_AUTH_TOKEN` | operator bearer for an exposed WS port | HTTP header, opt-in |
+
+## The check
+
+`handleClientHello` compares in constant time before it records identity or
+capabilities. A mismatch sends `command_error` with code
+`unauthorized_client`, naming the file the daemon read, then closes with a
+policy violation — never a silent hangup. Because identity is recorded only
+after the token passes, a refused client also fails the existing
+`workspace_sessions` gate on every command that follows.
+
+A daemon holding no token authorizes nobody, rather than matching the client
+that also sent nothing. `Start()` mints before the port listens, so this only
+names a daemon someone constructed without it.
+
+Whatever the client pipelined behind its hello is already in the read buffer
+when the refusal is queued, and the message pump drops it: the
+`workspace_sessions` gate hangs up on the connection itself, which would close
+the socket before the write pump flushed the refusal — a silent close, arriving
+as `events: []` on the wire. So the pump stops dispatching once the send channel
+is closed, and the refusal is the last thing that connection hears.
+
+One exemption: a connection that cleared `ATTN_WS_AUTH_TOKEN` at the HTTP layer
+skips the client-token check. That bearer is only set when the port was
+deliberately exposed beyond loopback (`tailscale serve`, the remote-web
+setting), and the browser it serves cannot read a file on the daemon's disk.
+The two gates answer the same question — may this process speak here? — and the
+exposed-port one is the deliberate, stronger answer. Without the exemption,
+enabling remote web would close it. Loopback is unaffected: with no bearer set,
+the HTTP gate is skipped entirely and the client token is the only way in.
+
+Unix-socket commands never reach this handler — `daemon.go`'s socket dispatch
+is a separate switch, and file permissions already gate that path. The WS check
+is not weakened for it.
+
+## Admission
+
+Refusing commands is only half of it. The daemon used to push `initial_state`
+— every session, PR, workspace, ticket and setting — on connect, and register
+the connection with the hub, both before a single byte arrived from the client.
+A credential that gates writes while the whole read side streams to anyone who
+opens a socket would be theatre.
+
+So hub registration and the `initial_state` push moved out of the accept path
+into `admitClient`, called only once the hello passes. The hub is the sole
+fan-out, so a connection that has not presented the token is not merely refused
+its commands — it is invisible to every broadcast. The app already sent hello
+first thing on open, so nothing waits longer than it did.
+
+Registration became a direct, locked insert (`wsHub.add`) rather than a
+handoff on the `register` channel, which had no other user: admission is
+synchronous now, so there is no window in which a client is admitted but not
+yet receiving. The unregister side stays a channel — a disconnect is
+discovered on the read pump, not asked for — and now closes the send channel
+even for a connection that was never admitted, so its write pump still exits.
+
+## Clients
+
+One shared read per language, not N copies:
+
+- Go (`cmd/attn` plugin requests, `scripts/wsctl`) — `config.ClientToken()`.
+- Rust/Tauri — `profile::read_client_token()` behind the `get_client_token`
+  command, mirroring `get_browser_host_token`.
+- Frontend — Tauri `invoke` when in the app, `import.meta.env.VITE_CLIENT_TOKEN`
+  when running in a plain browser (`dev:vite`, Playwright). `vite.config.ts`
+  fills that in from the active profile's token file when it is not already set.
+- Harness (`app/scripts/real-app-harness`) — `clientTokenForProfile()` beside
+  the existing `dataDirForProfile()`.
+- Playwright e2e — a fixed token handed to both the throwaway daemon
+  (`ATTN_CLIENT_TOKEN`) and Vite (`VITE_CLIENT_TOKEN`).
+
+`plugins/attn-pi` does not dial the daemon's WebSocket; its host talks over the
+plugin runtime's stdio envelope, so there is nothing to change there.
+
+## Remote endpoints
+
+The brief scoped remote daemons out, but enforcing the token would have broken
+them outright: the hub relays through `attn ws-relay`, a raw TCP pipe, so the
+hub's own `client_hello` reaches the remote daemon end to end and would be
+refused.
+
+The hub reads the remote's token the way it already reads everything else on
+that host — over SSH, with `runSSHExit` running `attn client-token` before the
+dial. SSH access to the box is already full authority over it, so this grants
+nothing new. It is not a shared filesystem: no path is assumed beyond the
+remote binary the hub already invokes. When enrollment carries credentials, this
+call is the thing it replaces.
+
+The read happens after the connect succeeds — a host whose daemon has never run
+has nothing to read — and costs one more short SSH exec per connection attempt,
+on a path that already runs several. Not cached: the token is stable across
+restarts, so a cache would buy one exec per reconnect at the price of knowing
+when to invalidate it.
+
+A remote running an older binary cannot happen: the hub already parks any
+endpoint whose `SourceFingerprint` differs.
+
+## Protocol
+
+`client_token?: string` on `ClientHelloMessage`, `ProtocolVersion` 253 → 254,
+`PROTOCOL_VERSION` in `useDaemonSocket.ts` to match.

--- a/docs/plans/2026-08-16-local-ws-client-token.md
+++ b/docs/plans/2026-08-16-local-ws-client-token.md
@@ -126,5 +126,5 @@ endpoint whose `SourceFingerprint` differs.
 
 ## Protocol
 
-`client_token?: string` on `ClientHelloMessage`, `ProtocolVersion` 253 → 254,
+`client_token?: string` on `ClientHelloMessage`, `ProtocolVersion` 256 → 257,
 `PROTOCOL_VERSION` in `useDaemonSocket.ts` to match.

--- a/internal/config/clienttoken.go
+++ b/internal/config/clienttoken.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ClientTokenFile is the profile-data-dir name of the credential every local
+// client presents in client_hello. It sits beside the socket, and like the
+// socket it is owner-only: the WebSocket port has no file permissions of its
+// own, so this is what stands between another local process — including another
+// profile's app — and the full protocol.
+const ClientTokenFile = "client-token"
+
+// ClientTokenPath returns the active profile's client-token path.
+func ClientTokenPath() string {
+	return filepath.Join(attnDir(), ClientTokenFile)
+}
+
+// ClientToken returns the token a client should present. Empty when the file is
+// absent — the daemon's refusal names the path, which is a better answer than a
+// client guessing.
+//
+// ATTN_CLIENT_TOKEN wins so a harness can spawn a daemon and its clients with
+// one value instead of racing the file into existence.
+func ClientToken() string {
+	if token := strings.TrimSpace(os.Getenv("ATTN_CLIENT_TOKEN")); token != "" {
+		return token
+	}
+	data, err := os.ReadFile(ClientTokenPath())
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// EnsureClientToken returns the token stored under dir, minting one on first
+// use. The daemon calls it at startup against its own data root; reusing an
+// existing token is what keeps a daemon restart from stranding every client.
+func EnsureClientToken(dir string) (string, error) {
+	if token := strings.TrimSpace(os.Getenv("ATTN_CLIENT_TOKEN")); token != "" {
+		return token, nil
+	}
+	path := filepath.Join(dir, ClientTokenFile)
+	if data, err := os.ReadFile(path); err == nil {
+		if token := strings.TrimSpace(string(data)); token != "" {
+			return token, nil
+		}
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("create data directory %s: %w", dir, err)
+	}
+	random := make([]byte, 32)
+	if _, err := rand.Read(random); err != nil {
+		return "", fmt.Errorf("generate client token: %w", err)
+	}
+	token := hex.EncodeToString(random)
+	if err := os.WriteFile(path, []byte(token), 0o600); err != nil {
+		return "", fmt.Errorf("write client token %s: %w", path, err)
+	}
+	// WriteFile honours the mode only when it creates the file; an existing
+	// empty one keeps whatever mode it had.
+	if err := os.Chmod(path, 0o600); err != nil {
+		return "", fmt.Errorf("secure client token %s: %w", path, err)
+	}
+	return token, nil
+}

--- a/internal/config/clienttoken_test.go
+++ b/internal/config/clienttoken_test.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureClientTokenMintsOnceAndKeepsItOwnerOnly(t *testing.T) {
+	dir := t.TempDir()
+
+	first, err := EnsureClientToken(dir)
+	if err != nil {
+		t.Fatalf("EnsureClientToken() error = %v", err)
+	}
+	if len(first) != 64 {
+		t.Fatalf("token = %q (%d chars), want 64 hex chars", first, len(first))
+	}
+
+	// A restart must reuse it: a fresh token would strand every client that is
+	// already holding the old one.
+	second, err := EnsureClientToken(dir)
+	if err != nil {
+		t.Fatalf("EnsureClientToken() second call error = %v", err)
+	}
+	if second != first {
+		t.Fatalf("token changed across calls: %q then %q", first, second)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, ClientTokenFile))
+	if err != nil {
+		t.Fatalf("stat token: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("token mode = %#o, want 0600", mode)
+	}
+}
+
+func TestEnsureClientTokenMintsDistinctTokensPerProfile(t *testing.T) {
+	one, err := EnsureClientToken(t.TempDir())
+	if err != nil {
+		t.Fatalf("EnsureClientToken() error = %v", err)
+	}
+	two, err := EnsureClientToken(t.TempDir())
+	if err != nil {
+		t.Fatalf("EnsureClientToken() error = %v", err)
+	}
+	if one == two {
+		t.Fatal("two profiles minted the same token; the whole point is that they differ")
+	}
+}
+
+func TestClientTokenPrefersTheEnvironmentOverTheFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ATTN_DATA_DIR", dir)
+	if _, err := EnsureClientToken(dir); err != nil {
+		t.Fatalf("EnsureClientToken() error = %v", err)
+	}
+
+	t.Setenv("ATTN_CLIENT_TOKEN", "handed-over")
+	if got := ClientToken(); got != "handed-over" {
+		t.Fatalf("ClientToken() = %q, want the environment's value", got)
+	}
+	got, err := EnsureClientToken(dir)
+	if err != nil {
+		t.Fatalf("EnsureClientToken() error = %v", err)
+	}
+	if got != "handed-over" {
+		t.Fatalf("EnsureClientToken() = %q, want the environment's value", got)
+	}
+}
+
+func TestClientTokenIsEmptyWhenNothingMintedIt(t *testing.T) {
+	t.Setenv("ATTN_DATA_DIR", t.TempDir())
+	if got := ClientToken(); got != "" {
+		t.Fatalf("ClientToken() = %q, want empty so the daemon's refusal names the path", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -246,6 +246,7 @@ func ScopeTestEnvironment(dataDir string) {
 	os.Unsetenv("ATTN_SOCKET_PATH")
 	os.Unsetenv("ATTN_CONFIG_PATH")
 	os.Unsetenv("ATTN_PLUGIN_DIR")
+	os.Unsetenv("ATTN_CLIENT_TOKEN")
 }
 
 // defaultAttnDir computes the profile-aware default data dir from the real

--- a/internal/daemon/browser_test.go
+++ b/internal/daemon/browser_test.go
@@ -50,12 +50,15 @@ func TestBrowserHostRequiresMatchingToken(t *testing.T) {
 	t.Setenv("ATTN_BROWSER_HOST_TOKEN", "expected-secret")
 	client := newWorkspaceProtocolTestClient()
 	client.trustedTauriOrigin = true
-	d := &Daemon{}
+	// The browser-host secret is a second credential on top of the client
+	// token; the hello has to clear the first gate to reach it.
+	d := newHelloTestDaemon(t, "client-token")
 
 	d.handleClientHello(client, &protocol.ClientHelloMessage{
 		ClientKind:       "tauri-app",
 		Version:          "test",
 		Capabilities:     []string{protocol.CapabilityBrowserHost},
+		ClientToken:      protocol.Ptr("client-token"),
 		BrowserHostToken: protocol.Ptr("wrong-secret"),
 	})
 	if client.IsBrowserHost() {
@@ -66,6 +69,7 @@ func TestBrowserHostRequiresMatchingToken(t *testing.T) {
 		ClientKind:       "tauri-app",
 		Version:          "test",
 		Capabilities:     []string{protocol.CapabilityBrowserHost},
+		ClientToken:      protocol.Ptr("client-token"),
 		BrowserHostToken: protocol.Ptr("expected-secret"),
 	})
 	if !client.IsBrowserHost() {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -110,8 +110,12 @@ type Daemon struct {
 	pidFile          *os.File // Held open with flock for exclusive access
 	dataRoot         string
 	daemonInstanceID string
-	store            *store.Store
-	automationMu     sync.Mutex // serializes idempotent ensure/adopt delivery per profile
+	// clientToken gates the WebSocket port, which has no file permissions of its
+	// own. Read once at startup: every client_hello compares against it, and the
+	// file it came from is what the refusal names.
+	clientToken  string
+	store        *store.Store
+	automationMu sync.Mutex // serializes idempotent ensure/adopt delivery per profile
 	// wsAutomationMutationTimeout bounds how long a WS-originated automation
 	// mutation (set_enabled) waits to acquire automationMu before aborting
 	// without mutating. 0 resolves to defaultWSAutomationMutationTimeout via
@@ -1040,6 +1044,13 @@ func (d *Daemon) Start() error {
 			return fmt.Errorf("ensure daemon instance id: %w", err)
 		}
 		d.daemonInstanceID = instanceID
+	}
+	if d.clientToken == "" {
+		token, err := config.EnsureClientToken(d.dataRoot)
+		if err != nil {
+			return fmt.Errorf("ensure client token: %w", err)
+		}
+		d.clientToken = token
 	}
 	if err := d.ensureEnrollment(); err != nil {
 		return fmt.Errorf("ensure enrollment record: %w", err)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -150,6 +150,12 @@ func TestMain(m *testing.M) {
 	}
 	_ = os.Setenv(toolhome.EnvVar, toolHomeDir)
 
+	// Daemons here start against a per-test socket dir, not the scoped data dir,
+	// so a minted token would land somewhere config.ClientToken() never looks.
+	// One value for both ends is exactly what the override is for; tests that
+	// exercise the refusal set their own.
+	_ = os.Setenv("ATTN_CLIENT_TOKEN", "daemon-test-client-token")
+
 	code := m.Run()
 	os.RemoveAll(dataDir)
 	os.RemoveAll(toolHomeDir)
@@ -3079,13 +3085,14 @@ func TestDaemon_AttachFlowOverWebSocket(t *testing.T) {
 	}
 	defer conn.Close(websocket.StatusNormalClosure, "")
 
+	// The hello is what unlocks initial_state; other broadcasts may arrive first.
+	sendWorkspaceClientHello(t, conn)
 	initial := waitForDaemonWebSocketEvent(t, conn, 10*time.Second, func(evt map[string]interface{}) bool {
 		return asString(evt["event"]) == protocol.EventInitialState
 	})
 	if !initialStateIncludesSession(initial, sessionID) {
 		t.Fatalf("initial_state did not include smoke session %q", sessionID)
 	}
-	sendWorkspaceClientHello(t, conn)
 
 	if err := writeWS(conn, map[string]interface{}{
 		"cmd": protocol.CmdAttachSession,
@@ -3227,6 +3234,7 @@ func sendWorkspaceClientHello(t *testing.T, conn *websocket.Conn) {
 		"client_kind":  "daemon-test",
 		"version":      "protocol-" + protocol.ProtocolVersion,
 		"capabilities": []string{protocol.CapabilityWorkspaceSessions},
+		"client_token": config.ClientToken(),
 	}); err != nil {
 		t.Fatalf("send client hello: %v", err)
 	}
@@ -3937,13 +3945,13 @@ func TestDaemon_ApprovePR_ViaWebSocket(t *testing.T) {
 	}
 	defer conn.Close(websocket.StatusNormalClosure, "")
 
-	// Read initial state
+	// The hello is what unlocks initial_state; nothing arrives before it.
+	sendWorkspaceClientHello(t, conn)
 	_, initialData, err := conn.Read(ctx)
 	if err != nil {
 		t.Fatalf("Read initial state error: %v", err)
 	}
 	t.Logf("Initial state: %s", string(initialData))
-	sendWorkspaceClientHello(t, conn)
 
 	// Send approve command
 	prID := protocol.FormatPRID(ghClient.Host(), "test/repo", 42)
@@ -4153,7 +4161,8 @@ func TestDaemon_MutePR_ViaWebSocket(t *testing.T) {
 	}
 	defer wsConn.Close(websocket.StatusNormalClosure, "")
 
-	// Read initial state (other background broadcasts may arrive first).
+	// The hello is what unlocks initial_state; other broadcasts may arrive first.
+	sendWorkspaceClientHello(t, wsConn)
 	initialState := waitForProtocolWebSocketEvent(t, wsConn, protocol.EventInitialState)
 	if len(initialState.Prs) != 1 {
 		t.Fatalf("Expected 1 PR in initial state, got %d", len(initialState.Prs))
@@ -4236,9 +4245,9 @@ func TestDaemon_MuteRepo_ViaWebSocket(t *testing.T) {
 	}
 	defer wsConn.Close(websocket.StatusNormalClosure, "")
 
-	// Read initial state (other background broadcasts may arrive first).
-	waitForProtocolWebSocketEvent(t, wsConn, protocol.EventInitialState)
+	// The hello is what unlocks initial_state; other broadcasts may arrive first.
 	sendWorkspaceClientHello(t, wsConn)
+	waitForProtocolWebSocketEvent(t, wsConn, protocol.EventInitialState)
 
 	// Send mute_repo command
 	muteCmd := map[string]interface{}{
@@ -4322,7 +4331,8 @@ func TestDaemon_InitialState_IncludesRepoStates(t *testing.T) {
 	}
 	defer wsConn.Close(websocket.StatusNormalClosure, "")
 
-	// Read initial state (other background broadcasts may arrive first).
+	// The hello is what unlocks initial_state; other broadcasts may arrive first.
+	sendWorkspaceClientHello(t, wsConn)
 	initialState := waitForProtocolWebSocketEvent(t, wsConn, protocol.EventInitialState)
 
 	// Verify initial state includes repos
@@ -4388,7 +4398,8 @@ func TestDaemon_StateChange_BroadcastsToWebSocket(t *testing.T) {
 	}
 	defer wsConn.Close(websocket.StatusNormalClosure, "")
 
-	// Read initial state (other background broadcasts may arrive first).
+	// The hello is what unlocks initial_state; other broadcasts may arrive first.
+	sendWorkspaceClientHello(t, wsConn)
 	waitForProtocolWebSocketEvent(t, wsConn, protocol.EventInitialState)
 
 	// Update state to waiting_input via unix socket
@@ -4458,6 +4469,8 @@ func TestDaemon_HookReportedStatesReachClients(t *testing.T) {
 	}
 	defer wsConn.Close(websocket.StatusNormalClosure, "")
 
+	// The hello is what unlocks initial_state; other broadcasts may arrive first.
+	sendWorkspaceClientHello(t, wsConn)
 	waitForProtocolWebSocketEvent(t, wsConn, protocol.EventInitialState)
 
 	// A turn starts, the agent asks the user a question, the user answers and the
@@ -4520,7 +4533,8 @@ func TestDaemon_InjectTestSession_BroadcastsToWebSocket(t *testing.T) {
 	}
 	defer wsConn.Close(websocket.StatusNormalClosure, "")
 
-	// Read initial state
+	// The hello is what unlocks initial_state; nothing arrives before it.
+	sendWorkspaceClientHello(t, wsConn)
 	_, _, err := wsConn.Read(ctx)
 	if err != nil {
 		t.Fatalf("Read initial state error: %v", err)

--- a/internal/daemon/plugin_driver_e2e_test.go
+++ b/internal/daemon/plugin_driver_e2e_test.go
@@ -112,10 +112,11 @@ func TestPluginDriverEndToEnd_InstalledProcessLaunchReportAndResumeThroughWorker
 	}
 	defer ws.Close(websocket.StatusNormalClosure, "")
 
+	// The hello is what unlocks initial_state; nothing arrives before it.
+	sendWorkspaceClientHello(t, ws)
 	_ = waitForDaemonWebSocketEvent(t, ws, 10*time.Second, func(event map[string]interface{}) bool {
 		return asString(event["event"]) == protocol.EventInitialState
 	})
-	sendWorkspaceClientHello(t, ws)
 
 	sessionID := "plugin-driver-e2e"
 	workspaceID := "workspace-" + sessionID

--- a/internal/daemon/real_agent_harness_test.go
+++ b/internal/daemon/real_agent_harness_test.go
@@ -83,6 +83,9 @@ func TestRealAgentHarness(t *testing.T) {
 		t.Fatalf("websocket dial: %v", err)
 	}
 	defer conn.Close(websocket.StatusNormalClosure, "")
+	// The daemon sends this connection nothing, and refuses every gated command
+	// on it, until the hello presents the client token.
+	sendWorkspaceClientHello(t, conn)
 
 	c := client.New(sockPath)
 	sessionID := wrapper.GenerateSessionID()

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -47,6 +47,9 @@ type wsClient struct {
 	// per-profile secret delivered only to the trusted main webview.
 	trustedTauriOrigin       bool
 	browserHostAuthenticated bool
+	// bearerAuthorized records that this connection cleared ATTN_WS_AUTH_TOKEN
+	// at the HTTP layer, which stands in for the client token — see handleWS.
+	bearerAuthorized bool
 
 	// PTY subscriptions keyed by session ID
 	attachedStreams map[string]ptybackend.Stream // session -> stream
@@ -59,6 +62,10 @@ type wsClient struct {
 	tileContentPending       map[string]time.Time
 	tileContentMu            sync.RWMutex
 
+	// admitted guards hub registration and the initial_state push, which happen
+	// when client_hello passes rather than when the socket opens. A client that
+	// helloes twice is still admitted once.
+	admitted sync.Once
 	// Identity + capabilities declared via client_hello.
 	clientKind    string
 	clientVersion string
@@ -402,7 +409,6 @@ type outboundMessage struct {
 type wsHub struct {
 	clients    map[*wsClient]bool
 	broadcast  chan outboundMessage
-	register   chan *wsClient
 	unregister chan *wsClient
 	mu         sync.RWMutex
 	// evictions remembers, per client_id, why the hub hung up — read back on the
@@ -432,7 +438,6 @@ func newWSHub() *wsHub {
 	return &wsHub{
 		clients:    make(map[*wsClient]bool),
 		broadcast:  make(chan outboundMessage, 256),
-		register:   make(chan *wsClient),
 		unregister: make(chan *wsClient),
 		logf:       func(format string, args ...interface{}) {}, // no-op by default
 	}
@@ -456,19 +461,14 @@ func previewBinaryForLog(data []byte) string {
 func (h *wsHub) run() {
 	for {
 		select {
-		case client := <-h.register:
-			h.mu.Lock()
-			h.clients[client] = true
-			h.mu.Unlock()
-
 		case client := <-h.unregister:
 			h.mu.Lock()
-			if _, ok := h.clients[client]; ok {
-				delete(h.clients, client)
-				client.closeSendChannel()
-				// Cleanup git status subscription
-				client.stopGitStatusPoll()
-			}
+			delete(h.clients, client)
+			// A connection refused at client_hello was never in the map, and
+			// its write pump still has to be let go. Both calls are idempotent,
+			// so the eviction path having run first costs nothing.
+			client.closeSendChannel()
+			client.stopGitStatusPoll()
 			h.mu.Unlock()
 
 		case message := <-h.broadcast:
@@ -496,6 +496,15 @@ func (h *wsHub) run() {
 			h.mu.Unlock()
 		}
 	}
+}
+
+// add takes a client into the fan-out, synchronously: from the caller's next
+// line the client is receiving broadcasts. Its counterpart is asynchronous
+// because a disconnect is discovered on the read pump, not asked for.
+func (h *wsHub) add(client *wsClient) {
+	h.mu.Lock()
+	h.clients[client] = true
+	h.mu.Unlock()
 }
 
 // Broadcast sends an event to all connected clients
@@ -715,6 +724,11 @@ func (d *Daemon) handleWS(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "forbidden origin", http.StatusForbidden)
 		return
 	}
+	// An operator-set bearer means this port was deliberately exposed beyond
+	// loopback (tailscale serve). Clearing it proves the same thing the client
+	// token proves, at the layer that fits the caller: a browser served from
+	// that port cannot read a file on the daemon's disk.
+	bearerAuthorized := false
 	if required := config.WSAuthToken(); required != "" {
 		provided := strings.TrimSpace(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
 		if provided == "" {
@@ -724,6 +738,7 @@ func (d *Daemon) handleWS(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
+		bearerAuthorized = true
 	}
 
 	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
@@ -745,16 +760,17 @@ func (d *Daemon) handleWS(w http.ResponseWriter, r *http.Request) {
 		recv:               make(chan []byte, 256), // buffer for incoming messages
 		connectedAt:        time.Now(),
 		trustedTauriOrigin: isTrustedTauriOrigin(origin),
+		bearerAuthorized:   bearerAuthorized,
 		attachedStreams:    make(map[string]ptybackend.Stream),
 		attachedRemote:     make(map[string]struct{}),
 		pendingRemote:      make(map[string]struct{}),
 	}
 
-	d.wsHub.register <- client
-	d.logf("WebSocket client connected (%d total)", d.wsHub.ClientCount())
-
-	// Send initial state unless recovery barrier is active.
-	d.scheduleInitialState(client)
+	// Not registered with the hub yet, and no initial_state: both wait for
+	// client_hello to present this profile's token. A connection the daemon has
+	// not authorized receives nothing it did not ask for — the hub is the only
+	// fan-out, so staying out of it is what keeps every broadcast away from it.
+	d.logf("WebSocket connection accepted, awaiting client_hello")
 
 	// Start ping keepalive (detects dead connections, keeps proxies happy)
 	done := make(chan struct{})
@@ -887,9 +903,25 @@ func (d *Daemon) sendOutboundBlocking(client *wsClient, message outboundMessage,
 // This runs in a dedicated goroutine to avoid blocking the read loop
 func (d *Daemon) wsMsgPump(client *wsClient) {
 	for data := range client.recv {
+		// A refused client_hello closes the send channel and leaves the write
+		// pump to deliver the refusal. Handling what the client had already
+		// pipelined behind that hello would answer with a second verdict — and
+		// the gates that hang up on their own would close the socket out from
+		// under the refusal that is still queued.
+		if client.sendChannelClosed() {
+			continue
+		}
 		d.handleClientMessage(client, data)
 	}
 	d.logf("WebSocket message pump exited")
+}
+
+// sendChannelClosed reports that the daemon has finished with this client and
+// is only waiting for the write pump to drain.
+func (c *wsClient) sendChannelClosed() bool {
+	c.sendMu.RLock()
+	defer c.sendMu.RUnlock()
+	return c.sendClosed
 }
 
 // The keepalive defaults, both carried over unchanged from when this loop was

--- a/internal/daemon/ws_eviction_test.go
+++ b/internal/daemon/ws_eviction_test.go
@@ -11,6 +11,7 @@ import (
 
 	"nhooyr.io/websocket"
 
+	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/protocol"
 )
 
@@ -24,6 +25,7 @@ func sendClientHelloAs(t *testing.T, conn *websocket.Conn, clientID string) {
 		"client_id":    clientID,
 		"version":      "protocol-" + protocol.ProtocolVersion,
 		"capabilities": []string{protocol.CapabilityWorkspaceSessions},
+		"client_token": config.ClientToken(),
 	}); err != nil {
 		t.Fatalf("send client hello: %v", err)
 	}

--- a/internal/daemon/ws_hello.go
+++ b/internal/daemon/ws_hello.go
@@ -60,7 +60,9 @@ func (d *Daemon) handleClientHello(client *wsClient, msg *protocol.ClientHelloMe
 // Registration happens here rather than at accept, and that is the read side of
 // the client token: the hub is the only fan-out, so a connection that has not
 // presented the token sees no broadcast and no initial_state — which is most of
-// what there is to see. A client that helloes twice is admitted once.
+// what there is to see. A client that helloes twice joins the hub once; the
+// token itself is checked on every hello, so a second one that fails still
+// closes an already-admitted connection.
 func (d *Daemon) admitClient(client *wsClient) {
 	client.admitted.Do(func() {
 		d.wsHub.add(client)

--- a/internal/daemon/ws_hello.go
+++ b/internal/daemon/ws_hello.go
@@ -2,7 +2,10 @@ package daemon
 
 import (
 	"crypto/subtle"
+	"fmt"
 	"strings"
+
+	"nhooyr.io/websocket"
 
 	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/protocol"
@@ -20,7 +23,14 @@ import (
 // connection was hung up on and could not be told why over a socket that was
 // already backed up, so the reason is handed to it here — once, and only if
 // the daemon is still holding one for the client_id it just named.
+//
+// Unix-socket commands never reach here: they have their own dispatch in
+// daemon.go, and file permissions on the socket already decide who may speak.
+// The WebSocket port has no such gate, which is what client_token is for.
 func (d *Daemon) handleClientHello(client *wsClient, msg *protocol.ClientHelloMessage) {
+	if !d.authorizeClientHello(client, msg) {
+		return
+	}
 	requiredToken := config.BrowserHostToken()
 	providedToken := strings.TrimSpace(protocol.Deref(msg.BrowserHostToken))
 	client.setBrowserHostAuthenticated(
@@ -38,7 +48,66 @@ func (d *Daemon) handleClientHello(client *wsClient, msg *protocol.ClientHelloMe
 		clientID,
 		msg.Capabilities,
 	)
+	d.admitClient(client)
 	if record, ok := d.wsHub.takeEviction(clientID); ok {
 		d.sendEvictionNotice(client, record)
 	}
+}
+
+// admitClient lets an authorized connection into the hub and hands it the
+// snapshot it has been waiting for.
+//
+// Registration happens here rather than at accept, and that is the read side of
+// the client token: the hub is the only fan-out, so a connection that has not
+// presented the token sees no broadcast and no initial_state — which is most of
+// what there is to see. A client that helloes twice is admitted once.
+func (d *Daemon) admitClient(client *wsClient) {
+	client.admitted.Do(func() {
+		d.wsHub.add(client)
+		d.logf("WebSocket client connected (%d total)", d.wsHub.ClientCount())
+		d.scheduleInitialState(client)
+	})
+}
+
+// authorizeClientHello refuses a hello that does not carry this profile's
+// client token. It runs before any identity is recorded, so a refused client
+// also fails the workspace_sessions gate on everything it sends afterwards, and
+// admitClient never runs for it.
+//
+// The refusal names the file it should have read: nobody reads our code, their
+// agents read our errors, and "unauthorized" alone is unfixable.
+func (d *Daemon) authorizeClientHello(client *wsClient, msg *protocol.ClientHelloMessage) bool {
+	if client.bearerAuthorized {
+		// Already proved itself at the HTTP layer with the operator's bearer,
+		// which is how a deliberately exposed port is gated. Asking a browser
+		// served from that port for a file on this disk would only close it.
+		return true
+	}
+	// The d.clientToken != "" half matters: a daemon holding no token refuses
+	// everyone rather than matching the client that also sent nothing.
+	provided := strings.TrimSpace(protocol.Deref(msg.ClientToken))
+	if d.clientToken != "" && subtle.ConstantTimeCompare([]byte(d.clientToken), []byte(provided)) == 1 {
+		return true
+	}
+	reason := fmt.Sprintf(
+		"client_hello refused: client_token does not match this daemon's. Read it from %s (owner-only) and send it as client_token; the daemon serving profile %q minted it.",
+		config.ClientTokenPath(),
+		config.Profile(),
+	)
+	if d.clientToken == "" {
+		reason = "client_hello refused: this daemon minted no client token, so it can authorize nobody. It was started without Daemon.Start."
+	}
+	d.logf("rejecting client hello from kind=%q: client_token mismatch", msg.ClientKind)
+	d.sendToClient(client, &protocol.WebSocketEvent{
+		Event:     protocol.EventCommandError,
+		Cmd:       protocol.Ptr(protocol.CmdClientHello),
+		Success:   protocol.Ptr(false),
+		Error:     protocol.Ptr(reason),
+		ErrorCode: protocol.Ptr(protocol.ErrorCodeUnauthorizedClient),
+	})
+	// Close through the send channel, not the connection: the write pump drains
+	// what is queued before it hangs up, which is what makes the refusal arrive
+	// rather than race the close.
+	client.closeSendChannelWithStatus(websocket.StatusPolicyViolation, protocol.ErrorCodeUnauthorizedClient)
+	return false
 }

--- a/internal/daemon/ws_hello_test.go
+++ b/internal/daemon/ws_hello_test.go
@@ -248,6 +248,11 @@ func TestClientHelloWithAnotherProfilesTokenIsRefused(t *testing.T) {
 // dialWhenListening retries until the connection is made, which is the signal itself:
 // Start() binds the unix socket before the WebSocket port, so waitForSocket
 // returning does not mean the port answers yet.
+//
+// The pause is backoff, not a guess at how long binding takes: a refused
+// connection comes back in microseconds, and the suite runs seven test binaries
+// against three procs, so an unpaced retry loop spends a whole core starving
+// them.
 func dialWhenListening(t *testing.T, ctx context.Context, url string) *websocket.Conn {
 	t.Helper()
 	for {
@@ -258,6 +263,7 @@ func dialWhenListening(t *testing.T, ctx context.Context, url string) *websocket
 		if ctx.Err() != nil {
 			t.Fatalf("websocket dial %s: %v", url, err)
 		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }
 

--- a/internal/daemon/ws_hello_test.go
+++ b/internal/daemon/ws_hello_test.go
@@ -1,0 +1,349 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+
+	"github.com/victorarias/attn/internal/config"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// drainClientEvents reads what the daemon queued for a client without waiting:
+// every send in these tests happens before the assertion, on this goroutine.
+func drainClientEvents(t *testing.T, client *wsClient) []protocol.WebSocketEvent {
+	t.Helper()
+	var events []protocol.WebSocketEvent
+	for {
+		select {
+		case msg, open := <-client.send:
+			if !open {
+				return events
+			}
+			var event protocol.WebSocketEvent
+			if err := json.Unmarshal(msg.payload, &event); err != nil {
+				t.Fatalf("unmarshal outbound message: %v", err)
+			}
+			events = append(events, event)
+		default:
+			return events
+		}
+	}
+}
+
+func eventNames(events []protocol.WebSocketEvent) []string {
+	names := make([]string, 0, len(events))
+	for _, event := range events {
+		names = append(names, event.Event)
+	}
+	return names
+}
+
+// newHelloTestDaemon is a daemon complete enough to admit a client: a store to
+// snapshot from and a hub to join. Nothing listens on the socket path.
+func newHelloTestDaemon(t *testing.T, token string) *Daemon {
+	t.Helper()
+	d := NewForTesting(filepath.Join(shortTempDir(t), "test.sock"))
+	d.clientToken = token
+	return d
+}
+
+func TestClientHelloAcceptsTheDaemonsToken(t *testing.T) {
+	t.Setenv("ATTN_DATA_DIR", t.TempDir())
+	client := newWorkspaceProtocolTestClient()
+	d := newHelloTestDaemon(t, "the-token")
+
+	d.handleClientHello(client, &protocol.ClientHelloMessage{
+		ClientKind:   "tauri-app",
+		Version:      "test",
+		Capabilities: []string{protocol.CapabilityWorkspaceSessions},
+		ClientToken:  protocol.Ptr("the-token"),
+	})
+
+	if !client.speaksWorkspaceProtocol() {
+		t.Fatal("hello with the right token did not record the client's capabilities")
+	}
+	if got := d.wsHub.ClientCount(); got != 1 {
+		t.Fatalf("hub holds %d clients after an accepted hello, want 1", got)
+	}
+	events := drainClientEvents(t, client)
+	if len(events) != 1 || events[0].Event != protocol.EventInitialState {
+		t.Fatalf("accepted hello sent %+v, want one initial_state", eventNames(events))
+	}
+}
+
+// An unauthorized connection must not see the machine. initial_state carries
+// every session, PR, workspace and ticket, so withholding it — and staying out
+// of the hub that fans out everything after it — is most of what the token buys.
+func TestRefusedClientNeverJoinsTheHubOrSeesState(t *testing.T) {
+	t.Setenv("ATTN_DATA_DIR", t.TempDir())
+	client := newWorkspaceProtocolTestClient()
+	d := newHelloTestDaemon(t, "the-token")
+
+	d.handleClientHello(client, &protocol.ClientHelloMessage{
+		ClientKind:   "impostor",
+		Version:      "test",
+		Capabilities: []string{protocol.CapabilityWorkspaceSessions},
+		ClientToken:  protocol.Ptr("guessed"),
+	})
+
+	if got := d.wsHub.ClientCount(); got != 0 {
+		t.Fatalf("hub holds %d clients after a refused hello, want 0", got)
+	}
+	for _, event := range drainClientEvents(t, client) {
+		if event.Event == protocol.EventInitialState {
+			t.Fatal("a refused client was handed initial_state")
+		}
+	}
+	// Anything broadcast afterwards must miss it too. An admitted client is the
+	// witness: the hub fans one message out to every client under a single lock,
+	// so once the admitted one holds it the refused one has been passed over.
+	go d.wsHub.run()
+	admitted := newWorkspaceProtocolTestClient()
+	d.handleClientHello(admitted, &protocol.ClientHelloMessage{
+		ClientKind:   "tauri-app",
+		Version:      "test",
+		Capabilities: []string{protocol.CapabilityWorkspaceSessions},
+		ClientToken:  protocol.Ptr("the-token"),
+	})
+	d.wsHub.Broadcast(&protocol.WebSocketEvent{Event: protocol.EventSettingsUpdated})
+	waitForClientEvent(t, admitted, protocol.EventSettingsUpdated)
+	for _, event := range drainClientEvents(t, client) {
+		if event.Event == protocol.EventSettingsUpdated {
+			t.Fatal("a refused client received a broadcast")
+		}
+	}
+}
+
+// waitForClientEvent blocks on the client's queue until the named event arrives,
+// which is the happens-before edge the caller needs — not a timeout.
+func waitForClientEvent(t *testing.T, client *wsClient, name string) {
+	t.Helper()
+	for {
+		select {
+		case msg, open := <-client.send:
+			if !open {
+				t.Fatalf("client hung up before %s arrived", name)
+			}
+			var event protocol.WebSocketEvent
+			if err := json.Unmarshal(msg.payload, &event); err != nil {
+				t.Fatalf("unmarshal outbound message: %v", err)
+			}
+			if event.Event == name {
+				return
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatalf("%s never arrived", name)
+		}
+	}
+}
+
+// A port exposed with ATTN_WS_AUTH_TOKEN is gated at the HTTP layer, and a
+// browser served from it cannot read a file on the daemon's disk. Clearing the
+// bearer stands in for the client token — otherwise remote web would close.
+func TestBearerAuthorizedClientNeedsNoClientToken(t *testing.T) {
+	t.Setenv("ATTN_DATA_DIR", t.TempDir())
+	client := newWorkspaceProtocolTestClient()
+	client.bearerAuthorized = true
+	d := newHelloTestDaemon(t, "the-token")
+
+	d.handleClientHello(client, &protocol.ClientHelloMessage{
+		ClientKind:   "remote-web",
+		Version:      "test",
+		Capabilities: []string{protocol.CapabilityWorkspaceSessions},
+	})
+
+	if !client.speaksWorkspaceProtocol() {
+		t.Fatal("a client that cleared the operator bearer was refused")
+	}
+	if got := d.wsHub.ClientCount(); got != 1 {
+		t.Fatalf("hub holds %d clients, want the bearer-authorized one", got)
+	}
+}
+
+// A daemon built without Start has no token, and must refuse rather than match
+// the client that also sent nothing.
+func TestDaemonWithoutATokenAuthorizesNobody(t *testing.T) {
+	t.Setenv("ATTN_DATA_DIR", t.TempDir())
+	client := newWorkspaceProtocolTestClient()
+	d := newHelloTestDaemon(t, "")
+
+	d.handleClientHello(client, &protocol.ClientHelloMessage{
+		ClientKind:   "tauri-app",
+		Version:      "test",
+		Capabilities: []string{protocol.CapabilityWorkspaceSessions},
+	})
+
+	if client.speaksWorkspaceProtocol() {
+		t.Fatal("a tokenless daemon admitted a tokenless client")
+	}
+}
+
+func TestClientHelloWithoutTheTokenIsRefusedAndSaysWhere(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("ATTN_DATA_DIR", dataDir)
+	client := newWorkspaceProtocolTestClient()
+	d := newHelloTestDaemon(t, "the-token")
+
+	d.handleClientHello(client, &protocol.ClientHelloMessage{
+		ClientKind:   "impostor",
+		Version:      "test",
+		Capabilities: []string{protocol.CapabilityWorkspaceSessions},
+	})
+
+	if client.speaksWorkspaceProtocol() {
+		t.Fatal("a refused client kept its capabilities; every later command would be accepted")
+	}
+	events := drainClientEvents(t, client)
+	if len(events) != 1 {
+		t.Fatalf("refusal sent %d events, want exactly one", len(events))
+	}
+	refusal := events[0]
+	if refusal.Event != protocol.EventCommandError {
+		t.Fatalf("event = %q, want %q", refusal.Event, protocol.EventCommandError)
+	}
+	if got := protocol.Deref(refusal.ErrorCode); got != protocol.ErrorCodeUnauthorizedClient {
+		t.Fatalf("error_code = %q, want %q", got, protocol.ErrorCodeUnauthorizedClient)
+	}
+	// The message is the whole fix: an agent that reads it knows which file to
+	// read next, which "unauthorized" alone never says.
+	message := protocol.Deref(refusal.Error)
+	if !strings.Contains(message, config.ClientTokenPath()) {
+		t.Fatalf("refusal %q does not name the token path %q", message, config.ClientTokenPath())
+	}
+	code, reason := client.closeStatus()
+	if reason != protocol.ErrorCodeUnauthorizedClient {
+		t.Fatalf("close reason = %q, want %q", reason, protocol.ErrorCodeUnauthorizedClient)
+	}
+	if code == 0 {
+		t.Fatal("connection was left open after a refused hello")
+	}
+}
+
+func TestClientHelloWithAnotherProfilesTokenIsRefused(t *testing.T) {
+	t.Setenv("ATTN_DATA_DIR", t.TempDir())
+	client := newWorkspaceProtocolTestClient()
+	d := newHelloTestDaemon(t, "this-profiles-token")
+
+	d.handleClientHello(client, &protocol.ClientHelloMessage{
+		ClientKind:   "tauri-app",
+		Version:      "test",
+		Capabilities: []string{protocol.CapabilityWorkspaceSessions},
+		ClientToken:  protocol.Ptr("another-profiles-token"),
+	})
+
+	if client.speaksWorkspaceProtocol() {
+		t.Fatal("a neighbouring profile's client was let onto this daemon")
+	}
+}
+
+// dialWhenListening retries until the connection is made, which is the signal itself:
+// Start() binds the unix socket before the WebSocket port, so waitForSocket
+// returning does not mean the port answers yet.
+func dialWhenListening(t *testing.T, ctx context.Context, url string) *websocket.Conn {
+	t.Helper()
+	for {
+		conn, _, err := websocket.Dial(ctx, url, nil)
+		if err == nil {
+			return conn
+		}
+		if ctx.Err() != nil {
+			t.Fatalf("websocket dial %s: %v", url, err)
+		}
+	}
+}
+
+// readCloseReason drains whatever is still in flight and reports why the daemon
+// hung up.
+func readCloseReason(t *testing.T, ctx context.Context, conn *websocket.Conn) string {
+	t.Helper()
+	for {
+		if _, _, err := conn.Read(ctx); err != nil {
+			var closeErr websocket.CloseError
+			if !errors.As(err, &closeErr) {
+				t.Fatalf("read until close: %v", err)
+			}
+			return closeErr.Reason
+		}
+	}
+}
+
+// The wire receipt: a daemon that actually started refuses an anonymous hello
+// over a real WebSocket and accepts the token it minted into its data root.
+func TestDaemonWebSocketRequiresTheClientToken(t *testing.T) {
+	port, err := freeTCPPort()
+	if err != nil {
+		t.Fatalf("freeTCPPort: %v", err)
+	}
+	t.Setenv("ATTN_WS_PORT", strconv.Itoa(port))
+	// Unset so Start() mints into the daemon's own data root, which is what
+	// production does and what the refusal message points at.
+	t.Setenv("ATTN_CLIENT_TOKEN", "")
+	tmpDir := shortTempDir(t)
+	sockPath := filepath.Join(tmpDir, "test.sock")
+	t.Setenv("ATTN_DATA_DIR", tmpDir)
+
+	d := NewForTesting(sockPath)
+	go d.Start()
+	defer d.Stop()
+	waitForSocket(t, sockPath, 5*time.Second)
+
+	if len(d.clientToken) != 64 {
+		t.Fatalf("daemon client token = %q, want the 64 hex chars Start() mints", d.clientToken)
+	}
+	if got := config.ClientToken(); got != d.clientToken {
+		t.Fatalf("token a client would read = %q, daemon holds %q", got, d.clientToken)
+	}
+
+	wsURL := fmt.Sprintf("ws://127.0.0.1:%d/ws", port)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	refused := dialWhenListening(t, ctx, wsURL)
+	defer refused.Close(websocket.StatusNormalClosure, "")
+	if err := writeWS(refused, map[string]interface{}{
+		"cmd":          protocol.CmdClientHello,
+		"client_kind":  "impostor",
+		"version":      "protocol-" + protocol.ProtocolVersion,
+		"capabilities": []string{protocol.CapabilityWorkspaceSessions},
+	}); err != nil {
+		t.Fatalf("send tokenless hello: %v", err)
+	}
+	// Pipelined behind the hello, the way a real client sends: it does not wait
+	// for a reply it has no reason to expect. This command must not be answered
+	// — the gate that refuses an unidentified client hangs up on the connection
+	// itself, which would destroy the refusal still queued behind it.
+	if err := writeWS(refused, map[string]interface{}{"cmd": protocol.CmdGetSettings}); err != nil {
+		t.Fatalf("send pipelined get_settings: %v", err)
+	}
+	event := waitForDaemonWebSocketEvent(t, refused, 10*time.Second, func(evt map[string]interface{}) bool {
+		return asString(evt["event"]) == protocol.EventCommandError
+	})
+	if got := asString(event["error_code"]); got != protocol.ErrorCodeUnauthorizedClient {
+		t.Fatalf("error_code = %q, want %q", got, protocol.ErrorCodeUnauthorizedClient)
+	}
+	if message := asString(event["error"]); !strings.Contains(message, filepath.Join(tmpDir, config.ClientTokenFile)) {
+		t.Fatalf("refusal %q does not name the token file under %q", message, tmpDir)
+	}
+	if reason := readCloseReason(t, ctx, refused); reason != protocol.ErrorCodeUnauthorizedClient {
+		t.Fatalf("closed with reason %q, want %q", reason, protocol.ErrorCodeUnauthorizedClient)
+	}
+
+	accepted := dialWhenListening(t, ctx, wsURL)
+	defer accepted.Close(websocket.StatusNormalClosure, "")
+	sendWorkspaceClientHello(t, accepted)
+	if err := writeWS(accepted, map[string]interface{}{"cmd": protocol.CmdGetSettings}); err != nil {
+		t.Fatalf("send get_settings: %v", err)
+	}
+	waitForDaemonWebSocketEvent(t, accepted, 10*time.Second, func(evt map[string]interface{}) bool {
+		return asString(evt["event"]) == protocol.EventSettingsUpdated
+	})
+}

--- a/internal/hub/manager.go
+++ b/internal/hub/manager.go
@@ -503,15 +503,20 @@ func (m *Manager) runEndpointLoop(ctx context.Context, id string) {
 			}
 		}
 
-		// Declare the workspace_sessions capability before anything else: the
-		// remote daemon rejects every gated command (register_workspace,
-		// spawn_session, forwarded client payloads, ...) from a connection
-		// that never sent client_hello, closing it with a policy violation.
-		// publishConnectionAndSendHello holds writeMu across publishing the
-		// connection and sending the hello so ForwardEndpointCommand can never
-		// win the race and write before it.
+		// Read after connecting, not before: a host whose daemon has never run
+		// has no token to read yet, and reaching here means it is up.
+		clientToken := m.remoteClientToken(ctx, record.SSHTarget, record.Profile)
+
+		// Present the token and declare the workspace_sessions capability
+		// before anything else: until this hello passes, the remote daemon
+		// sends this connection nothing at all — no initial_state, no
+		// broadcasts — and refuses every gated command (register_workspace,
+		// spawn_session, forwarded client payloads, ...) with a policy
+		// violation. publishConnectionAndSendHello holds writeMu across
+		// publishing the connection and sending the hello so
+		// ForwardEndpointCommand can never win the race and write before it.
 		connected := false
-		consumeErr := m.publishConnectionAndSendHello(ctx, id, conn, cmd)
+		consumeErr := m.publishConnectionAndSendHello(ctx, id, conn, cmd, clientToken)
 		if consumeErr == nil {
 			connected, consumeErr = m.consumeRemote(ctx, id, conn)
 		}
@@ -596,11 +601,16 @@ func versionMismatchStatus(e *VersionMismatchError) (string, string) {
 // re-broadcasts — so a binary frame would arrive as bytes it cannot parse and
 // would be pushed out as an invalid text message. Leaving the bit off makes the
 // remote daemon answer image pulls with base64 JSON, which survives the trip.
-func sendClientHello(ctx context.Context, conn *websocket.Conn) error {
+//
+// clientToken is the REMOTE daemon's, read off that host by remoteClientToken —
+// ws-relay is a raw byte pipe, so this hello reaches the remote daemon end to
+// end and is checked there like any other client's.
+func sendClientHello(ctx context.Context, conn *websocket.Conn, clientToken string) error {
 	payload, err := json.Marshal(protocol.ClientHelloMessage{
-		Cmd:        protocol.CmdClientHello,
-		ClientKind: "hub",
-		Version:    "protocol-" + protocol.ProtocolVersion,
+		Cmd:         protocol.CmdClientHello,
+		ClientKind:  "hub",
+		Version:     "protocol-" + protocol.ProtocolVersion,
+		ClientToken: protocol.Ptr(clientToken),
 		Capabilities: []string{
 			protocol.CapabilityWorkspaceSessions,
 			protocol.CapabilityKittyImages,
@@ -1717,7 +1727,7 @@ func (m *Manager) SetEndpointRemoteWeb(ctx context.Context, endpointID string, e
 // hello: ForwardEndpointCommand always reads runtime.conn under m.mu first,
 // so it either sees the old (nil or previous) connection, or it sees this
 // connection but then blocks on writeMu until the hello has been sent.
-func (m *Manager) publishConnectionAndSendHello(ctx context.Context, id string, conn *websocket.Conn, cmd *exec.Cmd) error {
+func (m *Manager) publishConnectionAndSendHello(ctx context.Context, id string, conn *websocket.Conn, cmd *exec.Cmd, clientToken string) error {
 	m.mu.Lock()
 	runtime, ok := m.runtimes[id]
 	if !ok {
@@ -1730,7 +1740,7 @@ func (m *Manager) publishConnectionAndSendHello(ctx context.Context, id string, 
 	m.mu.Unlock()
 	defer runtime.writeMu.Unlock()
 
-	return sendClientHello(ctx, conn)
+	return sendClientHello(ctx, conn, clientToken)
 }
 
 func (m *Manager) clearConnection(id string) {

--- a/internal/hub/manager_test.go
+++ b/internal/hub/manager_test.go
@@ -682,7 +682,7 @@ func TestSendClientHelloDeclaresExactlyTheRelaysCapabilities(t *testing.T) {
 	}
 	defer conn.Close(websocket.StatusNormalClosure, "")
 
-	if err := sendClientHello(ctx, conn); err != nil {
+	if err := sendClientHello(ctx, conn, "remote-token"); err != nil {
 		t.Fatalf("sendClientHello() error = %v", err)
 	}
 
@@ -761,7 +761,7 @@ func TestPublishConnectionAndSendHelloOrdersBeforeForwardedCommands(t *testing.T
 	}
 	defer conn.Close(websocket.StatusNormalClosure, "")
 
-	if err := manager.publishConnectionAndSendHello(ctx, "endpoint-1", conn, nil); err != nil {
+	if err := manager.publishConnectionAndSendHello(ctx, "endpoint-1", conn, nil, "remote-token"); err != nil {
 		t.Fatalf("publishConnectionAndSendHello() error = %v", err)
 	}
 

--- a/internal/hub/ssh.go
+++ b/internal/hub/ssh.go
@@ -106,6 +106,30 @@ func runSSHExit(ctx context.Context, target, profile, script string) (stdout, st
 	return stdout, stderr, -1, runErr
 }
 
+// remoteClientToken reads the remote profile's client token — the credential
+// its daemon requires in client_hello. The hub cannot mint or derive it: the
+// token lives in that host's profile data, and ws-relay is a byte pipe, so the
+// hub's hello is checked on the far side like any local client's.
+//
+// SSH is the only new thing this asks for, and the hub already has it — it runs
+// the remote `attn` binary over the same channel to start the relay. Access to
+// the box was already full authority over it.
+//
+// Empty on any failure: the daemon's own refusal names the file and the
+// profile, which is a better answer than a guess made here.
+func (m *Manager) remoteClientToken(ctx context.Context, target, profile string) string {
+	stdout, stderr, code, err := runSSHExit(ctx, target, profile, remoteAttnCommand(profile, "client-token"))
+	if err != nil {
+		m.logf("hub: remote client-token on %s failed: %v", target, err)
+		return ""
+	}
+	if code != 0 {
+		m.logf("hub: remote client-token on %s exited %d: %s", target, code, stderr)
+		return ""
+	}
+	return strings.TrimSpace(stdout)
+}
+
 func runSSH(ctx context.Context, target, profile, script string) (string, error) {
 	var stderr bytes.Buffer
 	cmd := exec.CommandContext(ctx, "ssh", append(sshBaseArgs(target), remoteShellCommand(profile, script))...)

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "256"
+const ProtocolVersion = "257"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only
@@ -44,6 +44,10 @@ const (
 	// never be answered again as written, so the tile's query is what has to
 	// change; resubscribing unchanged would fail the same way.
 	ErrorCodeCollectionRedeclared = "collection_redeclared"
+	// ErrorCodeUnauthorizedClient refuses a client_hello whose client_token does
+	// not match the daemon's. Nothing to retry on the same value — read the token
+	// file the message names, or ask the daemon that owns it.
+	ErrorCodeUnauthorizedClient = "unauthorized_client"
 )
 
 // AgentMessageMaxChars bounds one agent_msg. Measured 2026-08-10 against a live

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1766,6 +1766,9 @@ type ClientHelloMessage struct {
 	// ClientKind corresponds to the JSON schema field "client_kind".
 	ClientKind string `json:"client_kind"`
 
+	// ClientToken corresponds to the JSON schema field "client_token".
+	ClientToken *string `json:"client_token,omitempty,omitzero"`
+
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
 
@@ -7962,6 +7965,9 @@ type WebSocketEvent struct {
 
 	// Error corresponds to the JSON schema field "error".
 	Error *string `json:"error,omitempty,omitzero"`
+
+	// ErrorCode corresponds to the JSON schema field "error_code".
+	ErrorCode *string `json:"error_code,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -630,6 +630,11 @@ model ClientHelloMessage {
   client_kind: string;          // e.g. "tauri-app", "remote-web"
   version: string;              // free-form, used for diagnostics
   capabilities: string[];       // see capability docstrings above
+  // Per-profile credential from <data-dir>/client-token, minted by the daemon.
+  // The WebSocket port has no file permissions of its own, so this is what a
+  // local client proves before the daemon records its identity, registers it
+  // for broadcasts, or sends it initial_state.
+  client_token?: string;
   browser_host_token?: string;  // secret available only to the trusted Tauri main webview
   // Stable for as long as the client process lives, new on every restart. It is
   // what lets the daemon tell a reconnecting client why it was hung up on
@@ -5953,6 +5958,9 @@ model WebSocketEvent {
   // Common result fields
   success?: boolean;
   error?: string;
+  // Machine-readable failure class, so a client acts on the failure instead of
+  // matching English. See the ErrorCode constants in protocol/constants.go.
+  error_code?: string;
 
   // PR/worktree/branch operations
   action?: string;

--- a/scripts/wsctl/main.go
+++ b/scripts/wsctl/main.go
@@ -363,7 +363,11 @@ func list(_ []string) error {
 	conn.SetReadLimit(16 << 20)
 	defer conn.Close(websocket.StatusNormalClosure, "")
 
-	// First message after connect is initial_state.
+	// The hello unlocks the connection; initial_state is the first thing the
+	// daemon sends once it passes.
+	if err := sendClientHello(ctx, conn); err != nil {
+		return err
+	}
 	_, data, err := conn.Read(ctx)
 	if err != nil {
 		return fmt.Errorf("read initial_state: %w", err)
@@ -374,9 +378,6 @@ func list(_ []string) error {
 	}
 	if ev, _ := event["event"].(string); ev != "initial_state" {
 		return fmt.Errorf("expected initial_state, got %q", ev)
-	}
-	if err := sendClientHello(ctx, conn); err != nil {
-		return err
 	}
 	pretty, _ := json.MarshalIndent(map[string]any{
 		"workspaces": event["workspaces"],
@@ -404,8 +405,8 @@ func refreshPRs(args []string) error {
 
 // ── Wire helpers ─────────────────────────────────────────────────────────────
 
-// send opens a connection, drains the initial_state event, sends the
-// payload, and closes. No response read — fire-and-forget.
+// send opens a connection, presents the client token, drains initial_state,
+// sends the payload, and closes. No response read — fire-and-forget.
 func send(payload map[string]any) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
@@ -418,13 +419,13 @@ func send(payload map[string]any) error {
 	conn.SetReadLimit(16 << 20)
 	defer conn.Close(websocket.StatusNormalClosure, "")
 
-	// Daemon sends initial_state on connect; drain it before our write
-	// so the socket buffer doesn't backlog.
-	if _, _, err := conn.Read(ctx); err != nil {
-		return fmt.Errorf("drain initial_state: %w", err)
-	}
+	// The daemon sends initial_state once the hello passes; drain it before
+	// our write so the socket buffer doesn't backlog.
 	if err := sendClientHello(ctx, conn); err != nil {
 		return err
+	}
+	if _, _, err := conn.Read(ctx); err != nil {
+		return fmt.Errorf("drain initial_state: %w", err)
 	}
 
 	body, err := json.Marshal(payload)
@@ -467,11 +468,11 @@ func sendAndWaitMatch(payload map[string]any, expectedEvent string, match func(m
 	conn.SetReadLimit(16 << 20)
 	defer conn.Close(websocket.StatusNormalClosure, "")
 
-	if _, _, err := conn.Read(ctx); err != nil {
-		return nil, fmt.Errorf("drain initial_state: %w", err)
-	}
 	if err := sendClientHello(ctx, conn); err != nil {
 		return nil, err
+	}
+	if _, _, err := conn.Read(ctx); err != nil {
+		return nil, fmt.Errorf("drain initial_state: %w", err)
 	}
 
 	body, err := json.Marshal(payload)
@@ -517,6 +518,7 @@ func sendClientHello(ctx context.Context, conn *websocket.Conn) error {
 		"client_kind":  "wsctl",
 		"version":      "protocol-" + protocol.ProtocolVersion,
 		"capabilities": []string{protocol.CapabilityWorkspaceSessions},
+		"client_token": config.ClientToken(),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
The daemon listens on two things: a unix socket, gated by file permissions, and
a loopback WebSocket port, gated by nothing. Any local process that knew the
port spoke the full protocol — read every session, spawn agents, write files
through `fs_write`. #922 fenced profiles at the filesystem and spawn level, but
the wire carried no credential, so one profile's client could drive another
profile's daemon.

This closes it with a per-profile runtime token the daemon mints and every local
client presents in `client_hello`.

## The credential

`<data-dir>/client-token` — 32 bytes from `crypto/rand`, hex, written 0600.
Minted at `Start()` and reused on later startups, so a daemon restart does not
strand its clients. `ATTN_CLIENT_TOKEN` overrides the file for harnesses that
spawn a daemon and a client together.

Per-profile is the point: the same binary serves every profile, so the secret
lives in profile data. Nothing is baked at build time — a released binary would
ship a public secret.

Three token-shaped things now exist and do different jobs:

| | what it proves | where |
| --- | --- | --- |
| `client-token` | this process may speak the protocol at all | hello, every local client |
| `browser-host-token` | this client is the trusted Tauri main webview | hello, app only |
| `ATTN_WS_AUTH_TOKEN` | operator bearer for an exposed WS port | HTTP header, opt-in |

## Refusing is only half of it

The brief scoped this to the hello check. Building it turned up the bigger hole:
the daemon pushed `initial_state` — every session, PR, workspace, ticket and
setting — and registered the connection with the broadcast hub the moment the
socket opened, before a single byte arrived from the client. A credential that
gates writes while the whole read side streams to anyone who knows the port
would be theatre.

So hub registration and the `initial_state` push moved out of the accept path
into `admitClient`, called only once the hello passes. The hub is the sole
fan-out, so an unauthorized connection is now invisible to every broadcast, not
merely refused its commands. The app already sent hello first thing on open, so
nothing waits longer than it did.

Two things fell out of that:

- A daemon holding no token authorizes nobody. It used to match the client that
  also sent nothing — fail-open by accident. `Start()` mints before the port
  listens, so the refusal only names a daemon someone built without it.
- Hub registration became a direct locked insert (`wsHub.add`) instead of a
  handoff on the `register` channel, which had no other user. Admission is
  synchronous now, so there is no window where a client is admitted but not yet
  receiving. The unregister side stays a channel — a disconnect is discovered on
  the read pump, not asked for — and now releases the write pump even for a
  connection that was never admitted.

`/health`'s `ws_clients` consequently counts authorized clients. It has no
programmatic consumer.

## The check

`handleClientHello` compares in constant time before it records identity or
capabilities. A mismatch sends `command_error` with code `unauthorized_client`,
names the file the daemon read, then closes with a policy violation — never a
silent hangup. The refusal goes out through the send channel rather than
`conn.Close`, so the write pump drains it instead of racing the close.

One more thing had to move for that to hold. A client does not wait for a reply
to its hello, so whatever it pipelined behind it is already in the read buffer
when the refusal is queued. Answering it reaches the `workspace_sessions` gate,
which hangs up on the connection itself — closing the socket before the write
pump flushed the refusal. The live probe caught exactly that: a wrong-token
connection got `events: []` and a close reason naming the wrong problem. The
message pump now stops dispatching once a client's send channel is closed, so
the refusal is the last thing that connection hears.

Unix-socket commands never reach this handler: `daemon.go`'s socket dispatch is
a separate switch and file permissions already gate that path. The WS check is
not weakened for it.

One exemption, and it is the reason remote web still works: a connection that
cleared `ATTN_WS_AUTH_TOKEN` at the HTTP layer skips the client-token check.
That bearer is set only when the port was deliberately exposed beyond loopback
(`tailscale serve`), and the browser it serves cannot read a file on the
daemon's disk. Both gates answer "may this process speak here?", and the
exposed-port one is the deliberate, stronger answer. Loopback is unaffected —
with no bearer set the HTTP gate is skipped entirely, so the client token is the
only way in.

## Clients

One shared read per language, not N copies:

- Go (`cmd/attn` plugin requests, `scripts/wsctl`) — `config.ClientToken()`
- Rust/Tauri — `profile::read_client_token()` behind `get_client_token`,
  mirroring `get_browser_host_token`
- Frontend — Tauri `invoke` in the app; `import.meta.env.VITE_CLIENT_TOKEN` in a
  plain browser (`dev:vite`, Playwright), which cannot read a file.
  `vite.config.ts` fills that in from the active profile's token file **in serve
  mode only** — a built bundle must never carry it
- Harness — `harnessClientHello()` beside `dataDirForProfile()`
- Playwright e2e — one fixed token handed to both the throwaway daemon and Vite

`plugins/attn-pi` does not dial the daemon's WebSocket — its host talks over the
plugin runtime's stdio envelope — so it is a non-surface.

Six Go/JS call sites read `initial_state` *before* sending the hello, which the
old order tolerated and this one cannot. All are fixed to the app's order —
five daemon tests, three `wsctl` flows, and `pluginDaemonRequest`. One dead
harness helper is not: `openRemoteWebSocketControl` in `bridge-remote-hub.mjs`
has had no caller since it landed and never sent a hello at all, so it is left
alone rather than given untested code.

## Deviations from the brief

1. **Protocol 254, not 253.** main already held 253. Bumped past it in both
   lockstep spots.
2. **Remote endpoints could not stay out of scope.** `attn ws-relay` is a raw
   TCP byte pipe, so the hub's own `client_hello` reaches the remote daemon end
   to end and would have been refused — the relay would have broken outright.
   The hub reads the remote's token the way it already reads everything else on
   that host: over SSH, running the new `attn client-token` before the dial. SSH
   access to the box is already full authority over it, so this grants nothing
   new, and it is what enrollment will replace. One extra short SSH exec per
   connection attempt, on a path that already runs several.
3. **`error_code` added to `WebSocketEvent`**, so the app acts on the refusal
   instead of matching English. It opens the circuit rather than reconnecting,
   because reconnecting cannot help.
4. **The admission change above**, which the brief did not ask for.

## Verification

Unit:

- `internal/config` — mint once, reuse across restart, 0600, distinct per
  profile, env override, empty when nothing is minted
- `internal/daemon` — hello accepted with the token; refused without it, and the
  message names `config.ClientTokenPath()`; refused with another profile's
  token; a tokenless daemon authorizes nobody; a refused client never joins the
  hub, never sees `initial_state`, and misses a broadcast an admitted client
  receives
- Wire receipt: a real daemon on a free port refuses a tokenless dial with the
  named error, then serves a tokened one
- Frontend — the hello carries the token from `invoke`; an
  `unauthorized_client` `command_error` sets `connectionError` and does not
  reconnect

Both suites were mutation-checked: forcing the gate open fails 5 Go tests,
admitting before authorizing fails the admission test by name, and deleting the
message-pump guard fails the wire test 10/10.

`make test-quick` and `pnpm --dir app test` (2883 passed) are green, as is a
clean `go test ./internal/daemon/` (132s).

Live, on a throwaway `wsauth` profile installed from this branch:

```
$ attn preflight
PASS protocol.cli_app          CLI and installed app use protocol 254
PASS protocol.app_daemon       installed app and daemon use protocol 254
PASS routing.daemon            profile=wsauth socket=/Users/victor/.attn-wsauth/attn.sock port=21566
```

The token file is minted 0600 and reused across a daemon restart — same 64 hex
chars, same mtime.

Three dials at the port, driven by a throwaway node client:

```
--- no token at all
  events: ["command_error"]   close: 1008 "unauthorized_client"
  error_code: "unauthorized_client"
  error: client_hello refused: client_token does not match this daemon's. Read it
         from /Users/victor/.attn-wsauth/client-token (owner-only) and send it as
         client_token; the daemon serving profile "wsauth" minted it.

--- another profile's token
  events: ["command_error"]   close: 1008 "unauthorized_client"   (same message)

--- the profile's own token
  events: ["initial_state", "settings_updated"]
```

Then the installed app, which reads the token through `get_client_token`:

```
WebSocket connection accepted, awaiting client_hello
client hello: kind="tauri-app" version="protocol-254" capabilities=[workspace_sessions binary_pty_output kitty_images browser_host]
WebSocket client connected (1 total)
```

No recording: nothing about this is visible in the app when it works, and the
one new visible surface — an `unauthorized_client` connection error — cannot be
staged without corrupting the token file the app just read. The wire transcript
above is the receipt.

https://claude.ai/code/session_011eCeqJfq3FCokoRvTRfhku
