### PR TITLE
feat(attn-pi): auto mode in the session — suite composition, toggle, TUI surfaces

### DIFF
--- a/changelog.d/pi-auto-mode-in-the-session.yaml
+++ b/changelog.d/pi-auto-mode-in-the-session.yaml
@@ -1,0 +1,16 @@
+kind: added
+area: attn-pi
+change: >
+  Auto mode now runs in pi sessions. Work inside the session's working
+  directory runs untouched; anything reaching past it is judged against what
+  the conversation asked for, and a refusal comes back to the agent as its
+  tool result rather than stopping the run — approving it in your next reply
+  is what lets the agent retry. The status line says whether auto mode is on,
+  `/auto` toggles it, `--auto` and `--no-auto` set it at launch, a call being
+  judged says so instead of looking stuck, and blocked calls are listed until
+  you answer them. If auto mode ends up refusing call after call it asks once
+  whether to carry on, and an unattended session (`-p`, `--mode json`) keeps
+  refusing rather than guessing. attn sessions take their configuration from
+  attn; a plain pi gets the same extension with
+  `pi -e <plugin>/automode.js`, configured by a file under its own config
+  directory.

--- a/plugins/attn-pi/AGENTS.md
+++ b/plugins/attn-pi/AGENTS.md
@@ -361,11 +361,38 @@ rather than through dialogs. Design and slices:
   usage. A blocked call never reaches pi's result hook, so there is nothing to
   attach it to at the time — the session total is right, per-call attribution
   is not, and a session whose last act is a denial never reports that one.
-- Nothing loads it yet — it is not composed into `suite/` and
-  `build-bundled-plugins.sh` does not stage it.
 - attn's config reaches a pi session through the launch: the daemon hands the
   promoted config to a driver that advertises the `auto_mode` capability, and
   the driver forwards it as `ATTN_PI_AUTOMODE_CONFIG` (JSON, the exact shape
   `automode/config.ts` parses). Environment rather than argv because prose
   entries are multi-line and argv is world-readable. A config change reaches
   the next session; a live one is not refreshed.
+- Two entrypoints, one module. `suite/index.ts` composes auto mode in when
+  `ATTN_PI_AUTOMODE_CONFIG` is set — attn's launch injection — and builds
+  nothing at all when it is not, so a bare pi loading `suite.js` registers no
+  command, no flag and no handler for it. `automode/standalone.ts` is the same
+  extension for `pi -e automode.js`, reading the same JSON from
+  `attn-automode.json` under pi's config dir (`PI_CODING_AGENT_DIR`, or
+  `~/.pi/agent`). Both are staged by `build-bundled-plugins.sh`.
+- The `AutoMode` in `mode.ts` lives at module scope and survives session
+  transitions; the session state the factory owns does not. That is the line:
+  the user's `/auto` choice is theirs until they change it, while the verdict
+  cache and the breaker belong to one session.
+- Precedence is `/auto` > `--auto`/`--no-auto` > `enabled_default`. The flags
+  carry no default so an unset one reads as undefined, and the plan's
+  "flag > /auto" holds at launch, when there is no `/auto` yet — after one, the
+  command the user typed wins, because a command that loses to a flag is not a
+  command.
+- The classifier is built from `ctx.modelRegistry`, captured at
+  `session_start`. A session with no catalog refuses classified calls with a
+  named reason rather than running them.
+- Every UI surface is set on a transition and never on a timer: the status when
+  the mode changes, the working message for the length of one classification,
+  the denial widget when a call is denied and cleared when the user speaks. A
+  quiet session draws nothing.
+- The breaker asks once per episode through `ctx.ui.confirm`; `hasUI === false`
+  (`-p`, `--mode json`) is fail-closed, per `permission-gate.ts`'s precedent.
+  Answering yes clears the counters and judges the call that tripped it — it
+  approves nothing on its own.
+- Denials are reported through `AutoMode`'s `onDenial` seam. Nothing sets it
+  yet: attn-side reporting is slice 5.

--- a/plugins/attn-pi/README.md
+++ b/plugins/attn-pi/README.md
@@ -6,3 +6,33 @@ owns the PTY and session records; this plugin only decides what argv to run.
 
 See `AGENTS.md` for the pi invariants this driver relies on and
 `docs/plans/2026-07-19-pi-driver-plugin.md` for the implementation plan.
+
+## Auto mode outside attn
+
+`automode.js` is pi's permission system on its own: a safety envelope around
+the working directory, a classifier for everything past it, and approval by
+saying so in the conversation.
+
+```
+pi -e /path/to/attn-pi/automode.js --auto
+```
+
+`/auto` toggles it, `--auto` / `--no-auto` set it at launch, and the status
+line says which it is. Without a flag it starts off unless a config file turns
+it on:
+
+```jsonc
+// ~/.pi/agent/attn-automode.json  (or $PI_CODING_AGENT_DIR/attn-automode.json)
+{
+  "enabled_default": true,
+  "environment": ["this machine has no production credentials"],
+  "allow": ["git push origin*"],
+  "hard_deny": ["rm -rf /*"],
+  "classifier_model": "opencode-go/glm-5.3",
+  "escalation_model": "opencode-go/qwen3.8-max"
+}
+```
+
+Every field is optional; the models default to the ones the classifier receipt
+in `docs/plans/2026-08-16-pi-auto-mode.md` picked. A file without
+`enabled_default` configures auto mode without turning it on.

--- a/plugins/attn-pi/attn-plugin.toml
+++ b/plugins/attn-pi/attn-plugin.toml
@@ -1,5 +1,5 @@
 name = "attn-pi"
-version = "0.1.0"
+version = "0.2.0"
 attn_api_version = 5
 description = "pi driver for attn"
 

--- a/plugins/attn-pi/automode/index.ts
+++ b/plugins/attn-pi/automode/index.ts
@@ -12,6 +12,14 @@ import type { AutoModeConfig } from "./config";
 import { denialToolResult } from "./denial";
 import { describeCall, type ToolCall } from "./policy";
 import { AutoModeSession, type SessionDecision } from "./session";
