### PR TITLE
feat(automode): attn config storage, CLI, and launch injection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -437,6 +437,12 @@ forgets that position and `--since <RFC3339>` replays from an instant.
   give-up parking, per-child log capture). Consumers name a child and hand over
   a start function; the package knows nothing about what it supervises. The
   plugin runtime is one consumer, the app runtime's sidecar is the other
+- `internal/automode`: pi auto mode's config value and the rules about what may
+  be written into it — the Go mirror of `plugins/attn-pi/automode/config.ts`,
+  and the JSON handed to a driver at launch. Storage is
+  `internal/store/automode.go`, whose `PromoteAutoModeProposal` is the ONLY way
+  a pattern or a model reaches the config; every CLI-reachable verb writes a
+  proposal instead
 - `internal/classifier`: stop-time state classification
 - `internal/transcript`: assistant-message extraction from JSONL
 - `app`: Tauri frontend; WebSocket `ws://localhost:9849`

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -258,7 +258,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '253';
+export const PROTOCOL_VERSION = '254';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentMsgMessage, AgentMsgResult, AgentMsgStatus, AgentPeekMessage, AgentPeekResult, AgentPeekScreen, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, AppApplyMessage, AppApplyResult, AppConsumerInfo, AppInvocationInfo, AppListMessage, AppListResult, AppLogsMessage, AppLogsResult, AppRemoveMessage, AppRemoveResult, AppRollbackMessage, AppRollbackResult, AppRuntimeInfo, AppRuntimeRestartMessage, AppRuntimeRestartResult, AppRuntimeStatusMessage, AppRuntimeStatusResult, AppSetEnabledMessage, AppSetEnabledResult, AppStallInfo, AppStatusMessage, AppStatusResult, AppSummary, AppVersionInfo, AppWatchMessage, AppWatchResult, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, BusConsumerStatus, BusHealthEntry, BusProducerStatus, BusSetConsumerEnabledMessage, BusSetConsumerEnabledResultMessage, BusStatusGetMessage, BusStatusResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, CrewDayClose, CrewHandoffMessage, CrewHandoffResult, CrewListMessage, CrewListResult, CrewMember, CrewPrimeMessage, CrewPrimeResult, CrewSetMessage, CrewSetResult, CrewSleepMessage, CrewSleepResult, CrewSleepResultMessage, CrewUpdatedMessage, CrewWakeMessage, CrewWakeResult, CrewWakeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocUndefineMessage, DocUndefineResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GardenSeedsUpdatedMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, OpenSentFilesMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyInputProbeResultMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Seed, SeedEdge, SeedLinkMessage, SeedLinkResult, SeedListMessage, SeedListResult, SeedNote, SeedNoteMessage, SeedNoteResult, SeedNotesMessage, SeedNotesResult, SeedPlantMessage, SeedPlantResult, SeedPlotChild, SeedPlotMessage, SeedPlotProgress, SeedPlotResult, SeedReadyMessage, SeedReadyResult, SeedRelation, SeedShowMessage, SeedShowResult, SeedTransitionMessage, SeedTransitionResult, SeedVar, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessageWindowStatus, SessionMessagesChangedMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketRow, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentMsgMessage, AgentMsgResult, AgentMsgStatus, AgentPeekMessage, AgentPeekResult, AgentPeekScreen, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, AppApplyMessage, AppApplyResult, AppConsumerInfo, AppInvocationInfo, AppListMessage, AppListResult, AppLogsMessage, AppLogsResult, AppRemoveMessage, AppRemoveResult, AppRollbackMessage, AppRollbackResult, AppRuntimeInfo, AppRuntimeRestartMessage, AppRuntimeRestartResult, AppRuntimeStatusMessage, AppRuntimeStatusResult, AppSetEnabledMessage, AppSetEnabledResult, AppStallInfo, AppStatusMessage, AppStatusResult, AppSummary, AppVersionInfo, AppWatchMessage, AppWatchResult, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutoModeConfigInfo, AutoModeDenialInfo, AutoModeDenialsMessage, AutoModeDenialsResult, AutoModeDiscardMessage, AutoModeDiscardResultMessage, AutoModeEnvAddMessage, AutoModeEnvRemoveMessage, AutoModeEnvResult, AutoModeGetMessage, AutoModePromoteMessage, AutoModePromoteResultMessage, AutoModeProposalInfo, AutoModeProposeMessage, AutoModeProposeResult, AutoModeShowMessage, AutoModeShowResult, AutoModeStateResultMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, BusConsumerStatus, BusHealthEntry, BusProducerStatus, BusSetConsumerEnabledMessage, BusSetConsumerEnabledResultMessage, BusStatusGetMessage, BusStatusResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, CrewDayClose, CrewHandoffMessage, CrewHandoffResult, CrewListMessage, CrewListResult, CrewMember, CrewPrimeMessage, CrewPrimeResult, CrewSetMessage, CrewSetResult, CrewSleepMessage, CrewSleepResult, CrewSleepResultMessage, CrewUpdatedMessage, CrewWakeMessage, CrewWakeResult, CrewWakeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocUndefineMessage, DocUndefineResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GardenSeedsUpdatedMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, OpenSentFilesMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyInputProbeResultMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Seed, SeedEdge, SeedLinkMessage, SeedLinkResult, SeedListMessage, SeedListResult, SeedNote, SeedNoteMessage, SeedNoteResult, SeedNotesMessage, SeedNotesResult, SeedPlantMessage, SeedPlantResult, SeedPlotChild, SeedPlotMessage, SeedPlotProgress, SeedPlotResult, SeedReadyMessage, SeedReadyResult, SeedRelation, SeedShowMessage, SeedShowResult, SeedTransitionMessage, SeedTransitionResult, SeedVar, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessageWindowStatus, SessionMessagesChangedMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketRow, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const activityStatusMessage = Convert.toActivityStatusMessage(json);
 //   const activityStatusResult = Convert.toActivityStatusResult(json);
@@ -53,6 +53,24 @@
 //   const attachSnapshot = Convert.toAttachSnapshot(json);
 //   const authorState = Convert.toAuthorState(json);
 //   const authorsUpdatedMessage = Convert.toAuthorsUpdatedMessage(json);
+//   const autoModeConfigInfo = Convert.toAutoModeConfigInfo(json);
+//   const autoModeDenialInfo = Convert.toAutoModeDenialInfo(json);
+//   const autoModeDenialsMessage = Convert.toAutoModeDenialsMessage(json);
+//   const autoModeDenialsResult = Convert.toAutoModeDenialsResult(json);
+//   const autoModeDiscardMessage = Convert.toAutoModeDiscardMessage(json);
+//   const autoModeDiscardResultMessage = Convert.toAutoModeDiscardResultMessage(json);
+//   const autoModeEnvAddMessage = Convert.toAutoModeEnvAddMessage(json);
+//   const autoModeEnvRemoveMessage = Convert.toAutoModeEnvRemoveMessage(json);
+//   const autoModeEnvResult = Convert.toAutoModeEnvResult(json);
+//   const autoModeGetMessage = Convert.toAutoModeGetMessage(json);
+//   const autoModePromoteMessage = Convert.toAutoModePromoteMessage(json);
+//   const autoModePromoteResultMessage = Convert.toAutoModePromoteResultMessage(json);
+//   const autoModeProposalInfo = Convert.toAutoModeProposalInfo(json);
+//   const autoModeProposeMessage = Convert.toAutoModeProposeMessage(json);
+//   const autoModeProposeResult = Convert.toAutoModeProposeResult(json);
+//   const autoModeShowMessage = Convert.toAutoModeShowMessage(json);
+//   const autoModeShowResult = Convert.toAutoModeShowResult(json);
+//   const autoModeStateResultMessage = Convert.toAutoModeStateResultMessage(json);
 //   const automationApplyMessage = Convert.toAutomationApplyMessage(json);
 //   const automationApplyResultMessage = Convert.toAutomationApplyResultMessage(json);
 //   const automationCleanupMessage = Convert.toAutomationCleanupMessage(json);
