### PR TITLE
fix(apps): retain facts while disabled

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -557,8 +557,9 @@ reaching no projection has to name the consumer that does read it.
   so handlers must tolerate redelivery. A failing handler stalls its own
   consumer rather than skipping the event.
 - Retention trims past the age window but never past an **enabled** consumer's
-  cursor. Disabled consumers do not pin the log; they resume at head with a
-  logged gap.
+  cursor or an **installed app** consumer's cursor. A disabled ordinary consumer
+  does not pin; a disabled installed app keeps its unread backlog until enable
+  or uninstall.
 - An enabled consumer that stops consuming therefore grows the log until someone
   intervenes, so past `bus.DefaultPinAlarmAge` the pin is reported: a warning
   notification, a `(PINNING …)` tag in `attn bus status`, and a badge on the

--- a/app/src/components/EventBusSettings.tsx
+++ b/app/src/components/EventBusSettings.tsx
@@ -253,8 +253,8 @@ export function EventBusSettings({ getBusStatus, setConsumerEnabled }: EventBusS
         <div className="bus-section-head">
           <h4>Consumers</h4>
           <span className="settings-hint">
-            Disabling a consumer stops delivery to it and stops it holding retention open. Its
-            cursor is kept, but once trimming passes it, enabling resumes at head with a logged gap.
+            Disabling stops delivery. Ordinary consumers release retention; installed apps keep
+            their cursor and unread backlog until they are enabled or uninstalled.
           </span>
         </div>
         {status.consumers.length === 0 ? (

--- a/apphost/src/dispatch.test.ts
+++ b/apphost/src/dispatch.test.ts
@@ -84,7 +84,7 @@ describe("reconcile dispatch", () => {
       version_id: 9,
       artifact,
       collections: [],
-      reason: { causes: ["re_enabled"], version: 9, throughSeq: 2, previousVersions: [] },
+      reason: { causes: ["version_changed"], version: 9, throughSeq: 2, previousVersions: [] },
     })
     expect(result.ok).toBe(false)
     expect(result.error).toContain("default export has no reconcile handler")

--- a/apphost/src/dispatch.ts
+++ b/apphost/src/dispatch.ts
@@ -66,7 +66,7 @@ export interface CommandResult {
 }
 
 export interface ReconcileReason {
-  causes: ("gap" | "re_enabled" | "version_changed")[]
+  causes: ("gap" | "version_changed")[]
   version: number
   throughSeq: number
   gap?: {

--- a/changelog.d/app-reconcile-contract.yaml
+++ b/changelog.d/app-reconcile-contract.yaml
@@ -2,6 +2,7 @@ kind: added
 area: apps
 change: >
   Subscribed apps can now declare a reconcile handler that rebuilds their
-  collections from a typed current-state snapshot after a bus gap, re-enable,
-  or version change. The handler runs in the ordinary app lane before later
-  facts, with the claimed reasons and bus fence fixed across retries.
+  collections from a typed current-state snapshot after a bus gap or version
+  change. The handler runs in the ordinary app lane before later facts, with
+  the claimed reasons and bus fence fixed across retries. Re-enable simply
+  resumes the retained lane from its frozen cursor.

--- a/changelog.d/app-reconcile-durable-fence.yaml
+++ b/changelog.d/app-reconcile-durable-fence.yaml
@@ -1,13 +1,13 @@
 kind: fixed
 area: apps
 change: >
-  App reconciliation is now durable at the event-bus boundary: a version move,
-  re-enable, or retained-history gap records the current bus-head fence, and an
-  app receives no later fact until that owed rebuild completes. Requests that
-  arrive during a rebuild remain owed for the next run, and a daemon restart
-  loses neither the request nor its cursor boundary.
+  App reconciliation is now durable at the event-bus boundary: a version move
+  records the app consumer's cursor and a retained-history gap records one
+  before the earliest surviving fact. An app receives no later fact until that
+  owed rebuild completes. Requests that arrive during a rebuild remain owed
+  for the next run, and a daemon restart loses neither the request nor its
+  cursor boundary.
 symptom: >
   An app that rebuilt a document collection from events could silently keep
-  stale rows after being re-enabled, falling behind retention, or changing
-  versions, because the bus resumed delivery without first rebuilding from
-  current state.
+  stale rows after falling behind retention or changing versions, because the
+  bus resumed delivery without first rebuilding from current state.

--- a/changelog.d/disabled-apps-retain-facts.yaml
+++ b/changelog.d/disabled-apps-retain-facts.yaml
@@ -1,0 +1,7 @@
+kind: fixed
+area: apps
+change: >
+  Disabled installed apps now keep their unread facts and resume from their
+  frozen cursor in order. Re-enabling no longer rebuilds or skips the retained
+  backlog, and version-change and gap reconciliation fences stop before every
+  fact the app is still owed.

--- a/changelog.d/reconcile-design-app-reconcile-handler.yaml
+++ b/changelog.d/reconcile-design-app-reconcile-handler.yaml
@@ -2,6 +2,7 @@ kind: internal
 area: apps
 change: >
   The approved app reconcile design defines how subscribed apps rebuild their
-  materialized collections after a retained-log gap, re-enable, or version
-  change. It fixes the trigger, ordering, retry, interruption, current-state
-  snapshot, legacy-app, and structured-export contracts before implementation.
+  materialized collections after a retained-log gap or version change, while
+  re-enable resumes retained delivery from the frozen cursor. It fixes the
+  trigger, ordering, retry, interruption, current-state snapshot, legacy-app,
+  and structured-export contracts before implementation.

--- a/changelog.d/reconcile-retention-note-installed-apps-pin.yaml
+++ b/changelog.d/reconcile-retention-note-installed-apps-pin.yaml
@@ -7,5 +7,5 @@ change: >
   capped tripwire replaces silent trimming. Review then reshaped the gates
   to carry the promise: re-enable is no longer a reconcile trigger (a
   retained lane just resumes), and fences moved off bus head so a retained
-  undelivered fact is never superseded. Doc only — the TrimBusEvents floor
-  and trigger changes ship separately.
+  undelivered fact is never superseded. The retention floor and reconcile
+  trigger implementation now carry that contract end to end.

--- a/cmd/attn/app.go
+++ b/cmd/attn/app.go
@@ -125,9 +125,9 @@ commands:
         resume delivery to the app, from wherever its consumer's cursor stands.
 
   disable <name>
-        stop delivering facts to the app. Its cursor is preserved, but a
-        disabled consumer no longer holds the event log's retention window open:
-        once trimming passes its cursor, enabling resumes it at head.
+        stop delivering facts to the app. Its cursor and unread backlog are
+        preserved for as long as the app remains installed; enabling resumes
+        delivery from that frozen cursor.
 
         This flips the app's bus consumer bit, which IS its enabled state. When
         the daemon is not running, attn bus disable app:<name> does the same
@@ -460,7 +460,7 @@ func runAppSetEnabled(args []string, enabled bool) {
 		fmt.Printf("app %s enabled: %s resumes from its cursor\n", result.Name, result.Consumer)
 		return
 	}
-	fmt.Printf("app %s disabled: %s stops receiving facts and no longer holds the event log open\n",
+	fmt.Printf("app %s disabled: %s stops receiving facts; its unread backlog stays retained until enable or uninstall\n",
 		result.Name, result.Consumer)
 }
 

--- a/cmd/attn/bus.go
+++ b/cmd/attn/bus.go
@@ -60,7 +60,8 @@ commands:
         filter, enabled bit, and lag (head - cursor, plus how long its oldest
         unread event has waited); and what is wrong with any of it.
 
-        Whichever enabled consumer sits lowest is tagged "(retention floor)".
+        Whichever enabled consumer or installed app consumer sits lowest is
+        tagged "(retention floor)".
         Once it has held that position past the alarm's tripwire it is tagged
         "(PINNING <size>)" instead, and the same crossing writes a warning
         notification — the log is growing for as long as that lasts.
@@ -74,13 +75,14 @@ commands:
         run one retention pass now instead of waiting for the daemon's hourly
         tick: drop events past the age window, and reduce the compactable fact
         classes to the newest event per subject. Both stop at the cursor floor,
-        so nothing an enabled consumer has yet to read is removed — a lagging
-        consumer pins the log, and bus status shows the lag.
+        so nothing an enabled consumer or installed app has yet to read is
+        removed — a lagging consumer pins the log, and bus status shows the lag.
 
   disable <consumer>
         stop delivering to a consumer. Its cursor is preserved, but a disabled
-        consumer no longer holds the retention window open: once trimming
-        passes its cursor, re-enabling resumes it at head and logs the gap.
+        ordinary consumer no longer holds the retention window open. An
+        installed app consumer retains its unread facts until the app is enabled
+        or uninstalled.
 
   enable <consumer>
         resume delivery from wherever the consumer's cursor stands.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -352,17 +352,19 @@ different blast radius.
 
 ## The retention floor, and the pin alarm
 
-The event log is trimmed by age, but never past the lowest cursor any **enabled**
-durable consumer still holds. That position is the **retention floor**, and the
-consumer sitting on it is said to **pin** the log: nothing at or below its cursor
-can be trimmed, because a durable consumer must not lose an unread fact. A
-disabled consumer does not pin — releasing the floor is exactly what `attn bus
-disable` is for.
+The event log is trimmed by age, but never past the lowest cursor held by an
+**enabled** durable consumer or an **installed app** consumer. That position is
+the **retention floor**, and the consumer sitting on it is said to **pin** the
+log: nothing above its cursor can be trimmed or compacted, because a durable
+consumer must not lose an unread fact. A disabled ordinary consumer does not
+pin. A disabled installed app does: its lane waits until the app is enabled or
+uninstalled, so a history app never silently loses facts.
 
 Holding the floor is ordinary. Every log has a floor holder and it is usually
 just the consumer that read least recently. What is not ordinary is holding it
-without moving: a consumer that is enabled and not consuming grows the log for as
-long as the condition lasts, and nothing ends that on its own.
+without moving: a consumer that participates in the floor and is not consuming
+grows the log for as long as the condition lasts, and nothing ends that on its
+own.
 
 The **pin alarm** is the tripwire that separates the two. Past it — an hour by
 default, measured against every stall attn resolves by itself — the pin stops

--- a/internal/appbuild/sdkdist/index.d.ts
+++ b/internal/appbuild/sdkdist/index.d.ts
@@ -98,11 +98,11 @@ export interface AppContext<Collections> {
  */
 export type Handler<Collections> = (event: AppEvent, ctx: AppContext<Collections>) => void | Promise<void>;
 /** Why attn requires the app to rebuild its derived collections. */
-export type ReconcileCause = "gap" | "re_enabled" | "version_changed";
+export type ReconcileCause = "gap" | "version_changed";
 export type { AppRegistryEntry, AppViewInfo, AuthorState, CrewMember, CurrentStateSnapshot, EndpointCapabilities, EndpointInfo, PR, RepoState, Seed, SeedEdge, SeedPlotProgress, SeedVar, Session, TicketRow, Workspace, WorkspaceLayout, WorkspacePane, } from "./currentState";
 /** The durable requests coalesced into one reconcile invocation. */
 export interface ReconcileReason {
-    /** Sorted as gap, re_enabled, version_changed, independent of arrival order. */
+    /** Sorted as gap, version_changed, independent of arrival order. */
     readonly causes: readonly ReconcileCause[];
     /** The version whose reconcile handler is running. */
     readonly version: number;

--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -58,11 +58,12 @@ func (e Event) Decode(v any) error {
 
 // Consumer is a durable consumer's persisted registration and position.
 type Consumer struct {
-	Name      string
-	Cursor    int64
-	Filter    string
-	Enabled   bool
-	UpdatedAt time.Time
+	Name          string
+	Cursor        int64
+	Filter        string
+	Enabled       bool
+	PinsRetention bool
+	UpdatedAt     time.Time
 }
 
 // Store is the persistence seam; the daemon adapts internal/store to it so
@@ -917,8 +918,8 @@ func (b *Bus) drain(d *durable) error {
 	}
 }
 
-// reconcileGap handles a cursor below the oldest surviving event (retention
-// trimmed past it while disabled or dead): resume at head, with a logged gap.
+// reconcileGap handles a cursor below the oldest surviving event: resume at
+// head, with a logged gap.
 func (b *Bus) reconcileGap(d *durable, gap Gap) error {
 	b.log("bus: consumer %s resumed at head %d; %d event(s) were trimmed before its cursor %d",
 		d.name, gap.Head, gap.Missed, gap.Cursor)
@@ -1016,9 +1017,9 @@ func (b *Bus) Trim() (int, error) {
 // bounding the log by the data it describes rather than by write frequency.
 // For these names durable delivery is at-least-once PER CHANGED SUBJECT, not
 // per write. Compaction honors the same cursor floor as trimming: an enabled
-// consumer must never lose an unread fact, and compacting above the floor would
-// punch holes that reconcileGap misreads as trimmed history. A stalled enabled
-// consumer pins compaction exactly as it pins trimming.
+// consumer and a disabled installed app must never lose an unread fact, and
+// compacting above the floor would punch holes that reconcileGap misreads as
+// trimmed history.
 func (b *Bus) compact() (int, error) {
 	if len(b.compactable) == 0 {
 		return 0, nil
@@ -1039,8 +1040,8 @@ func (b *Bus) compact() (int, error) {
 	return n, nil
 }
 
-// consumerFloor is the lowest position every enabled consumer has passed; with
-// none enabled it is the log head. A killed consumer must not pin the log.
+// consumerFloor is the lowest position every enabled consumer and every
+// installed app consumer has passed; with none it is the log head.
 func (b *Bus) consumerFloor() (int64, error) {
 	rows, err := b.store.ListConsumers()
 	if err != nil {
@@ -1048,7 +1049,7 @@ func (b *Bus) consumerFloor() (int64, error) {
 	}
 	floor := int64(-1)
 	for _, c := range rows {
-		if !c.Enabled {
+		if !c.Enabled && !c.PinsRetention {
 			continue
 		}
 		if floor < 0 || c.Cursor < floor {

--- a/internal/bus/bus_test.go
+++ b/internal/bus/bus_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 // memStore is an in-memory Store for the delivery tests. Its trim semantics
-// deliberately mirror the SQLite implementation (age window AND the enabled-only
-// cursor floor) so a test that passes here is not passing because the fake is
-// more permissive than the real thing.
+// deliberately mirror the SQLite implementation (age window AND the cursor
+// floor held by enabled consumers and installed apps) so a test that passes
+// here is not passing because the fake is more permissive than the real thing.
 type memStore struct {
 	mu        sync.Mutex
 	events    []Event
@@ -173,7 +173,7 @@ func (m *memStore) Trim(cutoff time.Time) (int, error) {
 	defer m.mu.Unlock()
 	floor := int64(-1)
 	for _, c := range m.consumers {
-		if !c.Enabled {
+		if !c.Enabled && !c.PinsRetention {
 			continue
 		}
 		if floor < 0 || c.Cursor < floor {

--- a/internal/bus/pin_test.go
+++ b/internal/bus/pin_test.go
@@ -143,8 +143,8 @@ func TestPinAlarmsMatchesTheSnapshot(t *testing.T) {
 	}
 }
 
-// A disabled consumer does not hold retention open — the kill switch is the way
-// out of exactly this condition, so it must not keep reporting it.
+// A disabled ordinary consumer does not hold retention open — the kill switch
+// is the way out of exactly this condition, so it must not keep reporting it.
 func TestDisabledConsumerNeverAlarms(t *testing.T) {
 	s := pinStore(t, "notifier", false, 30*24*time.Hour)
 	b := pinBus(t, s, time.Hour)

--- a/internal/bus/status.go
+++ b/internal/bus/status.go
@@ -145,12 +145,15 @@ func (p *Producer) surge() {
 
 // ConsumerStatus is one durable consumer's registration, position, and lag.
 type ConsumerStatus struct {
-	Name      string
-	Cursor    int64
-	Lag       int64
-	Filter    string
-	Enabled   bool
-	UpdatedAt time.Time
+	Name    string
+	Cursor  int64
+	Lag     int64
+	Filter  string
+	Enabled bool
+	// PinsRetention is true for an installed app consumer even while disabled.
+	// It is an internal policy input; HoldsRetentionFloor is the wire surface.
+	PinsRetention bool
+	UpdatedAt     time.Time
 	// Live is true when this process has a delivery loop for the consumer, and
 	// is meaningful only when Status.Delivering is set.
 	Live bool
@@ -159,8 +162,8 @@ type ConsumerStatus struct {
 	// OldestUnreadAt stamps the oldest event this consumer has not read; zero
 	// when it is caught up. Lag counts events, this says how long they waited.
 	OldestUnreadAt time.Time
-	// HoldsRetentionFloor marks the enabled consumer whose cursor is the floor
-	// retention stops at — the one pinning the log.
+	// HoldsRetentionFloor marks the consumer whose cursor is the floor retention
+	// stops at — enabled ordinary consumers and installed apps participate.
 	HoldsRetentionFloor bool
 	// PinAlarm marks that pin as past DefaultPinAlarmAge: no longer the system
 	// working, but an outage holding the log open.
@@ -326,6 +329,7 @@ func (b *Bus) Status() (Status, error) {
 			Lag:                 max64(head-c.Cursor, 0),
 			Filter:              c.Filter,
 			Enabled:             c.Enabled,
+			PinsRetention:       c.PinsRetention,
 			UpdatedAt:           c.UpdatedAt,
 			HoldsRetentionFloor: c.Name == floor,
 		}
@@ -378,6 +382,12 @@ func health(s Status, now time.Time) []Health {
 				Level: HealthWarn, Kind: HealthConsumerNotLive, Subject: c.Name,
 				Message: fmt.Sprintf("consumer %s is registered and enabled but has no delivery loop in this daemon, so nothing is reading its %s backlog",
 					c.Name, events(c.Lag)),
+			})
+		case !c.Enabled && c.PinsRetention:
+			out = append(out, Health{
+				Level: HealthWarn, Kind: HealthConsumerDisabled, Subject: c.Name,
+				Message: fmt.Sprintf("consumer %s is disabled: delivery is paused at seq %d and its installed app keeps the unread backlog; enable it to resume from this cursor or uninstall it to release retention",
+					c.Name, c.Cursor),
 			})
 		case !c.Enabled:
 			out = append(out, Health{
@@ -465,6 +475,7 @@ func (b *Bus) PinAlarms() ([]Pin, error) {
 			Cursor:              c.Cursor,
 			Lag:                 max64(head-c.Cursor, 0),
 			Enabled:             c.Enabled,
+			PinsRetention:       c.PinsRetention,
 			HoldsRetentionFloor: c.Name == floor,
 		}
 		if entry.Lag > 0 {
@@ -496,13 +507,13 @@ func surgeMessage(p Producer) string {
 		events(p.Events), p.Share*100, p.Subjects)
 }
 
-// retentionFloorName is the enabled consumer whose cursor retention stops at.
-// Disabled consumers are excluded exactly as the trim does — they do not pin.
+// retentionFloorName is the consumer whose cursor retention stops at. Enabled
+// consumers and installed app consumers participate in the same floor.
 func retentionFloorName(consumers []Consumer) string {
 	name := ""
 	floor := int64(-1)
 	for _, c := range consumers {
-		if !c.Enabled {
+		if !c.Enabled && !c.PinsRetention {
 			continue
 		}
 		if floor < 0 || c.Cursor < floor {

--- a/internal/bus/status_test.go
+++ b/internal/bus/status_test.go
@@ -353,11 +353,37 @@ func TestStatusWarnsAboutADisabledConsumer(t *testing.T) {
 	if !strings.Contains(h.Message, "killed") || !strings.Contains(h.Message, "disabled") {
 		t.Errorf("message %q must name the consumer and its state", h.Message)
 	}
-	// A disabled consumer does not pin the log, exactly as trimming treats it.
+	// A disabled ordinary consumer does not pin the log, exactly as trimming treats it.
 	for _, c := range status.Consumers {
 		if c.Name == "killed" && c.HoldsRetentionFloor {
 			t.Error("a disabled consumer must not be shown holding the retention floor")
 		}
+	}
+}
+
+func TestStatusShowsADisabledInstalledAppHoldingTheRetentionFloor(t *testing.T) {
+	b, s := statusBus(t)
+	publishAt(t, s, "ticket.updated", 4, 10, time.Hour)
+	if err := s.SaveConsumer(Consumer{
+		Name: "app:history", Cursor: 2, Enabled: false, PinsRetention: true,
+	}, statusNow); err != nil {
+		t.Fatalf("SaveConsumer: %v", err)
+	}
+
+	status, err := b.Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	c := consumerStatus(t, status, "app:history")
+	if !c.HoldsRetentionFloor {
+		t.Fatal("disabled installed app was not shown holding the retention floor")
+	}
+	if c.PinAlarm {
+		t.Fatal("disabled installed app used the enabled-consumer alarm before the lane cap has a receipt")
+	}
+	h, ok := findHealth(status, HealthConsumerDisabled, "app:history")
+	if !ok || !strings.Contains(h.Message, "keeps the unread backlog") || !strings.Contains(h.Message, "uninstall") {
+		t.Fatalf("disabled installed-app health = %+v", h)
 	}
 }
 

--- a/internal/daemon/app_autodisable_test.go
+++ b/internal/daemon/app_autodisable_test.go
@@ -274,17 +274,16 @@ func TestEnablingClearsTheStreakAndResumesDelivery(t *testing.T) {
 	}
 }
 
-// Disabling releases the retention floor. This is the whole reason auto-disable
-// exists: a stalled consumer holds the durable log open for everybody, and the
-// observable consequence is that nothing can be compacted past it.
-func TestADisabledAppNoLongerHoldsTheRetentionFloor(t *testing.T) {
+// Auto-disable stops broken code, but an installed app's lane remains durable.
+// Its compactable facts wait at the same frozen cursor as ordinary history.
+func TestADisabledInstalledAppStillHoldsTheRetentionFloor(t *testing.T) {
 	d := newAppDaemon(t)
 	clock := newAppTestClock(d)
 	installApp(t, d, "greeter", subscribing(FactDocumentChanged))
 	startFakeAppRuntime(t, d, failEvery("boom"))
 
 	// Several invalidations about one subject. Compaction reduces those to the
-	// newest — but only at or below the floor every enabled consumer has passed.
+	// newest — but only at or below the floor every participating consumer has passed.
 	for i := 0; i < 4; i++ {
 		d.publishFact(FactDocumentChanged, "app/greeter/seen/tk-1", nil)
 	}
@@ -304,13 +303,13 @@ func TestADisabledAppNoLongerHoldsTheRetentionFloor(t *testing.T) {
 	clock.advance(appAutoDisableStall + time.Minute)
 	waitFor(t, "the stalled app to be disabled", func() bool { return !appEnabled(t, d, "greeter") })
 
-	// Nothing else moved. The only difference is that a disabled consumer does
-	// not pin the log.
+	// Nothing else moved. Disabling stops delivery, but the installed app still
+	// owns this lane and its facts remain retained.
 	removed, err = d.eventBus.Trim()
 	if err != nil {
 		t.Fatalf("trim after the auto-disable: %v", err)
 	}
-	if removed == 0 {
-		t.Fatal("the disabled app is still holding the retention floor down")
+	if removed != 0 {
+		t.Fatalf("compaction removed %d retained event(s) after auto-disable", removed)
 	}
 }

--- a/internal/daemon/app_consumers.go
+++ b/internal/daemon/app_consumers.go
@@ -76,8 +76,8 @@ func (d *Daemon) appConnectWait() time.Duration {
 //
 // Fifteen minutes is roughly five rounds at the bus's two-minute retry cap —
 // long enough that a transient dependency (a git remote, a rebooting service)
-// recovers untouched, short enough that a genuinely broken app does not hold the
-// log for an afternoon.
+// recovers untouched, short enough to stop calling a genuinely broken app and
+// ask the user to intervene. Its installed lane remains retained while disabled.
 const appAutoDisableStall = 15 * time.Minute
 
 // appCrashStrikes is the second half of the auto-disable rule: an app the
@@ -216,7 +216,7 @@ func (d *Daemon) appPreDrain(name string) bus.PreDrain {
 			return nil
 		}
 		if gap != nil {
-			if _, err := d.store.RequestAppReconcileGap(name, gap.Cursor, gap.Earliest, gap.Head, d.appNow()); err != nil {
+			if _, err := d.store.RequestAppReconcileGap(name, gap.Cursor, gap.Earliest, d.appNow()); err != nil {
 				return fmt.Errorf("recording the gap reconciliation for app %q: %w", name, err)
 			}
 		}
@@ -276,7 +276,7 @@ func foldAppReconcileReason(versionID int64, claim store.AppReconcileClaim) appR
 			reason.PreviousVersions = append(reason.PreviousVersions, request.PreviousVersionID)
 		}
 	}
-	for _, cause := range []string{store.AppReconcileGap, store.AppReconcileReEnabled, store.AppReconcileVersionChange} {
+	for _, cause := range []string{store.AppReconcileGap, store.AppReconcileVersionChange} {
 		if seenCauses[cause] {
 			reason.Causes = append(reason.Causes, cause)
 		}

--- a/internal/daemon/app_reconcile_test.go
+++ b/internal/daemon/app_reconcile_test.go
@@ -19,7 +19,6 @@ func TestFoldAppReconcileReasonSortsCausesAndDeduplicatesPreviousVersions(t *tes
 	claim := store.AppReconcileClaim{
 		ThroughSeq: 18,
 		Requests: []store.AppReconcileRequest{
-			{Reason: store.AppReconcileReEnabled},
 			{Reason: store.AppReconcileVersionChange, PreviousVersionID: 3},
 			{Reason: store.AppReconcileGap, Cursor: 4, Earliest: 8, Missed: 3},
 			{Reason: store.AppReconcileVersionChange, PreviousVersionID: 3},
@@ -27,7 +26,7 @@ func TestFoldAppReconcileReasonSortsCausesAndDeduplicatesPreviousVersions(t *tes
 		},
 	}
 	got := foldAppReconcileReason(11, claim)
-	if !reflect.DeepEqual(got.Causes, []string{"gap", "re_enabled", "version_changed"}) {
+	if !reflect.DeepEqual(got.Causes, []string{"gap", "version_changed"}) {
 		t.Fatalf("causes = %v", got.Causes)
 	}
 	if got.Version != 11 || got.ThroughSeq != 18 {
@@ -58,7 +57,7 @@ func TestAppPreDrainDispatchesReconcileAndCompletesItsClaim(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if _, err := d.store.RequestAppReconcileGap("approval-gate", 1, 4, 6, now); err != nil {
+	if _, err := d.store.RequestAppReconcileGap("approval-gate", 1, 4, now); err != nil {
 		t.Fatal(err)
 	}
 	runtime := startFakeAppRuntime(t, d, nil)
@@ -91,7 +90,7 @@ func TestAppPreDrainDispatchesReconcileAndCompletesItsClaim(t *testing.T) {
 	if !reflect.DeepEqual(request.Collections, []string{"decisions"}) || !reflect.DeepEqual(request.Reason.Causes, []string{"gap"}) {
 		t.Fatalf("request = %+v", request)
 	}
-	if request.Reason.Gap == nil || request.Reason.ThroughSeq != 6 {
+	if request.Reason.Gap == nil || request.Reason.ThroughSeq != 3 {
 		t.Fatalf("reason = %+v", request.Reason)
 	}
 	snapshot := <-snapshots
@@ -102,7 +101,7 @@ func TestAppPreDrainDispatchesReconcileAndCompletesItsClaim(t *testing.T) {
 		t.Fatalf("pending after success = %+v, %v", claim, err)
 	}
 	consumer, _, err := d.store.GetBusConsumer(apps.ConsumerName("approval-gate"))
-	if err != nil || consumer.Cursor != 6 {
+	if err != nil || consumer.Cursor != 3 {
 		t.Fatalf("consumer = %+v, %v", consumer, err)
 	}
 }
@@ -119,7 +118,7 @@ func TestAppPreDrainRetriesTheSameClaimAfterAThrow(t *testing.T) {
 		t.Fatal(err)
 	}
 	seedAppConsumer(t, d, "approval-gate", true, 1)
-	if _, err := d.store.RequestAppReconcileGap("approval-gate", 1, 4, 6, now); err != nil {
+	if _, err := d.store.RequestAppReconcileGap("approval-gate", 1, 4, now); err != nil {
 		t.Fatal(err)
 	}
 	runtime := startFakeAppRuntime(t, d, nil)
@@ -157,12 +156,12 @@ func TestAppPreDrainRetriesTheSameClaimAfterAThrow(t *testing.T) {
 		t.Fatalf("claim after retry = %+v, %v", claim, err)
 	}
 	stored, _, err = d.store.GetBusConsumer(consumer.Name)
-	if err != nil || stored.Cursor != 6 {
+	if err != nil || stored.Cursor != 3 {
 		t.Fatalf("cursor after retry = %d, %v", stored.Cursor, err)
 	}
 }
 
-func TestAppPreDrainRecordsOneGapAndFencesFactsUntilCompletion(t *testing.T) {
+func TestAppPreDrainFencesAGapBeforeTheEarliestRetainedFact(t *testing.T) {
 	d := newDaemonForTest(t)
 	seedApp(t, d, "approval-gate", true)
 	gap := &bus.Gap{Cursor: 1, Earliest: 4, Head: 6, Missed: 2}
@@ -178,7 +177,7 @@ func TestAppPreDrainRecordsOneGapAndFencesFactsUntilCompletion(t *testing.T) {
 		t.Fatalf("pending = %+v, %v", claim, err)
 	}
 	request := claim.Requests[0]
-	if request.Reason != store.AppReconcileGap || request.Cursor != 1 || request.Earliest != 4 || request.Missed != 2 || request.ThroughSeq != 6 {
+	if request.Reason != store.AppReconcileGap || request.Cursor != 1 || request.Earliest != 4 || request.Missed != 2 || request.ThroughSeq != 3 {
 		t.Fatalf("gap request = %+v", request)
 	}
 	if err := d.store.CompleteAppReconcile("approval-gate", claim.ThroughRequestID, claim.ThroughSeq, time.Now()); err != nil {
@@ -188,7 +187,7 @@ func TestAppPreDrainRecordsOneGapAndFencesFactsUntilCompletion(t *testing.T) {
 		t.Fatalf("pre-drain after completion: %v", err)
 	}
 	consumer, ok, err := d.store.GetBusConsumer(apps.ConsumerName("approval-gate"))
-	if err != nil || !ok || consumer.Cursor != 6 {
+	if err != nil || !ok || consumer.Cursor != 3 {
 		t.Fatalf("consumer after completion = %+v, found=%t, err=%v", consumer, ok, err)
 	}
 }

--- a/internal/daemon/apps_test.go
+++ b/internal/daemon/apps_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -221,34 +222,71 @@ func TestAppEnableDisableFlipsTheConsumerBitAndPublishes(t *testing.T) {
 	}
 }
 
-func TestAppReEnableRecordsOneReconcileAtTheCurrentBusHead(t *testing.T) {
-	d := newDaemonForTest(t)
-	seedApp(t, d, "approval-gate", true)
-	if _, err := d.store.AppendBusEvent(store.BusEvent{Name: "ticket.created"}, time.Now()); err != nil {
-		t.Fatal(err)
-	}
+func TestAppReEnableResumesWithoutReconcileAndDeliversTheRetainedBacklogInOrder(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "approval-gate", subscribing("ticket.*"))
+	runtime := startFakeAppRuntime(t, d, nil)
 	if resp := appSetEnabled(t, d, "approval-gate", false); !resp.Ok {
 		t.Fatalf("disable: %v", protocol.Deref(resp.Error))
 	}
+	d.publishFact("ticket.created", "tk-1", nil)
+	d.publishFact("ticket.updated", "tk-1", nil)
 	if resp := appSetEnabled(t, d, "approval-gate", true); !resp.Ok {
 		t.Fatalf("enable: %v", protocol.Deref(resp.Error))
+	}
+	waitFor(t, "the retained backlog to be delivered", func() bool { return len(runtime.dispatchLog()) == 2 })
+	log := runtime.dispatchLog()
+	if got := []string{log[0].Event.Name, log[1].Event.Name}; !reflect.DeepEqual(got, []string{"ticket.created", "ticket.updated"}) {
+		t.Fatalf("delivery order = %v", got)
+	}
+	claim, err := d.store.AppReconcilePending("approval-gate")
+	if err != nil || len(claim.Requests) != 0 {
+		t.Fatalf("pending = %+v, %v", claim, err)
+	}
+	if got := len(runtime.reconcileLog()); got != 0 {
+		t.Fatalf("re-enable dispatched %d reconcile(s), want none", got)
+	}
+}
+
+func TestAppVersionChangeReconcilesAtTheFrozenCursorThenDeliversTheRetainedFact(t *testing.T) {
+	d := newAppDaemon(t)
+	firstManifest := subscribing("ticket.*")
+	firstManifest.Reconcile = true
+	first := installApp(t, d, "approval-gate", firstManifest)
+	runtime := startFakeAppRuntime(t, d, nil)
+	if resp := appSetEnabled(t, d, "approval-gate", false); !resp.Ok {
+		t.Fatalf("disable: %v", protocol.Deref(resp.Error))
+	}
+	d.publishFact("ticket.created", "tk-1", nil)
+	_, retainedSeq, err := d.store.BusBounds()
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondManifest := firstManifest
+	secondManifest.Description = "version two"
+	second := installApp(t, d, "approval-gate", secondManifest)
+	if second.ID == first.ID {
+		t.Fatalf("version did not move: first=%d second=%d", first.ID, second.ID)
 	}
 	claim, err := d.store.AppReconcilePending("approval-gate")
 	if err != nil || len(claim.Requests) != 1 {
 		t.Fatalf("pending = %+v, %v", claim, err)
 	}
-	if got := claim.Requests[0]; got.Reason != store.AppReconcileReEnabled || got.ThroughSeq != 2 {
-		t.Fatalf("request = %+v, want re-enabled through the pre-existing fact and disable fact", got)
+	if claim.ThroughSeq >= retainedSeq {
+		t.Fatalf("version fence %d covered retained undelivered fact %d", claim.ThroughSeq, retainedSeq)
 	}
 	if resp := appSetEnabled(t, d, "approval-gate", true); !resp.Ok {
-		t.Fatalf("no-op enable: %v", protocol.Deref(resp.Error))
+		t.Fatalf("enable: %v", protocol.Deref(resp.Error))
 	}
-	again, err := d.store.AppReconcilePending("approval-gate")
-	if err != nil || len(again.Requests) != 1 {
-		t.Fatalf("no-op enable added a request: %+v, %v", again, err)
+	waitFor(t, "reconcile followed by retained fact delivery", func() bool {
+		return len(runtime.reconcileLog()) == 1 && len(runtime.dispatchLog()) == 1
+	})
+	if got := runtime.reconcileLog()[0].Reason.ThroughSeq; got != claim.ThroughSeq {
+		t.Fatalf("dispatched reconcile fence = %d, want %d", got, claim.ThroughSeq)
 	}
-	if facts := appFacts(t, d, FactAppEnabledChanged); len(facts) != 2 {
-		t.Fatalf("enabled facts = %d, want only the disable and real re-enable", len(facts))
+	delivered := runtime.dispatchLog()[0]
+	if delivered.Event.Seq != retainedSeq || delivered.VersionID != second.ID {
+		t.Fatalf("retained delivery = seq %d version %d, want seq %d version %d", delivered.Event.Seq, delivered.VersionID, retainedSeq, second.ID)
 	}
 }
 

--- a/internal/daemon/bus_pin_alarm.go
+++ b/internal/daemon/bus_pin_alarm.go
@@ -12,10 +12,10 @@ import (
 	"github.com/victorarias/attn/internal/store"
 )
 
-// The event log never trims past an enabled consumer's cursor, which is the
-// right rule and also means a consumer that is enabled and not consuming makes
-// the log grow for as long as the condition lasts. Until now the only way to
-// notice was to go and look — `attn bus status`, or the event bus settings page.
+// An enabled consumer that is not consuming makes the log grow for as long as
+// the condition lasts. Until now the only way to notice was to go and look —
+// `attn bus status`, or the event bus settings page. Disabled installed-app
+// lanes are retained deliberately and wait for a measured per-lane tripwire.
 //
 // This is the half that does not wait to be looked at. `internal/bus` decides
 // what counts as a pin worth reporting (DefaultPinAlarmAge carries the receipt);

--- a/internal/daemon/bus_store.go
+++ b/internal/daemon/bus_store.go
@@ -131,10 +131,11 @@ func (a *sqlBusStore) PendingBytes(above int64) (int64, error) {
 
 func busConsumerFromRow(r store.BusConsumer) bus.Consumer {
 	return bus.Consumer{
-		Name:      r.Name,
-		Cursor:    r.Cursor,
-		Filter:    r.Filter,
-		Enabled:   r.Enabled,
-		UpdatedAt: r.UpdatedAt,
+		Name:          r.Name,
+		Cursor:        r.Cursor,
+		Filter:        r.Filter,
+		Enabled:       r.Enabled,
+		PinsRetention: r.PinsRetention,
+		UpdatedAt:     r.UpdatedAt,
 	}
 }

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -2234,7 +2234,8 @@ model BusStatusResultMessage {
   baseline_window_seconds: float64;
   surge_rate_per_hour: float64;
   // How long an enabled consumer may pin the retention floor before the pin is
-  // reported. Carried so a client shows the limit beside the observed value.
+  // reported. Disabled installed-app lanes are retained but do not use this
+  // alarm; their future size tripwire needs a measured receipt first.
   pin_alarm_seconds: float64;
   producers: BusProducerStatus[];
   consumers: BusConsumerStatus[];
@@ -2242,8 +2243,9 @@ model BusStatusResultMessage {
 }
 
 // Flips a durable consumer's kill switch, the same bit `attn bus enable|disable`
-// writes. Disabling stops delivery and stops the consumer pinning retention; its
-// cursor is preserved, and re-enabling resumes from wherever trimming left it.
+// writes. Disabling stops delivery. An ordinary consumer stops pinning
+// retention; an installed app keeps its cursor and unread backlog until it is
+// enabled or uninstalled.
 model BusSetConsumerEnabledMessage {
   cmd: "bus_set_consumer_enabled";
   consumer: string;

--- a/internal/store/app_reconcile.go
+++ b/internal/store/app_reconcile.go
@@ -8,7 +8,6 @@ import (
 
 const (
 	AppReconcileGap           = "gap"
-	AppReconcileReEnabled     = "re_enabled"
 	AppReconcileVersionChange = "version_changed"
 )
 
@@ -91,7 +90,7 @@ func appReconcilePending(q reconcileQueryer, name string) (AppReconcileClaim, er
 
 // RequestAppReconcileGap records a retention gap. Retrying the same pre-drain
 // hook is idempotent; a different cursor or surviving window is a new trigger.
-func (s *Store) RequestAppReconcileGap(name string, cursor, earliest, throughSeq int64, now time.Time) (bool, error) {
+func (s *Store) RequestAppReconcileGap(name string, cursor, earliest int64, now time.Time) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.db == nil {
@@ -106,6 +105,7 @@ func (s *Store) RequestAppReconcileGap(name string, cursor, earliest, throughSeq
 	if err := tx.QueryRow(`SELECT current_version_id FROM apps WHERE name = ?`, name).Scan(&versionID); err != nil {
 		return false, err
 	}
+	throughSeq := earliest - 1
 	res, err := tx.Exec(`
 		INSERT OR IGNORE INTO app_reconcile_requests
 			(app_name, reason, version_id, through_seq, cursor, earliest, missed, created_at)
@@ -185,8 +185,11 @@ func appendAppReconcileRequest(tx *sql.Tx, name, reason string, versionID, throu
 	return err
 }
 
-func busHeadWith(q reconcileQueryer) (int64, error) {
-	var head sql.NullInt64
-	err := q.QueryRow(`SELECT MAX(seq) FROM bus_events`).Scan(&head)
-	return head.Int64, err
+func appConsumerCursorWith(q reconcileQueryer, name string) (int64, error) {
+	var cursor int64
+	err := q.QueryRow(`SELECT cursor FROM bus_consumers WHERE name = ?`, "app:"+name).Scan(&cursor)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	return cursor, err
 }

--- a/internal/store/app_reconcile_test.go
+++ b/internal/store/app_reconcile_test.go
@@ -30,12 +30,6 @@ func TestAppReconcileTriggersCoalesceAtOneClaimBoundary(t *testing.T) {
 	if _, err := s.AppendBusEvent(BusEvent{Name: "ticket.created"}, now); err != nil {
 		t.Fatal(err)
 	}
-	if exists, changed, err := s.SetAppBusConsumerEnabled("approval-gate", false, now); err != nil || !exists || !changed {
-		t.Fatalf("disable = exists:%t changed:%t err:%v", exists, changed, err)
-	}
-	if exists, changed, err := s.SetAppBusConsumerEnabled("approval-gate", true, now); err != nil || !exists || !changed {
-		t.Fatalf("enable = exists:%t changed:%t err:%v", exists, changed, err)
-	}
 	second, _, err := s.CommitAppVersion(AppVersion{
 		AppName: "approval-gate", ContentHash: "sha256:second",
 		Declaration: `{"name":"approval-gate"}`, ArtifactPath: "bundle-2.js",
@@ -43,11 +37,11 @@ func TestAppReconcileTriggersCoalesceAtOneClaimBoundary(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	inserted, err := s.RequestAppReconcileGap("approval-gate", 0, 3, 4, now)
+	inserted, err := s.RequestAppReconcileGap("approval-gate", 0, 3, now)
 	if err != nil || !inserted {
 		t.Fatalf("gap insert = %t, %v", inserted, err)
 	}
-	inserted, err = s.RequestAppReconcileGap("approval-gate", 0, 3, 4, now)
+	inserted, err = s.RequestAppReconcileGap("approval-gate", 0, 3, now)
 	if err != nil || inserted {
 		t.Fatalf("duplicate gap insert = %t, %v", inserted, err)
 	}
@@ -56,16 +50,16 @@ func TestAppReconcileTriggersCoalesceAtOneClaimBoundary(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(claim.Requests) != 3 {
-		t.Fatalf("pending = %+v, want re-enable, version, and one gap", claim.Requests)
+	if len(claim.Requests) != 2 {
+		t.Fatalf("pending = %+v, want version and one gap", claim.Requests)
 	}
-	if claim.Requests[0].Reason != AppReconcileReEnabled || claim.Requests[1].Reason != AppReconcileVersionChange || claim.Requests[2].Reason != AppReconcileGap {
+	if claim.Requests[0].Reason != AppReconcileVersionChange || claim.Requests[1].Reason != AppReconcileGap {
 		t.Fatalf("reason order = %+v", claim.Requests)
 	}
-	if claim.Requests[1].PreviousVersionID != first.ID || claim.Requests[1].VersionID != second.ID {
-		t.Fatalf("version request = %+v", claim.Requests[1])
+	if claim.Requests[0].PreviousVersionID != first.ID || claim.Requests[0].VersionID != second.ID {
+		t.Fatalf("version request = %+v", claim.Requests[0])
 	}
-	if claim.ThroughSeq != 4 || claim.ThroughRequestID != claim.Requests[2].ID {
+	if claim.ThroughSeq != 2 || claim.ThroughRequestID != claim.Requests[1].ID {
 		t.Fatalf("claim boundary = %+v", claim)
 	}
 }
@@ -74,10 +68,10 @@ func TestAppReconcileTriggerDuringRunRemainsOwedAndCompletionFencesCursor(t *tes
 	s := New()
 	now := time.Now().UTC().Truncate(time.Millisecond)
 	seedReconcileApp(t, s, now)
-	if _, _, err := s.SetAppBusConsumerEnabled("approval-gate", false, now); err != nil {
-		t.Fatal(err)
-	}
-	if _, _, err := s.SetAppBusConsumerEnabled("approval-gate", true, now); err != nil {
+	if _, _, err := s.CommitAppVersion(AppVersion{
+		AppName: "approval-gate", ContentHash: "sha256:second",
+		Declaration: `{"name":"approval-gate"}`, ArtifactPath: "bundle-2.js",
+	}, now); err != nil {
 		t.Fatal(err)
 	}
 	first, err := s.AppReconcilePending("approval-gate")
@@ -87,7 +81,7 @@ func TestAppReconcileTriggerDuringRunRemainsOwedAndCompletionFencesCursor(t *tes
 	if _, err := s.AppendBusEvent(BusEvent{Name: "ticket.updated"}, now); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.RequestAppReconcileGap("approval-gate", 0, 2, 1, now); err != nil {
+	if _, err := s.RequestAppReconcileGap("approval-gate", 0, 2, now); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.SetBusConsumerCursor("app:approval-gate", 9, now); err != nil {
@@ -114,10 +108,10 @@ func TestAppReconcileRequestSurvivesRestartUntilCompletion(t *testing.T) {
 		t.Fatal(err)
 	}
 	seedReconcileApp(t, s, now)
-	if _, _, err := s.SetAppBusConsumerEnabled("approval-gate", false, now); err != nil {
-		t.Fatal(err)
-	}
-	if _, _, err := s.SetAppBusConsumerEnabled("approval-gate", true, now); err != nil {
+	if _, _, err := s.CommitAppVersion(AppVersion{
+		AppName: "approval-gate", ContentHash: "sha256:second",
+		Declaration: `{"name":"approval-gate"}`, ArtifactPath: "bundle-2.js",
+	}, now); err != nil {
 		t.Fatal(err)
 	}
 	before, err := s.AppReconcilePending("approval-gate")
@@ -144,15 +138,64 @@ func TestAppReconcileRequestSurvivesRestartUntilCompletion(t *testing.T) {
 	}
 }
 
-func TestAppReconcileNoOpEnableAndInitialInstallCreateNoRequest(t *testing.T) {
+func TestAppReEnableCreatesNoReconcileRequest(t *testing.T) {
 	s := New()
 	now := time.Now().UTC().Truncate(time.Millisecond)
 	seedReconcileApp(t, s, now)
-	if exists, changed, err := s.SetAppBusConsumerEnabled("approval-gate", true, now); err != nil || !exists || changed {
-		t.Fatalf("no-op enable = exists:%t changed:%t err:%v", exists, changed, err)
+	if exists, changed, err := s.SetAppBusConsumerEnabled("approval-gate", false, now); err != nil || !exists || !changed {
+		t.Fatalf("disable = exists:%t changed:%t err:%v", exists, changed, err)
+	}
+	if exists, changed, err := s.SetAppBusConsumerEnabled("approval-gate", true, now); err != nil || !exists || !changed {
+		t.Fatalf("re-enable = exists:%t changed:%t err:%v", exists, changed, err)
 	}
 	if pending, err := s.AppReconcilePending("approval-gate"); err != nil || len(pending.Requests) != 0 {
 		t.Fatalf("pending = %+v, %v", pending, err)
+	}
+}
+
+func TestAppVersionChangeFenceStopsAtTheConsumerCursor(t *testing.T) {
+	s := New()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	seedReconcileApp(t, s, now)
+	first, err := s.AppendBusEvent(BusEvent{Name: "ticket.created"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.AppendBusEvent(BusEvent{Name: "ticket.updated"}, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetBusConsumerCursor("app:approval-gate", first, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := s.CommitAppVersion(AppVersion{
+		AppName: "approval-gate", ContentHash: "sha256:second",
+		Declaration: `{"name":"approval-gate"}`, ArtifactPath: "bundle-2.js",
+	}, now); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := s.AppReconcilePending("approval-gate")
+	if err != nil || len(claim.Requests) != 1 {
+		t.Fatalf("pending = %+v, %v", claim, err)
+	}
+	if got := claim.Requests[0].ThroughSeq; got != first {
+		t.Fatalf("version fence = %d, want consumer cursor %d; the retained fact above it must still be delivered", got, first)
+	}
+}
+
+func TestAppGapFenceStopsBeforeTheEarliestRetainedFact(t *testing.T) {
+	s := New()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	seedReconcileApp(t, s, now)
+	inserted, err := s.RequestAppReconcileGap("approval-gate", 1, 4, now)
+	if err != nil || !inserted {
+		t.Fatalf("gap insert = %t, %v", inserted, err)
+	}
+	claim, err := s.AppReconcilePending("approval-gate")
+	if err != nil || len(claim.Requests) != 1 {
+		t.Fatalf("pending = %+v, %v", claim, err)
+	}
+	if got := claim.Requests[0].ThroughSeq; got != 3 {
+		t.Fatalf("gap fence = %d, want earliest-1 = 3", got)
 	}
 }
 

--- a/internal/store/apps.go
+++ b/internal/store/apps.go
@@ -300,11 +300,11 @@ func (s *Store) CommitAppVersion(v AppVersion, now time.Time) (AppVersion, bool,
 		return AppVersion{}, false, err
 	}
 	if moved && previous != 0 {
-		head, err := busHeadWith(tx)
+		cursor, err := appConsumerCursorWith(tx, v.AppName)
 		if err != nil {
 			return AppVersion{}, false, err
 		}
-		if err := appendAppReconcileRequest(tx, v.AppName, AppReconcileVersionChange, v.ID, head, previous, now); err != nil {
+		if err := appendAppReconcileRequest(tx, v.AppName, AppReconcileVersionChange, v.ID, cursor, previous, now); err != nil {
 			return AppVersion{}, false, err
 		}
 	}
@@ -346,11 +346,11 @@ func (s *Store) SetAppCurrentVersion(name string, versionID int64, now time.Time
 		return err
 	}
 	if moved && previous != 0 {
-		head, err := busHeadWith(tx)
+		cursor, err := appConsumerCursorWith(tx, name)
 		if err != nil {
 			return err
 		}
-		if err := appendAppReconcileRequest(tx, name, AppReconcileVersionChange, versionID, head, previous, now); err != nil {
+		if err := appendAppReconcileRequest(tx, name, AppReconcileVersionChange, versionID, cursor, previous, now); err != nil {
 			return err
 		}
 	}
@@ -400,11 +400,11 @@ func (s *Store) StepAppVersionBack(name string, target int64, now time.Time) err
 		return err
 	}
 	if previous != 0 {
-		head, err := busHeadWith(tx)
+		cursor, err := appConsumerCursorWith(tx, name)
 		if err != nil {
 			return err
 		}
-		if err := appendAppReconcileRequest(tx, name, AppReconcileVersionChange, versionID, head, previous, now); err != nil {
+		if err := appendAppReconcileRequest(tx, name, AppReconcileVersionChange, versionID, cursor, previous, now); err != nil {
 			return err
 		}
 	}

--- a/internal/store/bus.go
+++ b/internal/store/bus.go
@@ -22,14 +22,16 @@ type BusEvent struct {
 	CreatedAt time.Time
 }
 
-// BusConsumer is a durable consumer's registration and position. Enabled=false
-// is the kill switch: not delivered to, and deliberately not pinning retention.
+// BusConsumer is a durable consumer's registration and position. PinsRetention
+// is derived when listing: installed app consumers retain their backlog even
+// while disabled. It is never persisted separately from the app registry.
 type BusConsumer struct {
-	Name      string
-	Cursor    int64
-	Filter    string
-	Enabled   bool
-	UpdatedAt time.Time
+	Name          string
+	Cursor        int64
+	Filter        string
+	Enabled       bool
+	PinsRetention bool
+	UpdatedAt     time.Time
 }
 
 // AppendBusEvent appends a fact and returns its seq. No dedup: two identical
@@ -216,9 +218,9 @@ func (s *Store) SetBusConsumerEnabled(name string, enabled bool, now time.Time) 
 	return n > 0, err
 }
 
-// SetAppBusConsumerEnabled flips an app consumer and records a false-to-true
-// reconciliation trigger in the same transaction. changed distinguishes a real
-// transition from an idempotent request.
+// SetAppBusConsumerEnabled flips an app consumer. changed distinguishes a real
+// transition from an idempotent request. Re-enabling resumes from the frozen
+// cursor; it does not create a reconciliation request.
 func (s *Store) SetAppBusConsumerEnabled(appName string, enabled bool, now time.Time) (exists, changed bool, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -248,21 +250,6 @@ func (s *Store) SetAppBusConsumerEnabled(appName string, enabled bool, now time.
 	stamp := now.UTC().Format(sortableTimeFormat)
 	if _, err := tx.Exec(`UPDATE bus_consumers SET enabled = ?, updated_at = ? WHERE name = ?`, want, stamp, consumerName); err != nil {
 		return false, false, err
-	}
-	if enabled {
-		var versionID sql.NullInt64
-		if err := tx.QueryRow(`SELECT current_version_id FROM apps WHERE name = ?`, appName).Scan(&versionID); err != nil {
-			return false, false, err
-		}
-		if versionID.Valid {
-			head, err := busHeadWith(tx)
-			if err != nil {
-				return false, false, err
-			}
-			if err := appendAppReconcileRequest(tx, appName, AppReconcileReEnabled, versionID.Int64, head, 0, now); err != nil {
-				return false, false, err
-			}
-		}
 	}
 	return true, true, tx.Commit()
 }
@@ -294,7 +281,10 @@ func (s *Store) ListBusConsumers() ([]BusConsumer, error) {
 		return nil, nil
 	}
 	rows, err := s.db.Query(`
-		SELECT name, cursor, filter, enabled, updated_at FROM bus_consumers ORDER BY name ASC
+		SELECT c.name, c.cursor, c.filter, c.enabled,
+		       EXISTS (SELECT 1 FROM apps a WHERE c.name = 'app:' || a.name),
+		       c.updated_at
+		FROM bus_consumers c ORDER BY c.name ASC
 	`)
 	if err != nil {
 		return nil, err
@@ -308,19 +298,21 @@ func (s *Store) ListBusConsumers() ([]BusConsumer, error) {
 			enabled   int
 			updatedAt string
 		)
-		if err := rows.Scan(&c.Name, &c.Cursor, &c.Filter, &enabled, &updatedAt); err != nil {
+		var pinsRetention int
+		if err := rows.Scan(&c.Name, &c.Cursor, &c.Filter, &enabled, &pinsRetention, &updatedAt); err != nil {
 			return nil, err
 		}
 		c.Enabled = enabled != 0
+		c.PinsRetention = pinsRetention != 0
 		c.UpdatedAt = parseTicketTime(updatedAt)
 		out = append(out, c)
 	}
 	return out, rows.Err()
 }
 
-// TrimBusEvents deletes events older than cutoff that every ENABLED consumer
-// has passed. Disabled consumers are excluded from the floor on purpose: a
-// killed consumer must not pin the log; internal/bus resumes it at head.
+// TrimBusEvents deletes events older than cutoff that every enabled consumer
+// and every installed app consumer has passed. A disabled installed app keeps
+// its backlog; a disabled orphan row with no app registry entry pins nothing.
 func (s *Store) TrimBusEvents(cutoff time.Time) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -332,7 +324,10 @@ func (s *Store) TrimBusEvents(cutoff time.Time) (int, error) {
 		DELETE FROM bus_events
 		WHERE created_at < ?
 		  AND seq <= COALESCE(
-		      (SELECT MIN(cursor) FROM bus_consumers WHERE enabled = 1),
+		      (SELECT MIN(c.cursor)
+		         FROM bus_consumers c
+		        WHERE c.enabled = 1
+		           OR EXISTS (SELECT 1 FROM apps a WHERE c.name = 'app:' || a.name)),
 		      (SELECT COALESCE(MAX(seq), 0) FROM bus_events)
 		  )
 	`, formatTicketTime(cutoff))
@@ -344,10 +339,10 @@ func (s *Store) TrimBusEvents(cutoff time.Time) (int, error) {
 }
 
 // CompactBusEvents keeps only the newest fact per subject among the named
-// names, at or below floor (the cursor floor: every enabled consumer has read
-// those rows, so removal costs no delivery and punches no holes above the
-// floor). Which names are compactable is internal/bus's call. An empty name
-// list compacts nothing, not everything.
+// names, at or below floor (the cursor floor: every enabled consumer and every
+// installed app consumer has read those rows, so removal costs no delivery and
+// punches no holes above the floor). Which names are compactable is
+// internal/bus's call. An empty name list compacts nothing, not everything.
 func (s *Store) CompactBusEvents(names []string, floor int64) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/store/bus_test.go
+++ b/internal/store/bus_test.go
@@ -160,9 +160,8 @@ func TestSaveBusConsumerPreservesCursorAndEnabled(t *testing.T) {
 	}
 }
 
-// Deleting a registration is what ends its hold on the retention floor: while the
-// row exists and is enabled, events it has not read cannot be trimmed, however
-// long ago whoever served it went away.
+// Deleting a registration ends its hold on the retention floor. An enabled row
+// pins regardless of whether a registry entry still serves it.
 func TestDeleteBusConsumerReleasesTheRetentionFloor(t *testing.T) {
 	s := New()
 	t.Cleanup(func() { _ = s.Close() })
@@ -283,20 +282,45 @@ func TestTrimBusEventsKeepsEventsInsideTheWindow(t *testing.T) {
 	}
 }
 
-// A killed consumer must not pin the log forever. This is the deliberate
-// asymmetry with the lagging-consumer case above.
-func TestTrimBusEventsIgnoresDisabledConsumers(t *testing.T) {
+// A disabled installed app keeps the facts above its frozen cursor. Re-enable
+// resumes from there, so trimming that backlog would silently lose history.
+func TestTrimBusEventsKeepsDisabledInstalledAppBacklog(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	read := appendBus(t, s, "a.happened", "", busBase)
+	unread := appendBus(t, s, "b.happened", "", busBase.Add(time.Minute))
+
+	if err := s.SaveApp("history", busBase); err != nil {
+		t.Fatalf("SaveApp: %v", err)
+	}
+	if err := s.SaveBusConsumer(BusConsumer{Name: "app:history", Cursor: read, Filter: "*", Enabled: false}, busBase); err != nil {
+		t.Fatalf("SaveBusConsumer: %v", err)
+	}
+
+	n, err := s.TrimBusEvents(busBase.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("TrimBusEvents: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("trimmed %d events, want only the row the disabled app already read", n)
+	}
+	earliest, _, err := s.BusBounds()
+	if err != nil || earliest != unread {
+		t.Fatalf("earliest = %d, %v; want disabled app backlog at %d", earliest, err, unread)
+	}
+}
+
+// A disabled app-shaped row with no registry entry serves no install and does
+// not pin retention. Uninstall normally deletes it; this keeps stale rows safe.
+func TestTrimBusEventsIgnoresDisabledOrphanedAppConsumer(t *testing.T) {
 	s := New()
 	t.Cleanup(func() { _ = s.Close() })
 
 	appendBus(t, s, "a.happened", "", busBase)
 	appendBus(t, s, "b.happened", "", busBase.Add(time.Minute))
-
-	if err := s.SaveBusConsumer(BusConsumer{Name: "killed", Cursor: 0, Filter: "*", Enabled: true}, busBase); err != nil {
+	if err := s.SaveBusConsumer(BusConsumer{Name: "app:removed", Cursor: 0, Filter: "*", Enabled: false}, busBase); err != nil {
 		t.Fatalf("SaveBusConsumer: %v", err)
-	}
-	if _, err := s.SetBusConsumerEnabled("killed", false, busBase); err != nil {
-		t.Fatalf("SetBusConsumerEnabled: %v", err)
 	}
 
 	n, err := s.TrimBusEvents(busBase.Add(time.Hour))
@@ -304,7 +328,7 @@ func TestTrimBusEventsIgnoresDisabledConsumers(t *testing.T) {
 		t.Fatalf("TrimBusEvents: %v", err)
 	}
 	if n != 2 {
-		t.Fatalf("a disabled consumer pinned the log: trimmed %d, want 2", n)
+		t.Fatalf("orphaned disabled row pinned the log: trimmed %d, want 2", n)
 	}
 }
 

--- a/sdk/attn-app/src/index.ts
+++ b/sdk/attn-app/src/index.ts
@@ -137,7 +137,7 @@ export type Handler<Collections> = (
 ) => void | Promise<void>
 
 /** Why attn requires the app to rebuild its derived collections. */
-export type ReconcileCause = "gap" | "re_enabled" | "version_changed"
+export type ReconcileCause = "gap" | "version_changed"
 
 export type {
   AppRegistryEntry,
@@ -162,7 +162,7 @@ export type {
 
 /** The durable requests coalesced into one reconcile invocation. */
 export interface ReconcileReason {
-  /** Sorted as gap, re_enabled, version_changed, independent of arrival order. */
+  /** Sorted as gap, version_changed, independent of arrival order. */
   readonly causes: readonly ReconcileCause[]
   /** The version whose reconcile handler is running. */
   readonly version: number


### PR DESCRIPTION
## TL;DR

Disabled installed apps now keep their unread event-bus facts, so enabling an app resumes from its frozen cursor without a reconcile pass or silent history loss. Version-change reconciliation stops at that cursor, while gap reconciliation stops immediately before the earliest retained fact, preserving everything still deliverable.

## Why

The shipped reconcile path had two halves of one contract pointing in opposite directions. Disabling an app released the global retention floor, while re-enabling inserted a reconcile request fenced at bus head. A history-accumulating app could therefore lose unread facts, then rebuild through a fence that also skipped facts which were still retained.

An installed app owns its consumer lane until uninstall. Its enabled bit pauses delivery; it does not abandon the lane.

## What changed

- Retention and compaction now include every installed app consumer in the cursor floor, enabled or disabled. A disabled orphan row still releases retention because no app registry entry serves it.
- Re-enable is a plain resume from the frozen cursor. The `re_enabled` reconcile cause and request insertion are gone from the store, SDK, runtime host, generated declaration, and tests.
- Version changes capture the app consumer cursor inside the same pointer transaction. Gap requests derive their fence as `earliest - 1`.
- Bus status and operator copy distinguish disabled ordinary consumers from disabled installed apps. Installed app lanes show as retention-floor holders, but deliberately do not use the enabled-consumer age alarm; the per-lane cap remains out until it has a measurement receipt.

The most useful review path is `internal/store/bus.go` for the installed-app floor, `internal/bus/bus.go` for matching compaction behavior, and `internal/store/apps.go` plus `internal/store/app_reconcile.go` for the two reconcile fences. The daemon witnesses in `internal/daemon/apps_test.go` cover delivery ordering across resume and version change.

## Manual verification

On an isolated profile, a disabled installed app held an old unread fact at seq 64 through a trim that otherwise removed expired rows. Uninstall removed its consumer, and the next trim removed that same fact.

With a retained fact at seq 40 and the app cursor frozen at 38, applying version 2 recorded `version_changed through=38`; enabling ran that reconcile and then delivered seq 40 under version 2. In a synthetic gap with earliest seq 59, the request recorded `gap through=58`, then delivered seq 59 after reconciliation.

## Out of scope

The per-lane retention cap stays out until real lane growth has been measured. This PR does not include slice 4+, crew work, or A5 exit work.