+import {
+  autoModeDenialWidgetKey,
+  breakerQuestion,
+  classifyingWorkingMessage,
+  denialNotice,
+  denialWidgetLines,
+  type AutoModeUILike,
+} from "./ui";
 import { mergeUsage, UsageLedger, type UsageLike } from "./usage";
 
 export type ToolCallEventLike = {
@@ -52,6 +60,9 @@ export type ToolResultEventResultLike = { usage?: UsageLike };
 export type AutoModeContextLike = {
   cwd: string;
   signal?: AbortSignal;
+  /** False in `-p` and `--mode json`: nothing can be asked there. */
+  hasUI?: boolean;
+  ui?: AutoModeUILike;
 };
 
 export type AutoModeExtensionAPILike = {
@@ -84,8 +95,13 @@ export type AutoModeDenial = {
 export type AutoModeOptions = {
   config: AutoModeConfig;
   classifier: Classifier;
-  /** Auto mode off registers nothing: pi behaves exactly as it does without this extension. */
-  enabled?: boolean;
+  /**
+   * Whether auto mode judges this call, asked per call because `/auto` can
+   * turn it off mid-session. Off means the handlers stay registered and do
+   * nothing but keep listening to the conversation, so turning it back on has
+   * the context it needs.
+   */
+  isEnabled?: () => boolean;
   /** Called for every blocked call, for the surfaces that report denials. */
   onDenial?: (denial: AutoModeDenial) => void;
   /**
@@ -102,26 +118,71 @@ export type AutoModeOptions = {
  */
 export function createAutoMode(options: AutoModeOptions): (pi: AutoModeExtensionAPILike) => void {
   return function autoMode(pi: AutoModeExtensionAPILike): void {
-    if (options.enabled === false) return;
-    const session = new AutoModeSession(options.config, options.classifier);
+    // The ctx of the call being judged, so the classification's "checking…"
+    // feedback appears for exactly as long as a classification runs — and only
+    // when one runs at all, which is the envelope's whole point. pi runs tool
+    // calls in parallel, so both are counted rather than flagged: the last one
+    // to finish is what puts the working message back.
+    let judging: AutoModeContextLike | undefined;
+    let deciding = 0;
+    let checking = 0;
+    const classifier: Classifier = {
+      classify: async (request) => {
+        const ui = uiOf(judging);
+        checking += 1;
+        ui?.setWorkingMessage(classifyingWorkingMessage);
+        try {
+          return await options.classifier.classify(request);
+        } finally {
+          checking -= 1;
+          if (checking === 0) ui?.setWorkingMessage();
+        }
+      },
+    };
+    const session = new AutoModeSession(options.config, classifier);
+    // Denials since the user last spoke, which is also when the widget listing
+    // them is cleared: speaking is what drops them, so it is what unshows them.
+    let standing: AutoModeDenial[] = [];
+    // The breaker asks once per episode. Answering it, or speaking, ends one.
+    let breakerAsked = false;
 
     pi.on("tool_call", async (event, ctx) => {
+      if (options.isEnabled?.() === false) return undefined;
       const call: ToolCall = { toolName: event.toolName, input: event.input };
+      const decideOptions = { cwd: ctx.cwd, signal: ctx.signal };
       let decision: SessionDecision;
+      judging = ctx;
+      deciding += 1;
       try {
-        decision = await session.decide(call, { cwd: ctx.cwd, signal: ctx.signal });
+        decision = await session.decide(call, decideOptions);
+        if (decision.outcome === "block" && decision.rule === "circuit-breaker" && !breakerAsked) {
+          breakerAsked = true;
+          if (await askToResume(session, ctx)) {
+            breakerAsked = false;
+            session.resumeAfterBreaker();
+            decision = await session.decide(call, decideOptions);
+          }
+        }
       } catch (error) {
         // pi already blocks a tool whose tool_call handler throws, but the
         // model would get pi's error text instead of the denial contract.
         return { block: true, reason: denialToolResult({ action: describeCall(call), reason: failureReason(error) }) };
+      } finally {
+        deciding -= 1;
+        // Held only while a call is in flight: a ctx from a superseded session
+        // generation throws on any use.
+        if (deciding === 0) judging = undefined;
       }
       if (decision.outcome === "run") return undefined;
-      options.onDenial?.({
+      const denial: AutoModeDenial = {
         toolCallId: event.toolCallId,
         action: decision.action,
         reason: decision.reason,
         rule: decision.rule,
-      });
+      };
+      options.onDenial?.(denial);
+      standing = [...standing, denial];
+      showDenial(ctx, denial, standing);
       return { block: true, reason: decision.toolResult };
     });
 
@@ -131,17 +192,26 @@ export function createAutoMode(options: AutoModeOptions): (pi: AutoModeExtension
     // emitted this event, so the source is remembered here for the seam that
     // cannot see it.
     let promptIsUsers = true;
-    pi.on("input", (event) => {
+    pi.on("input", (event, ctx) => {
       promptIsUsers = event.source !== "extension";
-      if (promptIsUsers) session.noteUserInput(event.text);
+      if (!promptIsUsers) return;
+      session.noteUserInput(event.text);
+      breakerAsked = false;
+      if (standing.length > 0) {
+        standing = [];
+        uiOf(ctx)?.setWidget(autoModeDenialWidgetKey, undefined);
+      }
     });
 
     // The turn's prompt, for the deliveries that never surface as an input
     // event (an SDK `session.prompt`, a launch brief). noteUserInput drops the
     // repeat when a message arrives on both seams. The addendum is appended
-    // whoever prompted — the agent is under auto mode either way.
+    // whoever prompted — the agent is under auto mode either way — but only
+    // while auto mode is on: telling an agent about a permission system that
+    // is off would have it asking for approvals nothing is going to withhold.
     pi.on("before_agent_start", (event) => {
       if (promptIsUsers) session.noteUserInput(event.prompt);
+      if (options.isEnabled?.() === false) return {};
       return { systemPrompt: `${event.systemPrompt}\n\n${autoModeSystemPromptAddendum()}` };
     });
 
@@ -159,6 +229,39 @@ export function createAutoMode(options: AutoModeOptions): (pi: AutoModeExtension
       return held ? { usage: mergeUsage(event.usage, held) } : undefined;
     });
   };
+}
+
+/**
+ * pi's UI, when there is one to talk to. `-p` and `--mode json` say so with
+ * hasUI, and a duck-typed ctx (a test's, an older pi's) may carry no ui at all.
+ */
+function uiOf(ctx: AutoModeContextLike | undefined): AutoModeUILike | undefined {
+  return ctx?.hasUI === false ? undefined : ctx?.ui;
+}
+
+/** The denial the user sees: a line as it happens, and a list that stays. */
+function showDenial(ctx: AutoModeContextLike, denial: AutoModeDenial, standing: readonly AutoModeDenial[]): void {
+  const ui = uiOf(ctx);
+  if (!ui) return;
+  ui.notify(denialNotice(denial), "warning");
+  ui.setWidget(autoModeDenialWidgetKey, denialWidgetLines(standing));
+}
+
+/**
+ * The breaker's one question. No UI is fail-closed on purpose: an unattended
+ * run has nobody to answer, and the answer is what resumes auto mode.
+ */
+async function askToResume(session: AutoModeSession, ctx: AutoModeContextLike): Promise<boolean> {
+  const ui = uiOf(ctx);
+  if (!ui) return false;
+  const breaker = session.breaker();
+  const question = breakerQuestion(breaker.consecutive, breaker.total);
+  try {
+    return await ui.confirm(question.title, question.message);
+  } catch {
+    // A dialog that could not be shown is not an approval.
+    return false;
+  }
 }
 
 function messageText(message: MessageLike): string {

--- a/plugins/attn-pi/automode/mode.ts
+++ b/plugins/attn-pi/automode/mode.ts
@@ -1,0 +1,145 @@
+// Auto mode as a pi session sees it: the `/auto` command, the `--auto` /
+// `--no-auto` flags, the status indicator, and the classifier built from
+// whatever model registry the running session hands over.
+//
+// One instance of this class lives at module scope in the entrypoints
+// (suite/index.ts, standalone.ts) and `register` runs once per pi factory run,
+// per plugins/attn-pi/AGENTS.md's lifecycle invariants. That is what makes the
+// user's `/auto` choice outlive a /new or a resume in the same process, while
+// the verdict cache and the breaker — owned by the factory below — do not.
+import type { Classifier } from "./classifier";
+import type { AutoModeConfig } from "./config";
+import {
+  createAutoMode,
+  type AutoModeContextLike,
+  type AutoModeDenial,
+  type AutoModeExtensionAPILike,
+} from "./index";
+import { ModelClassifier, type ModelRegistryLike } from "./model-classifier";
+import { autoModeStatusKey, autoModeStatusText } from "./ui";
+import { UsageLedger } from "./usage";
+
+export type AutoModeSessionContextLike = AutoModeContextLike & {
+  /** pi's ModelRegistry, the only way to reach the classifier's model. */
+  modelRegistry?: ModelRegistryLike;
+};
+
+export type SessionStartEventLike = { type: "session_start" };
+
+export type AutoModePiLike = AutoModeExtensionAPILike & {
+  on(event: "session_start", handler: (event: SessionStartEventLike, ctx: AutoModeSessionContextLike) => void): void;
+  registerCommand(
+    name: string,
+    options: { description?: string; handler: (args: string, ctx: AutoModeContextLike) => Promise<void> | void },
+  ): void;
+  registerFlag(name: string, options: { description?: string; type: "boolean" | "string" }): void;
+  getFlag(name: string): boolean | string | undefined;
+};
+
+export type AutoModeSetup = {
+  config: AutoModeConfig;
+  /**
+   * Reported for every blocked call. The seam attn's own surfaces hang off;
+   * bare pi leaves it unset.
+   */
+  onDenial?: (denial: AutoModeDenial) => void;
+  /** Said once, at the first session start that has a UI. A broken config is the caller. */
+  notice?: string;
+};
+
+export class AutoMode {
+  private readonly usage = new UsageLedger();
+  private readonly extension: (pi: AutoModeExtensionAPILike) => void;
+  /** The session's own registry, captured from the first ctx that carries one. */
+  private registry: ModelRegistryLike | undefined;
+  private classifier: { registry: ModelRegistryLike; instance: Classifier } | undefined;
+  /** What `/auto` last said. Undefined until the user says anything. */
+  private choice: boolean | undefined;
+  /** What the launch flags said. Undefined when neither was passed. */
+  private flag: boolean | undefined;
+  private noticed = false;
+
+  constructor(private readonly setup: AutoModeSetup) {
+    this.extension = createAutoMode({
+      config: setup.config,
+      classifier: { classify: (request) => this.judge().classify(request) },
+      isEnabled: () => this.enabled(),
+      onDenial: setup.onDenial,
+      usageLedger: this.usage,
+    });
+  }
+
+  /**
+   * The mode in force. A launch flag outranks the configured default, and the
+   * user's own `/auto` outranks both from the moment they use it — a command
+   * that silently loses to the flag it was typed to override is not a command.
+   */
+  enabled(): boolean {
+    return this.choice ?? this.flag ?? this.setup.config.enabledDefault;
+  }
+
+  register(pi: AutoModePiLike): void {
+    pi.registerFlag("auto", { description: "Start with attn auto mode on", type: "boolean" });
+    pi.registerFlag("no-auto", { description: "Start with attn auto mode off", type: "boolean" });
+    // No flag carries a default, so an unset one reads as undefined rather
+    // than as a false somebody typed. --no-auto wins a session given both.
+    this.flag = pi.getFlag("no-auto") === true ? false : pi.getFlag("auto") === true ? true : undefined;
+
+    pi.registerCommand("auto", {
+      description: "Toggle attn auto mode (on | off | status)",
+      handler: (args, ctx) => this.command(args, ctx),
+    });
+
+    pi.on("session_start", (_event, ctx) => {
+      if (ctx.modelRegistry) this.registry = ctx.modelRegistry;
+      this.paint(ctx);
+      if (this.setup.notice !== undefined && !this.noticed && ctx.ui) {
+        this.noticed = true;
+        ctx.ui.notify(this.setup.notice, "warning");
+      }
+    });
+
+    this.extension(pi);
+  }
+
+  private command(args: string, ctx: AutoModeContextLike): void {
+    const asked = args.trim().toLowerCase();
+    if (asked === "on") this.choice = true;
+    else if (asked === "off") this.choice = false;
+    else if (asked === "" || asked === "toggle") this.choice = !this.enabled();
+    else if (asked !== "status") {
+      ctx.ui?.notify(`/auto takes on, off, status, or nothing at all — not ${JSON.stringify(asked)}.`, "error");
+      return;
+    }
+    this.paint(ctx);
+    ctx.ui?.notify(
+      this.enabled()
+        ? "auto mode is on: work inside this directory runs free, anything past it is judged."
+        : "auto mode is off: pi runs every tool call, as it does without it.",
+      "info",
+    );
+  }
+
+  private paint(ctx: AutoModeContextLike): void {
+    ctx.ui?.setStatus(autoModeStatusKey, autoModeStatusText(this.enabled()));
+  }
+
+  /** The classifier for the registry this session is running against. */
+  private judge(): Classifier {
+    const registry = this.registry;
+    if (!registry) {
+      throw new Error("auto mode has no model catalog to judge this call against");
+    }
+    if (this.classifier?.registry !== registry) {
+      this.classifier = {
+        registry,
+        instance: new ModelClassifier({
+          registry,
+          config: this.setup.config,
+          onUsage: (usage) => this.usage.add(usage),
+        }),
+      };
+    }
+    return this.classifier.instance;
+  }
+}

--- a/plugins/attn-pi/automode/session.ts
+++ b/plugins/attn-pi/automode/session.ts
@@ -67,6 +67,17 @@ export class AutoModeSession {
     this.totalDenials = 0;
   }
 
+  /**
+   * The user answered the breaker's question. It clears the counters and
+   * nothing else: resuming means calls get judged again, not that the call
+   * that tripped the breaker is approved. The deny cache stays, so a refusal
+   * the user has not spoken to still stands.
+   */
+  resumeAfterBreaker(): void {
+    this.consecutiveDenials = 0;
+    this.totalDenials = 0;
+  }
+
   /** The agent said something. Only what it SAID: never a tool result. */
   noteAssistantText(text: string): void {
     this.transcript.record("assistant", text);

--- a/plugins/attn-pi/automode/source.ts
+++ b/plugins/attn-pi/automode/source.ts
@@ -1,0 +1,101 @@
+// Where a session's auto mode config comes from. Two callers, two answers:
+// attn hands it over in ATTN_PI_AUTOMODE_CONFIG at spawn, and bare pi reads
+// the same JSON from a file under pi's config directory.
+//
+// A config that cannot be read never turns auto mode off. The shipped defaults
+// take over and the session is told so — the alternative is a session that
+// silently lost its permission system because of a typo.
+import { join } from "node:path";
+import { homedir } from "node:os";
+import {
+  defaultAutoModeConfig,
+  loadAutoModeConfig,
+  type AutoModeConfig,
+  type RawAutoModeConfig,
+} from "./config";
+
+/** attn's channel. Environment, not argv: prose entries are multi-line. */
+export const autoModeConfigEnvVar = "ATTN_PI_AUTOMODE_CONFIG";
+
+/** Bare pi's channel, under `PI_CODING_AGENT_DIR` or `~/.pi/agent`. */
+export const autoModeConfigFileName = "attn-automode.json";
+
+export type AutoModeSource = {
+  config: AutoModeConfig;
+  /** What went wrong reading it, for the session to say out loud. Absent when nothing did. */
+  problem?: string;
+};
+
+export type EnvironmentLike = Record<string, string | undefined>;
+
+export function autoModeConfigFilePath(env: EnvironmentLike): string {
+  const configured = env.PI_CODING_AGENT_DIR?.trim();
+  return join(configured && configured !== "" ? configured : join(homedir(), ".pi", "agent"), autoModeConfigFileName);
+}
+
+/**
+ * The config an attn session was launched with. Undefined means attn sent
+ * none — auto mode is not built at all and the session runs as bare pi does.
+ */
+export function attnAutoModeSource(env: EnvironmentLike): AutoModeSource | undefined {
+  const raw = env[autoModeConfigEnvVar]?.trim();
+  if (!raw) return undefined;
+  return parseSource(raw, `attn sent an auto mode config this session could not read`);
+}
+
+/**
+ * Bare pi's config: the same environment variable when one is set (so
+ * `pi -e automode.js` inside attn behaves like the suite), otherwise the file.
+ *
+ * With neither, auto mode is off. Bare pi has no attn to have decided
+ * otherwise, so running it is something the user asks for — with `--auto`, or
+ * by writing the file.
+ */
+export function standaloneAutoModeSource(
+  env: EnvironmentLike,
+  readFile: (path: string) => string | undefined,
+): AutoModeSource {
+  const fromAttn = attnAutoModeSource(env);
+  if (fromAttn) return fromAttn;
+
+  const path = autoModeConfigFilePath(env);
+  let contents: string | undefined;
+  try {
+    contents = readFile(path);
+  } catch (error) {
+    return { config: offByDefault(defaultAutoModeConfig), problem: `${path} could not be read: ${message(error)}` };
+  }
+  if (contents === undefined) return { config: offByDefault(defaultAutoModeConfig) };
+
+  const source = parseSource(contents, `${path} could not be read`);
+  // A file that does not say whether auto mode starts on does not turn it on:
+  // writing one is how a bare pi user configures auto mode, not how they
+  // enable it.
+  return source.statedEnabledDefault ? source : { ...source, config: offByDefault(source.config) };
+}
+
+type ParsedSource = AutoModeSource & { statedEnabledDefault: boolean };
+
+function parseSource(raw: string, whatWentWrong: string): ParsedSource {
+  try {
+    const parsed = JSON.parse(raw) as RawAutoModeConfig;
+    return { config: loadAutoModeConfig(parsed), statedEnabledDefault: typeof parsed?.enabled_default === "boolean" };
+  } catch (error) {
+    // Counted as having stated it: a file too broken to read was still written
+    // by someone who wanted auto mode, and the safe reading of "I cannot tell"
+    // is on rather than off.
+    return {
+      config: defaultAutoModeConfig,
+      statedEnabledDefault: true,
+      problem: `${whatWentWrong}: ${message(error)}. Auto mode is running on its shipped defaults.`,
+    };
+  }
+}
+
+function offByDefault(config: AutoModeConfig): AutoModeConfig {
+  return { ...config, enabledDefault: false };
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/plugins/attn-pi/automode/standalone.ts
+++ b/plugins/attn-pi/automode/standalone.ts
@@ -1,0 +1,30 @@
+// Auto mode for a pi that knows nothing about attn: `pi -e automode.js`.
+//
+// Config comes from ATTN_PI_AUTOMODE_CONFIG when something set it, otherwise
+// from `attn-automode.json` under pi's config directory (`PI_CODING_AGENT_DIR`,
+// or `~/.pi/agent`) — the same JSON schema attn stores. With neither, auto
+// mode is built but starts off: `--auto` or `/auto` turns it on.
+//
+// Like suite/index.ts this file stays thin: one AutoMode at module scope, so
+// the user's `/auto` survives every session transition in this process, and
+// `register` re-binds it to each factory run.
+import { readFileSync } from "node:fs";
+import { AutoMode, type AutoModePiLike } from "./mode";
+import { standaloneAutoModeSource } from "./source";
+
+const source = standaloneAutoModeSource(process.env, readConfigFile);
+const autoMode = new AutoMode({ config: source.config, notice: source.problem });
+
+export default function attnAutoMode(pi: AutoModePiLike): void {
+  autoMode.register(pi);
+}
+
+/** Undefined for "there is no file", which is the ordinary case, not an error. */
+function readConfigFile(path: string): string | undefined {
+  try {
+    return readFileSync(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === "ENOENT") return undefined;
+    throw error;
+  }
+}

--- a/plugins/attn-pi/automode/ui.ts
+++ b/plugins/attn-pi/automode/ui.ts
@@ -1,0 +1,73 @@
+// What auto mode shows a person, and the slice of pi's ExtensionUIContext it
+// shows it through. Duck-typed like the rest of this module (pi 0.83.0,
+// core/extensions/types.ts) so `bun test` drives the whole surface.
+//
+// Everything here is set once, on a transition: a status that changes when the
+// mode changes, a working message that appears for the length of one
+// classification, a widget that changes when a call is denied. Nothing repaints
+// on a timer, and a session where nothing happens draws nothing.
+import type { AutoModeDenial } from "./index";
+
+/** Keys are namespaced: a user's own extensions share these registries. */
+export const autoModeStatusKey = "attn-auto-mode";
+export const autoModeDenialWidgetKey = "attn-auto-mode-denials";
+
+/** Shown for the ~2s a classification takes, so it does not read as a hang. */
+export const classifyingWorkingMessage = "auto mode is checking this call…";
+
+/** Denials the widget lists in full before it starts counting the rest. */
+export const denialWidgetLimit = 5;
+
+export type AutoModeUILike = {
+  setStatus(key: string, text: string | undefined): void;
+  setWorkingMessage(message?: string): void;
+  notify(message: string, type?: "info" | "warning" | "error"): void;
+  setWidget(key: string, content: string[] | undefined): void;
+  confirm(title: string, message: string): Promise<boolean>;
+};
+
+/**
+ * How much of a blocked call the surfaces show. A bash command carries the
+ * whole shell line and reads past four wrapped rows in the widget, which
+ * buries the reason underneath it — and the reason is what a person acts on.
+ * The model still gets the call in full: `denialToolResult` does not clamp.
+ */
+export const denialActionCharLimit = 80;
+
+export function autoModeStatusText(enabled: boolean): string {
+  return enabled ? "auto: on" : "auto: off";
+}
+
+export function denialNotice(denial: AutoModeDenial): string {
+  return `auto mode blocked ${clamp(denial.action)} — ${denial.reason}`;
+}
+
+function clamp(text: string): string {
+  return text.length <= denialActionCharLimit ? text : `${text.slice(0, denialActionCharLimit - 1)}…`;
+}
+
+/**
+ * The denials since the user last spoke. Speaking is what clears the list,
+ * which is the same act that clears the denials themselves: the next message
+ * may be the approval.
+ */
+export function denialWidgetLines(denials: readonly AutoModeDenial[]): string[] {
+  if (denials.length === 0) return [];
+  const shown = denials.slice(-denialWidgetLimit);
+  const hidden = denials.length - shown.length;
+  const lines = [`auto mode blocked ${denials.length} call${denials.length === 1 ? "" : "s"}:`];
+  if (hidden > 0) lines.push(`  … ${hidden} earlier`);
+  for (const denial of shown) lines.push(`  ${clamp(denial.action)} — ${denial.reason}`);
+  lines.push("  Approve in your reply to let the agent retry.");
+  return lines;
+}
+
+export function breakerQuestion(consecutive: number, total: number): { title: string; message: string } {
+  return {
+    title: "auto mode stopped judging calls",
+    message:
+      `It has refused ${consecutive} calls in a row and ${total} since you last spoke, so it stopped ` +
+      `rather than let the agent grind against the same refusal. Resume auto mode? Answering yes ` +
+      `judges this call and the ones after it normally; it does not approve anything on its own.`,
+  };
+}

--- a/plugins/attn-pi/package.json
+++ b/plugins/attn-pi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "attn-pi",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "test": "bun test"

--- a/plugins/attn-pi/src/index.ts
+++ b/plugins/attn-pi/src/index.ts
@@ -6,7 +6,7 @@ import { nisseAgentName, NisseDriver } from "./nisse-driver";
 import { RelayServer, type RelayConnection } from "./relay";
 import type { DriverSpawnParams, SessionClosedParams } from "./types";
 
-const pluginVersion = "0.1.0";
+const pluginVersion = "0.2.0";
 
 await runPlugin();
 

--- a/plugins/attn-pi/suite/index.ts
+++ b/plugins/attn-pi/suite/index.ts
@@ -10,6 +10,8 @@
 // against the current pi/ctx on each factory call. All testable behavior
 // lives in ./core, which has no pi import so it can run under `bun test`.
 import { VERSION } from "@earendil-works/pi-coding-agent";
+import { AutoMode, type AutoModePiLike } from "../automode/mode";
+import { attnAutoModeSource } from "../automode/source";
 import { AttnPiSuite, type ExtensionAPILike } from "./core";
 
 const suite = new AttnPiSuite({
@@ -18,6 +20,16 @@ const suite = new AttnPiSuite({
   piVersion: VERSION,
 });
 
-export default function attnPiSuite(pi: ExtensionAPILike): void {
+// Auto mode exists only when attn sent a config. A bare pi that loads this
+// suite registers no command, no flag and no handlers for it, and behaves
+// exactly as it does without the file. Denials are not reported anywhere yet;
+// AutoMode's onDenial is the seam attn's own surfaces will hang off.
+const autoModeSource = attnAutoModeSource(process.env);
+const autoMode = autoModeSource
+  ? new AutoMode({ config: autoModeSource.config, notice: autoModeSource.problem })
+  : undefined;
+
+export default function attnPiSuite(pi: ExtensionAPILike & AutoModePiLike): void {
   suite.register(pi);
+  autoMode?.register(pi);
 }

--- a/plugins/attn-pi/test/automode-composition.test.ts
+++ b/plugins/attn-pi/test/automode-composition.test.ts
@@ -1,0 +1,241 @@
+// How auto mode is turned on: the config it is handed, the flags and the
+// `/auto` command that override it, and the gate that keeps a bare pi
+// untouched.
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { defaultAutoModeConfig } from "../automode/config";
+import { AutoMode } from "../automode/mode";
+import type {
+  CompletionResult,
+  ModelLike,
+  ModelRegistryLike,
+  ProviderLike,
+  RequestAuthLike,
+} from "../automode/model-classifier";
+import {
+  attnAutoModeSource,
+  autoModeConfigEnvVar,
+  autoModeConfigFileName,
+  autoModeConfigFilePath,
+  standaloneAutoModeSource,
+} from "../automode/source";
+import { autoModeStatusKey } from "../automode/ui";
+import { FakePi, FakeUI, toolCall, uiContext } from "./automode-fake-pi";
+
+/** Answers every completion with one verdict, and counts what it was asked. */
+class CountingRegistry implements ModelRegistryLike {
+  calls = 0;
+
+  constructor(private readonly answer: CompletionResult) {}
+
+  find(provider: string, id: string): ModelLike | undefined {
+    return { provider, id };
+  }
+
+  getProvider(): ProviderLike {
+    return {
+      streamSimple: () => ({
+        result: async () => {
+          this.calls += 1;
+          return this.answer;
+        },
+      }),
+    };
+  }
+
+  async getApiKeyAndHeaders(): Promise<RequestAuthLike> {
+    return { ok: true, apiKey: "key" };
+  }
+
+  async getProviderAuth() {
+    return undefined;
+  }
+}
+
+function denies(): CompletionResult {
+  return {
+    content: [{ type: "text", text: JSON.stringify({ verdict: "deny", reason: "not asked for" }) }],
+    stopReason: "stop",
+  };
+}
+
+const push = () => toolCall("bash", { command: "git push --force origin main" });
+
+describe("the config a session is handed", () => {
+  test("no environment variable means attn sent nothing at all", () => {
+    expect(attnAutoModeSource({})).toBeUndefined();
+    expect(attnAutoModeSource({ [autoModeConfigEnvVar]: "   " })).toBeUndefined();
+  });
+
+  test("attn's JSON becomes the config auto mode runs on", () => {
+    const source = attnAutoModeSource({
+      [autoModeConfigEnvVar]: JSON.stringify({
+        enabled_default: false,
+        environment: ["never touch production data"],
+        allow: ["git push origin*"],
+        classifier_model: "opencode-go/glm-5.3",
+      }),
+    });
+    expect(source?.problem).toBeUndefined();
+    expect(source?.config.enabledDefault).toBe(false);
+    expect(source?.config.environment).toEqual(["never touch production data"]);
+    expect(source?.config.allow).toEqual(["git push origin*"]);
+  });
+
+  test("a config that cannot be read leaves auto mode on the shipped defaults, and says so", () => {
+    const source = attnAutoModeSource({ [autoModeConfigEnvVar]: "{ not json" });
+    expect(source?.config).toEqual(defaultAutoModeConfig);
+    expect(source?.problem).toContain("shipped defaults");
+  });
+
+  test("bare pi with no file gets auto mode off", () => {
+    const source = standaloneAutoModeSource({}, () => undefined);
+    expect(source.config.enabledDefault).toBe(false);
+    expect(source.problem).toBeUndefined();
+  });
+
+  test("bare pi reads the file, and only an explicit enabled_default turns it on", () => {
+    const read = (contents: string) => () => contents;
+    expect(standaloneAutoModeSource({}, read(JSON.stringify({ enabled_default: true }))).config.enabledDefault).toBe(
+      true,
+    );
+    expect(standaloneAutoModeSource({}, read(JSON.stringify({ allow: ["ls *"] }))).config.enabledDefault).toBe(false);
+    expect(standaloneAutoModeSource({}, read(JSON.stringify({ allow: ["ls *"] }))).config.allow).toEqual(["ls *"]);
+  });
+
+  test("bare pi prefers the environment attn set, so `pi -e automode.js` inside attn agrees with the suite", () => {
+    const source = standaloneAutoModeSource(
+      { [autoModeConfigEnvVar]: JSON.stringify({ enabled_default: true, environment: ["from attn"] }) },
+      () => {
+        throw new Error("the file must not be read when attn sent a config");
+      },
+    );
+    expect(source.config.environment).toEqual(["from attn"]);
+  });
+
+  test("an unreadable file is reported rather than silently ignored", () => {
+    const source = standaloneAutoModeSource({}, () => {
+      throw new Error("EACCES");
+    });
+    expect(source.problem).toContain("EACCES");
+    expect(source.config.enabledDefault).toBe(false);
+  });
+
+  test("the file lives under pi's config directory", () => {
+    expect(autoModeConfigFilePath({ PI_CODING_AGENT_DIR: "/tmp/pi" })).toBe(join("/tmp/pi", autoModeConfigFileName));
+    expect(autoModeConfigFilePath({})).toContain(join(".pi", "agent", autoModeConfigFileName));
+  });
+});
+
+describe("turning auto mode on and off", () => {
+  test("the configured default decides a session nobody told otherwise", () => {
+    expect(new AutoMode({ config: { ...defaultAutoModeConfig, enabledDefault: true } }).enabled()).toBe(true);
+    expect(new AutoMode({ config: { ...defaultAutoModeConfig, enabledDefault: false } }).enabled()).toBe(false);
+  });
+
+  test("a launch flag outranks the configured default, in both directions", () => {
+    const on = new AutoMode({ config: { ...defaultAutoModeConfig, enabledDefault: false } });
+    on.register(new FakePi().pass("auto"));
+    expect(on.enabled()).toBe(true);
+
+    const off = new AutoMode({ config: { ...defaultAutoModeConfig, enabledDefault: true } });
+    off.register(new FakePi().pass("no-auto"));
+    expect(off.enabled()).toBe(false);
+  });
+
+  test("a session given both flags starts off", () => {
+    const mode = new AutoMode({ config: defaultAutoModeConfig });
+    mode.register(new FakePi().pass("auto").pass("no-auto"));
+    expect(mode.enabled()).toBe(false);
+  });
+
+  test("/auto toggles, outranks the flag it was typed to override, and says where it landed", async () => {
+    const ui = new FakeUI();
+    const mode = new AutoMode({ config: { ...defaultAutoModeConfig, enabledDefault: true } });
+    const pi = new FakePi().pass("auto");
+    mode.register(pi);
+
+    await pi.run("auto", "", uiContext(ui));
+    expect(mode.enabled()).toBe(false);
+    expect(ui.statuses.get(autoModeStatusKey)).toBe("auto: off");
+    expect(ui.notices.at(-1)?.message).toContain("auto mode is off");
+
+    await pi.run("auto", "on", uiContext(ui));
+    expect(mode.enabled()).toBe(true);
+    expect(ui.statuses.get(autoModeStatusKey)).toBe("auto: on");
+  });
+
+  test("/auto status reports without changing anything", async () => {
+    const ui = new FakeUI();
+    const mode = new AutoMode({ config: defaultAutoModeConfig });
+    const pi = new FakePi();
+    mode.register(pi);
+    await pi.run("auto", "status", uiContext(ui));
+    expect(mode.enabled()).toBe(true);
+    expect(ui.notices.at(-1)?.message).toContain("auto mode is on");
+  });
+
+  test("/auto refuses an argument it does not understand, and changes nothing", async () => {
+    const ui = new FakeUI();
+    const mode = new AutoMode({ config: defaultAutoModeConfig });
+    const pi = new FakePi();
+    mode.register(pi);
+    await pi.run("auto", "maybe", uiContext(ui));
+    expect(mode.enabled()).toBe(true);
+    expect(ui.notices.at(-1)?.type).toBe("error");
+    expect(ui.statuses.size).toBe(0);
+  });
+
+  test("the status is painted as the session opens, before anything is asked of it", () => {
+    const ui = new FakeUI();
+    const mode = new AutoMode({ config: defaultAutoModeConfig });
+    const pi = new FakePi();
+    mode.register(pi);
+    pi.start(uiContext(ui));
+    expect(ui.statuses.get(autoModeStatusKey)).toBe("auto: on");
+  });
+
+  test("a broken config is said once, however many session transitions follow", () => {
+    const ui = new FakeUI();
+    const mode = new AutoMode({ config: defaultAutoModeConfig, notice: "the config could not be read" });
+    const pi = new FakePi();
+    mode.register(pi);
+    pi.start(uiContext(ui));
+    pi.start(uiContext(ui));
+    expect(ui.notices.filter((notice) => notice.message.includes("could not be read"))).toHaveLength(1);
+  });
+
+  test("auto mode off judges nothing, so a toggled-off session costs no classifier call", async () => {
+    const registry = new CountingRegistry(denies());
+    const mode = new AutoMode({ config: { ...defaultAutoModeConfig, enabledDefault: false } });
+    const pi = new FakePi();
+    mode.register(pi);
+    pi.start(uiContext(new FakeUI(), { modelRegistry: registry }));
+
+    expect(await pi.toolCall?.(push(), uiContext(new FakeUI()))).toBeUndefined();
+    expect(registry.calls).toBe(0);
+  });
+
+  test("the classifier is built from the session's own model registry", async () => {
+    const registry = new CountingRegistry(denies());
+    const mode = new AutoMode({ config: defaultAutoModeConfig });
+    const pi = new FakePi();
+    mode.register(pi);
+    pi.start(uiContext(new FakeUI(), { modelRegistry: registry }));
+
+    const blocked = await pi.toolCall?.(push(), uiContext(new FakeUI()));
+    expect(blocked?.block).toBe(true);
+    expect(blocked?.reason).toContain("not asked for");
+    expect(registry.calls).toBe(1);
+  });
+
+  test("a session with no model catalog refuses the call and names why", async () => {
+    const mode = new AutoMode({ config: defaultAutoModeConfig });
+    const pi = new FakePi();
+    mode.register(pi);
+
+    const blocked = await pi.toolCall?.(push(), uiContext(new FakeUI()));
+    expect(blocked?.block).toBe(true);
+    expect(blocked?.reason).toContain("no model catalog");
+  });
+});

--- a/plugins/attn-pi/test/automode-extension.test.ts
+++ b/plugins/attn-pi/test/automode-extension.test.ts
@@ -8,7 +8,7 @@ import { assistantMessage, ctx, FakePi, toolCall, userInput } from "./automode-f
 
 function wire(
   classifier: Classifier,
-  extra: { enabled?: boolean; onDenial?: (denial: AutoModeDenial) => void; usageLedger?: UsageLedger } = {},
+  extra: { isEnabled?: () => boolean; onDenial?: (denial: AutoModeDenial) => void; usageLedger?: UsageLedger } = {},
 ): FakePi {
   const pi = new FakePi();
   createAutoMode({ config: defaultAutoModeConfig, classifier, ...extra })(pi);
@@ -74,10 +74,28 @@ describe("auto mode extension", () => {
     expect((await call())?.block).toBe(true);
   });
 
-  test("auto mode off registers nothing", () => {
-    const pi = wire(new StubClassifier(), { enabled: false });
-    expect(pi.toolCall).toBeUndefined();
-    expect(pi.input).toBeUndefined();
+  test("auto mode off judges nothing, and still listens to the conversation", async () => {
+    const classifier = new StubClassifier({ verdict: "deny", reason: "no" });
+    let on = false;
+    const pi = wire(classifier, { isEnabled: () => on });
+    const push = () => pi.toolCall?.(toolCall("bash", { command: "git push --force" }), ctx);
+
+    expect(await push()).toBeUndefined();
+    expect(classifier.requests).toHaveLength(0);
+
+    pi.say("clean up the branch");
+    on = true;
+    expect((await push())?.block).toBe(true);
+    expect(classifier.requests[0]?.transcript).toEqual([{ role: "user", text: "clean up the branch" }]);
+  });
+
+  test("auto mode off leaves the system prompt alone", () => {
+    const pi = wire(new StubClassifier(), { isEnabled: () => false });
+    const result = pi.beforeAgentStart?.(
+      { type: "before_agent_start", prompt: "ship it", systemPrompt: "pi's own prompt" },
+      ctx,
+    );
+    expect(result?.systemPrompt).toBeUndefined();
   });
 
   test("each factory run gets its own session state", async () => {

--- a/plugins/attn-pi/test/automode-fake-pi.ts
+++ b/plugins/attn-pi/test/automode-fake-pi.ts
@@ -13,14 +13,22 @@ import type {
   ToolResultEventLike,
   ToolResultEventResultLike,
 } from "../automode/index";
+import type { AutoModePiLike, AutoModeSessionContextLike, SessionStartEventLike } from "../automode/mode";
+import type { AutoModeUILike } from "../automode/ui";
 
 type ToolCallHandler = (
   event: ToolCallEventLike,
   ctx: AutoModeContextLike,
 ) => ToolCallEventResultLike | undefined | Promise<ToolCallEventResultLike | undefined>;
 
-export class FakePi implements AutoModeExtensionAPILike {
+export class FakePi implements AutoModeExtensionAPILike, AutoModePiLike {
   toolCall: ToolCallHandler | undefined;
+  sessionStart: ((event: SessionStartEventLike, ctx: AutoModeSessionContextLike) => void) | undefined;
+  /** name -> handler, as pi's command registry holds them. */
+  readonly commands = new Map<string, (args: string, ctx: AutoModeContextLike) => Promise<void> | void>();
+  /** Registered flags, and the values a launch passed. */
+  readonly registeredFlags = new Set<string>();
+  readonly flagValues = new Map<string, boolean | string>();
   input: ((event: InputEventLike, ctx: AutoModeContextLike) => void) | undefined;
   beforeAgentStart:
     | ((event: BeforeAgentStartEventLike, ctx: AutoModeContextLike) => BeforeAgentStartResultLike)
@@ -41,12 +49,46 @@ export class FakePi implements AutoModeExtensionAPILike {
     event: "tool_result",
     handler: (event: ToolResultEventLike, ctx: AutoModeContextLike) => ToolResultEventResultLike | undefined,
   ): void;
+  on(
+    event: "session_start",
+    handler: (event: SessionStartEventLike, ctx: AutoModeSessionContextLike) => void,
+  ): void;
   on(event: string, handler: unknown): void {
     if (event === "tool_call") this.toolCall = handler as ToolCallHandler;
     if (event === "input") this.input = handler as FakePi["input"];
     if (event === "before_agent_start") this.beforeAgentStart = handler as FakePi["beforeAgentStart"];
     if (event === "message_end") this.messageEnd = handler as FakePi["messageEnd"];
     if (event === "tool_result") this.toolResult = handler as FakePi["toolResult"];
+    if (event === "session_start") this.sessionStart = handler as FakePi["sessionStart"];
+  }
+
+  registerCommand(
+    name: string,
+    options: { description?: string; handler: (args: string, ctx: AutoModeContextLike) => Promise<void> | void },
+  ): void {
+    this.commands.set(name, options.handler);
+  }
+
+  registerFlag(name: string): void {
+    this.registeredFlags.add(name);
+  }
+
+  getFlag(name: string): boolean | string | undefined {
+    return this.registeredFlags.has(name) ? this.flagValues.get(name) : undefined;
+  }
+
+  /** What pi does with `--<name>` on a boolean flag: sets it true. */
+  pass(flag: string): this {
+    this.flagValues.set(flag, true);
+    return this;
+  }
+
+  start(ctx: AutoModeSessionContextLike): void {
+    this.sessionStart?.({ type: "session_start" }, ctx);
+  }
+
+  async run(command: string, args: string, ctx: AutoModeContextLike): Promise<void> {
+    await this.commands.get(command)?.(args, ctx);
   }
 
   /**
@@ -64,6 +106,45 @@ export class FakePi implements AutoModeExtensionAPILike {
 }
 
 export const ctx: AutoModeContextLike = { cwd: "/work/repo" };
+
+/** pi's ExtensionUIContext, recorded rather than drawn. */
+export class FakeUI implements AutoModeUILike {
+  readonly statuses = new Map<string, string | undefined>();
+  readonly widgets = new Map<string, string[] | undefined>();
+  readonly notices: { message: string; type?: string }[] = [];
+  /** Every setWorkingMessage call in order; undefined is "back to pi's own". */
+  readonly workingMessages: (string | undefined)[] = [];
+  readonly questions: { title: string; message: string }[] = [];
+  answer = false;
+
+  setStatus(key: string, text: string | undefined): void {
+    this.statuses.set(key, text);
+  }
+
+  setWorkingMessage(message?: string): void {
+    this.workingMessages.push(message);
+  }
+
+  notify(message: string, type?: "info" | "warning" | "error"): void {
+    this.notices.push({ message, type });
+  }
+
+  setWidget(key: string, content: string[] | undefined): void {
+    this.widgets.set(key, content);
+  }
+
+  async confirm(title: string, message: string): Promise<boolean> {
+    this.questions.push({ title, message });
+    return this.answer;
+  }
+}
+
+export function uiContext(
+  ui: AutoModeUILike,
+  overrides: Partial<AutoModeSessionContextLike> = {},
+): AutoModeSessionContextLike {
+  return { cwd: "/work/repo", hasUI: true, ui, ...overrides };
+}
 
 export function toolCall(
   toolName: string,

--- a/plugins/attn-pi/test/automode-suite-gate.test.ts
+++ b/plugins/attn-pi/test/automode-suite-gate.test.ts
@@ -1,0 +1,57 @@
+// The two entrypoints, loaded the way pi loads them: attn's suite, which
+// composes auto mode in only when attn sent a config, and the standalone
+// bundle a bare pi gets with `-e`.
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { autoModeConfigEnvVar } from "../automode/source";
+
+const probe = join(import.meta.dir, "automode-suite-probe.ts");
+const suiteEntry = join(import.meta.dir, "..", "suite", "index.ts");
+const standaloneEntry = join(import.meta.dir, "..", "automode", "standalone.ts");
+
+type Registered = { events: string[]; commands: string[]; flags: string[] };
+
+async function load(entrypoint: string, env: Record<string, string>): Promise<Registered> {
+  const run = Bun.spawn([process.execPath, "run", probe, entrypoint], {
+    // A clean environment, so a machine that happens to run attn does not hand
+    // this test a config nobody asked for.
+    env: { PATH: process.env.PATH ?? "", HOME: process.env.HOME ?? "", ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(run.stdout).text(),
+    new Response(run.stderr).text(),
+    run.exited,
+  ]);
+  if (code !== 0) throw new Error(`suite probe failed (${code}): ${stderr}`);
+  return JSON.parse(stdout) as Registered;
+}
+
+describe("suite composition", () => {
+  test("a bare pi loading the suite is untouched by auto mode", async () => {
+    const registered = await load(suiteEntry, {});
+    expect(registered.commands).toEqual([]);
+    expect(registered.flags).toEqual([]);
+    expect(registered.events).toEqual([]);
+  });
+
+  test("attn's config composes auto mode into the suite", async () => {
+    const registered = await load(suiteEntry, {
+      [autoModeConfigEnvVar]: JSON.stringify({ enabled_default: true }),
+    });
+    expect(registered.commands).toEqual(["auto"]);
+    expect(registered.flags).toEqual(["auto", "no-auto"]);
+    expect(registered.events).toContain("tool_call");
+    expect(registered.events).toContain("session_start");
+  });
+});
+
+describe("the standalone extension", () => {
+  test("`pi -e automode.js` registers auto mode with no attn anywhere", async () => {
+    const registered = await load(standaloneEntry, { PI_CODING_AGENT_DIR: "/nonexistent" });
+    expect(registered.commands).toEqual(["auto"]);
+    expect(registered.flags).toEqual(["auto", "no-auto"]);
+    expect(registered.events).toContain("tool_call");
+  });
+});

--- a/plugins/attn-pi/test/automode-suite-probe.ts
+++ b/plugins/attn-pi/test/automode-suite-probe.ts
@@ -1,0 +1,32 @@
+// Loads an extension entrypoint (argv[2]) the way pi does — a default export
+// called with pi's API — and prints what it registered.
+//
+// A subprocess rather than an import: an entrypoint reads its environment once
+// at module scope, which is exactly the behavior under test, and a module
+// loaded twice in one bun process reads it once.
+export {};
+
+const registered = { events: [] as string[], commands: [] as string[], flags: [] as string[] };
+
+const pi = {
+  on(event: string): void {
+    registered.events.push(event);
+  },
+  registerCommand(name: string): void {
+    registered.commands.push(name);
+  },
+  registerFlag(name: string): void {
+    registered.flags.push(name);
+  },
+  getFlag(): undefined {
+    return undefined;
+  },
+  sendUserMessage(): void {},
+};
+
+const entrypoint = process.argv[2];
+if (!entrypoint) throw new Error("usage: automode-suite-probe.ts <entrypoint>");
+const { default: factory } = await import(entrypoint);
+(factory as (pi: unknown) => void)(pi);
+
+console.log(JSON.stringify(registered));

--- a/plugins/attn-pi/test/automode-ux.test.ts
+++ b/plugins/attn-pi/test/automode-ux.test.ts
@@ -1,0 +1,167 @@
+// What a person sees while auto mode works: the checking feedback, the
+// denial, and the breaker's one question.
+import { describe, expect, test } from "bun:test";
+import { StubClassifier, type Classifier } from "../automode/classifier";
+import { defaultAutoModeConfig } from "../automode/config";
+import { createAutoMode } from "../automode/index";
+import { consecutiveDenialLimit } from "../automode/session";
+import {
+  autoModeDenialWidgetKey,
+  classifyingWorkingMessage,
+  denialActionCharLimit,
+  denialWidgetLimit,
+} from "../automode/ui";
+import { ctx, FakePi, FakeUI, toolCall, uiContext, userInput } from "./automode-fake-pi";
+
+function wire(classifier: Classifier): FakePi {
+  const pi = new FakePi();
+  createAutoMode({ config: defaultAutoModeConfig, classifier })(pi);
+  return pi;
+}
+
+const push = (id = "call-1") => toolCall("bash", { command: "git push --force origin main" }, id);
+
+describe("auto mode's session surfaces", () => {
+  test("a classified call says it is checking, and stops saying it when it is done", async () => {
+    const ui = new FakeUI();
+    const pi = wire(new StubClassifier({ verdict: "allow" }));
+    await pi.toolCall?.(push(), uiContext(ui));
+    expect(ui.workingMessages).toEqual([classifyingWorkingMessage, undefined]);
+  });
+
+  test("an envelope call says nothing: the invisible path stays invisible", async () => {
+    const ui = new FakeUI();
+    const pi = wire(new StubClassifier({ verdict: "allow" }));
+    expect(await pi.toolCall?.(toolCall("bash", { command: "git status" }), uiContext(ui))).toBeUndefined();
+    expect(ui.workingMessages).toEqual([]);
+    expect(ui.notices).toEqual([]);
+    expect(ui.widgets.size).toBe(0);
+  });
+
+  test("the checking feedback is cleared even when the classifier throws", async () => {
+    const ui = new FakeUI();
+    const exploding: Classifier = {
+      classify: async () => {
+        throw new Error("classifier exploded");
+      },
+    };
+    const pi = wire(exploding);
+    await pi.toolCall?.(push(), uiContext(ui));
+    expect(ui.workingMessages).toEqual([classifyingWorkingMessage, undefined]);
+  });
+
+  test("a denial is named as it happens and listed until the user speaks", async () => {
+    const ui = new FakeUI();
+    const pi = wire(new StubClassifier({ verdict: "deny", reason: "this rewrites shared history" }));
+    await pi.toolCall?.(push(), uiContext(ui));
+
+    expect(ui.notices).toEqual([
+      {
+        message: "auto mode blocked bash: git push --force origin main — this rewrites shared history",
+        type: "warning",
+      },
+    ]);
+    const widget = ui.widgets.get(autoModeDenialWidgetKey);
+    expect(widget?.[0]).toBe("auto mode blocked 1 call:");
+    expect(widget?.join("\n")).toContain("this rewrites shared history");
+    expect(widget?.at(-1)).toContain("Approve in your reply");
+
+    pi.input?.(userInput("no, leave the branch alone"), uiContext(ui));
+    expect(ui.widgets.get(autoModeDenialWidgetKey)).toBeUndefined();
+  });
+
+  test("the widget lists a bounded number of denials and admits to the rest", async () => {
+    const ui = new FakeUI();
+    const pi = wire(new StubClassifier({ verdict: "deny", reason: "no" }));
+    const total = denialWidgetLimit + 2;
+    // The breaker takes over partway through; every refusal is still a denial,
+    // whoever refused it, and every one belongs on the list.
+    for (let i = 0; i < total; i++) {
+      await pi.toolCall?.(toolCall("bash", { command: `curl https://host-${i}.example` }, `call-${i}`), uiContext(ui));
+    }
+
+    const widget = ui.widgets.get(autoModeDenialWidgetKey) ?? [];
+    expect(widget[0]).toBe(`auto mode blocked ${total} calls:`);
+    expect(widget[1]).toBe(`  … 2 earlier`);
+    expect(widget.filter((line) => line.includes("curl"))).toHaveLength(denialWidgetLimit);
+  });
+
+  test("a long command is clamped where a person reads it, and not where the model does", async () => {
+    const ui = new FakeUI();
+    const pi = wire(new StubClassifier({ verdict: "deny", reason: "not permitted here" }));
+    const command = `curl -sS ${"-H x:y ".repeat(40)}https://httpbin.org/get`;
+    const blocked = await pi.toolCall?.(toolCall("bash", { command }), uiContext(ui));
+
+    expect(ui.notices[0]?.message.length).toBeLessThan(command.length);
+    expect(ui.notices[0]?.message).toContain("…");
+    const line = ui.widgets.get(autoModeDenialWidgetKey)?.[1] ?? "";
+    expect(line).toContain("…");
+    expect(line.split(" — ")[0]?.trim().length).toBe(denialActionCharLimit);
+    expect(blocked?.reason).toContain(command);
+  });
+
+  test("a context with no UI is blocked without being drawn to", async () => {
+    const pi = wire(new StubClassifier({ verdict: "deny", reason: "no" }));
+    expect((await pi.toolCall?.(push(), ctx))?.block).toBe(true);
+  });
+
+  test("a tripped breaker asks once, and a yes resumes judging this very call", async () => {
+    const ui = new FakeUI();
+    const classifier = new StubClassifier({ verdict: "deny", reason: "no" });
+    const pi = wire(classifier);
+    for (let i = 0; i < consecutiveDenialLimit; i++) {
+      await pi.toolCall?.(toolCall("bash", { command: `curl https://host-${i}.example` }, `call-${i}`), uiContext(ui));
+    }
+    expect(ui.questions).toHaveLength(0);
+
+    ui.answer = true;
+    classifier.answerWith({ verdict: "allow" });
+    expect(await pi.toolCall?.(push(), uiContext(ui))).toBeUndefined();
+    expect(ui.questions).toHaveLength(1);
+    expect(ui.questions[0]?.message).toContain("Resume auto mode?");
+  });
+
+  test("a no leaves the call blocked and is not asked again until the user speaks", async () => {
+    const ui = new FakeUI();
+    const classifier = new StubClassifier({ verdict: "deny", reason: "no" });
+    const pi = wire(classifier);
+    for (let i = 0; i < consecutiveDenialLimit; i++) {
+      await pi.toolCall?.(toolCall("bash", { command: `curl https://host-${i}.example` }, `call-${i}`), uiContext(ui));
+    }
+
+    expect((await pi.toolCall?.(push(), uiContext(ui)))?.block).toBe(true);
+    expect((await pi.toolCall?.(push("call-b"), uiContext(ui)))?.block).toBe(true);
+    expect(ui.questions).toHaveLength(1);
+
+    pi.input?.(userInput("what happened?"), uiContext(ui));
+    // Speaking clears the breaker outright, so the next trip is a fresh episode.
+    for (let i = 0; i < consecutiveDenialLimit; i++) {
+      await pi.toolCall?.(toolCall("bash", { command: `curl https://later-${i}.example` }, `later-${i}`), uiContext(ui));
+    }
+    await pi.toolCall?.(push("call-c"), uiContext(ui));
+    expect(ui.questions).toHaveLength(2);
+  });
+
+  test("a breaker with no UI to ask stays closed", async () => {
+    const pi = wire(new StubClassifier({ verdict: "deny", reason: "no" }));
+    for (let i = 0; i < consecutiveDenialLimit; i++) {
+      await pi.toolCall?.(toolCall("bash", { command: `curl https://host-${i}.example` }, `call-${i}`), ctx);
+    }
+    const blocked = await pi.toolCall?.(push(), ctx);
+    expect(blocked?.block).toBe(true);
+    expect(blocked?.reason).toContain("stopped judging");
+  });
+
+  test("print mode carries a ui object and still gets no dialog", async () => {
+    const ui = new FakeUI();
+    ui.answer = true;
+    const printCtx = uiContext(ui, { hasUI: false });
+    const pi = wire(new StubClassifier({ verdict: "deny", reason: "no" }));
+    for (let i = 0; i < consecutiveDenialLimit; i++) {
+      await pi.toolCall?.(toolCall("bash", { command: `curl https://host-${i}.example` }, `call-${i}`), printCtx);
+    }
+    expect((await pi.toolCall?.(push(), printCtx))?.block).toBe(true);
+    expect(ui.questions).toHaveLength(0);
+    expect(ui.notices).toEqual([]);
+  });
+});

--- a/scripts/build-bundled-plugins.sh
+++ b/scripts/build-bundled-plugins.sh
@@ -121,6 +121,11 @@ stage_plugin() {
     # must stay an external import.
     bun build "${source_dir}/suite/index.ts" --target=node --format=esm --minify \
       --external "@earendil-works/pi-coding-agent" --outfile "${stage_dir}/suite.js"
+    # Auto mode ships inside suite.js by import; this second bundle is the same
+    # extension for a pi that knows nothing about attn (`pi -e automode.js`),
+    # under the same external rule.
+    bun build "${source_dir}/automode/standalone.ts" --target=node --format=esm --minify \
+      --external "@earendil-works/pi-coding-agent" --outfile "${stage_dir}/automode.js"
     # nisse is its own process: attn's daemon spawns one per conversation
     # session and talks to it over pipes, so it is a second executable beside
     # the driver rather than code inside it. pi is bundled in (not external)


### PR DESCRIPTION
Slice 3 of pi auto mode ([plan](docs/plans/2026-08-16-pi-auto-mode.md)): the
extension built in slices 1+2 now actually runs in a session, and a person can
see what it is doing.

#932 injects the promoted config as `ATTN_PI_AUTOMODE_CONFIG`; this consumes it.

## What lands

- **Suite composition.** `suite/index.ts` builds auto mode only when
  `ATTN_PI_AUTOMODE_CONFIG` is present. Missing env constructs nothing at all —
  no command, no flag, no handler — so a bare pi loading `suite.js` is byte-for-
  byte the pi it was. A subprocess test loads the real entrypoint and asserts
  exactly what got registered on each side of that gate.
- **Standalone bare pi.** `automode/standalone.ts` default-exports the same
  extension for `pi -e <plugin>/automode.js`, reading the same JSON from
  `attn-automode.json` under pi's config dir (`PI_CODING_AGENT_DIR`, else
  `~/.pi/agent`). Off unless the file says `enabled_default` or `--auto` does.
- **Toggle.** `/auto` (`on` | `off` | `status`, bare toggles) plus `--auto` /
  `--no-auto`.
- **Visible state.** A status line (`auto: on` / `auto: off`), a working message
  for the length of one classification so ~2s never reads as a hang, and a
  denial that names what was blocked and why — as a notice when it happens and
  as a list that stands until the user speaks.
- **The breaker's question.** A tripped circuit breaker asks once through
  `ctx.ui.confirm`; yes clears the counters and re-judges the call that tripped
  it. `hasUI === false` (`-p`, `--mode json`) is fail-closed.
- **Staging.** `build-bundled-plugins.sh` stages `automode.js` beside
  `suite.js`; plugin version 0.1.0 → 0.2.0 in the three places it checks.

## The one place I read the plan differently

The plan says precedence is `flag > /auto > config default`. Taken literally,
`--auto` would make `/auto` a dead command for the rest of the session. What
shipped is `/auto > flag > enabled_default`: the flag decides where the session
starts, and the command the user typed wins after that. A command that loses to
a flag is not a command.

## Verification

`bun test`: 371 pass (composition gating, precedence, every UI seam against a
duck-typed ctx).

Live, on a throwaway profile installed from this branch, with the environment
prose set through the real CLI (`attn automode env add …`) and the config
arriving through the daemon's own injection — not a hand-exported variable:

1. **Envelope invisibility** — `ls -la`, `cat README.md`, `git status`: three
   calls, `Took 0.0s` each, `$0.000`, nothing drawn.
2. **A real denial** — asked whether the machine can reach the internet; the
   curl is refused against the configured environment, the run continues, and
   the agent explains and asks.
3. **The conversational grant** — approved the host in chat, the same call
   retried and returned `HTTP 200`.
4. **`/auto`** — `off` → status reads `auto: off`, `status` reports it, bare
   `/auto` turns it back on.
5. **Bare pi** — the built `automode.js` loads under `pi -e` and registers
   `--auto` / `--no-auto` with no attn around; the missing-env no-op is covered
   by the subprocess gate test.

The clip is 2 and 3, end to end:

![grant2](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/a4c5bf04a26962e5325496502e7a8339b66641f8/delegate-automode-ux-d5f177a4/grant2.gif)

[Full-quality recording (mp4)](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/a4c5bf04a26962e5325496502e7a8339b66641f8/delegate-automode-ux-d5f177a4/grant2.mp4)

## Not in this slice

Denial reporting back to attn (the `onDenial` seam is deliberately unset),
settings UI and the launch-parameter toggle (slice 5); the deterministic harness
scenario and flipping attn-wide defaults (slice 6).

https://claude.ai/code/session_01DYtDmNQA9Huw6EHQnKLvCD