@@ -1197,6 +1215,217 @@ export interface AuthorElement {
 
 export enum AuthorsUpdatedMessageEvent {
     AuthorsUpdated = "authors_updated",
+}
+
+export interface AutoModeConfigInfo {
+    allow:            string[];
+    classifier_model: string;
+    enabled_default:  boolean;
+    environment:      string[];
+    escalation_model: string;
+    hard_deny:        string[];
+    [property: string]: any;
+}
+
+export interface AutoModeDenialInfo {
+    created_at: string;
+    id:         number;
+    reason:     string;
+    session_id: string;
+    signature:  string;
+    tool:       string;
+    [property: string]: any;
+}
+
+export interface AutoModeDenialsMessage {
+    cmd:    AutoModeDenialsMessageCmd;
+    limit?: number;
+    [property: string]: any;
+}
+
+export enum AutoModeDenialsMessageCmd {
+    AutomodeDenials = "automode_denials",
+}
+
+export interface AutoModeDenialsResult {
+    denials: DenialElement[];
+    [property: string]: any;
+}
+
+export interface DenialElement {
+    created_at: string;
+    id:         number;
+    reason:     string;
+    session_id: string;
+    signature:  string;
+    tool:       string;
+    [property: string]: any;
+}
+
+export interface AutoModeDiscardMessage {
+    cmd:        AutoModeDiscardMessageCmd;
+    id:         number;
+    request_id: string;
+    [property: string]: any;
+}
+
+export enum AutoModeDiscardMessageCmd {
+    AutomodeDiscard = "automode_discard",
+}
+
+export interface AutoModeDiscardResultMessage {
+    error?:     string;
+    event:      AutoModeDiscardResultMessageEvent;
+    proposal?:  Proposal;
+    request_id: string;
+    success:    boolean;
+    [property: string]: any;
+}
+
+export enum AutoModeDiscardResultMessageEvent {
+    AutomodeDiscardResult = "automode_discard_result",
+}
+
+export interface Proposal {
+    created_at:  string;
+    id:          number;
+    kind:        string;
+    proposed_by: string;
+    resolved_at: string;
+    state:       string;
+    target:      string;
+    value:       string;
+    [property: string]: any;
+}
+
+export interface AutoModeEnvAddMessage {
+    cmd:  AutoModeEnvAddMessageCmd;
+    text: string;
+    [property: string]: any;
+}
+
+export enum AutoModeEnvAddMessageCmd {
+    AutomodeEnvAdd = "automode_env_add",
+}
+
+export interface AutoModeEnvRemoveMessage {
+    cmd:   AutoModeEnvRemoveMessageCmd;
+    index: number;
+    [property: string]: any;
+}
+
+export enum AutoModeEnvRemoveMessageCmd {
+    AutomodeEnvRemove = "automode_env_remove",
+}
+
+export interface AutoModeEnvResult {
+    environment: string[];
+    [property: string]: any;
+}
+
+export interface AutoModeGetMessage {
+    cmd:        AutoModeGetMessageCmd;
+    request_id: string;
+    [property: string]: any;
+}
+
+export enum AutoModeGetMessageCmd {
+    AutomodeGet = "automode_get",
+}
+
+export interface AutoModePromoteMessage {
+    cmd:        AutoModePromoteMessageCmd;
+    id:         number;
+    request_id: string;
+    [property: string]: any;
+}
+
+export enum AutoModePromoteMessageCmd {
+    AutomodePromote = "automode_promote",
+}
+
+export interface AutoModePromoteResultMessage {
+    config?:    Config;
+    error?:     string;
+    event:      AutoModePromoteResultMessageEvent;
+    proposal?:  Proposal;
+    request_id: string;
+    success:    boolean;
+    [property: string]: any;
+}
+
+export interface Config {
+    allow:            string[];
+    classifier_model: string;
+    enabled_default:  boolean;
+    environment:      string[];
+    escalation_model: string;
+    hard_deny:        string[];
+    [property: string]: any;
+}
+
+export enum AutoModePromoteResultMessageEvent {
+    AutomodePromoteResult = "automode_promote_result",
+}
+
+export interface AutoModeProposalInfo {
+    created_at:  string;
+    id:          number;
+    kind:        string;
+    proposed_by: string;
+    resolved_at: string;
+    state:       string;
+    target:      string;
+    value:       string;
+    [property: string]: any;
+}
+
+export interface AutoModeProposeMessage {
+    cmd:          AutoModeProposeMessageCmd;
+    kind:         string;
+    proposed_by?: string;
+    target?:      string;
+    value:        string;
+    [property: string]: any;
+}
+
+export enum AutoModeProposeMessageCmd {
+    AutomodePropose = "automode_propose",
+}
+
+export interface AutoModeProposeResult {
+    proposal: Proposal;
+    [property: string]: any;
+}
+
+export interface AutoModeShowMessage {
+    cmd: AutoModeShowMessageCmd;
+    [property: string]: any;
+}
+
+export enum AutoModeShowMessageCmd {
+    AutomodeShow = "automode_show",
+}
+
+export interface AutoModeShowResult {
+    config:    Config;
+    proposals: Proposal[];
+    [property: string]: any;
+}
+
+export interface AutoModeStateResultMessage {
+    config:     Config;
+    denials:    DenialElement[];
+    error?:     string;
+    event:      AutoModeStateResultMessageEvent;
+    proposals:  Proposal[];
+    request_id: string;
+    success:    boolean;
+    [property: string]: any;
+}
+
+export enum AutoModeStateResultMessageEvent {
+    AutomodeStateResult = "automode_state_result",
 }
 
 export interface AutomationApplyMessage {
@@ -5366,6 +5595,10 @@ export interface Response {
     app_status_result?:                    AppStatusResultObject;
     app_watch_result?:                     AppWatchResultObject;
     authors?:                              AuthorElement[];
+    automode_denials_result?:              AutomodeDenialsResult;
+    automode_env_result?:                  AutomodeEnvResult;
+    automode_propose_result?:              AutomodeProposeResult;
+    automode_show_result?:                 AutomodeShowResult;
     crew_handoff_result?:                  CrewHandoffResultObject;
     crew_list_result?:                     CrewListResultObject;
     crew_prime_result?:                    CrewPrimeResultObject;
@@ -5540,6 +5773,27 @@ export interface AppStatusResultObject {
 
 export interface AppWatchResultObject {
     invocation: InvocationElement;
+    [property: string]: any;
+}
+
+export interface AutomodeDenialsResult {
+    denials: DenialElement[];
+    [property: string]: any;
+}
+
+export interface AutomodeEnvResult {
+    environment: string[];
+    [property: string]: any;
+}
+
+export interface AutomodeProposeResult {
+    proposal: Proposal;
+    [property: string]: any;
+}
+
+export interface AutomodeShowResult {
+    config:    Config;
+    proposals: Proposal[];
     [property: string]: any;
 }
 
@@ -8626,6 +8880,150 @@ export class Convert {
 
     public static authorsUpdatedMessageToJson(value: AuthorsUpdatedMessage): string {
         return JSON.stringify(uncast(value, r("AuthorsUpdatedMessage")), null, 2);
+    }
+
+    public static toAutoModeConfigInfo(json: string): AutoModeConfigInfo {
+        return cast(JSON.parse(json), r("AutoModeConfigInfo"));
+    }
+
+    public static autoModeConfigInfoToJson(value: AutoModeConfigInfo): string {
+        return JSON.stringify(uncast(value, r("AutoModeConfigInfo")), null, 2);
+    }
+
+    public static toAutoModeDenialInfo(json: string): AutoModeDenialInfo {
+        return cast(JSON.parse(json), r("AutoModeDenialInfo"));
+    }
+
+    public static autoModeDenialInfoToJson(value: AutoModeDenialInfo): string {
+        return JSON.stringify(uncast(value, r("AutoModeDenialInfo")), null, 2);
+    }
+
+    public static toAutoModeDenialsMessage(json: string): AutoModeDenialsMessage {
+        return cast(JSON.parse(json), r("AutoModeDenialsMessage"));
+    }
+
+    public static autoModeDenialsMessageToJson(value: AutoModeDenialsMessage): string {
+        return JSON.stringify(uncast(value, r("AutoModeDenialsMessage")), null, 2);
+    }
+
+    public static toAutoModeDenialsResult(json: string): AutoModeDenialsResult {
+        return cast(JSON.parse(json), r("AutoModeDenialsResult"));
+    }
+
+    public static autoModeDenialsResultToJson(value: AutoModeDenialsResult): string {
+        return JSON.stringify(uncast(value, r("AutoModeDenialsResult")), null, 2);
+    }
+
+    public static toAutoModeDiscardMessage(json: string): AutoModeDiscardMessage {
+        return cast(JSON.parse(json), r("AutoModeDiscardMessage"));
+    }
+
+    public static autoModeDiscardMessageToJson(value: AutoModeDiscardMessage): string {
+        return JSON.stringify(uncast(value, r("AutoModeDiscardMessage")), null, 2);
+    }
+
+    public static toAutoModeDiscardResultMessage(json: string): AutoModeDiscardResultMessage {
+        return cast(JSON.parse(json), r("AutoModeDiscardResultMessage"));
+    }
+
+    public static autoModeDiscardResultMessageToJson(value: AutoModeDiscardResultMessage): string {
+        return JSON.stringify(uncast(value, r("AutoModeDiscardResultMessage")), null, 2);
+    }
+
+    public static toAutoModeEnvAddMessage(json: string): AutoModeEnvAddMessage {
+        return cast(JSON.parse(json), r("AutoModeEnvAddMessage"));
+    }
+
+    public static autoModeEnvAddMessageToJson(value: AutoModeEnvAddMessage): string {
+        return JSON.stringify(uncast(value, r("AutoModeEnvAddMessage")), null, 2);
+    }
+
+    public static toAutoModeEnvRemoveMessage(json: string): AutoModeEnvRemoveMessage {
+        return cast(JSON.parse(json), r("AutoModeEnvRemoveMessage"));
+    }
+
+    public static autoModeEnvRemoveMessageToJson(value: AutoModeEnvRemoveMessage): string {
+        return JSON.stringify(uncast(value, r("AutoModeEnvRemoveMessage")), null, 2);
+    }
+
+    public static toAutoModeEnvResult(json: string): AutoModeEnvResult {
+        return cast(JSON.parse(json), r("AutoModeEnvResult"));
+    }
+
+    public static autoModeEnvResultToJson(value: AutoModeEnvResult): string {
+        return JSON.stringify(uncast(value, r("AutoModeEnvResult")), null, 2);
+    }
+
+    public static toAutoModeGetMessage(json: string): AutoModeGetMessage {
+        return cast(JSON.parse(json), r("AutoModeGetMessage"));
+    }
+
+    public static autoModeGetMessageToJson(value: AutoModeGetMessage): string {
+        return JSON.stringify(uncast(value, r("AutoModeGetMessage")), null, 2);
+    }
+
+    public static toAutoModePromoteMessage(json: string): AutoModePromoteMessage {
+        return cast(JSON.parse(json), r("AutoModePromoteMessage"));
+    }
+
+    public static autoModePromoteMessageToJson(value: AutoModePromoteMessage): string {
+        return JSON.stringify(uncast(value, r("AutoModePromoteMessage")), null, 2);
+    }
+
+    public static toAutoModePromoteResultMessage(json: string): AutoModePromoteResultMessage {
+        return cast(JSON.parse(json), r("AutoModePromoteResultMessage"));
+    }
+
+    public static autoModePromoteResultMessageToJson(value: AutoModePromoteResultMessage): string {
+        return JSON.stringify(uncast(value, r("AutoModePromoteResultMessage")), null, 2);
+    }
+
+    public static toAutoModeProposalInfo(json: string): AutoModeProposalInfo {
+        return cast(JSON.parse(json), r("AutoModeProposalInfo"));
+    }
+
+    public static autoModeProposalInfoToJson(value: AutoModeProposalInfo): string {
+        return JSON.stringify(uncast(value, r("AutoModeProposalInfo")), null, 2);
+    }
+
+    public static toAutoModeProposeMessage(json: string): AutoModeProposeMessage {
+        return cast(JSON.parse(json), r("AutoModeProposeMessage"));
+    }
+
+    public static autoModeProposeMessageToJson(value: AutoModeProposeMessage): string {
+        return JSON.stringify(uncast(value, r("AutoModeProposeMessage")), null, 2);
+    }
+
+    public static toAutoModeProposeResult(json: string): AutoModeProposeResult {
+        return cast(JSON.parse(json), r("AutoModeProposeResult"));
+    }
+
+    public static autoModeProposeResultToJson(value: AutoModeProposeResult): string {
+        return JSON.stringify(uncast(value, r("AutoModeProposeResult")), null, 2);
+    }
+
+    public static toAutoModeShowMessage(json: string): AutoModeShowMessage {
+        return cast(JSON.parse(json), r("AutoModeShowMessage"));
+    }
+
+    public static autoModeShowMessageToJson(value: AutoModeShowMessage): string {
+        return JSON.stringify(uncast(value, r("AutoModeShowMessage")), null, 2);
+    }
+
+    public static toAutoModeShowResult(json: string): AutoModeShowResult {
+        return cast(JSON.parse(json), r("AutoModeShowResult"));
+    }
+
+    public static autoModeShowResultToJson(value: AutoModeShowResult): string {
+        return JSON.stringify(uncast(value, r("AutoModeShowResult")), null, 2);
+    }
+
+    public static toAutoModeStateResultMessage(json: string): AutoModeStateResultMessage {
+        return cast(JSON.parse(json), r("AutoModeStateResultMessage"));
+    }
+
+    public static autoModeStateResultMessageToJson(value: AutoModeStateResultMessage): string {
+        return JSON.stringify(uncast(value, r("AutoModeStateResultMessage")), null, 2);
     }
 
     public static toAutomationApplyMessage(json: string): AutomationApplyMessage {
@@ -13133,6 +13531,131 @@ const typeMap: any = {
         { json: "author", js: "author", typ: "" },
         { json: "muted", js: "muted", typ: true },
     ], "any"),
+    "AutoModeConfigInfo": o([
+        { json: "allow", js: "allow", typ: a("") },
+        { json: "classifier_model", js: "classifier_model", typ: "" },
+        { json: "enabled_default", js: "enabled_default", typ: true },
+        { json: "environment", js: "environment", typ: a("") },
+        { json: "escalation_model", js: "escalation_model", typ: "" },
+        { json: "hard_deny", js: "hard_deny", typ: a("") },
+    ], "any"),
+    "AutoModeDenialInfo": o([
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "id", js: "id", typ: 0 },
+        { json: "reason", js: "reason", typ: "" },
+        { json: "session_id", js: "session_id", typ: "" },
+        { json: "signature", js: "signature", typ: "" },
+        { json: "tool", js: "tool", typ: "" },
+    ], "any"),
+    "AutoModeDenialsMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AutoModeDenialsMessageCmd") },
+        { json: "limit", js: "limit", typ: u(undefined, 0) },
+    ], "any"),
+    "AutoModeDenialsResult": o([
+        { json: "denials", js: "denials", typ: a(r("DenialElement")) },
+    ], "any"),
+    "DenialElement": o([
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "id", js: "id", typ: 0 },
+        { json: "reason", js: "reason", typ: "" },
+        { json: "session_id", js: "session_id", typ: "" },
+        { json: "signature", js: "signature", typ: "" },
+        { json: "tool", js: "tool", typ: "" },
+    ], "any"),
+    "AutoModeDiscardMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AutoModeDiscardMessageCmd") },
+        { json: "id", js: "id", typ: 0 },
+        { json: "request_id", js: "request_id", typ: "" },
+    ], "any"),
+    "AutoModeDiscardResultMessage": o([
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("AutoModeDiscardResultMessageEvent") },
+        { json: "proposal", js: "proposal", typ: u(undefined, r("Proposal")) },
+        { json: "request_id", js: "request_id", typ: "" },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
+    "Proposal": o([
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "id", js: "id", typ: 0 },
+        { json: "kind", js: "kind", typ: "" },
+        { json: "proposed_by", js: "proposed_by", typ: "" },
+        { json: "resolved_at", js: "resolved_at", typ: "" },
+        { json: "state", js: "state", typ: "" },
+        { json: "target", js: "target", typ: "" },
+        { json: "value", js: "value", typ: "" },
+    ], "any"),
+    "AutoModeEnvAddMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AutoModeEnvAddMessageCmd") },
+        { json: "text", js: "text", typ: "" },
+    ], "any"),
+    "AutoModeEnvRemoveMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AutoModeEnvRemoveMessageCmd") },
+        { json: "index", js: "index", typ: 0 },
+    ], "any"),
+    "AutoModeEnvResult": o([
+        { json: "environment", js: "environment", typ: a("") },
+    ], "any"),
+    "AutoModeGetMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AutoModeGetMessageCmd") },
+        { json: "request_id", js: "request_id", typ: "" },
+    ], "any"),
+    "AutoModePromoteMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AutoModePromoteMessageCmd") },
+        { json: "id", js: "id", typ: 0 },
+        { json: "request_id", js: "request_id", typ: "" },
+    ], "any"),
+    "AutoModePromoteResultMessage": o([
+        { json: "config", js: "config", typ: u(undefined, r("Config")) },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("AutoModePromoteResultMessageEvent") },
+        { json: "proposal", js: "proposal", typ: u(undefined, r("Proposal")) },
+        { json: "request_id", js: "request_id", typ: "" },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
+    "Config": o([
+        { json: "allow", js: "allow", typ: a("") },
+        { json: "classifier_model", js: "classifier_model", typ: "" },
+        { json: "enabled_default", js: "enabled_default", typ: true },
+        { json: "environment", js: "environment", typ: a("") },
+        { json: "escalation_model", js: "escalation_model", typ: "" },
+        { json: "hard_deny", js: "hard_deny", typ: a("") },
+    ], "any"),
+    "AutoModeProposalInfo": o([
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "id", js: "id", typ: 0 },
+        { json: "kind", js: "kind", typ: "" },
+        { json: "proposed_by", js: "proposed_by", typ: "" },
+        { json: "resolved_at", js: "resolved_at", typ: "" },
+        { json: "state", js: "state", typ: "" },
+        { json: "target", js: "target", typ: "" },
+        { json: "value", js: "value", typ: "" },
+    ], "any"),
+    "AutoModeProposeMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AutoModeProposeMessageCmd") },
+        { json: "kind", js: "kind", typ: "" },
+        { json: "proposed_by", js: "proposed_by", typ: u(undefined, "") },
+        { json: "target", js: "target", typ: u(undefined, "") },
+        { json: "value", js: "value", typ: "" },
+    ], "any"),
+    "AutoModeProposeResult": o([
+        { json: "proposal", js: "proposal", typ: r("Proposal") },
+    ], "any"),
+    "AutoModeShowMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AutoModeShowMessageCmd") },
+    ], "any"),
+    "AutoModeShowResult": o([
+        { json: "config", js: "config", typ: r("Config") },
+        { json: "proposals", js: "proposals", typ: a(r("Proposal")) },
+    ], "any"),
+    "AutoModeStateResultMessage": o([
+        { json: "config", js: "config", typ: r("Config") },
+        { json: "denials", js: "denials", typ: a(r("DenialElement")) },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("AutoModeStateResultMessageEvent") },
+        { json: "proposals", js: "proposals", typ: a(r("Proposal")) },
+        { json: "request_id", js: "request_id", typ: "" },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
     "AutomationApplyMessage": o([
         { json: "cmd", js: "cmd", typ: r("AutomationApplyMessageCmd") },
         { json: "definition_yaml", js: "definition_yaml", typ: "" },
@@ -15624,6 +16147,10 @@ const typeMap: any = {
         { json: "app_status_result", js: "app_status_result", typ: u(undefined, r("AppStatusResultObject")) },
         { json: "app_watch_result", js: "app_watch_result", typ: u(undefined, r("AppWatchResultObject")) },
         { json: "authors", js: "authors", typ: u(undefined, a(r("AuthorElement"))) },
+        { json: "automode_denials_result", js: "automode_denials_result", typ: u(undefined, r("AutomodeDenialsResult")) },
+        { json: "automode_env_result", js: "automode_env_result", typ: u(undefined, r("AutomodeEnvResult")) },
+        { json: "automode_propose_result", js: "automode_propose_result", typ: u(undefined, r("AutomodeProposeResult")) },
+        { json: "automode_show_result", js: "automode_show_result", typ: u(undefined, r("AutomodeShowResult")) },
         { json: "crew_handoff_result", js: "crew_handoff_result", typ: u(undefined, r("CrewHandoffResultObject")) },
         { json: "crew_list_result", js: "crew_list_result", typ: u(undefined, r("CrewListResultObject")) },
         { json: "crew_prime_result", js: "crew_prime_result", typ: u(undefined, r("CrewPrimeResultObject")) },
@@ -15772,6 +16299,19 @@ const typeMap: any = {
     ], "any"),
     "AppWatchResultObject": o([
         { json: "invocation", js: "invocation", typ: r("InvocationElement") },
+    ], "any"),
+    "AutomodeDenialsResult": o([
+        { json: "denials", js: "denials", typ: a(r("DenialElement")) },
+    ], "any"),
+    "AutomodeEnvResult": o([
+        { json: "environment", js: "environment", typ: a("") },
+    ], "any"),
+    "AutomodeProposeResult": o([
+        { json: "proposal", js: "proposal", typ: r("Proposal") },
+    ], "any"),
+    "AutomodeShowResult": o([
+        { json: "config", js: "config", typ: r("Config") },
+        { json: "proposals", js: "proposals", typ: a(r("Proposal")) },
     ], "any"),
     "CrewHandoffResultObject": o([
         { json: "member", js: "member", typ: "" },
@@ -17503,6 +18043,39 @@ const typeMap: any = {
     ],
     "AuthorsUpdatedMessageEvent": [
         "authors_updated",
+    ],
+    "AutoModeDenialsMessageCmd": [
+        "automode_denials",
+    ],
+    "AutoModeDiscardMessageCmd": [
+        "automode_discard",
+    ],
+    "AutoModeDiscardResultMessageEvent": [
+        "automode_discard_result",
+    ],
+    "AutoModeEnvAddMessageCmd": [
+        "automode_env_add",
+    ],
+    "AutoModeEnvRemoveMessageCmd": [
+        "automode_env_remove",
+    ],
+    "AutoModeGetMessageCmd": [
+        "automode_get",
+    ],
+    "AutoModePromoteMessageCmd": [
+        "automode_promote",
+    ],
+    "AutoModePromoteResultMessageEvent": [
+        "automode_promote_result",
+    ],
+    "AutoModeProposeMessageCmd": [
+        "automode_propose",
+    ],
+    "AutoModeShowMessageCmd": [
+        "automode_show",
+    ],
+    "AutoModeStateResultMessageEvent": [
+        "automode_state_result",
     ],
     "AutomationApplyMessageCmd": [
         "automation_apply",

--- a/changelog.d/automode-config-cli.yaml
+++ b/changelog.d/automode-config-cli.yaml
@@ -1,0 +1,10 @@
+kind: added
+area: cli
+change: >
+  `attn automode` configures pi's auto mode: `show` reads the effective
+  policy, `env add`/`env remove` edit the prose the classifier reads about
+  this machine, `denials` lists refused calls, and `allow`, `deny` and
+  `model` record a proposal for review. Those three deliberately change
+  nothing on their own — a proposal only takes effect once a human promotes
+  it in the attn app, so an agent cannot write its own permissions. A pi
+  session is handed the promoted config when it launches.

--- a/cmd/attn/automode.go
+++ b/cmd/attn/automode.go
@@ -1,0 +1,345 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/victorarias/attn/internal/automode"
+	"github.com/victorarias/attn/internal/client"
+	"github.com/victorarias/attn/internal/config"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// `attn automode` is auto mode's operator and agent surface: pi's permission
+// system, configured from attn. Design:
+// docs/plans/2026-08-16-pi-auto-mode.md.
+//
+// This CLI proposes; it never promotes. `allow`, `deny` and `model` record a
+// proposal a human reviews in the app, and every one of them says so on the way
+// out — an agent that read "recorded" and inferred "in force" would keep running
+// into the same denial. There is no promote verb here, and adding one would undo
+// the design: the app is the only place a policy change becomes real.
+
+func runAutoMode() {
+	if len(os.Args) < 3 || os.Args[2] == "-h" || os.Args[2] == "--help" {
+		writeAutoModeHelp(os.Stdout)
+		return
+	}
+	args := os.Args[3:]
+	switch os.Args[2] {
+	case "show":
+		runAutoModeShow(args)
+	case "env":
+		runAutoModeEnv(args)
+	case "allow":
+		runAutoModePropose("allow", automode.KindAllow, "", args)
+	case "deny":
+		runAutoModePropose("deny", automode.KindDeny, "", args)
+	case "model":
+		runAutoModeModel(args)
+	case "denials":
+		runAutoModeDenials(args)
+	default:
+		fmt.Fprintf(os.Stderr, "automode: unknown command %q\n", os.Args[2])
+		writeAutoModeHelp(os.Stderr)
+		os.Exit(2)
+	}
+}
+
+func writeAutoModeHelp(w io.Writer) {
+	fmt.Fprint(w, `usage: attn automode <command>
+
+pi's auto mode: a static safety envelope plus a classifier for everything that
+reaches past it. This CLI proposes changes; only the attn app promotes one.
+
+commands:
+  show                              effective config and pending proposals
+  env                               list the classifier's environment prose
+  env add <text>                    add one prose entry
+  env remove <index>                remove the entry at <index> (see env)
+  allow <pattern>                   propose an allow entry
+  deny <pattern>                    propose a hard-deny entry
+  model classifier <provider/id>    propose the layer-2a model
+  model escalation <provider/id>    propose the layer-2b model
+  denials [--limit <n>]             recent denials, newest first
+
+Every command takes --json.
+
+allow, deny and model RECORD A PROPOSAL. Nothing they write changes what a
+session runs under until a human promotes it in the app. A broad allow pattern —
+one with no literal characters left after the wildcards — is refused outright.
+
+Environment prose is a direct edit: it is what the classifier reads about this
+machine, not a rule that skips it.
+`)
+}
+
+func autoModeClient() *client.Client {
+	return client.New(config.SocketPath())
+}
+
+func autoModeFail(verb string, err error) {
+	fmt.Fprintf(os.Stderr, "automode %s: %v\n", verb, err)
+	os.Exit(1)
+}
+
+func runAutoModeShow(args []string) {
+	asJSON := hasFlag(args, "--json")
+	result, err := autoModeClient().AutoModeShow()
+	if err != nil {
+		autoModeFail("show", err)
+	}
+	if result == nil {
+		autoModeFail("show", fmt.Errorf("daemon returned no result"))
+	}
+	if asJSON {
+		writeJSON(result)
+		return
+	}
+	cfg := result.Config
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(w, "enabled by default\t%t\n", cfg.EnabledDefault)
+	fmt.Fprintf(w, "classifier model\t%s\n", cfg.ClassifierModel)
+	fmt.Fprintf(w, "escalation model\t%s\n", cfg.EscalationModel)
+	w.Flush()
+	printAutoModeList("environment", cfg.Environment)
+	printAutoModeList("allow", cfg.Allow)
+	printAutoModeList("hard deny", cfg.HardDeny)
+	if len(result.Proposals) == 0 {
+		fmt.Println("\npending proposals: none")
+		return
+	}
+	fmt.Printf("\npending proposals (promote them in the attn app):\n")
+	pw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	for _, p := range result.Proposals {
+		fmt.Fprintf(pw, "  %d\t%s\t%s\t%s\n", p.ID, p.Kind, autoModeProposalSubject(p), p.CreatedAt)
+	}
+	pw.Flush()
+}
+
+func printAutoModeList(label string, values []string) {
+	if len(values) == 0 {
+		fmt.Printf("\n%s: none\n", label)
+		return
+	}
+	fmt.Printf("\n%s:\n", label)
+	for i, value := range values {
+		fmt.Printf("  %d  %s\n", i, value)
+	}
+}
+
+func autoModeProposalSubject(p protocol.AutoModeProposalInfo) string {
+	if p.Target != "" {
+		return p.Target + " " + p.Value
+	}
+	return p.Value
+}
+
+func runAutoModeEnv(args []string) {
+	if len(args) == 0 || strings.HasPrefix(args[0], "--") {
+		runAutoModeEnvList(args)
+		return
+	}
+	switch args[0] {
+	case "add":
+		runAutoModeEnvAdd(args[1:])
+	case "remove":
+		runAutoModeEnvRemove(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "automode env: unknown command %q (want add or remove)\n", args[0])
+		os.Exit(2)
+	}
+}
+
+func runAutoModeEnvList(args []string) {
+	asJSON := hasFlag(args, "--json")
+	result, err := autoModeClient().AutoModeShow()
+	if err != nil {
+		autoModeFail("env", err)
+	}
+	if result == nil {
+		autoModeFail("env", fmt.Errorf("daemon returned no result"))
+	}
+	if asJSON {
+		writeJSON(protocol.AutoModeEnvResult{Environment: result.Config.Environment})
+		return
+	}
+	if len(result.Config.Environment) == 0 {
+		fmt.Println("no environment entries")
+		return
+	}
+	for i, entry := range result.Config.Environment {
+		fmt.Printf("%d  %s\n", i, entry)
+	}
+}
+
+func runAutoModeEnvAdd(args []string) {
+	asJSON := hasFlag(args, "--json")
+	text := strings.TrimSpace(strings.Join(stripFlags(args), " "))
+	if text == "" {
+		fmt.Fprintln(os.Stderr, "automode env add: needs the prose to add")
+		os.Exit(2)
+	}
+	result, err := autoModeClient().AutoModeEnvAdd(text)
+	if err != nil {
+		autoModeFail("env add", err)
+	}
+	printAutoModeEnvResult(result, asJSON)
+}
+
+func runAutoModeEnvRemove(args []string) {
+	asJSON := hasFlag(args, "--json")
+	rest := stripFlags(args)
+	if len(rest) != 1 {
+		fmt.Fprintln(os.Stderr, "automode env remove: needs one index (see `attn automode env`)")
+		os.Exit(2)
+	}
+	index, err := strconv.Atoi(rest[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "automode env remove: %q is not an index\n", rest[0])
+		os.Exit(2)
+	}
+	result, err := autoModeClient().AutoModeEnvRemove(index)
+	if err != nil {
+		autoModeFail("env remove", err)
+	}
+	printAutoModeEnvResult(result, asJSON)
+}
+
+func printAutoModeEnvResult(result *protocol.AutoModeEnvResult, asJSON bool) {
+	if result == nil {
+		autoModeFail("env", fmt.Errorf("daemon returned no result"))
+	}
+	if asJSON {
+		writeJSON(result)
+		return
+	}
+	if len(result.Environment) == 0 {
+		fmt.Println("no environment entries")
+		return
+	}
+	for i, entry := range result.Environment {
+		fmt.Printf("%d  %s\n", i, entry)
+	}
+}
+
+func runAutoModeModel(args []string) {
+	rest := stripFlags(args)
+	if len(rest) < 1 {
+		fmt.Fprintln(os.Stderr, "automode model: needs classifier or escalation")
+		os.Exit(2)
+	}
+	target := rest[0]
+	if target != automode.TargetClassifier && target != automode.TargetEscalation {
+		fmt.Fprintf(os.Stderr, "automode model: target must be %s or %s, got %q\n",
+			automode.TargetClassifier, automode.TargetEscalation, target)
+		os.Exit(2)
+	}
+	proposeAutoMode("model "+target, automode.KindModel, target, rest[1:], hasFlag(args, "--json"))
+}
+
+func runAutoModePropose(verb, kind, target string, args []string) {
+	proposeAutoMode(verb, kind, target, stripFlags(args), hasFlag(args, "--json"))
+}
+
+func proposeAutoMode(verb, kind, target string, rest []string, asJSON bool) {
+	value := strings.TrimSpace(strings.Join(rest, " "))
+	if value == "" {
+		fmt.Fprintf(os.Stderr, "automode %s: needs a value\n", verb)
+		os.Exit(2)
+	}
+	result, err := autoModeClient().AutoModePropose(kind, target, value, autoModeProposer())
+	if err != nil {
+		autoModeFail(verb, err)
+	}
+	if result == nil {
+		autoModeFail(verb, fmt.Errorf("daemon returned no result"))
+	}
+	if asJSON {
+		writeJSON(result)
+		return
+	}
+	fmt.Printf("recorded proposal %d: %s %s\n", result.Proposal.ID, result.Proposal.Kind,
+		autoModeProposalSubject(result.Proposal))
+	fmt.Println("This changed nothing yet. Promote it in the attn app to put it in force.")
+}
+
+// autoModeProposer records who asked, when the caller is an attn session. It is
+// attribution for the human reviewing the list, not authorization: a proposal
+// from anyone is equally inert.
+func autoModeProposer() string {
+	return strings.TrimSpace(os.Getenv("ATTN_SESSION_ID"))
+}
+
+func runAutoModeDenials(args []string) {
+	asJSON := hasFlag(args, "--json")
+	limit := 0
+	rest := stripFlags(args)
+	if value, ok := takeStringFlag(args, "--limit"); ok {
+		parsed, err := strconv.Atoi(value)
+		if err != nil || parsed <= 0 {
+			fmt.Fprintf(os.Stderr, "automode denials: --limit wants a positive number, got %q\n", value)
+			os.Exit(2)
+		}
+		limit = parsed
+	}
+	if len(rest) > 0 {
+		fmt.Fprintf(os.Stderr, "automode denials: unexpected argument %q\n", rest[0])
+		os.Exit(2)
+	}
+	result, err := autoModeClient().AutoModeDenials(limit)
+	if err != nil {
+		autoModeFail("denials", err)
+	}
+	if result == nil {
+		autoModeFail("denials", fmt.Errorf("daemon returned no result"))
+	}
+	if asJSON {
+		writeJSON(result)
+		return
+	}
+	if len(result.Denials) == 0 {
+		fmt.Println("no denials recorded")
+		return
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	for _, denial := range result.Denials {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", denial.CreatedAt, denial.SessionID, denial.Signature, denial.Reason)
+	}
+	w.Flush()
+}
+
+// stripFlags drops every --flag and its value from a positional argument list.
+func stripFlags(args []string) []string {
+	out := []string{}
+	for i := 0; i < len(args); i++ {
+		if !strings.HasPrefix(args[i], "--") {
+			out = append(out, args[i])
+			continue
+		}
+		if autoModeFlagTakesValue(args[i]) && i+1 < len(args) {
+			i++
+		}
+	}
+	return out
+}
+
+func takeStringFlag(args []string, flag string) (string, bool) {
+	for i, arg := range args {
+		if arg == flag && i+1 < len(args) {
+			return args[i+1], true
+		}
+		if strings.HasPrefix(arg, flag+"=") {
+			return strings.TrimPrefix(arg, flag+"="), true
+		}
+	}
+	return "", false
+}
+
+func autoModeFlagTakesValue(flag string) bool {
+	return flag == "--limit"
+}

--- a/cmd/attn/automode_test.go
+++ b/cmd/attn/automode_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The pattern an agent types is the whole payload, and it routinely contains
+// spaces and wildcards. These pin that flags never eat part of it.
+
+func TestAutoModeStripFlagsKeepsThePattern(t *testing.T) {
+	cases := []struct {
+		args []string
+		want string
+	}{
+		{[]string{"git", "push", "origin*"}, "git push origin*"},
+		{[]string{"--json", "git", "push", "origin*"}, "git push origin*"},
+		{[]string{"git", "push", "origin*", "--json"}, "git push origin*"},
+	}
+	for _, tc := range cases {
+		got := strings.Join(stripFlags(tc.args), " ")
+		if got != tc.want {
+			t.Errorf("stripFlags(%v) = %q, want %q", tc.args, got, tc.want)
+		}
+	}
+}
+
+// --limit takes a value, so its argument must not survive as a positional and
+// be read as part of a pattern.
+func TestAutoModeStripFlagsDropsAValuedFlagsArgument(t *testing.T) {
+	if got := stripFlags([]string{"--limit", "5"}); len(got) != 0 {
+		t.Fatalf("stripFlags dropped %v, want nothing left", got)
+	}
+	if got := stripFlags([]string{"--limit=5", "extra"}); len(got) != 1 || got[0] != "extra" {
+		t.Fatalf("stripFlags = %v, want only the positional", got)
+	}
+}
+
+func TestAutoModeTakeStringFlagReadsBothForms(t *testing.T) {
+	for _, args := range [][]string{{"--limit", "5"}, {"--limit=5"}} {
+		value, ok := takeStringFlag(args, "--limit")
+		if !ok || value != "5" {
+			t.Errorf("takeStringFlag(%v) = %q ok=%t", args, value, ok)
+		}
+	}
+	if _, ok := takeStringFlag([]string{"--json"}, "--limit"); ok {
+		t.Error("takeStringFlag found a flag that is not there")
+	}
+}

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -264,6 +264,9 @@ func main() {
 	case "app":
 		maybePrintProfileBanner()
 		runApp()
+	case "automode":
+		maybePrintProfileBanner()
+		runAutoMode()
 	case "journal":
 		maybePrintProfileBanner()
 		runJournal()

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -815,3 +815,28 @@ conversation agent unchanged — and say **pi** for the engine underneath. On th
 wire and in the CLI the agent is `nisse` (`attn delegate --agent nisse`); its
 launch environment is the `ATTN_NISSE_*` block; the plugin that registers it is
 `plugins/attn-pi`, which also registers the PTY-backed `pi` agent.
+
+## Auto mode, proposals, and promotion
+
+**Auto mode** is pi's permission system: a static safety envelope (work inside
+the session's working directory runs free), a classifier for everything that
+reaches past it, and denials the agent answers conversationally rather than
+through a dialog. Design:
+[docs/plans/2026-08-16-pi-auto-mode.md](plans/2026-08-16-pi-auto-mode.md).
+
+Its **config** is daemon-owned and global: the environment prose the classifier
+reads about this machine, the allow and hard-deny patterns, the classifier and
+escalation models, and whether attn sessions start with auto mode on. A pi
+session is handed the config it launches with; changing it reaches the next
+session, not the running one.
+
+A **proposal** is a requested change to that config — an allow pattern, a hard
+deny, or a model — recorded and inert. **Promotion** is a human applying one in
+the attn app, and it is the only thing that changes what a session runs under.
+The asymmetry is the point: `attn automode allow …` is reachable by any agent
+and only ever proposes, while promotion has no CLI at all. An agent must not be
+able to write its own leash.
+
+Environment prose is the exception: `attn automode env add` edits it directly,
+because it describes the machine to the classifier rather than naming a rule
+that skips it.

--- a/internal/automode/automode.go
+++ b/internal/automode/automode.go
@@ -1,0 +1,133 @@
+// Package automode is attn's half of pi's auto mode: the config value the
+// pi-side decision tree is evaluated against, and the rules about what may be
+// written into it.
+//
+// It is the Go mirror of plugins/attn-pi/automode/config.ts, and the JSON tags
+// here ARE that file's `RawAutoModeConfig` — a Config marshalled by this package
+// is what `loadAutoModeConfig` parses on the other side. The two must stay in
+// lockstep; a field renamed here without renaming it there silently drops to the
+// pi-side default.
+//
+// Design: docs/plans/2026-08-16-pi-auto-mode.md.
+package automode
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Defaults from the classifier receipt in the plan doc. They are settings, not
+// pins: a stored empty model means "whichever default ships", so changing these
+// reaches every user who never picked one.
+const (
+	DefaultClassifierModel = "opencode-go/glm-5.3"
+	DefaultEscalationModel = "opencode-go/qwen3.8-max"
+)
+
+// Config is auto mode's promoted policy — what a session actually launches
+// with. Everything in it has been through the app; a proposal is not part of it
+// until a human promotes one.
+type Config struct {
+	// Whether an attn session starts with auto mode on.
+	EnabledDefault bool `json:"enabled_default"`
+	// Prose the classifier reads to learn what this machine may do.
+	Environment []string `json:"environment"`
+	// Narrow patterns that skip the classifier and run.
+	Allow []string `json:"allow"`
+	// Patterns refused before anything else looks at the call.
+	HardDeny []string `json:"hard_deny"`
+	// Layer 2a, and layer 2b for what 2a cannot decide. Always resolved: a
+	// caller never has to know what the built-in default is.
+	ClassifierModel string `json:"classifier_model"`
+	EscalationModel string `json:"escalation_model"`
+}
+
+// Defaults is the config a machine that has never been configured runs on.
+func Defaults() Config {
+	return Config{
+		EnabledDefault:  true,
+		Environment:     []string{},
+		Allow:           []string{},
+		HardDeny:        []string{},
+		ClassifierModel: DefaultClassifierModel,
+		EscalationModel: DefaultEscalationModel,
+	}
+}
+
+// Proposal kinds and model targets. A proposal names one change; promotion in
+// the app is what applies it.
+const (
+	KindAllow = "allow"
+	KindDeny  = "deny"
+	KindModel = "model"
+
+	TargetClassifier = "classifier"
+	TargetEscalation = "escalation"
+
+	StatePending   = "pending"
+	StatePromoted  = "promoted"
+	StateDiscarded = "discarded"
+)
+
+// IsBroadPattern reports whether a pattern names nothing: with the wildcards and
+// whitespace removed there is no literal left, so it matches every call it is
+// asked about. Mirrors isBroadPattern in config.ts.
+func IsBroadPattern(pattern string) bool {
+	stripped := strings.Map(func(r rune) rune {
+		switch r {
+		case '*', '?', ' ', '\t', '\n', '\r':
+			return -1
+		}
+		return r
+	}, pattern)
+	return stripped == ""
+}
+
+// ValidateAllowPattern refuses an allow entry that names nothing. Only allow is
+// checked: a broad hard-deny refuses everything, which is safe, while a broad
+// allow is the leash removing itself.
+func ValidateAllowPattern(pattern string) error {
+	if strings.TrimSpace(pattern) == "" {
+		return fmt.Errorf("allow pattern is empty")
+	}
+	if IsBroadPattern(pattern) {
+		return fmt.Errorf(
+			"broad allow pattern %q is refused: an allow entry must name something. "+
+				"A blanket allow is what the classifier exists to replace", pattern)
+	}
+	return nil
+}
+
+// ValidateProposal checks one proposed change before it is recorded. Refusing at
+// submission is what keeps an unpromotable entry out of the app's review list.
+func ValidateProposal(kind, target, value string) error {
+	value = strings.TrimSpace(value)
+	switch kind {
+	case KindAllow:
+		if target != "" {
+			return fmt.Errorf("an %s proposal takes no target", kind)
+		}
+		return ValidateAllowPattern(value)
+	case KindDeny:
+		if target != "" {
+			return fmt.Errorf("a %s proposal takes no target", kind)
+		}
+		if value == "" {
+			return fmt.Errorf("deny pattern is empty")
+		}
+		return nil
+	case KindModel:
+		if target != TargetClassifier && target != TargetEscalation {
+			return fmt.Errorf("model target must be %q or %q, got %q", TargetClassifier, TargetEscalation, target)
+		}
+		if value == "" {
+			return fmt.Errorf("model id is empty")
+		}
+		if !strings.Contains(value, "/") {
+			return fmt.Errorf("model %q is not a provider/id pair", value)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown proposal kind %q (want %s, %s or %s)", kind, KindAllow, KindDeny, KindModel)
+	}
+}

--- a/internal/automode/automode_test.go
+++ b/internal/automode/automode_test.go
@@ -1,0 +1,88 @@
+package automode
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestIsBroadPatternMatchesTheTypeScriptRule(t *testing.T) {
+	broad := []string{"*", "**", "?", " * ", "* ?", "", "\t*"}
+	for _, pattern := range broad {
+		if !IsBroadPattern(pattern) {
+			t.Errorf("IsBroadPattern(%q) = false, want true", pattern)
+		}
+	}
+	narrow := []string{"git push*", "rm -rf /*", "bash curl*", "a", "*.sh"}
+	for _, pattern := range narrow {
+		if IsBroadPattern(pattern) {
+			t.Errorf("IsBroadPattern(%q) = true, want false", pattern)
+		}
+	}
+}
+
+func TestValidateProposalRefusesABroadAllow(t *testing.T) {
+	err := ValidateProposal(KindAllow, "", "*")
+	if err == nil {
+		t.Fatal("a broad allow pattern was accepted")
+	}
+	if !strings.Contains(err.Error(), "broad allow pattern") {
+		t.Fatalf("error does not name the limit: %v", err)
+	}
+}
+
+// A blanket hard-deny refuses everything, which is the safe direction — only
+// allow is guarded.
+func TestValidateProposalAcceptsABroadDeny(t *testing.T) {
+	if err := ValidateProposal(KindDeny, "", "*"); err != nil {
+		t.Fatalf("broad deny refused: %v", err)
+	}
+}
+
+func TestValidateProposalChecksModelShape(t *testing.T) {
+	if err := ValidateProposal(KindModel, TargetClassifier, "opencode-go/glm-5.3"); err != nil {
+		t.Fatalf("valid model refused: %v", err)
+	}
+	for _, tc := range []struct{ target, value string }{
+		{"", "opencode-go/glm-5.3"},
+		{"main", "opencode-go/glm-5.3"},
+		{TargetClassifier, "glm-5.3"},
+		{TargetEscalation, ""},
+	} {
+		if err := ValidateProposal(KindModel, tc.target, tc.value); err == nil {
+			t.Errorf("ValidateProposal(model, %q, %q) was accepted", tc.target, tc.value)
+		}
+	}
+}
+
+func TestValidateProposalRejectsUnknownKinds(t *testing.T) {
+	if err := ValidateProposal("promote", "", "anything"); err == nil {
+		t.Fatal("unknown proposal kind was accepted")
+	}
+}
+
+// The JSON here IS plugins/attn-pi/automode/config.ts's RawAutoModeConfig. A
+// field renamed on one side without the other silently drops to the pi-side
+// default, so the names are pinned by a test rather than by memory.
+func TestConfigMarshalsIntoThePiSideShape(t *testing.T) {
+	raw, err := json.Marshal(Defaults())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	want := []string{
+		"enabled_default", "environment", "allow", "hard_deny",
+		"classifier_model", "escalation_model",
+	}
+	if len(fields) != len(want) {
+		t.Fatalf("config has %d fields, want exactly %d: %s", len(fields), len(want), raw)
+	}
+	for _, name := range want {
+		if _, ok := fields[name]; !ok {
+			t.Errorf("config is missing %q: %s", name, raw)
+		}
+	}
+}

--- a/internal/client/automode.go
+++ b/internal/client/automode.go
@@ -1,0 +1,60 @@
+package client
+
+import "github.com/victorarias/attn/internal/protocol"
+
+// Auto mode's client surface — the propose-only half. There is no Promote here
+// and there will not be one: promotion is a WebSocket command the app sends,
+// because a human in the app is the trust boundary a CLI caller cannot fake.
+
+func (c *Client) AutoModeShow() (*protocol.AutoModeShowResult, error) {
+	resp, err := c.send(protocol.AutoModeShowMessage{Cmd: protocol.CmdAutoModeShow})
+	if err != nil {
+		return nil, err
+	}
+	return resp.AutomodeShowResult, nil
+}
+
+func (c *Client) AutoModeEnvAdd(text string) (*protocol.AutoModeEnvResult, error) {
+	resp, err := c.send(protocol.AutoModeEnvAddMessage{Cmd: protocol.CmdAutoModeEnvAdd, Text: text})
+	if err != nil {
+		return nil, err
+	}
+	return resp.AutomodeEnvResult, nil
+}
+
+func (c *Client) AutoModeEnvRemove(index int) (*protocol.AutoModeEnvResult, error) {
+	resp, err := c.send(protocol.AutoModeEnvRemoveMessage{Cmd: protocol.CmdAutoModeEnvRemove, Index: index})
+	if err != nil {
+		return nil, err
+	}
+	return resp.AutomodeEnvResult, nil
+}
+
+// AutoModePropose records a proposed change. It never changes what a session
+// launches with; the result carries the proposal id a human promotes in the app.
+func (c *Client) AutoModePropose(kind, target, value, proposedBy string) (*protocol.AutoModeProposeResult, error) {
+	msg := protocol.AutoModeProposeMessage{Cmd: protocol.CmdAutoModePropose, Kind: kind, Value: value}
+	if target != "" {
+		msg.Target = protocol.Ptr(target)
+	}
+	if proposedBy != "" {
+		msg.ProposedBy = protocol.Ptr(proposedBy)
+	}
+	resp, err := c.send(msg)
+	if err != nil {
+		return nil, err
+	}
+	return resp.AutomodeProposeResult, nil
+}
+
+func (c *Client) AutoModeDenials(limit int) (*protocol.AutoModeDenialsResult, error) {
+	msg := protocol.AutoModeDenialsMessage{Cmd: protocol.CmdAutoModeDenials}
+	if limit > 0 {
+		msg.Limit = protocol.Ptr(limit)
+	}
+	resp, err := c.send(msg)
+	if err != nil {
+		return nil, err
+	}
+	return resp.AutomodeDenialsResult, nil
+}

--- a/internal/daemon/automode.go
+++ b/internal/daemon/automode.go
@@ -1,0 +1,226 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/automode"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// Auto mode's daemon surface, split across two transports on purpose.
+//
+// This file holds the unix-socket half — the one `attn automode` and therefore
+// every agent can reach. It reads, it edits environment prose, and it records
+// proposals. Nothing here can change the patterns or models a pi session
+// launches with; ws_automode.go holds the app-only half that can.
+//
+// Design: docs/plans/2026-08-16-pi-auto-mode.md.
+
+const automodeDenialsDefaultLimit = 20
+
+func (d *Daemon) sendAutoModeResponse(conn net.Conn, resp protocol.Response) {
+	if err := json.NewEncoder(conn).Encode(resp); err != nil {
+		d.logf("automode: writing response: %v", err)
+	}
+}
+
+// requireAutoModeStore refuses every verb on a daemon with no database rather
+// than answering with the defaults, which would read as a configured machine.
+func (d *Daemon) requireAutoModeStore(conn net.Conn) bool {
+	if d.store == nil {
+		d.sendError(conn, "no database")
+		return false
+	}
+	return true
+}
+
+func (d *Daemon) handleAutoModeShow(conn net.Conn, _ *protocol.AutoModeShowMessage) {
+	if !d.requireAutoModeStore(conn) {
+		return
+	}
+	cfg, err := d.store.GetAutoModeConfig()
+	if err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	proposals, err := d.store.ListAutoModeProposals(automode.StatePending)
+	if err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	d.sendAutoModeResponse(conn, protocol.Response{
+		Ok: true,
+		AutomodeShowResult: &protocol.AutoModeShowResult{
+			Config:    autoModeConfigInfo(cfg),
+			Proposals: autoModeProposalInfos(proposals),
+		},
+	})
+}
+
+func (d *Daemon) handleAutoModeEnvAdd(conn net.Conn, msg *protocol.AutoModeEnvAddMessage) {
+	if !d.requireAutoModeStore(conn) {
+		return
+	}
+	text := strings.TrimSpace(msg.Text)
+	if text == "" {
+		d.sendError(conn, "automode_env_add: text is required")
+		return
+	}
+	cfg, err := d.store.GetAutoModeConfig()
+	if err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	updated, err := d.store.SetAutoModeEnvironment(append(cfg.Environment, text), time.Now())
+	if err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	d.sendAutoModeResponse(conn, protocol.Response{
+		Ok:                true,
+		AutomodeEnvResult: &protocol.AutoModeEnvResult{Environment: updated.Environment},
+	})
+}
+
+func (d *Daemon) handleAutoModeEnvRemove(conn net.Conn, msg *protocol.AutoModeEnvRemoveMessage) {
+	if !d.requireAutoModeStore(conn) {
+		return
+	}
+	cfg, err := d.store.GetAutoModeConfig()
+	if err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	index := msg.Index
+	if index < 0 || index >= len(cfg.Environment) {
+		d.sendError(conn, fmt.Sprintf(
+			"automode_env_remove: index %d is out of range; there are %d environment entries",
+			index, len(cfg.Environment)))
+		return
+	}
+	entries := append([]string{}, cfg.Environment[:index]...)
+	entries = append(entries, cfg.Environment[index+1:]...)
+	updated, err := d.store.SetAutoModeEnvironment(entries, time.Now())
+	if err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	d.sendAutoModeResponse(conn, protocol.Response{
+		Ok:                true,
+		AutomodeEnvResult: &protocol.AutoModeEnvResult{Environment: updated.Environment},
+	})
+}
+
+// handleAutoModePropose records a proposal and nothing else. A caller that
+// expected an allow to take effect gets a proposal id back; the CLI says so in
+// as many words, because a silent "recorded, inert" is how an agent concludes
+// its own rule is live.
+func (d *Daemon) handleAutoModePropose(conn net.Conn, msg *protocol.AutoModeProposeMessage) {
+	if !d.requireAutoModeStore(conn) {
+		return
+	}
+	proposal, err := d.store.CreateAutoModeProposal(
+		strings.TrimSpace(msg.Kind),
+		strings.TrimSpace(protocol.Deref(msg.Target)),
+		strings.TrimSpace(msg.Value),
+		strings.TrimSpace(protocol.Deref(msg.ProposedBy)),
+		time.Now(),
+	)
+	if err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	d.sendAutoModeResponse(conn, protocol.Response{
+		Ok: true,
+		AutomodeProposeResult: &protocol.AutoModeProposeResult{
+			Proposal: autoModeProposalInfo(proposal),
+		},
+	})
+}
+
+func (d *Daemon) handleAutoModeDenials(conn net.Conn, msg *protocol.AutoModeDenialsMessage) {
+	if !d.requireAutoModeStore(conn) {
+		return
+	}
+	limit := automodeDenialsDefaultLimit
+	if msg.Limit != nil && *msg.Limit > 0 {
+		limit = *msg.Limit
+	}
+	denials, err := d.store.ListAutoModeDenials(limit)
+	if err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	d.sendAutoModeResponse(conn, protocol.Response{
+		Ok: true,
+		AutomodeDenialsResult: &protocol.AutoModeDenialsResult{
+			Denials: autoModeDenialInfos(denials),
+		},
+	})
+}
+
+func autoModeConfigInfo(cfg automode.Config) protocol.AutoModeConfigInfo {
+	return protocol.AutoModeConfigInfo{
+		EnabledDefault:  cfg.EnabledDefault,
+		Environment:     nonNilStrings(cfg.Environment),
+		Allow:           nonNilStrings(cfg.Allow),
+		HardDeny:        nonNilStrings(cfg.HardDeny),
+		ClassifierModel: cfg.ClassifierModel,
+		EscalationModel: cfg.EscalationModel,
+	}
+}
+
+func autoModeProposalInfo(p store.AutoModeProposal) protocol.AutoModeProposalInfo {
+	return protocol.AutoModeProposalInfo{
+		ID:         int(p.ID),
+		Kind:       p.Kind,
+		Target:     p.Target,
+		Value:      p.Value,
+		ProposedBy: p.ProposedBy,
+		State:      p.State,
+		CreatedAt:  formatAutoModeStamp(p.CreatedAt),
+		ResolvedAt: formatAutoModeStamp(p.ResolvedAt),
+	}
+}
+
+func autoModeProposalInfos(proposals []store.AutoModeProposal) []protocol.AutoModeProposalInfo {
+	out := make([]protocol.AutoModeProposalInfo, 0, len(proposals))
+	for _, p := range proposals {
+		out = append(out, autoModeProposalInfo(p))
+	}
+	return out
+}
+
+func autoModeDenialInfos(denials []store.AutoModeDenial) []protocol.AutoModeDenialInfo {
+	out := make([]protocol.AutoModeDenialInfo, 0, len(denials))
+	for _, denial := range denials {
+		out = append(out, protocol.AutoModeDenialInfo{
+			ID:        int(denial.ID),
+			SessionID: denial.SessionID,
+			Tool:      denial.Tool,
+			Signature: denial.Signature,
+			Reason:    denial.Reason,
+			CreatedAt: formatAutoModeStamp(denial.CreatedAt),
+		})
+	}
+	return out
+}
+
+func formatAutoModeStamp(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+func nonNilStrings(values []string) []string {
+	if values == nil {
+		return []string{}
+	}
+	return values
+}

--- a/internal/daemon/automode_launch_test.go
+++ b/internal/daemon/automode_launch_test.go
@@ -91,6 +91,68 @@ func TestSpawnCarriesThePromotedAutoModeConfig(t *testing.T) {
 	<-requestDone
 }
 
+// A reload replaces the runtime in place, so it resolves the config the same
+// way a spawn does — and that is where a session picks up a promotion made
+// while it was running.
+func TestReloadCarriesThePromotedAutoModeConfig(t *testing.T) {
+	backend := &fakeReloadBackend{
+		liveIDs: []string{"snipe-session"},
+		info:    ptybackend.SessionInfo{Cols: 100, Rows: 32},
+		params:  ptybackend.SessionLaunchParams{Recorded: true},
+	}
+	d := newReloadTestDaemon(t, backend)
+	addTestWorkspace(d, "ws-snipe-session", t.TempDir())
+	addReloadSession(d, "snipe-session", protocol.SessionAgent("snipe"), protocol.SessionStateIdle)
+	d.store.SetSetting(SettingNotebookRoot, t.TempDir())
+
+	now := time.Now().UTC()
+	proposal, err := d.store.CreateAutoModeProposal(automode.KindDeny, "", "curl *", "", now)
+	if err != nil {
+		t.Fatalf("propose: %v", err)
+	}
+	if _, _, err := d.store.PromoteAutoModeProposal(proposal.ID, now); err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+
+	plugin, done := startPluginPipe(t, d, "snipe-plugin", nil)
+	defer func() {
+		_ = plugin.Close()
+		<-done
+	}()
+	registerTestPluginDriver(t, plugin, "snipe", map[string]bool{
+		"resume": true, "launch_instructions": true, "auto_mode": true,
+	})
+
+	resumed := make(chan struct{})
+	go func() {
+		defer close(resumed)
+		request := decodeJSONRPCMessage(t, plugin)
+		if request.Method != "driver.resume" {
+			t.Errorf("method = %q, want driver.resume", request.Method)
+			return
+		}
+		var params pluginDriverSpawnParams
+		if err := json.Unmarshal(request.Params, &params); err != nil {
+			t.Errorf("decode resume params: %v", err)
+			return
+		}
+		if params.AutoMode == nil {
+			t.Error("resume params carry no auto mode config")
+		} else if len(params.AutoMode.HardDeny) != 1 || params.AutoMode.HardDeny[0] != "curl *" {
+			t.Errorf("auto mode hard deny = %v, want the promoted pattern", params.AutoMode.HardDeny)
+		}
+		respondPluginRequest(t, plugin, request, pluginDriverSpawnResult{Argv: []string{"snipe"}})
+	}()
+
+	d.reloadSessionAgent("snipe-session")
+
+	select {
+	case <-resumed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("driver.resume was never requested")
+	}
+}
+
 func TestSpawnOmitsAutoModeForADriverThatDoesNotAskForIt(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	d.ptyBackend = &fakeSpawnBackend{}

--- a/internal/daemon/automode_launch_test.go
+++ b/internal/daemon/automode_launch_test.go
@@ -1,0 +1,130 @@
+package daemon
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/automode"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/ptybackend"
+)
+
+// Auto mode reaches a session through the launch, not through a live refresh: a
+// spawn carries the config that is promoted at that moment, and a change after
+// it applies to the next session.
+
+func TestSpawnCarriesThePromotedAutoModeConfig(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.ptyBackend = &fakeSpawnBackend{}
+	now := time.Now().UTC()
+	proposal, err := d.store.CreateAutoModeProposal(automode.KindAllow, "", "git push origin*", "", now)
+	if err != nil {
+		t.Fatalf("propose: %v", err)
+	}
+	if _, _, err := d.store.PromoteAutoModeProposal(proposal.ID, now); err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	if _, err := d.store.SetAutoModeEnvironment([]string{"never touch prod"}, now); err != nil {
+		t.Fatalf("set environment: %v", err)
+	}
+
+	client, done := startPluginPipe(t, d, "snipe-plugin", nil)
+	defer func() {
+		_ = client.Close()
+		<-done
+	}()
+	registerTestPluginDriver(t, client, "snipe", map[string]bool{
+		"launch_instructions": true, "auto_mode": true,
+	})
+
+	requestDone := make(chan struct{})
+	go func() {
+		defer close(requestDone)
+		request := decodeJSONRPCMessage(t, client)
+		var params pluginDriverSpawnParams
+		if err := json.Unmarshal(request.Params, &params); err != nil {
+			t.Errorf("decode spawn params: %v", err)
+			return
+		}
+		if params.AutoMode == nil {
+			t.Error("spawn params carry no auto mode config")
+			return
+		}
+		if len(params.AutoMode.Allow) != 1 || params.AutoMode.Allow[0] != "git push origin*" {
+			t.Errorf("auto mode allow = %v, want the promoted pattern", params.AutoMode.Allow)
+		}
+		if len(params.AutoMode.Environment) != 1 {
+			t.Errorf("auto mode environment = %v", params.AutoMode.Environment)
+		}
+		if params.AutoMode.ClassifierModel != automode.DefaultClassifierModel {
+			t.Errorf("classifier model = %q", params.AutoMode.ClassifierModel)
+		}
+		// The payload IS plugins/attn-pi/automode/config.ts's raw shape, so the
+		// wire keys are checked rather than only the decoded struct.
+		var raw struct {
+			AutoMode map[string]json.RawMessage `json:"auto_mode"`
+		}
+		if err := json.Unmarshal(request.Params, &raw); err != nil {
+			t.Errorf("decode raw spawn params: %v", err)
+			return
+		}
+		for _, key := range []string{"enabled_default", "environment", "allow", "hard_deny", "classifier_model", "escalation_model"} {
+			if _, ok := raw.AutoMode[key]; !ok {
+				t.Errorf("auto mode payload is missing %q", key)
+			}
+		}
+		respondPluginRequest(t, client, request, pluginDriverSpawnResult{Argv: []string{"snipe"}})
+	}()
+
+	addTestWorkspace(d, "workspace-snipe", t.TempDir())
+	ws := &wsClient{send: make(chan outboundMessage, 2), attachedStreams: make(map[string]ptybackend.Stream)}
+	d.handleSpawnSession(ws, &protocol.SpawnSessionMessage{
+		ID:          "snipe-session",
+		Cwd:         t.TempDir(),
+		WorkspaceID: "workspace-snipe",
+		Agent:       "snipe",
+		Cols:        80,
+		Rows:        24,
+	})
+	<-requestDone
+}
+
+func TestSpawnOmitsAutoModeForADriverThatDoesNotAskForIt(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.ptyBackend = &fakeSpawnBackend{}
+	client, done := startPluginPipe(t, d, "snipe-plugin", nil)
+	defer func() {
+		_ = client.Close()
+		<-done
+	}()
+	registerTestPluginDriver(t, client, "snipe", map[string]bool{"launch_instructions": true})
+
+	requestDone := make(chan struct{})
+	go func() {
+		defer close(requestDone)
+		request := decodeJSONRPCMessage(t, client)
+		var params pluginDriverSpawnParams
+		if err := json.Unmarshal(request.Params, &params); err != nil {
+			t.Errorf("decode spawn params: %v", err)
+			return
+		}
+		if params.AutoMode != nil {
+			t.Errorf("a driver without the auto_mode capability was handed %+v", params.AutoMode)
+		}
+		respondPluginRequest(t, client, request, pluginDriverSpawnResult{Argv: []string{"snipe"}})
+	}()
+
+	addTestWorkspace(d, "workspace-snipe", t.TempDir())
+	ws := &wsClient{send: make(chan outboundMessage, 2), attachedStreams: make(map[string]ptybackend.Stream)}
+	d.handleSpawnSession(ws, &protocol.SpawnSessionMessage{
+		ID:          "snipe-session",
+		Cwd:         t.TempDir(),
+		WorkspaceID: "workspace-snipe",
+		Agent:       "snipe",
+		Cols:        80,
+		Rows:        24,
+	})
+	<-requestDone
+}

--- a/internal/daemon/automode_test.go
+++ b/internal/daemon/automode_test.go
@@ -1,0 +1,220 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/automode"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// Auto mode's two transports and the line between them. What these pin is the
+// asymmetry: everything the CLI can reach only records an intention, and the
+// verbs that change what a session runs under answer the app alone.
+
+func automodeShow(t *testing.T, d *Daemon) *protocol.AutoModeShowResult {
+	t.Helper()
+	resp := docCall(t, func(c net.Conn) {
+		d.handleAutoModeShow(c, &protocol.AutoModeShowMessage{Cmd: protocol.CmdAutoModeShow})
+	})
+	if !resp.Ok {
+		t.Fatalf("automode show: %v", protocol.Deref(resp.Error))
+	}
+	return resp.AutomodeShowResult
+}
+
+func automodePropose(t *testing.T, d *Daemon, kind, target, value string) protocol.Response {
+	t.Helper()
+	msg := &protocol.AutoModeProposeMessage{Cmd: protocol.CmdAutoModePropose, Kind: kind, Value: value}
+	if target != "" {
+		msg.Target = protocol.Ptr(target)
+	}
+	return docCall(t, func(c net.Conn) { d.handleAutoModePropose(c, msg) })
+}
+
+func TestAutoModeShowAnswersDefaultsOnAFreshProfile(t *testing.T) {
+	d := newDaemonForTest(t)
+	result := automodeShow(t, d)
+	if result.Config.ClassifierModel != automode.DefaultClassifierModel {
+		t.Errorf("classifier model = %q", result.Config.ClassifierModel)
+	}
+	// The lists must marshal as [] rather than null: a client rendering a
+	// settings section should not have to tell "no entries" from "no answer".
+	if result.Config.Allow == nil || result.Config.Environment == nil || result.Config.HardDeny == nil {
+		t.Fatalf("a config list came back nil: %+v", result.Config)
+	}
+	if len(result.Proposals) != 0 {
+		t.Fatalf("a fresh profile has %d proposals", len(result.Proposals))
+	}
+}
+
+// The whole security design in one test: the CLI's allow verb is inert.
+func TestAutoModeAllowOnlyProposes(t *testing.T) {
+	d := newDaemonForTest(t)
+	resp := automodePropose(t, d, automode.KindAllow, "", "git push origin*")
+	if !resp.Ok {
+		t.Fatalf("propose: %v", protocol.Deref(resp.Error))
+	}
+	if resp.AutomodeProposeResult.Proposal.State != automode.StatePending {
+		t.Errorf("proposal state = %q", resp.AutomodeProposeResult.Proposal.State)
+	}
+	after := automodeShow(t, d)
+	if len(after.Config.Allow) != 0 {
+		t.Fatalf("effective allow list changed to %v", after.Config.Allow)
+	}
+	if len(after.Proposals) != 1 {
+		t.Fatalf("proposals = %d, want the one just recorded", len(after.Proposals))
+	}
+}
+
+func TestAutoModeProposeRefusesABroadAllowByName(t *testing.T) {
+	d := newDaemonForTest(t)
+	resp := automodePropose(t, d, automode.KindAllow, "", "*")
+	if resp.Ok {
+		t.Fatal("a broad allow proposal was accepted")
+	}
+	if !strings.Contains(protocol.Deref(resp.Error), "broad allow pattern") {
+		t.Fatalf("refusal does not name the limit: %q", protocol.Deref(resp.Error))
+	}
+	if len(automodeShow(t, d).Proposals) != 0 {
+		t.Fatal("the refused proposal reached the review list")
+	}
+}
+
+func TestAutoModeEnvironmentAddAndRemove(t *testing.T) {
+	d := newDaemonForTest(t)
+	for _, text := range []string{"pushing to origin is fine", "never touch prod"} {
+		resp := docCall(t, func(c net.Conn) {
+			d.handleAutoModeEnvAdd(c, &protocol.AutoModeEnvAddMessage{Cmd: protocol.CmdAutoModeEnvAdd, Text: text})
+		})
+		if !resp.Ok {
+			t.Fatalf("env add: %v", protocol.Deref(resp.Error))
+		}
+	}
+	resp := docCall(t, func(c net.Conn) {
+		d.handleAutoModeEnvRemove(c, &protocol.AutoModeEnvRemoveMessage{Cmd: protocol.CmdAutoModeEnvRemove, Index: 0})
+	})
+	if !resp.Ok {
+		t.Fatalf("env remove: %v", protocol.Deref(resp.Error))
+	}
+	if got := resp.AutomodeEnvResult.Environment; len(got) != 1 || got[0] != "never touch prod" {
+		t.Fatalf("environment = %v", got)
+	}
+
+	// An out-of-range index names the limit and the ask rather than silently
+	// removing nothing.
+	resp = docCall(t, func(c net.Conn) {
+		d.handleAutoModeEnvRemove(c, &protocol.AutoModeEnvRemoveMessage{Cmd: protocol.CmdAutoModeEnvRemove, Index: 7})
+	})
+	if resp.Ok {
+		t.Fatal("removing entry 7 of 1 succeeded")
+	}
+	if msg := protocol.Deref(resp.Error); !strings.Contains(msg, "7") || !strings.Contains(msg, "1 environment entries") {
+		t.Fatalf("refusal does not carry the limit and the ask: %q", msg)
+	}
+}
+
+func TestAutoModeDenialsIsEmptyUntilSlice5ReportsThem(t *testing.T) {
+	d := newDaemonForTest(t)
+	resp := docCall(t, func(c net.Conn) {
+		d.handleAutoModeDenials(c, &protocol.AutoModeDenialsMessage{Cmd: protocol.CmdAutoModeDenials})
+	})
+	if !resp.Ok {
+		t.Fatalf("denials: %v", protocol.Deref(resp.Error))
+	}
+	if len(resp.AutomodeDenialsResult.Denials) != 0 {
+		t.Fatalf("denials = %+v", resp.AutomodeDenialsResult.Denials)
+	}
+}
+
+func TestAutoModePromoteFromTheAppPutsItInForce(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "daemon.sock"))
+	resp := automodePropose(t, d, automode.KindAllow, "", "git push origin*")
+	if !resp.Ok {
+		t.Fatalf("propose: %v", protocol.Deref(resp.Error))
+	}
+	id := resp.AutomodeProposeResult.Proposal.ID
+
+	client := busTestClient()
+	d.handleAutoModePromote(client, &protocol.AutoModePromoteMessage{ID: id, RequestID: "r1"})
+	var promoted protocol.AutoModePromoteResultMessage
+	nextBusMessage(t, client, &promoted)
+	if !promoted.Success {
+		t.Fatalf("promote failed: %q", protocol.Deref(promoted.Error))
+	}
+	if promoted.Config == nil || len(promoted.Config.Allow) != 1 {
+		t.Fatalf("promoted config = %+v", promoted.Config)
+	}
+	if got := automodeShow(t, d); len(got.Config.Allow) != 1 || len(got.Proposals) != 0 {
+		t.Fatalf("show after promote: allow=%v pending=%d", got.Config.Allow, len(got.Proposals))
+	}
+}
+
+func TestAutoModeDiscardFromTheAppClosesWithoutApplying(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "daemon.sock"))
+	resp := automodePropose(t, d, automode.KindModel, automode.TargetClassifier, "opencode-go/other-model")
+	if !resp.Ok {
+		t.Fatalf("propose: %v", protocol.Deref(resp.Error))
+	}
+	client := busTestClient()
+	d.handleAutoModeDiscard(client, &protocol.AutoModeDiscardMessage{
+		ID: resp.AutomodeProposeResult.Proposal.ID, RequestID: "r1",
+	})
+	var discarded protocol.AutoModeDiscardResultMessage
+	nextBusMessage(t, client, &discarded)
+	if !discarded.Success {
+		t.Fatalf("discard failed: %q", protocol.Deref(discarded.Error))
+	}
+	got := automodeShow(t, d)
+	if got.Config.ClassifierModel != automode.DefaultClassifierModel {
+		t.Errorf("classifier model = %q after a discard", got.Config.ClassifierModel)
+	}
+	if len(got.Proposals) != 0 {
+		t.Errorf("discarded proposal is still pending")
+	}
+}
+
+func TestAutoModePromoteRefusesAnUnknownProposal(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "daemon.sock"))
+	client := busTestClient()
+	d.handleAutoModePromote(client, &protocol.AutoModePromoteMessage{ID: 404, RequestID: "r1"})
+	var result protocol.AutoModePromoteResultMessage
+	nextBusMessage(t, client, &result)
+	if result.Success {
+		t.Fatal("promoting a proposal that does not exist succeeded")
+	}
+	if !strings.Contains(protocol.Deref(result.Error), "404") {
+		t.Fatalf("refusal does not name the ask: %q", protocol.Deref(result.Error))
+	}
+}
+
+// Promotion has no unix-socket half, and that absence is the trust boundary: an
+// agent reaches this socket, a human reaches the app. A future change that
+// registers a case for it fails here.
+func TestPromotionIsNotReachableOverTheUnixSocket(t *testing.T) {
+	d := newDaemonForTest(t)
+	for _, cmd := range []string{protocol.CmdAutoModePromote, protocol.CmdAutoModeDiscard} {
+		client, server := net.Pipe()
+		go func() {
+			d.handleConnection(server)
+		}()
+		payload := `{"cmd":"` + cmd + `","id":1,"request_id":"r1"}`
+		if _, err := client.Write([]byte(payload)); err != nil {
+			t.Fatalf("write %s: %v", cmd, err)
+		}
+		var resp protocol.Response
+		if err := json.NewDecoder(client).Decode(&resp); err != nil {
+			t.Fatalf("decode %s response: %v", cmd, err)
+		}
+		client.Close()
+		if resp.Ok {
+			t.Fatalf("%s was answered over the unix socket", cmd)
+		}
+		if got := protocol.Deref(resp.Error); !strings.Contains(got, "unknown command") {
+			t.Fatalf("%s was refused for the wrong reason: %q", cmd, got)
+		}
+	}
+}

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -217,6 +217,16 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdAppRuntimeStatus:  commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdAppRuntimeRestart: commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdAppWatch:          commandMetadata(ScopeHubLocal, false, true),
+	// Auto mode's config is the hub's own database, and none of these touches a
+	// PTY, so a hub answers them itself and none blocks during recovery.
+	protocol.CmdAutoModeShow:      commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdAutoModeEnvAdd:    commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdAutoModeEnvRemove: commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdAutoModePropose:   commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdAutoModeDenials:   commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdAutoModeGet:       commandMetadata(ScopeHubLocal, false, false),
+	protocol.CmdAutoModePromote:   commandMetadata(ScopeHubLocal, false, false),
+	protocol.CmdAutoModeDiscard:   commandMetadata(ScopeHubLocal, false, false),
 }
 
 func shouldLogWSCommand(cmd string) bool {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2749,6 +2749,18 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleAppRuntimeRestart(conn, msg.(*protocol.AppRuntimeRestartMessage))
 	case protocol.CmdAppWatch: // wire: app_watch
 		d.handleAppWatch(conn, msg.(*protocol.AppWatchMessage))
+	// Auto mode's agent-reachable verbs. automode_promote and automode_discard
+	// are deliberately absent: they exist on the WebSocket alone.
+	case protocol.CmdAutoModeShow: // wire: automode_show
+		d.handleAutoModeShow(conn, msg.(*protocol.AutoModeShowMessage))
+	case protocol.CmdAutoModeEnvAdd: // wire: automode_env_add
+		d.handleAutoModeEnvAdd(conn, msg.(*protocol.AutoModeEnvAddMessage))
+	case protocol.CmdAutoModeEnvRemove: // wire: automode_env_remove
+		d.handleAutoModeEnvRemove(conn, msg.(*protocol.AutoModeEnvRemoveMessage))
+	case protocol.CmdAutoModePropose: // wire: automode_propose
+		d.handleAutoModePropose(conn, msg.(*protocol.AutoModeProposeMessage))
+	case protocol.CmdAutoModeDenials: // wire: automode_denials
+		d.handleAutoModeDenials(conn, msg.(*protocol.AutoModeDenialsMessage))
 	case protocol.CmdTicketCreate: // wire: ticket_create
 		d.handleTicketCreate(conn, msg.(*protocol.TicketCreateMessage))
 	case protocol.CmdTicketComment: // wire: ticket_comment

--- a/internal/daemon/plugin_driver.go
+++ b/internal/daemon/plugin_driver.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	agentdriver "github.com/victorarias/attn/internal/agent"
+	"github.com/victorarias/attn/internal/automode"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/ptybackend"
 )
@@ -55,6 +56,11 @@ type pluginDriverSpawnParams struct {
 	InitialPrompt string                    `json:"initial_prompt,omitempty"`
 	Metadata      json.RawMessage           `json:"metadata,omitempty"`
 	Instructions  *pluginLaunchInstructions `json:"instructions,omitempty"`
+	// The promoted auto-mode config, for a driver that advertises `auto_mode`.
+	// It is the exact JSON shape plugins/attn-pi/automode/config.ts parses, so a
+	// driver forwards it to the session rather than translating it. Config
+	// changes reach new sessions only; a live session is not refreshed.
+	AutoMode *automode.Config `json:"auto_mode,omitempty"`
 }
 
 type pluginDriverSpawnResult struct {
@@ -201,6 +207,7 @@ func validatePluginDriverCapabilities(values map[string]bool) (map[string]bool, 
 		"effort_pin":          {},
 		"launch_instructions": {},
 		"conversation":        {},
+		"auto_mode":           {},
 	}
 	out := make(map[string]bool, len(values))
 	for name, enabled := range values {

--- a/internal/daemon/reload.go
+++ b/internal/daemon/reload.go
@@ -486,6 +486,14 @@ func (d *Daemon) preparePluginReload(session *protocol.Session, opts *ptybackend
 		Effort:       opts.Effort,
 		Instructions: instructions,
 	}
+	if reg.Capabilities["auto_mode"] {
+		cfg, err := d.store.GetAutoModeConfig()
+		if err != nil {
+			prepared.abort()
+			return nil, fmt.Errorf("read auto mode config: %w", err)
+		}
+		params.AutoMode = &cfg
+	}
 	if metadata := strings.TrimSpace(d.store.GetAgentMetadata(session.ID)); metadata != "" && json.Valid([]byte(metadata)) {
 		params.Metadata = json.RawMessage(metadata)
 	}

--- a/internal/daemon/spawn_pipeline.go
+++ b/internal/daemon/spawn_pipeline.go
@@ -347,6 +347,15 @@ func (d *Daemon) executeSpawn(req *spawnRequest, plan *spawnPlan) *spawnOutcome 
 			}
 			params.Instructions, plan.instructionsRollback = instructions, rollback
 		}
+		if req.pluginDriver.Capabilities["auto_mode"] {
+			cfg, err := d.store.GetAutoModeConfig()
+			if err != nil {
+				d.finishPluginSessionLaunch(msg.ID, false)
+				plan.rollback(d, msg.ID)
+				return &spawnOutcome{err: fmt.Errorf("read auto mode config: %w", err)}
+			}
+			params.AutoMode = &cfg
+		}
 		result, err := d.resolvePluginDriverLaunch(req.pluginDriver, params, req.existingSession != nil && req.pluginDriver.Capabilities["resume"])
 		if err != nil {
 			d.finishPluginSessionLaunch(msg.ID, false)

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -1326,6 +1326,14 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		d.handleBusStatusGet(client, msg.(*protocol.BusStatusGetMessage))
 	case protocol.CmdBusSetConsumerEnabled: // wire: bus_set_consumer_enabled
 		d.handleBusSetConsumerEnabled(client, msg.(*protocol.BusSetConsumerEnabledMessage))
+	// Auto mode's app-only verbs. Promotion is here and nowhere else: a human in
+	// the app is the trust boundary a CLI caller cannot fake.
+	case protocol.CmdAutoModeGet: // wire: automode_get
+		d.handleAutoModeGet(client, msg.(*protocol.AutoModeGetMessage))
+	case protocol.CmdAutoModePromote: // wire: automode_promote
+		d.handleAutoModePromote(client, msg.(*protocol.AutoModePromoteMessage))
+	case protocol.CmdAutoModeDiscard: // wire: automode_discard
+		d.handleAutoModeDiscard(client, msg.(*protocol.AutoModeDiscardMessage))
 	case protocol.CmdPtyResize: // wire: pty_resize
 		d.handlePtyResize(client, msg.(*protocol.PtyResizeMessage))
 	case protocol.CmdKillSession: // wire: kill_session

--- a/internal/daemon/ws_automode.go
+++ b/internal/daemon/ws_automode.go
@@ -1,0 +1,99 @@
+package daemon
+
+import (
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/automode"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// Auto mode's app-only half: the read the settings section renders, and the two
+// verbs that resolve a proposal.
+//
+// Promotion exists here and on no other transport. That is not an oversight to
+// be tidied up later by adding a CLI verb — it is the whole security design. An
+// agent reaches the unix socket; a human reaches the app. Only what a human
+// touches may change the policy a session runs under.
+
+func (d *Daemon) handleAutoModeGet(client *wsClient, msg *protocol.AutoModeGetMessage) {
+	requestID := strings.TrimSpace(msg.RequestID)
+	if requestID == "" {
+		d.sendCommandError(client, protocol.CmdAutoModeGet, "automode_get is missing a request id")
+		return
+	}
+	result := protocol.AutoModeStateResultMessage{
+		Event:     protocol.EventAutoModeStateResult,
+		RequestID: requestID,
+	}
+	cfg, err := d.store.GetAutoModeConfig()
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+		d.sendToClient(client, result)
+		return
+	}
+	proposals, err := d.store.ListAutoModeProposals(automode.StatePending)
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+		d.sendToClient(client, result)
+		return
+	}
+	denials, err := d.store.ListAutoModeDenials(automodeDenialsDefaultLimit)
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+		d.sendToClient(client, result)
+		return
+	}
+	result.Config = autoModeConfigInfo(cfg)
+	result.Proposals = autoModeProposalInfos(proposals)
+	result.Denials = autoModeDenialInfos(denials)
+	result.Success = true
+	d.sendToClient(client, result)
+}
+
+func (d *Daemon) handleAutoModePromote(client *wsClient, msg *protocol.AutoModePromoteMessage) {
+	requestID := strings.TrimSpace(msg.RequestID)
+	if requestID == "" {
+		d.sendCommandError(client, protocol.CmdAutoModePromote, "automode_promote is missing a request id")
+		return
+	}
+	result := protocol.AutoModePromoteResultMessage{
+		Event:     protocol.EventAutoModePromoteResult,
+		RequestID: requestID,
+	}
+	proposal, cfg, err := d.store.PromoteAutoModeProposal(int64(msg.ID), time.Now())
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+		d.sendToClient(client, result)
+		return
+	}
+	d.logf("automode: promoted proposal %d (%s %s)", proposal.ID, proposal.Kind, proposal.Value)
+	info := autoModeProposalInfo(proposal)
+	config := autoModeConfigInfo(cfg)
+	result.Proposal = &info
+	result.Config = &config
+	result.Success = true
+	d.sendToClient(client, result)
+}
+
+func (d *Daemon) handleAutoModeDiscard(client *wsClient, msg *protocol.AutoModeDiscardMessage) {
+	requestID := strings.TrimSpace(msg.RequestID)
+	if requestID == "" {
+		d.sendCommandError(client, protocol.CmdAutoModeDiscard, "automode_discard is missing a request id")
+		return
+	}
+	result := protocol.AutoModeDiscardResultMessage{
+		Event:     protocol.EventAutoModeDiscardResult,
+		RequestID: requestID,
+	}
+	proposal, err := d.store.DiscardAutoModeProposal(int64(msg.ID), time.Now())
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+		d.sendToClient(client, result)
+		return
+	}
+	info := autoModeProposalInfo(proposal)
+	result.Proposal = &info
+	result.Success = true
+	d.sendToClient(client, result)
+}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "253"
+const ProtocolVersion = "254"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only
@@ -136,6 +136,14 @@ const (
 	CmdAppRuntimeStatus                      = "app_runtime_status"
 	CmdAppRuntimeRestart                     = "app_runtime_restart"
 	CmdAppWatch                              = "app_watch"
+	// Auto mode's agent-reachable half. Every one of these records or reads;
+	// none of them changes what a session launches with. Promotion is on the
+	// WebSocket surface alone — see CmdAutoModePromote.
+	CmdAutoModeShow                          = "automode_show"
+	CmdAutoModeEnvAdd                        = "automode_env_add"
+	CmdAutoModeEnvRemove                     = "automode_env_remove"
+	CmdAutoModePropose                       = "automode_propose"
+	CmdAutoModeDenials                       = "automode_denials"
 	CmdGetTicket                             = "get_ticket"
 	CmdTicketChangeStatus                    = "ticket_change_status"
 	CmdTicketAddComment                      = "ticket_add_comment"
@@ -292,6 +300,11 @@ const (
 	CmdListPastConversations                 = "list_past_conversations"
 	CmdBusStatusGet                          = "bus_status_get"
 	CmdBusSetConsumerEnabled                 = "bus_set_consumer_enabled"
+	// Auto mode's app-only half. Promotion and discard exist here and nowhere
+	// else: a human in the app is the trust boundary a CLI caller cannot fake.
+	CmdAutoModeGet                           = "automode_get"
+	CmdAutoModePromote                       = "automode_promote"
+	CmdAutoModeDiscard                       = "automode_discard"
 	CmdPtyResize                             = "pty_resize"
 	CmdKillSession                           = "kill_session"
 	CmdReloadSession                         = "reload_session"
@@ -470,6 +483,9 @@ const (
 	EventPastConversationsResult         = "past_conversations_result"
 	EventBusStatusResult                 = "bus_status_result"
 	EventBusSetConsumerEnabledResult     = "bus_set_consumer_enabled_result"
+	EventAutoModeStateResult             = "automode_state_result"
+	EventAutoModePromoteResult           = "automode_promote_result"
+	EventAutoModeDiscardResult           = "automode_discard_result"
 	EventSessionAnnotationsGetResult     = "session_annotations_get_result"
 	EventSessionAnnotationsSaveResult    = "session_annotations_save_result"
 	EventSessionAnnotationsClearResult   = "session_annotations_clear_result"
@@ -831,6 +847,41 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdAppWatch:
 		var msg AppWatchMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAutoModeShow:
+		var msg AutoModeShowMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAutoModeEnvAdd:
+		var msg AutoModeEnvAddMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAutoModeEnvRemove:
+		var msg AutoModeEnvRemoveMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAutoModePropose:
+		var msg AutoModeProposeMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAutoModeDenials:
+		var msg AutoModeDenialsMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}
@@ -1869,6 +1920,27 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 		var msg BusStatusGetMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, fmt.Errorf("unmarshal bus_status_get: %w", err)
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAutoModeGet:
+		var msg AutoModeGetMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, fmt.Errorf("unmarshal automode_get: %w", err)
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAutoModePromote:
+		var msg AutoModePromoteMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, fmt.Errorf("unmarshal automode_promote: %w", err)
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAutoModeDiscard:
+		var msg AutoModeDiscardMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, fmt.Errorf("unmarshal automode_discard: %w", err)
 		}
 		return peek.Cmd, &msg, nil
 

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -136,14 +136,6 @@ const (
 	CmdAppRuntimeStatus                      = "app_runtime_status"
 	CmdAppRuntimeRestart                     = "app_runtime_restart"
 	CmdAppWatch                              = "app_watch"
-	// Auto mode's agent-reachable half. Every one of these records or reads;
-	// none of them changes what a session launches with. Promotion is on the
-	// WebSocket surface alone — see CmdAutoModePromote.
-	CmdAutoModeShow                          = "automode_show"
-	CmdAutoModeEnvAdd                        = "automode_env_add"
-	CmdAutoModeEnvRemove                     = "automode_env_remove"
-	CmdAutoModePropose                       = "automode_propose"
-	CmdAutoModeDenials                       = "automode_denials"
 	CmdGetTicket                             = "get_ticket"
 	CmdTicketChangeStatus                    = "ticket_change_status"
 	CmdTicketAddComment                      = "ticket_add_comment"
@@ -300,11 +292,6 @@ const (
 	CmdListPastConversations                 = "list_past_conversations"
 	CmdBusStatusGet                          = "bus_status_get"
 	CmdBusSetConsumerEnabled                 = "bus_set_consumer_enabled"
-	// Auto mode's app-only half. Promotion and discard exist here and nowhere
-	// else: a human in the app is the trust boundary a CLI caller cannot fake.
-	CmdAutoModeGet                           = "automode_get"
-	CmdAutoModePromote                       = "automode_promote"
-	CmdAutoModeDiscard                       = "automode_discard"
 	CmdPtyResize                             = "pty_resize"
 	CmdKillSession                           = "kill_session"
 	CmdReloadSession                         = "reload_session"
@@ -346,6 +333,23 @@ const (
 	CmdSetWorkspaceRank                      = "set_workspace_rank"
 	CmdSetChiefOfStaff                       = "set_chief_of_staff"
 	CmdSetSessionContextWindowCap            = "set_session_context_window_cap"
+)
+
+// Auto mode's commands, split by which surface may reach them. The first group
+// is agent-reachable over the unix socket and every one of its members reads or
+// records a proposal — none changes what a session launches with. The second
+// group is the app's alone: a human in the app is the trust boundary a CLI
+// caller cannot fake, so promotion lives here and nowhere else.
+const (
+	CmdAutoModeShow      = "automode_show"
+	CmdAutoModeEnvAdd    = "automode_env_add"
+	CmdAutoModeEnvRemove = "automode_env_remove"
+	CmdAutoModePropose   = "automode_propose"
+	CmdAutoModeDenials   = "automode_denials"
+
+	CmdAutoModeGet     = "automode_get"
+	CmdAutoModePromote = "automode_promote"
+	CmdAutoModeDiscard = "automode_discard"
 )
 
 // Per-action automations result events (socket + WS share one command set;

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -743,6 +743,231 @@ type AuthorsUpdatedMessage struct {
 	Event string `json:"event"`
 }
 
+type AutoModeConfigInfo struct {
+	// Allow corresponds to the JSON schema field "allow".
+	Allow []string `json:"allow"`
+
+	// ClassifierModel corresponds to the JSON schema field "classifier_model".
+	ClassifierModel string `json:"classifier_model"`
+
+	// EnabledDefault corresponds to the JSON schema field "enabled_default".
+	EnabledDefault bool `json:"enabled_default"`
+
+	// Environment corresponds to the JSON schema field "environment".
+	Environment []string `json:"environment"`
+
+	// EscalationModel corresponds to the JSON schema field "escalation_model".
+	EscalationModel string `json:"escalation_model"`
+
+	// HardDeny corresponds to the JSON schema field "hard_deny".
+	HardDeny []string `json:"hard_deny"`
+}
+
+type AutoModeDenialInfo struct {
+	// CreatedAt corresponds to the JSON schema field "created_at".
+	CreatedAt string `json:"created_at"`
+
+	// ID corresponds to the JSON schema field "id".
+	ID int `json:"id"`
+
+	// Reason corresponds to the JSON schema field "reason".
+	Reason string `json:"reason"`
+
+	// SessionID corresponds to the JSON schema field "session_id".
+	SessionID string `json:"session_id"`
+
+	// Signature corresponds to the JSON schema field "signature".
+	Signature string `json:"signature"`
+
+	// Tool corresponds to the JSON schema field "tool".
+	Tool string `json:"tool"`
+}
+
+type AutoModeDenialsMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Limit corresponds to the JSON schema field "limit".
+	Limit *int `json:"limit,omitempty,omitzero"`
+}
+
+type AutoModeDenialsResult struct {
+	// Denials corresponds to the JSON schema field "denials".
+	Denials []AutoModeDenialInfo `json:"denials"`
+}
+
+type AutoModeDiscardMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// ID corresponds to the JSON schema field "id".
+	ID int `json:"id"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+}
+
+type AutoModeDiscardResultMessage struct {
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// Proposal corresponds to the JSON schema field "proposal".
+	Proposal *AutoModeProposalInfo `json:"proposal,omitempty,omitzero"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+}
+
+type AutoModeEnvAddMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Text corresponds to the JSON schema field "text".
+	Text string `json:"text"`
+}
+
+type AutoModeEnvRemoveMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Index corresponds to the JSON schema field "index".
+	Index int `json:"index"`
+}
+
+type AutoModeEnvResult struct {
+	// Environment corresponds to the JSON schema field "environment".
+	Environment []string `json:"environment"`
+}
+
+type AutoModeGetMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+}
+
+type AutoModePromoteMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// ID corresponds to the JSON schema field "id".
+	ID int `json:"id"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+}
+
+type AutoModePromoteResultMessage struct {
+	// Config corresponds to the JSON schema field "config".
+	Config *AutoModeConfigInfo `json:"config,omitempty,omitzero"`
+
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// Proposal corresponds to the JSON schema field "proposal".
+	Proposal *AutoModeProposalInfo `json:"proposal,omitempty,omitzero"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+}
+
+type AutoModeProposalInfo struct {
+	// CreatedAt corresponds to the JSON schema field "created_at".
+	CreatedAt string `json:"created_at"`
+
+	// ID corresponds to the JSON schema field "id".
+	ID int `json:"id"`
+
+	// Kind corresponds to the JSON schema field "kind".
+	Kind string `json:"kind"`
+
+	// ProposedBy corresponds to the JSON schema field "proposed_by".
+	ProposedBy string `json:"proposed_by"`
+
+	// ResolvedAt corresponds to the JSON schema field "resolved_at".
+	ResolvedAt string `json:"resolved_at"`
+
+	// State corresponds to the JSON schema field "state".
+	State string `json:"state"`
+
+	// Target corresponds to the JSON schema field "target".
+	Target string `json:"target"`
+
+	// Value corresponds to the JSON schema field "value".
+	Value string `json:"value"`
+}
+
+type AutoModeProposeMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Kind corresponds to the JSON schema field "kind".
+	Kind string `json:"kind"`
+
+	// ProposedBy corresponds to the JSON schema field "proposed_by".
+	ProposedBy *string `json:"proposed_by,omitempty,omitzero"`
+
+	// Target corresponds to the JSON schema field "target".
+	Target *string `json:"target,omitempty,omitzero"`
+
+	// Value corresponds to the JSON schema field "value".
+	Value string `json:"value"`
+}
+
+type AutoModeProposeResult struct {
+	// Proposal corresponds to the JSON schema field "proposal".
+	Proposal AutoModeProposalInfo `json:"proposal"`
+}
+
+type AutoModeShowMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+}
+
+type AutoModeShowResult struct {
+	// Config corresponds to the JSON schema field "config".
+	Config AutoModeConfigInfo `json:"config"`
+
+	// Proposals corresponds to the JSON schema field "proposals".
+	Proposals []AutoModeProposalInfo `json:"proposals"`
+}
+
+type AutoModeStateResultMessage struct {
+	// Config corresponds to the JSON schema field "config".
+	Config AutoModeConfigInfo `json:"config"`
+
+	// Denials corresponds to the JSON schema field "denials".
+	Denials []AutoModeDenialInfo `json:"denials"`
+
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// Proposals corresponds to the JSON schema field "proposals".
+	Proposals []AutoModeProposalInfo `json:"proposals"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+}
+
 type AutomationApplyMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -5432,6 +5657,20 @@ type Response struct {
 
 	// Authors corresponds to the JSON schema field "authors".
 	Authors []AuthorState `json:"authors,omitempty,omitzero"`
+
+	// AutomodeDenialsResult corresponds to the JSON schema field
+	// "automode_denials_result".
+	AutomodeDenialsResult *AutoModeDenialsResult `json:"automode_denials_result,omitempty,omitzero"`
+
+	// AutomodeEnvResult corresponds to the JSON schema field "automode_env_result".
+	AutomodeEnvResult *AutoModeEnvResult `json:"automode_env_result,omitempty,omitzero"`
+
+	// AutomodeProposeResult corresponds to the JSON schema field
+	// "automode_propose_result".
+	AutomodeProposeResult *AutoModeProposeResult `json:"automode_propose_result,omitempty,omitzero"`
+
+	// AutomodeShowResult corresponds to the JSON schema field "automode_show_result".
+	AutomodeShowResult *AutoModeShowResult `json:"automode_show_result,omitempty,omitzero"`
 
 	// CrewHandoffResult corresponds to the JSON schema field "crew_handoff_result".
 	CrewHandoffResult *CrewHandoffResult `json:"crew_handoff_result,omitempty,omitzero"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -4897,6 +4897,163 @@ model AppRollbackResult {
 }
 
 // ============================================================================
+// Auto mode
+// ============================================================================
+//
+// pi's permission system, configured attn-side. Design:
+// docs/plans/2026-08-16-pi-auto-mode.md.
+//
+// The surface is deliberately split in two, and the split IS the security
+// design. These commands — everything an agent can reach over the unix socket —
+// only ever record a PROPOSAL, which changes nothing a session launches with.
+// Promotion lives on the WebSocket surface alone (automode_promote), because a
+// human in the app is the trust boundary no CLI caller can fake. An agent must
+// not be able to write its own leash.
+
+// Auto mode's promoted config: what a pi session actually launches with. Model
+// fields are always resolved — a machine that never picked one gets the shipped
+// default here rather than an empty string the caller would have to fill in.
+model AutoModeConfigInfo {
+  "enabled_default": boolean;
+  "environment": string[];
+  "allow": string[];
+  "hard_deny": string[];
+  "classifier_model": string;
+  "escalation_model": string;
+}
+
+// One proposed change awaiting a human. "value" is a pattern for allow/deny and
+// a `provider/id` for model; "target" names which model and is empty otherwise.
+model AutoModeProposalInfo {
+  "id": safeint;
+  // "allow" | "deny" | "model".
+  "kind": string;
+  // "classifier" | "escalation" for a model proposal; empty otherwise.
+  "target": string;
+  "value": string;
+  // Who proposed it, when the caller said. Empty when nobody did.
+  "proposed_by": string;
+  // "pending" | "promoted" | "discarded".
+  "state": string;
+  "created_at": string;
+  // Empty while still pending.
+  "resolved_at": string;
+}
+
+// One call auto mode refused. Nothing reports these until slice 5; the shape
+// ships now so the reader and the writer are never introduced separately.
+model AutoModeDenialInfo {
+  "id": safeint;
+  "session_id": string;
+  "tool": string;
+  "signature": string;
+  "reason": string;
+  "created_at": string;
+}
+
+model AutoModeShowMessage {
+  "cmd": "automode_show";
+}
+
+model AutoModeShowResult {
+  "config": AutoModeConfigInfo;
+  // Everything still pending, oldest first.
+  "proposals": AutoModeProposalInfo[];
+}
+
+// Environment prose is a direct write, not a proposal — the plan's public
+// interface specifies `env add`/`env remove` as edits.
+model AutoModeEnvAddMessage {
+  "cmd": "automode_env_add";
+  "text": string;
+}
+
+model AutoModeEnvRemoveMessage {
+  "cmd": "automode_env_remove";
+  // Zero-based index into the entries `automode_show` returned.
+  "index": safeint;
+}
+
+model AutoModeEnvResult {
+  "environment": string[];
+}
+
+// Record a proposal. Refused at submission when it could never be promoted — a
+// broad allow pattern most of all, mirroring the pi-side config loader.
+model AutoModeProposeMessage {
+  "cmd": "automode_propose";
+  "kind": string;
+  "target"?: string;
+  "value": string;
+  "proposed_by"?: string;
+}
+
+model AutoModeProposeResult {
+  "proposal": AutoModeProposalInfo;
+}
+
+model AutoModeDenialsMessage {
+  "cmd": "automode_denials";
+  "limit"?: safeint;
+}
+
+model AutoModeDenialsResult {
+  "denials": AutoModeDenialInfo[];
+}
+
+// The app's read: config plus the pending proposals its settings section
+// reviews, plus the recent denials it lists.
+model AutoModeGetMessage {
+  cmd: "automode_get";
+  request_id: string;
+}
+
+model AutoModeStateResultMessage {
+  event: "automode_state_result";
+  request_id: string;
+  success: boolean;
+  error?: string;
+  config: AutoModeConfigInfo;
+  proposals: AutoModeProposalInfo[];
+  denials: AutoModeDenialInfo[];
+}
+
+// Apply a pending proposal to the config. The app only — this command has no
+// unix-socket half, and that absence is the whole trust boundary.
+model AutoModePromoteMessage {
+  cmd: "automode_promote";
+  id: safeint;
+  request_id: string;
+}
+
+model AutoModePromoteResultMessage {
+  event: "automode_promote_result";
+  request_id: string;
+  success: boolean;
+  error?: string;
+  proposal?: AutoModeProposalInfo;
+  // The config as it stands after the promotion.
+  config?: AutoModeConfigInfo;
+}
+
+// Close a pending proposal without applying it. App-only for symmetry: the
+// review list is the app's, and a caller that cannot promote must not be able to
+// clear what a human has not seen.
+model AutoModeDiscardMessage {
+  cmd: "automode_discard";
+  id: safeint;
+  request_id: string;
+}
+
+model AutoModeDiscardResultMessage {
+  event: "automode_discard_result";
+  request_id: string;
+  success: boolean;
+  error?: string;
+  proposal?: AutoModeProposalInfo;
+}
+
+// ============================================================================
 // Response Types
 // ============================================================================
 
@@ -4983,6 +5140,10 @@ model Response {
   app_runtime_status_result?: AppRuntimeStatusResult;
   app_runtime_restart_result?: AppRuntimeRestartResult;
   app_watch_result?: AppWatchResult;
+  automode_show_result?: AutoModeShowResult;
+  automode_env_result?: AutoModeEnvResult;
+  automode_propose_result?: AutoModeProposeResult;
+  automode_denials_result?: AutoModeDenialsResult;
 }
 
 // One recorded state observation and its fate. Outcome separates the ways an
@@ -5966,4 +6127,7 @@ alias DaemonEvent =
   | MarkdownAnnotationsSubmitResultMessage
   | PastConversationsResultMessage
   | BusStatusResultMessage
-  | BusSetConsumerEnabledResultMessage;
+  | BusSetConsumerEnabledResultMessage
+  | AutoModeStateResultMessage
+  | AutoModePromoteResultMessage
+  | AutoModeDiscardResultMessage;

--- a/internal/store/automode.go
+++ b/internal/store/automode.go
@@ -1,0 +1,445 @@
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/victorarias/attn/internal/automode"
+)
+
+// Auto mode's persistence (migration 109): the promoted config, the proposals
+// waiting on a human, and the denials a session reported.
+//
+// The asymmetry between the two write paths is the point, and it lives here
+// rather than in any one caller: PromoteAutoModeProposal is the ONLY way a
+// pattern or a model reaches the config row, and it is reachable from the app
+// alone. Everything an agent can call writes a proposal, which changes nothing
+// a session launches with.
+//
+// Design: docs/plans/2026-08-16-pi-auto-mode.md.
+
+// AutoModeProposal is one proposed change and what became of it. Value is a
+// pattern for allow/deny and a `provider/id` for model; Target names which model
+// and is empty otherwise.
+type AutoModeProposal struct {
+	ID         int64
+	Kind       string
+	Target     string
+	Value      string
+	ProposedBy string
+	State      string
+	CreatedAt  time.Time
+	ResolvedAt time.Time
+}
+
+// AutoModeDenial is one call auto mode refused. Nothing writes these yet —
+// reporting arrives with slice 5 — but the shape ships now so the CLI's
+// `denials` verb reads the table it will always read.
+type AutoModeDenial struct {
+	ID        int64
+	SessionID string
+	Tool      string
+	Signature string
+	Reason    string
+	CreatedAt time.Time
+}
+
+// GetAutoModeConfig reads the promoted config, resolved: a machine with no row,
+// or a row that never named a model, gets the shipped defaults rather than empty
+// strings a caller would have to know how to fill in.
+func (s *Store) GetAutoModeConfig() (automode.Config, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.readAutoModeConfig(s.db)
+}
+
+// readAutoModeConfig takes a rowQuerier (documents.go) so the same read serves a
+// plain get and the read-back inside a promote's transaction.
+func (s *Store) readAutoModeConfig(q rowQuerier) (automode.Config, error) {
+	cfg := automode.Defaults()
+	if s.db == nil {
+		return cfg, nil
+	}
+	var (
+		enabled                          int
+		environment, allow, hardDeny     string
+		classifierModel, escalationModel string
+	)
+	err := q.QueryRow(`
+		SELECT enabled_default, environment, allow_patterns, hard_deny,
+		       classifier_model, escalation_model
+		FROM automode_config WHERE id = 1
+	`).Scan(&enabled, &environment, &allow, &hardDeny, &classifierModel, &escalationModel)
+	if err == sql.ErrNoRows {
+		return cfg, nil
+	}
+	if err != nil {
+		return cfg, err
+	}
+	cfg.EnabledDefault = enabled != 0
+	if cfg.Environment, err = decodeStringList(environment, "environment"); err != nil {
+		return automode.Defaults(), err
+	}
+	if cfg.Allow, err = decodeStringList(allow, "allow"); err != nil {
+		return automode.Defaults(), err
+	}
+	if cfg.HardDeny, err = decodeStringList(hardDeny, "hard_deny"); err != nil {
+		return automode.Defaults(), err
+	}
+	if classifierModel != "" {
+		cfg.ClassifierModel = classifierModel
+	}
+	if escalationModel != "" {
+		cfg.EscalationModel = escalationModel
+	}
+	return cfg, nil
+}
+
+// SetAutoModeEnvironment replaces the classifier's environment prose. Unlike the
+// pattern and model lists this is a direct write with no proposal in front of
+// it, which is what the plan's public interface specifies.
+func (s *Store) SetAutoModeEnvironment(entries []string, now time.Time) (automode.Config, error) {
+	return s.mutateAutoModeConfig(now, func(cfg *automode.Config) error {
+		cfg.Environment = append([]string{}, entries...)
+		return nil
+	})
+}
+
+// SetAutoModeEnabledDefault flips whether new attn sessions start with auto mode
+// on.
+func (s *Store) SetAutoModeEnabledDefault(enabled bool, now time.Time) (automode.Config, error) {
+	return s.mutateAutoModeConfig(now, func(cfg *automode.Config) error {
+		cfg.EnabledDefault = enabled
+		return nil
+	})
+}
+
+// CreateAutoModeProposal records a proposed change. It validates first, so a
+// proposal that could never be promoted never reaches the app's review list.
+func (s *Store) CreateAutoModeProposal(kind, target, value, proposedBy string, now time.Time) (AutoModeProposal, error) {
+	if err := automode.ValidateProposal(kind, target, value); err != nil {
+		return AutoModeProposal{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return AutoModeProposal{}, fmt.Errorf("store: no database")
+	}
+	stamp := now.UTC().Format(sortableTimeFormat)
+	res, err := s.db.Exec(`
+		INSERT INTO automode_proposals (kind, target, value, proposed_by, state, created_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, kind, target, value, proposedBy, automode.StatePending, stamp)
+	if err != nil {
+		return AutoModeProposal{}, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return AutoModeProposal{}, err
+	}
+	return AutoModeProposal{
+		ID: id, Kind: kind, Target: target, Value: value,
+		ProposedBy: proposedBy, State: automode.StatePending, CreatedAt: now.UTC(),
+	}, nil
+}
+
+// ListAutoModeProposals returns proposals in the state given, oldest first. An
+// empty state means every proposal.
+func (s *Store) ListAutoModeProposals(state string) ([]AutoModeProposal, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.db == nil {
+		return nil, nil
+	}
+	query := `SELECT id, kind, target, value, proposed_by, state, created_at, resolved_at
+		FROM automode_proposals`
+	args := []any{}
+	if state != "" {
+		query += ` WHERE state = ?`
+		args = append(args, state)
+	}
+	query += ` ORDER BY id ASC`
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []AutoModeProposal
+	for rows.Next() {
+		p, err := scanAutoModeProposal(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+// PromoteAutoModeProposal applies a pending proposal to the config and marks it
+// promoted, in one transaction. This is auto mode's trust boundary: nothing else
+// writes a pattern or a model into the config row, and only the app reaches it.
+//
+// Promoting an allow re-validates the pattern rather than trusting the recorded
+// row — the guard belongs on the path that changes what runs, not only on the
+// path that records an intention.
+func (s *Store) PromoteAutoModeProposal(id int64, now time.Time) (AutoModeProposal, automode.Config, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return AutoModeProposal{}, automode.Config{}, fmt.Errorf("store: no database")
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return AutoModeProposal{}, automode.Config{}, err
+	}
+	defer tx.Rollback()
+
+	proposal, err := scanAutoModeProposal(tx.QueryRow(`
+		SELECT id, kind, target, value, proposed_by, state, created_at, resolved_at
+		FROM automode_proposals WHERE id = ?`, id))
+	if err == sql.ErrNoRows {
+		return AutoModeProposal{}, automode.Config{}, fmt.Errorf("no auto mode proposal %d", id)
+	}
+	if err != nil {
+		return AutoModeProposal{}, automode.Config{}, err
+	}
+	if proposal.State != automode.StatePending {
+		return AutoModeProposal{}, automode.Config{}, fmt.Errorf("auto mode proposal %d is already %s", id, proposal.State)
+	}
+	if err := automode.ValidateProposal(proposal.Kind, proposal.Target, proposal.Value); err != nil {
+		return AutoModeProposal{}, automode.Config{}, err
+	}
+
+	cfg, err := s.readAutoModeConfig(tx)
+	if err != nil {
+		return AutoModeProposal{}, automode.Config{}, err
+	}
+	switch proposal.Kind {
+	case automode.KindAllow:
+		cfg.Allow = appendUnique(cfg.Allow, proposal.Value)
+	case automode.KindDeny:
+		cfg.HardDeny = appendUnique(cfg.HardDeny, proposal.Value)
+	case automode.KindModel:
+		if proposal.Target == automode.TargetClassifier {
+			cfg.ClassifierModel = proposal.Value
+		} else {
+			cfg.EscalationModel = proposal.Value
+		}
+	}
+	if err := writeAutoModeConfig(tx, cfg, now); err != nil {
+		return AutoModeProposal{}, automode.Config{}, err
+	}
+	stamp := now.UTC().Format(sortableTimeFormat)
+	if _, err := tx.Exec(`UPDATE automode_proposals SET state = ?, resolved_at = ? WHERE id = ?`,
+		automode.StatePromoted, stamp, id); err != nil {
+		return AutoModeProposal{}, automode.Config{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return AutoModeProposal{}, automode.Config{}, err
+	}
+	proposal.State = automode.StatePromoted
+	proposal.ResolvedAt = now.UTC()
+	return proposal, cfg, nil
+}
+
+// DiscardAutoModeProposal closes a pending proposal without applying it.
+func (s *Store) DiscardAutoModeProposal(id int64, now time.Time) (AutoModeProposal, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return AutoModeProposal{}, fmt.Errorf("store: no database")
+	}
+	proposal, err := scanAutoModeProposal(s.db.QueryRow(`
+		SELECT id, kind, target, value, proposed_by, state, created_at, resolved_at
+		FROM automode_proposals WHERE id = ?`, id))
+	if err == sql.ErrNoRows {
+		return AutoModeProposal{}, fmt.Errorf("no auto mode proposal %d", id)
+	}
+	if err != nil {
+		return AutoModeProposal{}, err
+	}
+	if proposal.State != automode.StatePending {
+		return AutoModeProposal{}, fmt.Errorf("auto mode proposal %d is already %s", id, proposal.State)
+	}
+	stamp := now.UTC().Format(sortableTimeFormat)
+	if _, err := s.db.Exec(`UPDATE automode_proposals SET state = ?, resolved_at = ? WHERE id = ?`,
+		automode.StateDiscarded, stamp, id); err != nil {
+		return AutoModeProposal{}, err
+	}
+	proposal.State = automode.StateDiscarded
+	proposal.ResolvedAt = now.UTC()
+	return proposal, nil
+}
+
+// RecordAutoModeDenial stores one refused call. Slice 5 wires the reports; this
+// is the writer they land in.
+func (s *Store) RecordAutoModeDenial(sessionID, tool, signature, reason string, now time.Time) (AutoModeDenial, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return AutoModeDenial{}, fmt.Errorf("store: no database")
+	}
+	stamp := now.UTC().Format(sortableTimeFormat)
+	res, err := s.db.Exec(`
+		INSERT INTO automode_denials (session_id, tool, signature, reason, created_at)
+		VALUES (?, ?, ?, ?, ?)
+	`, sessionID, tool, signature, reason, stamp)
+	if err != nil {
+		return AutoModeDenial{}, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return AutoModeDenial{}, err
+	}
+	return AutoModeDenial{
+		ID: id, SessionID: sessionID, Tool: tool, Signature: signature,
+		Reason: reason, CreatedAt: now.UTC(),
+	}, nil
+}
+
+// ListAutoModeDenials returns the most recent denials, newest first.
+func (s *Store) ListAutoModeDenials(limit int) ([]AutoModeDenial, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.db == nil {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	rows, err := s.db.Query(`
+		SELECT id, session_id, tool, signature, reason, created_at
+		FROM automode_denials ORDER BY id DESC LIMIT ?`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []AutoModeDenial
+	for rows.Next() {
+		var d AutoModeDenial
+		var created string
+		if err := rows.Scan(&d.ID, &d.SessionID, &d.Tool, &d.Signature, &d.Reason, &created); err != nil {
+			return nil, err
+		}
+		d.CreatedAt = parseStoredTime(created)
+		out = append(out, d)
+	}
+	return out, rows.Err()
+}
+
+// mutateAutoModeConfig reads the config, applies a change, and writes it back
+// under the store's write lock.
+func (s *Store) mutateAutoModeConfig(now time.Time, apply func(*automode.Config) error) (automode.Config, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return automode.Config{}, fmt.Errorf("store: no database")
+	}
+	cfg, err := s.readAutoModeConfig(s.db)
+	if err != nil {
+		return automode.Config{}, err
+	}
+	if err := apply(&cfg); err != nil {
+		return automode.Config{}, err
+	}
+	if err := writeAutoModeConfig(s.db, cfg, now); err != nil {
+		return automode.Config{}, err
+	}
+	return cfg, nil
+}
+
+// writeAutoModeConfig takes an execer (jobs.go) so it writes through either a
+// *sql.DB or a promote's transaction.
+func writeAutoModeConfig(e execer, cfg automode.Config, now time.Time) error {
+	environment, err := encodeStringList(cfg.Environment)
+	if err != nil {
+		return err
+	}
+	allow, err := encodeStringList(cfg.Allow)
+	if err != nil {
+		return err
+	}
+	hardDeny, err := encodeStringList(cfg.HardDeny)
+	if err != nil {
+		return err
+	}
+	enabled := 0
+	if cfg.EnabledDefault {
+		enabled = 1
+	}
+	_, err = e.Exec(`
+		INSERT INTO automode_config
+			(id, enabled_default, environment, allow_patterns, hard_deny,
+			 classifier_model, escalation_model, updated_at)
+		VALUES (1, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			enabled_default  = excluded.enabled_default,
+			environment      = excluded.environment,
+			allow_patterns   = excluded.allow_patterns,
+			hard_deny        = excluded.hard_deny,
+			classifier_model = excluded.classifier_model,
+			escalation_model = excluded.escalation_model,
+			updated_at       = excluded.updated_at
+	`, enabled, environment, allow, hardDeny, cfg.ClassifierModel, cfg.EscalationModel,
+		now.UTC().Format(sortableTimeFormat))
+	return err
+}
+
+func scanAutoModeProposal(row interface{ Scan(...any) error }) (AutoModeProposal, error) {
+	var p AutoModeProposal
+	var created, resolved string
+	if err := row.Scan(&p.ID, &p.Kind, &p.Target, &p.Value, &p.ProposedBy, &p.State, &created, &resolved); err != nil {
+		return AutoModeProposal{}, err
+	}
+	p.CreatedAt = parseStoredTime(created)
+	p.ResolvedAt = parseStoredTime(resolved)
+	return p, nil
+}
+
+func parseStoredTime(value string) time.Time {
+	if value == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{sortableTimeFormat, time.RFC3339Nano, time.RFC3339} {
+		if t, err := time.Parse(layout, value); err == nil {
+			return t.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+func encodeStringList(values []string) (string, error) {
+	if values == nil {
+		values = []string{}
+	}
+	raw, err := json.Marshal(values)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+func decodeStringList(raw, field string) ([]string, error) {
+	if raw == "" {
+		return []string{}, nil
+	}
+	var out []string
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil, fmt.Errorf("automode config %s is not a JSON list: %w", field, err)
+	}
+	if out == nil {
+		out = []string{}
+	}
+	return out, nil
+}
+
+func appendUnique(values []string, value string) []string {
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}

--- a/internal/store/automode_test.go
+++ b/internal/store/automode_test.go
@@ -1,0 +1,238 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/automode"
+)
+
+func TestAutoModeConfigDefaultsOnAFreshDatabase(t *testing.T) {
+	s := New()
+	cfg, err := s.GetAutoModeConfig()
+	if err != nil {
+		t.Fatalf("get config: %v", err)
+	}
+	if cfg.ClassifierModel != automode.DefaultClassifierModel {
+		t.Errorf("classifier model = %q, want the shipped default", cfg.ClassifierModel)
+	}
+	if cfg.EscalationModel != automode.DefaultEscalationModel {
+		t.Errorf("escalation model = %q, want the shipped default", cfg.EscalationModel)
+	}
+	if !cfg.EnabledDefault {
+		t.Error("enabled_default = false on a fresh database, want true")
+	}
+	if len(cfg.Allow) != 0 || len(cfg.HardDeny) != 0 || len(cfg.Environment) != 0 {
+		t.Errorf("fresh config is not empty: %+v", cfg)
+	}
+}
+
+func TestAutoModeEnvironmentRoundTrips(t *testing.T) {
+	s := New()
+	now := time.Now().UTC()
+	cfg, err := s.SetAutoModeEnvironment([]string{"pushing to origin is fine", "never touch prod"}, now)
+	if err != nil {
+		t.Fatalf("set environment: %v", err)
+	}
+	if len(cfg.Environment) != 2 {
+		t.Fatalf("environment = %v, want two entries", cfg.Environment)
+	}
+	read, err := s.GetAutoModeConfig()
+	if err != nil {
+		t.Fatalf("get config: %v", err)
+	}
+	if read.Environment[1] != "never touch prod" {
+		t.Errorf("environment[1] = %q", read.Environment[1])
+	}
+	// Editing prose must not disturb the models a promote set.
+	if read.ClassifierModel != automode.DefaultClassifierModel {
+		t.Errorf("classifier model drifted to %q", read.ClassifierModel)
+	}
+}
+
+// The whole point of the split: recording a proposal changes nothing a session
+// launches with.
+func TestAutoModeProposalDoesNotChangeTheConfig(t *testing.T) {
+	s := New()
+	now := time.Now().UTC()
+	before, err := s.GetAutoModeConfig()
+	if err != nil {
+		t.Fatalf("get config: %v", err)
+	}
+	if _, err := s.CreateAutoModeProposal(automode.KindAllow, "", "git push origin*", "session-1", now); err != nil {
+		t.Fatalf("create proposal: %v", err)
+	}
+	if _, err := s.CreateAutoModeProposal(automode.KindModel, automode.TargetClassifier, "opencode-go/other-model", "", now); err != nil {
+		t.Fatalf("create model proposal: %v", err)
+	}
+	after, err := s.GetAutoModeConfig()
+	if err != nil {
+		t.Fatalf("get config: %v", err)
+	}
+	if len(after.Allow) != 0 {
+		t.Errorf("allow list changed to %v", after.Allow)
+	}
+	if after.ClassifierModel != before.ClassifierModel {
+		t.Errorf("classifier model changed to %q", after.ClassifierModel)
+	}
+	pending, err := s.ListAutoModeProposals(automode.StatePending)
+	if err != nil {
+		t.Fatalf("list proposals: %v", err)
+	}
+	if len(pending) != 2 {
+		t.Fatalf("pending proposals = %d, want 2", len(pending))
+	}
+	if pending[0].ProposedBy != "session-1" {
+		t.Errorf("proposed_by = %q, want the recorded session", pending[0].ProposedBy)
+	}
+}
+
+func TestAutoModeCreateProposalRefusesABroadAllow(t *testing.T) {
+	s := New()
+	if _, err := s.CreateAutoModeProposal(automode.KindAllow, "", "*", "", time.Now()); err == nil {
+		t.Fatal("a broad allow proposal was recorded")
+	}
+	pending, err := s.ListAutoModeProposals("")
+	if err != nil {
+		t.Fatalf("list proposals: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("a refused proposal reached the table: %+v", pending)
+	}
+}
+
+func TestAutoModePromoteAppliesAndClosesTheProposal(t *testing.T) {
+	s := New()
+	now := time.Now().UTC()
+	allow, err := s.CreateAutoModeProposal(automode.KindAllow, "", "git push origin*", "", now)
+	if err != nil {
+		t.Fatalf("create allow: %v", err)
+	}
+	model, err := s.CreateAutoModeProposal(automode.KindModel, automode.TargetEscalation, "opencode-go/kimi-k3", "", now)
+	if err != nil {
+		t.Fatalf("create model: %v", err)
+	}
+
+	promoted, cfg, err := s.PromoteAutoModeProposal(allow.ID, now)
+	if err != nil {
+		t.Fatalf("promote allow: %v", err)
+	}
+	if promoted.State != automode.StatePromoted || promoted.ResolvedAt.IsZero() {
+		t.Errorf("promoted proposal = %+v", promoted)
+	}
+	if len(cfg.Allow) != 1 || cfg.Allow[0] != "git push origin*" {
+		t.Fatalf("allow list = %v", cfg.Allow)
+	}
+	if _, cfg, err = s.PromoteAutoModeProposal(model.ID, now); err != nil {
+		t.Fatalf("promote model: %v", err)
+	}
+	if cfg.EscalationModel != "opencode-go/kimi-k3" {
+		t.Errorf("escalation model = %q", cfg.EscalationModel)
+	}
+	if cfg.ClassifierModel != automode.DefaultClassifierModel {
+		t.Errorf("classifier model = %q, want it untouched", cfg.ClassifierModel)
+	}
+
+	read, err := s.GetAutoModeConfig()
+	if err != nil {
+		t.Fatalf("get config: %v", err)
+	}
+	if len(read.Allow) != 1 || read.EscalationModel != "opencode-go/kimi-k3" {
+		t.Fatalf("promoted config did not survive the read: %+v", read)
+	}
+	pending, err := s.ListAutoModeProposals(automode.StatePending)
+	if err != nil {
+		t.Fatalf("list proposals: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("promoted proposals are still pending: %+v", pending)
+	}
+}
+
+func TestAutoModePromoteIsIdempotentlyRefusedTwice(t *testing.T) {
+	s := New()
+	now := time.Now().UTC()
+	p, err := s.CreateAutoModeProposal(automode.KindDeny, "", "rm -rf /*", "", now)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, _, err := s.PromoteAutoModeProposal(p.ID, now); err != nil {
+		t.Fatalf("first promote: %v", err)
+	}
+	if _, _, err := s.PromoteAutoModeProposal(p.ID, now); err == nil {
+		t.Fatal("a second promote was accepted")
+	}
+	cfg, err := s.GetAutoModeConfig()
+	if err != nil {
+		t.Fatalf("get config: %v", err)
+	}
+	if len(cfg.HardDeny) != 1 {
+		t.Fatalf("hard deny = %v, want one entry after two promotes", cfg.HardDeny)
+	}
+}
+
+func TestAutoModeDiscardLeavesTheConfigAlone(t *testing.T) {
+	s := New()
+	now := time.Now().UTC()
+	p, err := s.CreateAutoModeProposal(automode.KindAllow, "", "curl https://example.com*", "", now)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	discarded, err := s.DiscardAutoModeProposal(p.ID, now)
+	if err != nil {
+		t.Fatalf("discard: %v", err)
+	}
+	if discarded.State != automode.StateDiscarded {
+		t.Errorf("state = %q", discarded.State)
+	}
+	cfg, err := s.GetAutoModeConfig()
+	if err != nil {
+		t.Fatalf("get config: %v", err)
+	}
+	if len(cfg.Allow) != 0 {
+		t.Fatalf("allow list = %v after a discard", cfg.Allow)
+	}
+	if _, _, err := s.PromoteAutoModeProposal(p.ID, now); err == nil {
+		t.Fatal("a discarded proposal was promoted")
+	}
+}
+
+func TestAutoModeDenialsReadNewestFirst(t *testing.T) {
+	s := New()
+	now := time.Now().UTC()
+	for _, signature := range []string{"bash curl evil.example", "write /etc/hosts", "bash git push --force"} {
+		if _, err := s.RecordAutoModeDenial("session-1", "bash", signature, "outside the envelope", now); err != nil {
+			t.Fatalf("record denial: %v", err)
+		}
+	}
+	denials, err := s.ListAutoModeDenials(2)
+	if err != nil {
+		t.Fatalf("list denials: %v", err)
+	}
+	if len(denials) != 2 {
+		t.Fatalf("denials = %d, want the limit of 2", len(denials))
+	}
+	if denials[0].Signature != "bash git push --force" {
+		t.Errorf("newest denial = %q", denials[0].Signature)
+	}
+}
+
+// Migration 109 is what every one of these tests runs against; this asserts it
+// by name so a renumbering that skips it fails here rather than in production.
+func TestAutoModeMigrationCreatesItsTables(t *testing.T) {
+	s := New()
+	for _, table := range []string{"automode_config", "automode_proposals", "automode_denials"} {
+		var name string
+		err := s.db.QueryRow(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`, table).Scan(&name)
+		if err != nil {
+			t.Fatalf("table %s is missing: %v", table, err)
+		}
+	}
+	var applied int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM schema_migrations WHERE version = 109`).Scan(&applied); err != nil {
+		t.Fatalf("read schema_migrations: %v", err)
+	}
+	if applied != 1 {
+		t.Fatalf("migration 109 applied %d times, want once", applied)
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -1112,6 +1112,46 @@ CREATE INDEX IF NOT EXISTS idx_app_invocations_started ON app_invocations(starte
 	// Applied by applyMigration106, whose ALTER is column-guarded.
 	{106, "add durable per-session token cost state", ``},
 	{107, "record which ticket event a delivery covered", ``},
+	// Auto mode's home, at 109 because 108 is burned: a branch still in flight
+	// applied it to a production database before merging, and migrateDB skips
+	// anything at or below the highest version already applied.
+	//
+	// One promoted config row, the proposals waiting on a human, and the denials
+	// slice 5 reports. The split is the security design: the CLI writes
+	// proposals, only the app promotes one into the config row, so an agent
+	// cannot write its own leash. Empty model columns mean "whichever default
+	// ships" — automode.Defaults() resolves them at read.
+	{109, "auto mode config, proposals and denials", `CREATE TABLE IF NOT EXISTS automode_config (
+    id               INTEGER PRIMARY KEY CHECK (id = 1),
+    enabled_default  INTEGER NOT NULL DEFAULT 1,
+    environment      TEXT NOT NULL DEFAULT '[]',
+    allow_patterns   TEXT NOT NULL DEFAULT '[]',
+    hard_deny        TEXT NOT NULL DEFAULT '[]',
+    classifier_model TEXT NOT NULL DEFAULT '',
+    escalation_model TEXT NOT NULL DEFAULT '',
+    updated_at       TEXT NOT NULL DEFAULT ''
+);
+CREATE TABLE IF NOT EXISTS automode_proposals (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind        TEXT NOT NULL,
+    target      TEXT NOT NULL DEFAULT '',
+    value       TEXT NOT NULL,
+    proposed_by TEXT NOT NULL DEFAULT '',
+    state       TEXT NOT NULL DEFAULT 'pending',
+    created_at  TEXT NOT NULL,
+    resolved_at TEXT NOT NULL DEFAULT ''
+);
+-- The review list: everything still pending, oldest first.
+CREATE INDEX IF NOT EXISTS idx_automode_proposals_state ON automode_proposals(state, id);
+CREATE TABLE IF NOT EXISTS automode_denials (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL DEFAULT '',
+    tool       TEXT NOT NULL DEFAULT '',
+    signature  TEXT NOT NULL DEFAULT '',
+    reason     TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_automode_denials_recent ON automode_denials(id DESC);`},
 }
 
 // migration99SQL is everything migration 99 does after its guarded ALTER.

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -1114,7 +1114,10 @@ CREATE INDEX IF NOT EXISTS idx_app_invocations_started ON app_invocations(starte
 	{107, "record which ticket event a delivery covered", ``},
 	// Auto mode's home, at 109 because 108 is burned: a branch still in flight
 	// applied it to a production database before merging, and migrateDB skips
-	// anything at or below the highest version already applied.
+	// anything at or below the highest version already applied. That cuts both
+	// ways — a database created after this lands sits at 109, so a later 108
+	// would be skipped there too. Whatever that branch ships must renumber
+	// above this one.
 	//
 	// One promoted config row, the proposals waiting on a human, and the denials
 	// slice 5 reports. The split is the security design: the CLI writes

--- a/plugins/attn-pi/AGENTS.md
+++ b/plugins/attn-pi/AGENTS.md
@@ -345,3 +345,9 @@ rather than through dialogs. Design and slices:
   auto mode cannot judge is refused, never run.
 - Nothing loads it yet — it is not composed into `suite/` and
   `build-bundled-plugins.sh` does not stage it.
+- attn's config reaches a pi session through the launch: the daemon hands the
+  promoted config to a driver that advertises the `auto_mode` capability, and
+  the driver forwards it as `ATTN_PI_AUTOMODE_CONFIG` (JSON, the exact shape
+  `automode/config.ts` parses). Environment rather than argv because prose
+  entries are multi-line and argv is world-readable. A config change reaches
+  the next session; a live one is not refreshed.

--- a/plugins/attn-pi/src/driver.ts
+++ b/plugins/attn-pi/src/driver.ts
@@ -90,6 +90,7 @@ export class PiDriver {
         effort_pin: true,
         state_reporting: true,
         message_delivery: true,
+        auto_mode: true,
       },
     });
     if (!result.ok) throw new Error("attn rejected pi driver registration");
@@ -119,7 +120,7 @@ export class PiDriver {
     return {
       argv: this.argvFor(availability.executable, metadata, params.initial_prompt, suitePath),
       cwd: params.cwd,
-      env: this.envFor(run.token),
+      env: this.envFor(run.token, params.auto_mode),
     };
   }
 
@@ -146,7 +147,7 @@ export class PiDriver {
     return {
       argv: this.argvFor(availability.executable, metadata, undefined, suitePath),
       cwd: params.cwd,
-      env: this.envFor(run.token),
+      env: this.envFor(run.token, params.auto_mode),
     };
   }
 
@@ -257,8 +258,14 @@ export class PiDriver {
     return this.suitePath;
   }
 
-  private envFor(token: string): Record<string, string> {
-    return { ATTN_PI_SUITE_SOCKET: this.relay.socketPath, ATTN_PI_TOKEN: token };
+  // The auto-mode config travels in the environment rather than argv: prose
+  // entries are multi-line text, and argv is world-readable. The JSON is exactly
+  // what automode/config.ts's loadAutoModeConfig parses, so the session side
+  // reads it without translating. Absent when attn sent none.
+  private envFor(token: string, autoMode: unknown): Record<string, string> {
+    const env: Record<string, string> = { ATTN_PI_SUITE_SOCKET: this.relay.socketPath, ATTN_PI_TOKEN: token };
+    if (autoMode !== undefined && autoMode !== null) env.ATTN_PI_AUTOMODE_CONFIG = JSON.stringify(autoMode);
+    return env;
   }
 
   private argvFor(

--- a/plugins/attn-pi/src/types.ts
+++ b/plugins/attn-pi/src/types.ts
@@ -76,6 +76,10 @@ export type DriverSpawnParams = {
   effort?: string;
   initial_prompt?: string;
   metadata?: unknown;
+  // attn's promoted auto-mode config, in the raw snake_case shape
+  // automode/config.ts parses (enabled_default, environment, allow, hard_deny,
+  // classifier_model, escalation_model). Absent when the daemon sent none.
+  auto_mode?: unknown;
 };
 
 export type DriverSpawnResult = {

--- a/plugins/attn-pi/test/driver.test.ts
+++ b/plugins/attn-pi/test/driver.test.ts
@@ -85,6 +85,7 @@ describe("PiDriver", () => {
         effort_pin: true,
         state_reporting: true,
         message_delivery: true,
+        auto_mode: true,
       },
     });
   });
@@ -101,6 +102,25 @@ describe("PiDriver", () => {
     expect(rpc.requests.find((call) => call.method === "driver.register")).toBeUndefined();
     const health = driver.health();
     expect(health.ok).toBe(false);
+  });
+
+  test("spawn forwards attn's auto mode config in the environment, and omits it when there is none", async () => {
+    const rpc = new FakeRPC();
+    const driver = newDriver({ rpc, runCommand: fakeRunCommand(), executable: "pi" });
+
+    const bare = await driver.spawn(params());
+    expect(bare.env?.ATTN_PI_AUTOMODE_CONFIG).toBeUndefined();
+
+    const config = {
+      enabled_default: true,
+      environment: ["never touch prod"],
+      allow: ["git push origin*"],
+      hard_deny: [],
+      classifier_model: "opencode-go/glm-5.3",
+      escalation_model: "opencode-go/qwen3.8-max",
+    };
+    const withConfig = await driver.spawn(params({ session_id: "session-2", run_id: "run-2", auto_mode: config }));
+    expect(JSON.parse(withConfig.env?.ATTN_PI_AUTOMODE_CONFIG ?? "null")).toEqual(config);
   });
 
   test("spawn returns a fresh session id, passes cwd through, and reports metadata", async () => {


### PR DESCRIPTION
Slice 4 of [pi auto mode](docs/plans/2026-08-16-pi-auto-mode.md): auto mode's
attn home. The policy core (slice 1, #929) decides; this gives it somewhere to
read its config from, a way for humans and agents to change it, and a way for it
to reach a session.

## The shape

**Storage** (`internal/store/automode.go`, migration 109). One promoted config
row — environment prose, allow patterns, hard denies, classifier and escalation
models, the enabled default — plus the proposals waiting on a human and the
denials slice 5 will report. Unset model columns mean "whichever default ships",
resolved at read, so changing a default reaches everyone who never picked one.

**The split, which is the security design.** Everything reachable over the unix
socket — and therefore by any agent — either reads or records a *proposal*.
`attn automode allow "git push origin*"` writes a row and says so in as many
words; it changes nothing a session runs under. Promotion and discard exist on
the WebSocket alone, because a human in the app is the trust boundary a CLI
caller cannot fake. `PromoteAutoModeProposal` is the only writer that puts a
pattern or a model into the config row, and a broad allow pattern (nothing left
after the wildcards) is refused both at submission and again at promotion,
mirroring `plugins/attn-pi/automode/config.ts`.

Environment prose is the deliberate exception: `env add`/`env remove` edit it
directly, per the plan's public interface, because it describes the machine to
the classifier rather than naming a rule that skips it. Worth flagging for
slice 5: prose is still classifier input an agent can write, so if that ever
feels too loose, it belongs behind proposals too — the storage would not have to
change.

**CLI.** `attn automode show | env [add|remove] | allow | deny | model
<classifier|escalation> <provider/id> | denials`, every verb with `--json`.
`denials` reads an empty table until slice 5 reports into it.

**Protocol** (254). Unix socket: `automode_show`, `automode_env_add`,
`automode_env_remove`, `automode_propose`, `automode_denials`. WebSocket:
`automode_get`, `automode_promote`, `automode_discard` — the app's settings
section lands in slice 5, but the daemon is the authority and the handlers ship
now.

**Launch injection.** A plugin driver that advertises the new `auto_mode`
capability is handed the promoted config at spawn and at reload/resume, in the
exact JSON shape `automode/config.ts` parses. The pi driver forwards it as
`ATTN_PI_AUTOMODE_CONFIG` — environment rather than argv, because prose entries
are multi-line and argv is world-readable. Consuming it is slice 3's job. A
config change reaches the next session; a live session is not refreshed.

Migration **109**, not 108: 108 was applied to a production database by a branch
still in flight, and `migrateDB` skips anything at or below the highest version
already applied.

## Tests

Go: storage (defaults, round trip, promote applies and closes, double promote
refused, discard leaves the config alone, migration 109 by name), the
propose-only semantics at the protocol boundary, the broad-allow refusal
carrying its own sentence, promote/discard over the app transport, and the two
launch cases (a driver with the capability gets the payload with the right wire
keys, one without gets nothing). One test drives `automode_promote` into the
unix-socket dispatcher and asserts "unknown command" — the absence is the trust
boundary, so it is pinned rather than assumed. Plus `internal/automode` unit
tests including a marshalling test that pins the six pi-side field names.

bun: the driver forwards the config and omits the variable when attn sent none.

## Live verification

Full tier — protocol change. Throwaway profile `amber-vole`
(`make install PROFILE=amber-vole`), bundled preflight clean (14 PASS, protocol
254 across CLI/app/daemon), then end to end against the running daemon:

- `automode show` on a fresh profile → shipped defaults, no proposals.
- `env add` twice, `env remove 0` → prose edits land immediately.
- `allow "git push origin*"`, a destructive-command deny, and
  `model classifier …` → three proposals recorded; `show` confirms the effective
  allow list is still empty.
- `allow "*"` → refused by name, exit 1, nothing recorded.
- Over the WebSocket as the app: `automode_get` → config + 3 pending;
  `automode_promote 1` → allow list now holds the pattern; `automode_discard 2`
  → classifier model untouched; `automode_get` → one pending left.
- `automode show` from the CLI agrees with all of it.
- Spawned a real `pi` session through `spawn_session` with the attn-pi plugin
  installed, with `ATTN_PI_EXECUTABLE` pointed at a probe that dumps its
  environment: the session received `ATTN_PI_AUTOMODE_CONFIG` carrying
  `{"enabled_default":true,"environment":["never touch production data"],"allow":["git push origin*"],"hard_deny":[],"classifier_model":"opencode-go/glm-5.3","escalation_model":"opencode-go/qwen3.8-max"}`
  — the promoted pattern and the prose, exactly as edited.

Profile cleaned afterwards (`attn profile clean amber-vole`: daemon stopped, 2
workers removed, 2 plugins terminated, app and data dir removed).

No app-visible UI in this slice, so no evidence recording.

## Not here

The settings UI and denial reporting (slice 5), the suite consuming the injected
config (slice 3), per-workspace scope, and the bare-pi file fallback. Nothing
broadcasts on config change yet — with no UI to update there is nothing to push;
slice 5 adds the fact and its projection alongside the section that renders it.

One thing slice 5 should carry: the WebSocket is localhost and scriptable — our
own test clients speak it — so "the app is the human" is a strong default rather
than a wall. The belt-and-suspenders the plan names is a shipped hard_deny
covering attn's own auto mode surfaces, so a pi session reaching for its own
leash is classified and denied rather than trusted by transport alone.

https://claude.ai/code/session_01PF34o9YcbFBk1eQbr1cb5s
