### PR TITLE
feat(automode): promotion surface, launch toggle, shipped safety defaults

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -247,6 +247,7 @@ interface SplitSessionOptions {
   endpointId?: string | null;
   label?: string;
   yoloMode?: boolean;
+  autoMode?: boolean;
 }
 
 function paneIdForSession(sessionId: string): string {
@@ -987,7 +988,7 @@ function AppContent({
     agent?: SessionAgent,
     endpointId?: string,
     yoloMode = false,
-    options?: { chiefOfStaff?: boolean; resumeConversationFile?: string },
+    options?: { chiefOfStaff?: boolean; resumeConversationFile?: string; autoMode?: boolean },
   ) => {
     const sessionId = providedSessionId || crypto.randomUUID();
     const workspaceId = `workspace-${sessionId}`;
@@ -996,7 +997,7 @@ function AppContent({
     let paneAdded = false;
     try {
       await sendRegisterWorkspace(workspaceId, label, cwd, endpointId);
-      const createdSessionId = await createSession(label, cwd, sessionId, agent, endpointId, yoloMode, workspaceId, options?.chiefOfStaff, options?.resumeConversationFile);
+      const createdSessionId = await createSession(label, cwd, sessionId, agent, endpointId, yoloMode, workspaceId, options?.chiefOfStaff, options?.resumeConversationFile, options?.autoMode);
       localCreated = true;
       // Capture spawn args synchronously, before any await that could let a daemon
       // sessions broadcast prune the just-created local session. At this point its
@@ -2081,6 +2082,9 @@ function AppContent({
         endpointId,
         agent === 'shell' ? false : options.yoloMode ?? activeSession.yoloMode,
         workspaceId,
+        undefined,
+        undefined,
+        agent === 'shell' ? undefined : options.autoMode,
       );
       const spawnArgs = takeSessionSpawnArgs(sessionId, 80, 24);
       await sendWorkspaceAddSessionPane(workspaceId, sessionId, label, { paneId: newPaneId, targetPaneId: paneId, direction });
@@ -2137,6 +2141,7 @@ function AppContent({
       yoloMode = false,
       chiefOfStaff = false,
       resumeConversationFile?: string,
+      autoMode?: boolean,
     ) => {
       const jobId = sessionCreationJobIdRef.current + 1;
       sessionCreationJobIdRef.current = jobId;
@@ -2173,6 +2178,7 @@ function AppContent({
           endpointId: endpointId ?? null,
           label: folderName,
           yoloMode,
+          autoMode,
         });
         return;
       }
@@ -2191,7 +2197,7 @@ function AppContent({
           selectedAgent,
           endpointId,
           yoloMode,
-          { chiefOfStaff, resumeConversationFile },
+          { chiefOfStaff, resumeConversationFile, autoMode },
         );
         setSessionCreationJob((current) => (
           current?.id === jobId
@@ -2216,6 +2222,7 @@ function AppContent({
     endpointId: string | undefined,
     agent: SessionAgent,
     yoloMode: boolean,
+    autoMode?: boolean,
   ) => {
     const endpointKey = endpointId || 'local';
     if (worktreeSessionCreateEndpointsRef.current.has(endpointKey)) {
@@ -2252,13 +2259,14 @@ function AppContent({
             endpointId: endpointId ?? null,
             label: folderName,
             yoloMode,
+            autoMode,
           });
           setSessionCreationJob((current) => (
             current?.id === jobId ? null : current
           ));
           return;
         }
-        const sessionId = await createWorkspaceSession(folderName, worktreePath, undefined, agent, endpointId, yoloMode);
+        const sessionId = await createWorkspaceSession(folderName, worktreePath, undefined, agent, endpointId, yoloMode, { autoMode });
         setSessionCreationJob((current) => (
           current?.id === jobId
             ? { ...current, label: folderName, path: worktreePath, phase: 'starting_session', sessionId }

--- a/app/src/App.worktreeCleanup.test.tsx
+++ b/app/src/App.worktreeCleanup.test.tsx
@@ -426,6 +426,7 @@ describe('worktree cleanup prompt', () => {
         expect.stringMatching(/^workspace-/),
         undefined,
         undefined,
+        undefined,
       );
     });
     expect(screen.getByRole('dialog')).toHaveTextContent('Starting session');
@@ -476,6 +477,9 @@ describe('worktree cleanup prompt', () => {
         undefined,
         false,
         'workspace-s1',
+        undefined,
+        undefined,
+        undefined,
       );
     });
     const sessionId = createSession.mock.calls[0][2];

--- a/app/src/components/AutoModeSettings.css
+++ b/app/src/components/AutoModeSettings.css
@@ -1,0 +1,116 @@
+/* Auto mode settings section. Only the classes this section owns; the block,
+   intro, kicker, pill, action, hint, empty and warning vocabulary comes from
+   SettingsModal.css. */
+
+.automode-state {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.automode-section-head {
+  display: grid;
+  gap: 4px;
+  margin-top: 6px;
+}
+
+.automode-section-head h4 {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
+}
+
+/* The review list: what is waiting, who asked, and the two ways out. */
+.automode-proposals {
+  display: grid;
+  gap: 6px;
+}
+
+.automode-proposal {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 6px;
+  background: var(--color-bg-elevated);
+}
+
+.automode-proposal-subject {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.automode-proposal-origin {
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-xs);
+  white-space: nowrap;
+}
+
+.automode-proposal-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.automode-value {
+  overflow: hidden;
+  color: var(--color-text-primary);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: var(--font-size-sm);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The policy those promotions produce. */
+.automode-config {
+  display: grid;
+  gap: 6px;
+  padding: 8px 10px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 6px;
+  background: var(--color-bg-elevated);
+}
+
+.automode-field {
+  display: grid;
+  grid-template-columns: 130px minmax(0, 1fr);
+  align-items: start;
+  gap: 10px;
+}
+
+.automode-field-label {
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.automode-field-value {
+  min-width: 0;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+}
+
+.automode-mono {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+.automode-patterns {
+  display: grid;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.automode-footer {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 6px;
+}

--- a/app/src/components/AutoModeSettings.promotion.test.tsx
+++ b/app/src/components/AutoModeSettings.promotion.test.tsx
@@ -1,0 +1,193 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AutoModeSettings } from './AutoModeSettings';
+import type {
+  AutoModeConfigInfo,
+  AutoModeProposalInfo,
+  AutoModePromotion,
+  AutoModeState,
+} from '../hooks/daemonAutoModeEvents';
+import { useAutoModePolicy } from '../hooks/useAutoModePolicy';
+
+const config = (over: Partial<AutoModeConfigInfo> = {}): AutoModeConfigInfo => ({
+  enabled_default: true,
+  environment: [],
+  allow: [],
+  hard_deny: ['*attn automode env*'],
+  classifier_model: 'opencode-go/glm-5.3',
+  escalation_model: 'opencode-go/qwen3.8-max',
+  ...over,
+});
+
+const proposal = (over: Partial<AutoModeProposalInfo> = {}): AutoModeProposalInfo => ({
+  id: 7,
+  kind: 'allow',
+  target: '',
+  value: 'git push origin*',
+  proposed_by: 'session-a',
+  state: 'pending',
+  created_at: '2026-08-16T10:00:00Z',
+  resolved_at: '',
+  ...over,
+});
+
+const state = (over: Partial<AutoModeState> = {}): AutoModeState => ({
+  config: config(),
+  proposals: [],
+  denials: [],
+  ...over,
+});
+
+// The section is a view over the hook; driving both together is what makes the
+// promote flow — act, re-read, redraw — an assertion rather than three.
+function Harness(props: {
+  getState: () => Promise<AutoModeState>;
+  promoteProposal: (id: number) => Promise<AutoModePromotion>;
+  discardProposal: (id: number) => Promise<AutoModePromotion>;
+}) {
+  const policy = useAutoModePolicy({ enabled: true, ...props });
+  return <AutoModeSettings policy={policy} />;
+}
+
+const resolved = (): AutoModePromotion => ({ proposal: proposal(), config: config() });
+
+function renderPane(value: AutoModeState, over: Partial<{
+  promoteProposal: (id: number) => Promise<AutoModePromotion>;
+  discardProposal: (id: number) => Promise<AutoModePromotion>;
+}> = {}) {
+  const getState = vi.fn().mockResolvedValue(value);
+  const promoteProposal = over.promoteProposal ?? vi.fn().mockResolvedValue(resolved());
+  const discardProposal = over.discardProposal ?? vi.fn().mockResolvedValue(resolved());
+  render(
+    <Harness
+      getState={getState}
+      promoteProposal={promoteProposal}
+      discardProposal={discardProposal}
+    />,
+  );
+  return { getState, promoteProposal, discardProposal };
+}
+
+describe('AutoModeSettings', () => {
+  it('reads auto mode once on open and does not loop', async () => {
+    const { getState } = renderPane(state());
+    await waitFor(() => screen.getByTestId('automode-config'));
+
+    expect(getState).toHaveBeenCalledTimes(1);
+    await new Promise((done) => setTimeout(done, 50));
+    expect(getState).toHaveBeenCalledTimes(1);
+  });
+
+  // The list is the whole reason this section exists. An empty one has to read
+  // as "nobody proposed anything", never as a panel that failed to load.
+  it('explains an empty proposal list rather than showing nothing', async () => {
+    renderPane(state());
+    const empty = await screen.findByTestId('automode-no-proposals');
+    expect(empty).toHaveTextContent('No proposals are waiting');
+    expect(screen.queryByTestId('automode-proposals')).toBeNull();
+  });
+
+  it('shows what each proposal asks for and who asked', async () => {
+    renderPane(state({
+      proposals: [
+        proposal(),
+        proposal({ id: 8, kind: 'model', target: 'classifier', value: 'opencode-go/other', proposed_by: '' }),
+      ],
+    }));
+    await screen.findByTestId('automode-proposals');
+
+    const allow = screen.getByTestId('automode-proposal-7');
+    expect(allow).toHaveTextContent('allow');
+    expect(allow).toHaveTextContent('git push origin*');
+    expect(allow).toHaveTextContent('session-a');
+
+    const model = screen.getByTestId('automode-proposal-8');
+    expect(model).toHaveTextContent('classifier model');
+    // A CLI caller that named nobody is still shown, rather than left blank.
+    expect(model).toHaveTextContent('unattributed');
+  });
+
+  // Promotion is auto mode's trust boundary: this button is the only thing in
+  // the system that turns a proposal into policy.
+  it('promotes a proposal and re-reads the result', async () => {
+    const promoteProposal = vi.fn().mockResolvedValue(resolved());
+    const { getState } = renderPane(state({ proposals: [proposal()] }), { promoteProposal });
+    await screen.findByTestId('automode-proposals');
+
+    fireEvent.click(screen.getByTestId('automode-promote-7'));
+    await waitFor(() => expect(promoteProposal).toHaveBeenCalledWith(7));
+    // The daemon is authoritative: the config shown is a re-read, not a guess
+    // about what promoting did to it.
+    await waitFor(() => expect(getState).toHaveBeenCalledTimes(2));
+  });
+
+  // The way in needs the way out: a proposal nobody wants has to be closable
+  // from the same list, or it sits there forever.
+  it('discards a proposal and re-reads the result', async () => {
+    const discardProposal = vi.fn().mockResolvedValue(resolved());
+    const { getState } = renderPane(state({ proposals: [proposal()] }), { discardProposal });
+    await screen.findByTestId('automode-proposals');
+
+    fireEvent.click(screen.getByTestId('automode-discard-7'));
+    await waitFor(() => expect(discardProposal).toHaveBeenCalledWith(7));
+    await waitFor(() => expect(getState).toHaveBeenCalledTimes(2));
+  });
+
+  it('shows the failure when a promotion is refused and keeps the list', async () => {
+    const promoteProposal = vi.fn().mockRejectedValue(new Error('auto mode proposal 7 is already promoted'));
+    renderPane(state({ proposals: [proposal()] }), { promoteProposal });
+    await screen.findByTestId('automode-proposals');
+
+    fireEvent.click(screen.getByTestId('automode-promote-7'));
+    await waitFor(() => screen.getByText('auto mode proposal 7 is already promoted'));
+    // A failed action must not blank a good snapshot.
+    expect(screen.getByTestId('automode-proposal-7')).toBeInTheDocument();
+  });
+
+  // The policy is shown beside the list so promoting is a decision with the
+  // current state in view, not a guess.
+  it('shows the effective policy a session would launch with', async () => {
+    renderPane(state({
+      config: config({
+        enabled_default: false,
+        allow: ['git push origin*'],
+        hard_deny: ['*attn automode env*', 'rm -rf /*'],
+        environment: ['never touch prod'],
+      }),
+    }));
+    const shown = await screen.findByTestId('automode-config');
+
+    expect(shown).toHaveTextContent('Auto mode off');
+    expect(shown).toHaveTextContent('opencode-go/glm-5.3');
+    expect(shown).toHaveTextContent('opencode-go/qwen3.8-max');
+    // The shipped denies are resolved in daemon-side, so they show up here
+    // without anyone having promoted them.
+    expect(screen.getByTestId('automode-hard-deny')).toHaveTextContent('*attn automode env*');
+    expect(screen.getByTestId('automode-allow')).toHaveTextContent('git push origin*');
+    expect(screen.getByTestId('automode-environment')).toHaveTextContent('never touch prod');
+  });
+
+  it('says so when a list is empty rather than leaving a blank row', async () => {
+    renderPane(state({ config: config({ hard_deny: [] }) }));
+    await screen.findByTestId('automode-config');
+
+    expect(screen.getByTestId('automode-allow')).toHaveTextContent('Nothing skips the classifier');
+    expect(screen.getByTestId('automode-hard-deny')).toHaveTextContent('Nothing is refused');
+  });
+
+  it('offers a retry when auto mode cannot be read at all', async () => {
+    const getState = vi.fn().mockRejectedValue(new Error('no database'));
+    render(
+      <Harness
+        getState={getState}
+        promoteProposal={vi.fn()}
+        discardProposal={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => screen.getByText('no database'));
+    getState.mockResolvedValue(state());
+    fireEvent.click(screen.getByText('Try again'));
+    await waitFor(() => screen.getByTestId('automode-config'));
+  });
+});

--- a/app/src/components/AutoModeSettings.tsx
+++ b/app/src/components/AutoModeSettings.tsx
@@ -1,0 +1,223 @@
+// Auto mode settings: the proposals waiting on a human, and the policy they
+// resolve into.
+//
+// This section is auto mode's trust boundary made visible. An agent can propose
+// a pattern or a model over the CLI and nothing happens; a person promoting one
+// here is what puts it in front of the next pi session. That is why promote and
+// discard exist on this transport alone, and why the effective policy is shown
+// beside the list rather than a page away.
+//
+// Design: docs/plans/2026-08-16-pi-auto-mode.md.
+
+import type { AutoModeProposalInfo } from '../hooks/daemonAutoModeEvents';
+import type { AutoModePolicy } from '../hooks/useAutoModePolicy';
+import './AutoModeSettings.css';
+
+interface AutoModeSettingsProps {
+  policy: AutoModePolicy;
+}
+
+export function AutoModeSettings({ policy }: AutoModeSettingsProps) {
+  const { state, error, loading, resolvingID, refresh, promote, discard } = policy;
+
+  if (error && !state) {
+    return (
+      <section className="settings-block">
+        {renderIntro()}
+        <div className="settings-block-body">
+          <div className="automode-state">
+            <span className="settings-warning">{error}</span>
+            <button type="button" className="settings-action" onClick={() => void refresh()}>
+              Try again
+            </button>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  if (!state) {
+    return (
+      <section className="settings-block">
+        {renderIntro()}
+        <div className="settings-block-body">
+          <div className="automode-state" data-testid="automode-loading">
+            Reading auto mode…
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  const { config, proposals } = state;
+
+  return (
+    <section className="settings-block" data-testid="settings-automode">
+      {renderIntro()}
+      <div className="settings-block-body">
+        {error && <span className="settings-warning">{error}</span>}
+
+        <div className="automode-section-head">
+          <h4>Proposed rules</h4>
+          <p className="settings-description">
+            An agent can propose a pattern or a model from <code>attn automode</code>;
+            nothing it proposes changes what a session runs under until it is
+            promoted here.
+          </p>
+        </div>
+
+        {proposals.length === 0 ? (
+          <div className="settings-empty" data-testid="automode-no-proposals">
+            No proposals are waiting. Anything an agent proposes shows up here.
+          </div>
+        ) : (
+          <div className="automode-proposals" data-testid="automode-proposals">
+            {proposals.map((proposal) => (
+              <div
+                key={proposal.id}
+                className="automode-proposal"
+                data-testid={`automode-proposal-${proposal.id}`}
+              >
+                <span className="automode-proposal-subject">
+                  <span className={`settings-pill ${proposal.kind === 'allow' ? 'warn' : ''}`}>
+                    {proposalKindLabel(proposal)}
+                  </span>
+                  <code className="automode-value">{proposal.value}</code>
+                </span>
+                <span className="automode-proposal-origin">
+                  {proposal.proposed_by || 'unattributed'}
+                  {proposal.created_at && ` · ${formatStamp(proposal.created_at)}`}
+                </span>
+                <span className="automode-proposal-actions">
+                  <button
+                    type="button"
+                    className="settings-action"
+                    data-testid={`automode-promote-${proposal.id}`}
+                    disabled={resolvingID !== null}
+                    onClick={() => void promote(proposal.id)}
+                  >
+                    Promote
+                  </button>
+                  <button
+                    type="button"
+                    className="settings-action danger"
+                    data-testid={`automode-discard-${proposal.id}`}
+                    disabled={resolvingID !== null}
+                    onClick={() => void discard(proposal.id)}
+                  >
+                    Discard
+                  </button>
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="automode-section-head">
+          <h4>Effective policy</h4>
+          <p className="settings-description">
+            What a pi session launches with today. Prose and models are edited
+            from <code>attn automode</code>; patterns arrive here by promotion.
+          </p>
+        </div>
+
+        <div className="automode-config" data-testid="automode-config">
+          <div className="automode-field">
+            <span className="automode-field-label">New sessions</span>
+            <span className="automode-field-value">
+              <span className={`settings-pill ${config.enabled_default ? 'good' : ''}`}>
+                {config.enabled_default ? 'Auto mode on' : 'Auto mode off'}
+              </span>
+            </span>
+          </div>
+          <div className="automode-field">
+            <span className="automode-field-label">Classifier</span>
+            <span className="automode-field-value automode-mono">{config.classifier_model}</span>
+          </div>
+          <div className="automode-field">
+            <span className="automode-field-label">Escalation</span>
+            <span className="automode-field-value automode-mono">{config.escalation_model}</span>
+          </div>
+          {renderPatterns('Allowed', 'automode-allow', config.allow, 'Nothing skips the classifier.')}
+          {renderPatterns(
+            'Hard denied',
+            'automode-hard-deny',
+            config.hard_deny,
+            'Nothing is refused before the classifier sees it.',
+          )}
+          {renderPatterns(
+            'Environment',
+            'automode-environment',
+            config.environment,
+            'The classifier is told nothing about this machine.',
+          )}
+        </div>
+
+        <div className="automode-footer">
+          <button
+            type="button"
+            className="settings-action"
+            data-testid="automode-refresh"
+            disabled={loading}
+            onClick={() => void refresh()}
+          >
+            {loading ? 'Reading…' : 'Refresh'}
+          </button>
+          <span className="settings-hint">
+            A promotion reaches the next session that launches; a running one keeps
+            the policy it started with.
+          </span>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function renderPatterns(label: string, testID: string, values: string[], empty: string) {
+  return (
+    <div className="automode-field">
+      <span className="automode-field-label">{label}</span>
+      <span className="automode-field-value" data-testid={testID}>
+        {values.length === 0 ? (
+          <span className="settings-hint">{empty}</span>
+        ) : (
+          <ul className="automode-patterns">
+            {values.map((value) => (
+              <li key={value}>
+                <code className="automode-value">{value}</code>
+              </li>
+            ))}
+          </ul>
+        )}
+      </span>
+    </div>
+  );
+}
+
+/** `deny` and `allow` take no target; a model proposal names which model. */
+function proposalKindLabel(proposal: AutoModeProposalInfo): string {
+  if (proposal.kind === 'model') {
+    return proposal.target ? `${proposal.target} model` : 'model';
+  }
+  return proposal.kind;
+}
+
+function formatStamp(value: string): string {
+  const at = new Date(value);
+  if (Number.isNaN(at.getTime())) return value;
+  return at.toLocaleString();
+}
+
+function renderIntro() {
+  return (
+    <div className="settings-block-intro">
+      <span className="settings-kicker">Auto Mode</span>
+      <h3>pi's safety envelope</h3>
+      <p className="settings-description">
+        Work inside a session's own directory runs free; anything reaching
+        further is judged by a classifier against what the conversation asked
+        for. Agents propose changes to that policy — you promote them.
+      </p>
+    </div>
+  );
+}

--- a/app/src/components/LocationPicker.autoMode.test.tsx
+++ b/app/src/components/LocationPicker.autoMode.test.tsx
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '../test/utils';
+import { LocationPicker } from './LocationPicker';
+import { SettingsProvider } from '../contexts/SettingsContext';
+
+const useFilesystemSuggestionsMock = vi.fn();
+
+vi.mock('../hooks/useFilesystemSuggestions', () => ({
+  useFilesystemSuggestions: () => useFilesystemSuggestionsMock(),
+}));
+
+// A plugin-driver agent that advertises auto_mode, the way attn-pi does. The
+// per-session toggle is offered for those and nothing else.
+const PI_SETTINGS = {
+  snipe_available: 'true',
+  snipe_cap_auto_mode: 'true',
+  claude_cap_auto_mode: 'false',
+};
+
+const inspectsTo = (resolved: string) => vi.fn(async (inputPath: string) => ({
+  success: true,
+  inspection: {
+    input_path: inputPath,
+    resolved_path: resolved,
+    home_path: '/home/remote',
+    exists: true,
+    is_directory: true,
+  },
+}));
+
+function renderPicker(settings: Record<string, string>) {
+  const onSelect = vi.fn();
+  const onInspectPath = inspectsTo('/home/remote/projects');
+  render(
+    <SettingsProvider settings={settings} setSetting={vi.fn()}>
+      <LocationPicker
+        isOpen
+        purpose="workspace"
+        onClose={vi.fn()}
+        onSelect={onSelect}
+        onInspectPath={onInspectPath}
+        agentAvailability={{ shell: true, claude: true, codex: true, snipe: true }}
+        endpoints={[]}
+      />
+    </SettingsProvider>,
+  );
+  return { onSelect };
+}
+
+const launch = () => {
+  const input = screen.getByTestId('location-picker-path-input');
+  fireEvent.change(input, { target: { value: '/home/remote/projects' } });
+  fireEvent.keyDown(input, { key: 'Enter' });
+};
+
+const pickSnipe = () => fireEvent.click(screen.getByRole('radio', { name: /snipe/i }));
+
+describe('LocationPicker auto mode toggle', () => {
+  beforeEach(() => {
+    useFilesystemSuggestionsMock.mockReset();
+    useFilesystemSuggestionsMock.mockReturnValue({
+      suggestions: [], loading: false, error: null, currentDir: '',
+    });
+  });
+
+  it('offers the toggle only for an agent whose driver advertises auto mode', () => {
+    renderPicker(PI_SETTINGS);
+    expect(screen.queryByTestId('location-picker-automode-toggle')).not.toBeInTheDocument();
+
+    pickSnipe();
+    expect(screen.getByTestId('location-picker-automode-toggle')).toBeInTheDocument();
+  });
+
+  // The launcher sees what the session will actually get, which means starting
+  // from the promoted default rather than from a hardcoded guess.
+  it('starts from the promoted default', () => {
+    renderPicker({ ...PI_SETTINGS, automode_enabled_default: 'false' });
+    pickSnipe();
+
+    expect(screen.getByTestId('location-picker-automode-toggle')).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('sends the default through when the launcher leaves it alone', async () => {
+    const { onSelect } = renderPicker(PI_SETTINGS);
+    pickSnipe();
+    launch();
+
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects', 'snipe', undefined, false, false, undefined, true);
+    });
+  });
+
+  // Turning it off is the whole point of a per-session override, and "off" has
+  // to travel as an answer — not as an absent field the daemon reads as
+  // "follow the default", which is what it was just overridden away from.
+  it('sends an explicit off when the launcher turns it off', async () => {
+    const { onSelect } = renderPicker(PI_SETTINGS);
+    pickSnipe();
+    fireEvent.click(screen.getByTestId('location-picker-automode-toggle'));
+    launch();
+
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects', 'snipe', undefined, false, false, undefined, false);
+    });
+  });
+
+  it('says nothing about auto mode for an agent that has none', async () => {
+    const { onSelect } = renderPicker(PI_SETTINGS);
+    launch();
+
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects', 'claude', undefined, false, false, undefined, undefined);
+    });
+  });
+});

--- a/app/src/components/LocationPicker.test.tsx
+++ b/app/src/components/LocationPicker.test.tsx
@@ -168,7 +168,7 @@ describe('LocationPicker', () => {
 
     await waitFor(() => {
       expect(onInspectPath).toHaveBeenCalledWith('/home/remote/projects/remote-repo', 'ep-1');
-      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects/remote-repo', 'snipe', 'ep-1', false, false, undefined);
+      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects/remote-repo', 'snipe', 'ep-1', false, false, undefined, undefined);
     });
     expect(onGetRepoInfo).not.toHaveBeenCalled();
   });
@@ -199,7 +199,7 @@ describe('LocationPicker', () => {
 
     await waitFor(() => {
       expect(onInspectPath).toHaveBeenCalledWith('~/projects', undefined);
-      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects', 'claude', undefined, false, false, undefined);
+      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects', 'claude', undefined, false, false, undefined, undefined);
     });
   });
 
@@ -222,7 +222,7 @@ describe('LocationPicker', () => {
 
     await waitFor(() => {
       expect(onInspectPath).toHaveBeenCalledWith('~/projects', undefined);
-      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects', 'claude', undefined, false, false, undefined);
+      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects', 'claude', undefined, false, false, undefined, undefined);
     });
   });
 
@@ -356,7 +356,7 @@ describe('LocationPicker', () => {
 
     await waitFor(() => {
       expect(onInspectPath).toHaveBeenCalledWith('/', undefined);
-      expect(onSelect).toHaveBeenCalledWith('/', 'claude', undefined, false, false, undefined);
+      expect(onSelect).toHaveBeenCalledWith('/', 'claude', undefined, false, false, undefined, undefined);
     });
   });
 
@@ -388,7 +388,7 @@ describe('LocationPicker', () => {
 
     await waitFor(() => {
       expect(onInspectPath).toHaveBeenCalledWith('/tmp/project', undefined);
-      expect(onSelect).toHaveBeenCalledWith('/tmp/project', 'claude', undefined, false, false, undefined);
+      expect(onSelect).toHaveBeenCalledWith('/tmp/project', 'claude', undefined, false, false, undefined, undefined);
     });
   });
 
@@ -431,7 +431,7 @@ describe('LocationPicker', () => {
 
     await waitFor(() => {
       expect(onInspectPath).toHaveBeenCalledWith('/home/remote/projects/recent-repo', undefined);
-      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects/recent-repo', 'claude', undefined, false, false, undefined);
+      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects/recent-repo', 'claude', undefined, false, false, undefined, undefined);
     });
   });
 
@@ -527,7 +527,7 @@ describe('LocationPicker', () => {
 
     await waitFor(() => {
       expect(onInspectPath).toHaveBeenCalledWith('/tmp/other', undefined);
-      expect(onSelect).toHaveBeenCalledWith('/tmp/other', 'claude', undefined, false, false, undefined);
+      expect(onSelect).toHaveBeenCalledWith('/tmp/other', 'claude', undefined, false, false, undefined, undefined);
     });
   });
 
@@ -602,7 +602,7 @@ describe('LocationPicker', () => {
         'feat-images',
         undefined,
       );
-      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects/exsin--feat-more', 'claude', undefined, false, false, undefined);
+      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects/exsin--feat-more', 'claude', undefined, false, false, undefined, undefined);
     });
   });
 
@@ -643,7 +643,7 @@ describe('LocationPicker', () => {
       fireEvent.click(screen.getByTestId('repo-option-0'));
 
       expect(setSetting).toHaveBeenCalledWith(destinationKey, 'main_repo');
-      expect(onSelect).toHaveBeenCalledWith(repoRoot, 'claude', undefined, false, false, undefined);
+      expect(onSelect).toHaveBeenCalledWith(repoRoot, 'claude', undefined, false, false, undefined, undefined);
     });
 
     it('records a new worktree when one is created', async () => {
@@ -676,7 +676,7 @@ describe('LocationPicker', () => {
       fireEvent.click(screen.getByTestId('repo-option-1'));
 
       await waitFor(() => {
-        expect(onSelect).toHaveBeenCalledWith('/home/remote/projects/exsin--feat-images', 'claude', undefined, false, false, undefined);
+        expect(onSelect).toHaveBeenCalledWith('/home/remote/projects/exsin--feat-images', 'claude', undefined, false, false, undefined, undefined);
       });
       expect(setSetting).not.toHaveBeenCalled();
     });
@@ -705,7 +705,7 @@ describe('LocationPicker', () => {
       expect(screen.getByTestId('repo-option-0')).toHaveClass('selected');
       fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'Enter' });
 
-      expect(onSelect).toHaveBeenCalledWith(repoRoot, 'claude', undefined, false, false, undefined);
+      expect(onSelect).toHaveBeenCalledWith(repoRoot, 'claude', undefined, false, false, undefined, undefined);
       expect(onCreateWorktree).not.toHaveBeenCalled();
     });
 
@@ -1043,7 +1043,7 @@ describe('LocationPicker', () => {
 
     await waitFor(() => {
       expect(onInspectPath).toHaveBeenCalledWith('/', 'ep-1');
-      expect(onSelect).toHaveBeenCalledWith('/', 'codex', 'ep-1', false, false, undefined);
+      expect(onSelect).toHaveBeenCalledWith('/', 'codex', 'ep-1', false, false, undefined, undefined);
     });
   });
 
@@ -1219,7 +1219,7 @@ describe('LocationPicker', () => {
     });
 
     await waitFor(() => {
-      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects/exsin', 'claude', undefined, false, false, undefined);
+      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects/exsin', 'claude', undefined, false, false, undefined, undefined);
     });
   });
 
@@ -1304,7 +1304,7 @@ describe('LocationPicker', () => {
 
     await waitFor(() => {
       expect(onError).toHaveBeenCalledWith('unborn HEAD');
-      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects/exsin', 'claude', undefined, false, false, undefined);
+      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects/exsin', 'claude', undefined, false, false, undefined, undefined);
     });
   });
 
@@ -1430,7 +1430,7 @@ describe('LocationPicker', () => {
     fireEvent.keyDown(screen.getByTestId('location-picker-path-input'), { key: 'Enter' });
 
     await waitFor(() => {
-      expect(onSelect).toHaveBeenCalledWith('/tmp/other', 'claude', undefined, false, false, undefined);
+      expect(onSelect).toHaveBeenCalledWith('/tmp/other', 'claude', undefined, false, false, undefined, undefined);
     });
 
     firstRepoInfoGate.resolve({
@@ -1600,7 +1600,7 @@ describe('LocationPicker', () => {
     fireEvent.keyDown(input, { key: 'Enter' });
 
     await waitFor(() => {
-      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects/remote-repo', 'claude', 'ep-1', true, false, undefined);
+      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects/remote-repo', 'claude', 'ep-1', true, false, undefined, undefined);
     });
   });
 
@@ -1651,7 +1651,7 @@ describe('LocationPicker', () => {
       fireEvent.keyDown(input, { key: 'Enter' });
 
       await waitFor(() => {
-        expect(onSelect).toHaveBeenCalledWith('/home/remote/projects', 'claude', undefined, false, true, undefined);
+        expect(onSelect).toHaveBeenCalledWith('/home/remote/projects', 'claude', undefined, false, true, undefined, undefined);
       });
     });
 
@@ -1664,7 +1664,7 @@ describe('LocationPicker', () => {
       fireEvent.keyDown(input, { key: 'Enter' });
 
       await waitFor(() => {
-        expect(onSelect).toHaveBeenCalledWith('/home/remote/projects', 'claude', undefined, false, false, undefined);
+        expect(onSelect).toHaveBeenCalledWith('/home/remote/projects', 'claude', undefined, false, false, undefined, undefined);
       });
     });
   });

--- a/app/src/components/LocationPicker.tsx
+++ b/app/src/components/LocationPicker.tsx
@@ -961,6 +961,8 @@ export function LocationPicker({
     rememberRepoDestination,
     repoRootPath,
     agent,
+    autoMode,
+    autoModeSupported,
     effectiveAgentAvailability,
     selectedEndpointId,
     setSelectedPathFromPhysical,

--- a/app/src/components/LocationPicker.tsx
+++ b/app/src/components/LocationPicker.tsx
@@ -78,13 +78,14 @@ interface LocationPickerProps {
     yoloMode?: boolean,
     chiefOfStaff?: boolean,
     resumeConversationFile?: string,
+    autoMode?: boolean,
   ) => void;
   onGetRecentLocations?: (endpointId?: string) => Promise<{ locations: RecentLocation[]; home_path?: string }>;
   onBrowseDirectory?: (inputPath: string, endpointId?: string) => Promise<BrowseDirectoryResult>;
   onInspectPath?: (path: string, endpointId?: string) => Promise<InspectPathResult>;
   onGetRepoInfo?: (mainRepo: string, endpointId?: string) => Promise<{ success: boolean; info?: BackendRepoInfo; error?: string }>;
   onCreateWorktree?: (mainRepo: string, branch: string, path?: string, startingFrom?: string, endpointId?: string) => Promise<{ success: boolean; path?: string; error?: string }>;
-  onCreateWorktreeSession?: (mainRepo: string, branch: string, startingFrom: string, endpointId: string | undefined, agent: SessionAgent, yoloMode: boolean) => void;
+  onCreateWorktreeSession?: (mainRepo: string, branch: string, startingFrom: string, endpointId: string | undefined, agent: SessionAgent, yoloMode: boolean, autoMode?: boolean) => void;
   onDeleteWorktree?: (path: string, endpointId?: string, options?: { force?: boolean }) => Promise<{ success: boolean; error?: string }>;
   onError?: (message: string) => void;
   projectsDirectory?: string;
@@ -127,6 +128,12 @@ const MAX_RECENT_LOCATIONS = 10;
 const SESSION_AGENT_KEY = 'new_session_agent';
 const SESSION_YOLO_KEY = 'new_session_yolo';
 const SESSION_DESTINATION_KEY = 'new_session_destination';
+// READ-ONLY, daemon-computed: the promoted auto mode config's enabled_default.
+// The toggle starts here so the picker shows what a session would get, and the
+// launcher's answer is always sent explicitly — a default that moves later must
+// not silently move a session that was already launched.
+const AUTOMODE_DEFAULT_KEY = 'automode_enabled_default';
+const AUTOMODE_CAPABILITY = 'auto_mode';
 const LOCAL_TARGET = '__local__';
 const TERMINAL_AGENT: SessionAgent = 'shell';
 const TARGET_SHORTCUT_KEYS = ['q', 'w', 'e', 'r', 'a', 's', 'd', 'f', 'g', 'z', 'x', 'c', 'v', 'b'];
@@ -293,6 +300,7 @@ export function LocationPicker({
   const [targetId, setTargetId] = useState(LOCAL_TARGET);
   const [yoloMode, setYoloMode] = useState(false);
   const [chiefOfStaff, setChiefOfStaff] = useState(false);
+  const [autoMode, setAutoMode] = useState(true);
   // The conversation this session will pick up from, '' for a fresh one.
   const [resumeFile, setResumeFile] = useState('');
   const [pastConversations, setPastConversations] = useState<PastConversation[]>([]);
@@ -439,6 +447,10 @@ export function LocationPicker({
 
   const savedAgent = normalizeAgent(settings[SESSION_AGENT_KEY]);
   const yoloSupported = Boolean(agentCapabilities[agent]?.yolo);
+  // Only a driver that advertises auto_mode is handed the config at spawn, so
+  // only its sessions have anything to toggle.
+  const autoModeSupported = Boolean(agentCapabilities[agent]?.[AUTOMODE_CAPABILITY]);
+  const autoModeDefault = parseBooleanSetting(settings[AUTOMODE_DEFAULT_KEY]) ?? true;
   // The "create as chief" toggle is offered only when no chief exists yet (the
   // role is single-holder), the selected agent has a guidance launch path
   // (claude/codex only, matching the daemon's agentSupportsChiefReload gate), and
@@ -507,6 +519,10 @@ export function LocationPicker({
       setChiefOfStaff(false);
     }
   }, [chiefToggleEligible]);
+
+  useEffect(() => {
+    setAutoMode((prev) => (prev === autoModeDefault ? prev : autoModeDefault));
+  }, [autoModeDefault]);
 
   // The listing is read once per opening of the bar, and dropped when the bar
   // goes away — switching agent or target must not leave a resume selected that
@@ -671,10 +687,13 @@ export function LocationPicker({
       yoloMode && yoloSupported,
       chiefOfStaff && chiefToggleEligible,
       resumeEligible && resumeFile !== '' ? resumeFile : undefined,
+      autoModeSupported ? autoMode : undefined,
     );
     onClose();
   }, [
     agent,
+    autoMode,
+    autoModeSupported,
     chiefOfStaff,
     chiefToggleEligible,
     effectiveAgentAvailability,
@@ -905,6 +924,7 @@ export function LocationPicker({
         selectedEndpointId,
         selectedAgent,
         yoloMode && yoloSupported,
+        autoModeSupported ? autoMode : undefined,
       );
       onClose();
       return;
@@ -1103,6 +1123,27 @@ export function LocationPicker({
             </div>
           </div>
         </div>
+        {autoModeSupported && (
+          <div className="picker-chief-bar">
+            <div className="picker-agent-label">AUTO MODE</div>
+            <div className="picker-chief-controls">
+              <div className="agent-toggle">
+                <button
+                  type="button"
+                  className={`agent-option ${autoMode ? 'active' : ''}`}
+                  data-testid="location-picker-automode-toggle"
+                  role="switch"
+                  aria-checked={autoMode}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => setAutoMode((prev) => !prev)}
+                  title="Judge calls that reach outside this session's directory against what the conversation asked for, instead of running everything"
+                >
+                  <span className="agent-option-name">{autoMode ? 'On' : 'Off'}</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
         {chiefToggleEligible && (
           <div className="picker-chief-bar">
             <div className="picker-agent-label">CHIEF OF STAFF</div>

--- a/app/src/components/SettingsModal.autoModeBadge.test.tsx
+++ b/app/src/components/SettingsModal.autoModeBadge.test.tsx
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '../test/utils';
+import { SettingsModal } from './SettingsModal';
+import type { AutoModeState } from '../hooks/daemonAutoModeEvents';
+
+const daemonApi = vi.hoisted(() => ({
+  sendGetSettings: vi.fn(),
+  sendBusStatusGet: vi.fn(() => new Promise(() => {})),
+  sendBusSetConsumerEnabled: vi.fn(),
+  sendAutoModeGet: vi.fn(),
+  sendAutoModePromote: vi.fn(),
+  sendAutoModeDiscard: vi.fn(),
+}));
+vi.mock('../contexts/DaemonApiContext', () => ({ useDaemonApi: () => daemonApi }));
+
+const autoModeState = (proposals: number): AutoModeState => ({
+  config: {
+    enabled_default: true,
+    environment: [],
+    allow: [],
+    hard_deny: [],
+    classifier_model: 'opencode-go/glm-5.3',
+    escalation_model: 'opencode-go/qwen3.8-max',
+  },
+  proposals: Array.from({ length: proposals }, (_unused, index) => ({
+    id: index + 1,
+    kind: 'allow',
+    target: '',
+    value: `curl https://example.com/${index}*`,
+    proposed_by: 'session-a',
+    state: 'pending',
+    created_at: '2026-08-16T10:00:00Z',
+    resolved_at: '',
+  })),
+  denials: [],
+});
+
+function renderModal(isOpen = true) {
+  return render(
+    <SettingsModal
+      isOpen={isOpen}
+      onClose={vi.fn()}
+      mutedRepos={[]}
+      githubHosts={[]}
+      onUnmuteRepo={vi.fn()}
+      mutedAuthors={[]}
+      onUnmuteAuthor={vi.fn()}
+      settings={{}}
+      endpoints={[]}
+      plugins={[]}
+      pluginIssues={[]}
+      onAddEndpoint={vi.fn().mockResolvedValue({ success: true })}
+      onUpdateEndpoint={vi.fn().mockResolvedValue({ success: true })}
+      onRemoveEndpoint={vi.fn().mockResolvedValue({ success: true })}
+      onSetEndpointRemoteWeb={vi.fn().mockResolvedValue({ success: true })}
+      onListPlugins={vi.fn().mockResolvedValue({ plugins: [], issues: [] })}
+      onInstallPlugin={vi.fn().mockResolvedValue({ success: true })}
+      onRemovePlugin={vi.fn().mockResolvedValue({ success: true })}
+      onSetPluginPriority={vi.fn().mockResolvedValue({ success: true })}
+      onSetSetting={vi.fn()}
+      themePreference="system"
+      onSetTheme={vi.fn()}
+    />,
+  );
+}
+
+describe('SettingsModal auto mode badge', () => {
+  // Proposals nobody sees are proposals that rot: the count has to be on the
+  // nav row before anyone opens the section.
+  it('counts waiting proposals on the nav row without opening the section', async () => {
+    daemonApi.sendAutoModeGet.mockResolvedValue(autoModeState(3));
+    renderModal();
+
+    const nav = await screen.findByTestId('settings-nav-autoMode');
+    await waitFor(() => expect(nav).toHaveTextContent('3'));
+    expect(nav.querySelector('.settings-nav-count')).toHaveClass('waiting');
+    // Reading happens once for both surfaces, not once per surface.
+    expect(daemonApi.sendAutoModeGet).toHaveBeenCalledTimes(1);
+    // Still on whichever section was open — the badge did not navigate anyone.
+    expect(screen.queryByTestId('settings-automode-config')).toBeNull();
+  });
+
+  it('leaves the count unmarked when nothing is waiting', async () => {
+    daemonApi.sendAutoModeGet.mockResolvedValue(autoModeState(0));
+    renderModal();
+
+    const nav = await screen.findByTestId('settings-nav-autoMode');
+    await waitFor(() => expect(nav).toHaveTextContent('0'));
+    expect(nav.querySelector('.settings-nav-count')).not.toHaveClass('waiting');
+  });
+
+  it('opens the section from the nav row', async () => {
+    daemonApi.sendAutoModeGet.mockResolvedValue(autoModeState(1));
+    renderModal();
+
+    fireEvent.click(await screen.findByTestId('settings-nav-autoMode'));
+    await screen.findByTestId('automode-proposals');
+    expect(screen.getByTestId('settings-section-autoMode')).toBeInTheDocument();
+  });
+
+  // A closed panel holds nothing: no read while it is shut, and no stale
+  // snapshot kept across a close.
+  it('reads nothing while the modal is closed', async () => {
+    daemonApi.sendAutoModeGet.mockClear();
+    daemonApi.sendAutoModeGet.mockResolvedValue(autoModeState(2));
+    renderModal(false);
+
+    await new Promise((done) => setTimeout(done, 20));
+    expect(daemonApi.sendAutoModeGet).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/components/SettingsModal.css
+++ b/app/src/components/SettingsModal.css
@@ -184,6 +184,14 @@
   line-height: 18px;
 }
 
+/* A count that is waiting on the reader, not just describing the section:
+   proposals nobody promotes are proposals that rot. Mirrors .settings-pill.bad. */
+.settings-nav-count.waiting {
+  border-color: rgba(255, 116, 108, 0.42);
+  background: rgba(255, 116, 108, 0.11);
+  color: #ff746c;
+}
+
 .settings-body {
   position: relative;
   min-height: 0;

--- a/app/src/components/SettingsModal.test.tsx
+++ b/app/src/components/SettingsModal.test.tsx
@@ -7,6 +7,9 @@ const daemonApi = vi.hoisted(() => ({
   sendGetSettings: vi.fn(),
   sendBusStatusGet: vi.fn(() => new Promise(() => {})),
   sendBusSetConsumerEnabled: vi.fn(),
+  sendAutoModeGet: vi.fn(() => new Promise(() => {})),
+  sendAutoModePromote: vi.fn(),
+  sendAutoModeDiscard: vi.fn(),
 }));
 vi.mock('../contexts/DaemonApiContext', () => ({ useDaemonApi: () => daemonApi }));
 

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -12,6 +12,8 @@ import {
 } from '../hooks/useDaemonSocket';
 import { BackgroundTasksSettings } from './BackgroundTasksSettings';
 import { EventBusSettings } from './EventBusSettings';
+import { AutoModeSettings } from './AutoModeSettings';
+import { useAutoModePolicy } from '../hooks/useAutoModePolicy';
 import {
   assertValidSettingsSectionID,
   setSettingsAutomationHandle,
@@ -100,7 +102,7 @@ interface SettingsModalProps {
   taskChangeSignal?: number;
 }
 
-type SettingsSectionID = 'general' | 'connectivity' | 'plugins' | 'agents' | 'data' | 'review' | 'hygiene' | 'backgroundTasks' | 'eventBus';
+type SettingsSectionID = 'general' | 'connectivity' | 'plugins' | 'agents' | 'data' | 'review' | 'hygiene' | 'backgroundTasks' | 'eventBus' | 'autoMode';
 
 // Fallback shown when the daemon has not yet sent a normalized value; the daemon
 // mirrors this default (agent.DefaultContextWindowCap) for both context-window caps.
@@ -203,7 +205,23 @@ export function SettingsModal({
   retryTask,
   taskChangeSignal,
 }: SettingsModalProps) {
-  const { sendGetSettings, sendBusStatusGet, sendBusSetConsumerEnabled } = useDaemonApi();
+  const {
+    sendGetSettings,
+    sendBusStatusGet,
+    sendBusSetConsumerEnabled,
+    sendAutoModeGet,
+    sendAutoModePromote,
+    sendAutoModeDiscard,
+  } = useDaemonApi();
+  // Read here rather than inside the section: the nav badge needs the pending
+  // count before the section mounts, and one read serves both. Gated on the
+  // modal being open, so a closed panel holds nothing.
+  const autoModePolicy = useAutoModePolicy({
+    enabled: isOpen,
+    getState: sendAutoModeGet,
+    promoteProposal: sendAutoModePromote,
+    discardProposal: sendAutoModeDiscard,
+  });
   const [projectsDir, setProjectsDir] = useState(settings.projects_directory || '');
   const [notebookRoot, setNotebookRoot] = useState(settings['notebook.root'] || '');
   const [agentExecutables, setAgentExecutables] = useState<Record<SessionAgent, string>>({});
@@ -1087,6 +1105,14 @@ export function SettingsModal({
           count: 1,
           keywords: 'event bus log durable facts producers consumers cursor lag retention compaction trim stalled disabled kill switch seq',
         },
+        {
+          id: 'autoMode',
+          label: 'Auto mode',
+          title: 'Auto mode',
+          description: "pi's safety envelope: the policy sessions launch with, and the rule changes agents have proposed.",
+          count: autoModePolicy.pendingCount,
+          keywords: 'auto mode automode pi safety envelope classifier proposals promote discard allow deny hard deny patterns policy permissions',
+        },
       ],
     },
     {
@@ -1135,6 +1161,7 @@ export function SettingsModal({
     orderedAgentList.length,
     pluginIssues.length,
     plugins.length,
+    autoModePolicy.pendingCount,
   ]);
 
   const filteredNavGroups = useMemo(() => {
@@ -1205,6 +1232,21 @@ export function SettingsModal({
               {modelCaptureEnabled ? 'capture on' : 'capture off'}
             </span>
             <span className="settings-pill">{modelCaptureBytes}</span>
+          </>
+        );
+      case 'autoMode':
+        return (
+          <>
+            <span className={`settings-pill ${autoModePolicy.pendingCount === 0 ? 'good' : 'warn'}`}>
+              {autoModePolicy.pendingCount === 0
+                ? 'nothing waiting'
+                : `${autoModePolicy.pendingCount} proposal${autoModePolicy.pendingCount === 1 ? '' : 's'} waiting`}
+            </span>
+            {autoModePolicy.state && (
+              <span className="settings-pill">
+                {autoModePolicy.state.config.enabled_default ? 'on by default' : 'off by default'}
+              </span>
+            )}
           </>
         );
       case 'hygiene':
@@ -2845,6 +2887,8 @@ export function SettingsModal({
         return renderBackgroundTasksSettings();
       case 'eventBus':
         return renderEventBusSettings();
+      case 'autoMode':
+        return <AutoModeSettings policy={autoModePolicy} />;
       case 'connectivity':
       default:
         return renderConnectivitySettings();
@@ -2893,7 +2937,9 @@ export function SettingsModal({
                       onClick={() => setSelectedSection(item.id)}
                     >
                       <span>{item.label}</span>
-                      <span className="settings-nav-count">{item.count}</span>
+                      <span className={`settings-nav-count${item.id === 'autoMode' && item.count > 0 ? ' waiting' : ''}`}>
+                        {item.count}
+                      </span>
                     </button>
                   ))}
                 </div>

--- a/app/src/components/settingsAutomation.ts
+++ b/app/src/components/settingsAutomation.ts
@@ -15,6 +15,7 @@ const SETTINGS_SECTION_IDS = [
   'hygiene',
   'backgroundTasks',
   'eventBus',
+  'autoMode',
 ] as const;
 
 export type SettingsAutomationSectionID = (typeof SETTINGS_SECTION_IDS)[number];

--- a/app/src/hooks/daemonAutoModeEvents.ts
+++ b/app/src/hooks/daemonAutoModeEvents.ts
@@ -1,0 +1,116 @@
+// pi auto mode: the three results the auto mode settings section waits on.
+//
+// Its own module rather than a case in the hook's switch, for the same reason
+// daemonBusEvents.ts is one — the domain is self-contained. Reached from the
+// switch's `default` chain.
+//
+// Design: docs/plans/2026-08-16-pi-auto-mode.md.
+
+import type {
+  AutoModeConfigInfo,
+  AutoModeDenialInfo,
+  AutoModeProposalInfo,
+} from '../types/generated';
+import { type PendingRequests, settlePendingRequest } from './daemonPendingRequests';
+
+export type { AutoModeConfigInfo, AutoModeDenialInfo, AutoModeProposalInfo };
+
+/** The promoted policy plus everything waiting on a human. */
+export interface AutoModeState {
+  config: AutoModeConfigInfo;
+  /** Pending only — the daemon resolves promoted and discarded ones away. */
+  proposals: AutoModeProposalInfo[];
+  denials: AutoModeDenialInfo[];
+}
+
+/** What a promote answers with: the resolved proposal and the config it produced. */
+export interface AutoModePromotion {
+  proposal: AutoModeProposalInfo | null;
+  config: AutoModeConfigInfo | null;
+}
+
+// A loosely typed view of the wire event: these arrive as parsed JSON, so every
+// field is checked rather than asserted.
+interface AutoModeDaemonEvent {
+  event?: string;
+  success?: boolean;
+  error?: string;
+  [key: string]: unknown;
+}
+
+const str = (value: unknown): string => (typeof value === 'string' ? value : '');
+const list = <T,>(value: unknown): T[] => (Array.isArray(value) ? (value as T[]) : []);
+
+const emptyConfig = (): AutoModeConfigInfo => ({
+  enabled_default: false,
+  environment: [],
+  allow: [],
+  hard_deny: [],
+  classifier_model: '',
+  escalation_model: '',
+});
+
+const toConfig = (value: unknown): AutoModeConfigInfo => {
+  if (typeof value !== 'object' || value === null) return emptyConfig();
+  const raw = value as Record<string, unknown>;
+  return {
+    enabled_default: raw.enabled_default === true,
+    environment: list<string>(raw.environment),
+    allow: list<string>(raw.allow),
+    hard_deny: list<string>(raw.hard_deny),
+    classifier_model: str(raw.classifier_model),
+    escalation_model: str(raw.escalation_model),
+  };
+};
+
+const toState = (event: AutoModeDaemonEvent): AutoModeState => ({
+  config: toConfig(event.config),
+  proposals: list<AutoModeProposalInfo>(event.proposals),
+  denials: list<AutoModeDenialInfo>(event.denials),
+});
+
+const toPromotion = (event: AutoModeDaemonEvent): AutoModePromotion => ({
+  proposal: (event.proposal as AutoModeProposalInfo | undefined) ?? null,
+  config: event.config === undefined ? null : toConfig(event.config),
+});
+
+/**
+ * Settles an auto mode result, or returns false for an event this module does
+ * not own so the caller can keep looking.
+ */
+export function handleAutoModeDaemonEvent(
+  event: AutoModeDaemonEvent,
+  pending: PendingRequests,
+): boolean {
+  switch (event.event) {
+    case 'automode_state_result':
+      settlePendingRequest(
+        pending,
+        'automode_get',
+        event,
+        toState,
+        'Reading auto mode failed',
+      );
+      return true;
+    case 'automode_promote_result':
+      settlePendingRequest(
+        pending,
+        'automode_promote',
+        event,
+        toPromotion,
+        'Promoting the proposal failed',
+      );
+      return true;
+    case 'automode_discard_result':
+      settlePendingRequest(
+        pending,
+        'automode_discard',
+        event,
+        toPromotion,
+        'Discarding the proposal failed',
+      );
+      return true;
+    default:
+      return false;
+  }
+}

--- a/app/src/hooks/useAutoModePolicy.ts
+++ b/app/src/hooks/useAutoModePolicy.ts
@@ -1,0 +1,114 @@
+// Auto mode's promoted policy and the proposals waiting on a human, read once
+// for the two surfaces that need it: the settings section that resolves them,
+// and the nav badge that says how many are waiting.
+//
+// One hook rather than a fetch inside the section, because the badge has to
+// know the count before the section mounts. `enabled` is what keeps a closed
+// panel holding nothing — no read, no state, no timer.
+//
+// Design: docs/plans/2026-08-16-pi-auto-mode.md.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { AutoModePromotion, AutoModeState } from './daemonAutoModeEvents';
+
+export interface AutoModePolicy {
+  state: AutoModeState | null;
+  /** The last failure, kept beside a good snapshot rather than replacing it. */
+  error: string | null;
+  loading: boolean;
+  /** The proposal a promote or discard is in flight for. */
+  resolvingID: number | null;
+  /** How many proposals are waiting on a human. */
+  pendingCount: number;
+  refresh: () => Promise<void>;
+  promote: (id: number) => Promise<void>;
+  discard: (id: number) => Promise<void>;
+}
+
+interface AutoModePolicyOptions {
+  /** False while the surface is closed: nothing is read and nothing is held. */
+  enabled: boolean;
+  getState: () => Promise<AutoModeState>;
+  promoteProposal: (id: number) => Promise<AutoModePromotion>;
+  discardProposal: (id: number) => Promise<AutoModePromotion>;
+}
+
+const message = (err: unknown, fallback: string): string =>
+  err instanceof Error ? err.message : fallback;
+
+export function useAutoModePolicy(options: AutoModePolicyOptions): AutoModePolicy {
+  const { enabled, getState, promoteProposal, discardProposal } = options;
+  const [state, setState] = useState<AutoModeState | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [resolvingID, setResolvingID] = useState<number | null>(null);
+  // Guards against an older answer landing after a newer one.
+  const seqRef = useRef(0);
+
+  const refresh = useCallback(async () => {
+    const seq = ++seqRef.current;
+    setLoading(true);
+    try {
+      const next = await getState();
+      if (seqRef.current !== seq) return;
+      setState(next);
+      setError(null);
+    } catch (err) {
+      if (seqRef.current !== seq) return;
+      setError(message(err, 'Could not read auto mode'));
+    } finally {
+      if (seqRef.current === seq) setLoading(false);
+    }
+  }, [getState]);
+
+  const resolve = useCallback(async (
+    id: number,
+    action: (id: number) => Promise<AutoModePromotion>,
+    fallback: string,
+  ) => {
+    setResolvingID(id);
+    try {
+      await action(id);
+      // The daemon is authoritative: the list reflects a re-read, never a
+      // local guess about what promoting did to the config.
+      await refresh();
+    } catch (err) {
+      setError(message(err, fallback));
+    } finally {
+      setResolvingID(null);
+    }
+  }, [refresh]);
+
+  const promote = useCallback(
+    (id: number) => resolve(id, promoteProposal, 'Could not promote the proposal'),
+    [resolve, promoteProposal],
+  );
+  const discard = useCallback(
+    (id: number) => resolve(id, discardProposal, 'Could not discard the proposal'),
+    [resolve, discardProposal],
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      // Drop the snapshot on close: reopening reads a fresh one, and a stale
+      // proposal list is worse than none.
+      seqRef.current++;
+      setState(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    void refresh();
+  }, [enabled, refresh]);
+
+  return {
+    state,
+    error,
+    loading,
+    resolvingID,
+    pendingCount: state?.proposals.length ?? 0,
+    refresh,
+    promote,
+    discard,
+  };
+}

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -70,6 +70,11 @@ import { decodeBinaryFrame } from '../pty/binaryPtyFrame';
 import { kittyImageBlobFromResult, kittyImageCache } from '../utils/kittyImageCache';
 import { resolveDaemonWebSocketURL, type DaemonEndpointProfile } from '../utils/daemonEndpoint';
 import { handleBusDaemonEvent, type BusStatus } from './daemonBusEvents';
+import {
+  handleAutoModeDaemonEvent,
+  type AutoModePromotion,
+  type AutoModeState,
+} from './daemonAutoModeEvents';
 import { handleFsDaemonEvent } from './daemonFsEvents';
 import { handleNotebookDaemonEvent } from './daemonNotebookEvents';
 import {
@@ -258,7 +263,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '254';
+export const PROTOCOL_VERSION = '255';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a
@@ -3034,6 +3039,7 @@ export function useDaemonSocket({
               }
             })) break;
             if (handleBusDaemonEvent(data, pending)) break;
+            if (handleAutoModeDaemonEvent(data, pending)) break;
             break;
           }
         }
@@ -3139,6 +3145,9 @@ export function useDaemonSocket({
       ...(args.resume_picker && { resume_picker: args.resume_picker }),
       ...(args.resume_conversation_file && { resume_conversation_file: args.resume_conversation_file }),
       ...(args.yolo_mode && { yolo_mode: args.yolo_mode }),
+      // Tri-state, unlike yolo: absent means "follow the promoted default", so
+      // an explicit false has to survive rather than be dropped as falsy.
+      ...(args.auto_mode !== undefined && { auto_mode: args.auto_mode }),
       ...(args.chief_of_staff && { chief_of_staff: args.chief_of_staff }),
       ...(args.spawned_from && { spawned_from: args.spawned_from }),
       ...(args.executable && { executable: args.executable }),
@@ -3401,6 +3410,35 @@ export function useDaemonSocket({
       'bus_set_consumer_enabled',
       { consumer, enabled },
       'Changing the consumer timed out',
+    );
+  }, [sendRequest]);
+
+  // Auto mode's app-only surface. `automode_get` reads the promoted policy and
+  // the proposals waiting on a human; promote and discard resolve one. The CLI
+  // can propose and nothing else — a human in the app is the trust boundary
+  // that keeps an agent from writing its own leash, which is why these three
+  // exist on this transport alone.
+  const sendAutoModeGet = useCallback((): Promise<AutoModeState> => {
+    return sendRequest<AutoModeState>(
+      'automode_get',
+      {},
+      'Reading auto mode timed out',
+    );
+  }, [sendRequest]);
+
+  const sendAutoModePromote = useCallback((id: number): Promise<AutoModePromotion> => {
+    return sendRequest<AutoModePromotion>(
+      'automode_promote',
+      { id },
+      'Promoting the proposal timed out',
+    );
+  }, [sendRequest]);
+
+  const sendAutoModeDiscard = useCallback((id: number): Promise<AutoModePromotion> => {
+    return sendRequest<AutoModePromotion>(
+      'automode_discard',
+      { id },
+      'Discarding the proposal timed out',
     );
   }, [sendRequest]);
 
@@ -5614,6 +5652,9 @@ export function useDaemonSocket({
     sendAgentSetModel,
     sendListPastConversations,
     sendBusStatusGet,
+    sendAutoModeGet,
+    sendAutoModePromote,
+    sendAutoModeDiscard,
     sendBusSetConsumerEnabled,
     sendTriggerNudge,
     sendSettleTurn,

--- a/app/src/pty/bridge.ts
+++ b/app/src/pty/bridge.ts
@@ -22,6 +22,8 @@ export interface PtySpawnArgs {
    */
   resume_conversation_file?: string;
   yolo_mode?: boolean | null;
+  /** Tri-state: absent follows the promoted auto mode default. */
+  auto_mode?: boolean;
   chief_of_staff?: boolean | null;
   /**
    * The session this one was split from. Only meaningful for a shell: the daemon

--- a/app/src/store/sessions.ts
+++ b/app/src/store/sessions.ts
@@ -42,6 +42,10 @@ export interface Session {
   // spawn args are taken. The daemon persists it in the launch intent, so a
   // revive does not need it back from here.
   resumeConversationFile?: string;
+  // The launcher's per-session auto mode choice, undefined for "follow the
+  // promoted default". Like resumeConversationFile it is carried only until the
+  // spawn args are taken; the daemon persists it in the launch intent.
+  autoMode?: boolean;
   transcriptMatched: boolean;
   branch?: string;
   isWorktree?: boolean;
@@ -88,6 +92,7 @@ interface SessionStore {
     // An existing conversation to pick up from. Only a conversation agent reads
     // it; every other agent ignores it.
     resumeConversationFile?: string,
+    autoMode?: boolean,
   ) => Promise<string>;
   closeSession: (id: string) => void;
   removeSessionLocalState: (id: string) => void;
@@ -195,6 +200,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     providedWorkspaceId: string,
     chiefOfStaff?: boolean,
     resumeConversationFile?: string,
+    autoMode?: boolean,
   ) => {
     // Use provided ID or generate new one
     const id = providedId || crypto.randomUUID();
@@ -214,6 +220,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
       yoloMode: yoloMode ?? false,
       chiefOfStaff: chiefOfStaff ?? false,
       resumeConversationFile,
+      autoMode,
       transcriptMatched: resolvedAgent !== 'codex',
       workspace: createDefaultWorkspaceState(),
       daemonActivePaneId: '',
@@ -294,6 +301,9 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
       yolo_mode: session.yoloMode ?? null,
       ...(session.chiefOfStaff ? { chief_of_staff: true } : {}),
       ...(session.resumeConversationFile ? { resume_conversation_file: session.resumeConversationFile } : {}),
+      // Explicit false is a real answer here — "the launcher turned auto mode
+      // off" — so the field is sent whenever it was set, never `&&`-collapsed.
+      ...(session.autoMode !== undefined ? { auto_mode: session.autoMode } : {}),
       ...(selectedExecutable ? { executable: selectedExecutable } : {}),
       ...(session.agent === 'claude' && selectedExecutable
         ? { claude_executable: selectedExecutable }

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -7083,6 +7083,7 @@ export enum SpawnResultMessageEvent {
 
 export interface SpawnSessionMessage {
     agent:                     string;
+    auto_mode?:                boolean;
     chief_of_staff?:           boolean;
     claude_executable?:        string;
     cmd:                       SpawnSessionMessageCmd;
@@ -17133,6 +17134,7 @@ const typeMap: any = {
     ], "any"),
     "SpawnSessionMessage": o([
         { json: "agent", js: "agent", typ: "" },
+        { json: "auto_mode", js: "auto_mode", typ: u(undefined, true) },
         { json: "chief_of_staff", js: "chief_of_staff", typ: u(undefined, true) },
         { json: "claude_executable", js: "claude_executable", typ: u(undefined, "") },
         { json: "cmd", js: "cmd", typ: r("SpawnSessionMessageCmd") },

--- a/changelog.d/automode-panel-promotion-surface.yaml
+++ b/changelog.d/automode-panel-promotion-surface.yaml
@@ -1,0 +1,20 @@
+kind: added
+area: automode
+change: >
+  Auto mode has a human surface. Settings gained an "Auto mode" section that
+  lists the rules sessions proposed — what each one asks for, who asked, and
+  when — with promote and discard beside each, and shows the effective policy
+  a session would launch with. The settings nav counts waiting proposals so
+  they cannot rot unseen. The session launcher gained an auto mode toggle for
+  agents whose driver supports it; it starts from the promoted default and the
+  per-session choice survives a revive or a reload. Auto mode also now ships
+  its own leash: the patterns that would let an agent rewrite auto mode's
+  policy — the mutating `attn automode` verbs and attn's own WebSocket port —
+  are hard-denied on every machine, resolved at read rather than written into
+  anyone's config, so `show` and `denials` stay reachable. Identical pending
+  proposals collapse into one, and a proposer is capped at 20 unresolved
+  proposals with an error that names the limit and the ask.
+notes: >
+  Slice 5a of the pi auto mode plan (docs/plans/2026-08-16-pi-auto-mode.md) —
+  the attn app/daemon half. Promotion remains app-only: the CLI can propose,
+  never promote. Denial reporting and the denials feed are a later slice.

--- a/docs/plans/2026-08-16-pi-auto-mode.md
+++ b/docs/plans/2026-08-16-pi-auto-mode.md
@@ -168,9 +168,14 @@ Classifier (layer 2a → 2b):
    bare pi.
 4. **attn config + CLI.** Storage + migrations, `attn automode` verbs with
    propose semantics, daemon injection into spawn, protocol additions.
-5. **attn visibility + promotion.** Denial fact → notification + session
-   activity; proposed-rules settings section (promote/discard); launch
-   parameter toggle.
+5. **attn visibility + promotion.** Split in two so promotion did not wait
+   on slice 3's relay.
+   - **5a — promotion surface.** Proposed-rules settings section
+     (promote/discard) with a waiting-proposals badge; launch parameter
+     toggle carried through spawn, revive, and reload; shipped hard denies
+     over auto mode's own surfaces; proposal dedupe and per-proposer cap.
+   - **5b — denial reporting.** Denial fact → notification + session
+     activity. Needs slice 3's suite relay.
 6. **Live verification pass.** Harness scenario, daily-driver soak,
    evidence recordings; defaults flipped on for attn sessions.
 

--- a/internal/automode/automode.go
+++ b/internal/automode/automode.go
@@ -54,6 +54,83 @@ func Defaults() Config {
 	}
 }
 
+// ShippedHardDeny is auto mode's own leash: the patterns every machine gets
+// whether or not anyone configured one. A session under auto mode reaching for
+// the surfaces that decide what auto mode permits is denied by policy here, not
+// only by which transport carries which verb.
+//
+// Two surfaces, matched against a call signature (the bare command, for bash):
+// the `attn automode` verbs that write — environment prose lands in the
+// classifier's own prompt, and a proposal the agent files is a line in the
+// human's review list — and the app's WebSocket port, where promotion lives.
+// The read-only verbs (`show`, `denials`) stay reachable on purpose: a denied
+// agent explaining what stopped it is the behavior the plan asks for.
+//
+// wsPort is the daemon's own port, which is per-profile, so the deny names the
+// port this machine actually listens on rather than a hardcoded 9849.
+func ShippedHardDeny(wsPort string) []string {
+	patterns := []string{
+		"*attn automode env*",
+		"*attn automode allow*",
+		"*attn automode deny *",
+		"*attn automode model*",
+	}
+	if wsPort = strings.TrimSpace(wsPort); wsPort != "" {
+		patterns = append(patterns,
+			"*localhost:"+wsPort+"*",
+			"*127.0.0.1:"+wsPort+"*",
+			"*[::1]:"+wsPort+"*",
+		)
+	}
+	return patterns
+}
+
+// ResolveHardDeny is what a caller reads: the shipped denies first, then
+// whatever a human promoted. Shipped entries are resolved at read rather than
+// written into anyone's row, the same way an unset model resolves to the
+// default — so changing this list reaches every machine, and no stored row can
+// drop an entry from it.
+func ResolveHardDeny(wsPort string, stored []string) []string {
+	resolved := ShippedHardDeny(wsPort)
+	for _, pattern := range stored {
+		resolved = appendUnique(resolved, pattern)
+	}
+	return resolved
+}
+
+// StripShippedHardDeny is ResolveHardDeny's inverse, for the write path: a
+// config read, changed, and written back must not persist the shipped entries
+// it was handed.
+func StripShippedHardDeny(wsPort string, resolved []string) []string {
+	shipped := map[string]bool{}
+	for _, pattern := range ShippedHardDeny(wsPort) {
+		shipped[pattern] = true
+	}
+	stored := []string{}
+	for _, pattern := range resolved {
+		if !shipped[pattern] {
+			stored = append(stored, pattern)
+		}
+	}
+	return stored
+}
+
+func appendUnique(values []string, value string) []string {
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}
+
+// MaxPendingProposalsPerProposer caps how many unresolved proposals one
+// proposer can hold. The receipt is pi's own circuit breaker: a session is
+// stopped for a human question at 20 denials (docs/plans/2026-08-16-pi-auto-mode.md),
+// and a denial is what prompts a proposal, so no healthy session reaches this.
+// A proposer that does has stopped asking and started burying the review list.
+const MaxPendingProposalsPerProposer = 20
+
 // Proposal kinds and model targets. A proposal names one change; promotion in
 // the app is what applies it.
 const (

--- a/internal/automode/automode_test.go
+++ b/internal/automode/automode_test.go
@@ -86,3 +86,55 @@ func TestConfigMarshalsIntoThePiSideShape(t *testing.T) {
 		}
 	}
 }
+
+func TestShippedHardDenyCoversAutoModesOwnSurfaces(t *testing.T) {
+	patterns := ShippedHardDeny("29849")
+	joined := strings.Join(patterns, "\n")
+	// The verbs that write: environment prose feeds the classifier's own prompt,
+	// and the rest file rows in the human's review list.
+	for _, verb := range []string{"env", "allow", "deny", "model"} {
+		if !strings.Contains(joined, "attn automode "+verb) {
+			t.Errorf("shipped hard deny does not cover `attn automode %s`: %v", verb, patterns)
+		}
+	}
+	// The read-only verbs stay reachable: a denied agent explaining what stopped
+	// it is behavior the plan asks for.
+	for _, verb := range []string{"show", "denials"} {
+		if strings.Contains(joined, "attn automode "+verb) {
+			t.Errorf("shipped hard deny covers the read-only verb %q: %v", verb, patterns)
+		}
+	}
+	if !strings.Contains(joined, "localhost:29849") {
+		t.Errorf("shipped hard deny does not name the daemon's own port: %v", patterns)
+	}
+	for _, pattern := range patterns {
+		if IsBroadPattern(pattern) {
+			t.Errorf("shipped hard deny %q names nothing", pattern)
+		}
+	}
+}
+
+func TestShippedHardDenyWithoutAPortNamesOnlyTheCLI(t *testing.T) {
+	for _, pattern := range ShippedHardDeny("") {
+		if strings.Contains(pattern, ":") {
+			t.Errorf("pattern %q names a port when none was given", pattern)
+		}
+	}
+}
+
+func TestResolveHardDenyPutsShippedFirstAndDropsDuplicates(t *testing.T) {
+	shipped := ShippedHardDeny("9849")
+	resolved := ResolveHardDeny("9849", []string{"ssh prod*", shipped[0], "ssh prod*"})
+	if len(resolved) != len(shipped)+1 {
+		t.Fatalf("resolved = %v, want the shipped set plus one stored pattern", resolved)
+	}
+	for i, pattern := range shipped {
+		if resolved[i] != pattern {
+			t.Fatalf("resolved[%d] = %q, want the shipped %q", i, resolved[i], pattern)
+		}
+	}
+	stored := StripShippedHardDeny("9849", resolved)
+	if len(stored) != 1 || stored[0] != "ssh prod*" {
+		t.Errorf("stripped = %v, want only the stored pattern", stored)
+	}
+}

--- a/internal/daemon/automode_launch_test.go
+++ b/internal/daemon/automode_launch_test.go
@@ -7,8 +7,10 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/automode"
+	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/ptybackend"
+	"github.com/victorarias/attn/internal/store"
 )
 
 // Auto mode reaches a session through the launch, not through a live refresh: a
@@ -138,8 +140,9 @@ func TestReloadCarriesThePromotedAutoModeConfig(t *testing.T) {
 		}
 		if params.AutoMode == nil {
 			t.Error("resume params carry no auto mode config")
-		} else if len(params.AutoMode.HardDeny) != 1 || params.AutoMode.HardDeny[0] != "curl *" {
-			t.Errorf("auto mode hard deny = %v, want the promoted pattern", params.AutoMode.HardDeny)
+		} else if promoted := automode.StripShippedHardDeny(config.WSPort(), params.AutoMode.HardDeny); len(promoted) != 1 || promoted[0] != "curl *" {
+			t.Errorf("auto mode hard deny = %v, want the promoted pattern beside the shipped ones",
+				params.AutoMode.HardDeny)
 		}
 		respondPluginRequest(t, plugin, request, pluginDriverSpawnResult{Argv: []string{"snipe"}})
 	}()
@@ -189,4 +192,149 @@ func TestSpawnOmitsAutoModeForADriverThatDoesNotAskForIt(t *testing.T) {
 		Rows:        24,
 	})
 	<-requestDone
+}
+
+// The per-session override is the launcher's answer, not a default: it beats
+// enabled_default in the payload and it survives into the launch intent, which
+// is what a revive relaunches from.
+func TestSpawnAppliesThePerSessionAutoModeOverride(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		enabledDefault bool
+		override       *bool
+		want           bool
+	}{
+		{name: "off overrides an on default", enabledDefault: true, override: protocol.Ptr(false), want: false},
+		{name: "on overrides an off default", enabledDefault: false, override: protocol.Ptr(true), want: true},
+		{name: "absent follows the default", enabledDefault: false, override: nil, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+			d.ptyBackend = &fakeSpawnBackend{}
+			if _, err := d.store.SetAutoModeEnabledDefault(tc.enabledDefault, time.Now().UTC()); err != nil {
+				t.Fatalf("set default: %v", err)
+			}
+
+			client, done := startPluginPipe(t, d, "snipe-plugin", nil)
+			defer func() {
+				_ = client.Close()
+				<-done
+			}()
+			registerTestPluginDriver(t, client, "snipe", map[string]bool{
+				"launch_instructions": true, "auto_mode": true,
+			})
+
+			requestDone := make(chan struct{})
+			go func() {
+				defer close(requestDone)
+				request := decodeJSONRPCMessage(t, client)
+				var params pluginDriverSpawnParams
+				if err := json.Unmarshal(request.Params, &params); err != nil {
+					t.Errorf("decode spawn params: %v", err)
+					return
+				}
+				if params.AutoMode == nil {
+					t.Error("spawn params carry no auto mode config")
+				} else if params.AutoMode.EnabledDefault != tc.want {
+					t.Errorf("enabled_default = %t, want %t", params.AutoMode.EnabledDefault, tc.want)
+				}
+				respondPluginRequest(t, client, request, pluginDriverSpawnResult{Argv: []string{"snipe"}})
+			}()
+
+			addTestWorkspace(d, "workspace-snipe", t.TempDir())
+			ws := &wsClient{send: make(chan outboundMessage, 2), attachedStreams: make(map[string]ptybackend.Stream)}
+			d.handleSpawnSession(ws, &protocol.SpawnSessionMessage{
+				ID:          "snipe-session",
+				Cwd:         t.TempDir(),
+				WorkspaceID: "workspace-snipe",
+				Agent:       "snipe",
+				Cols:        80,
+				Rows:        24,
+				AutoMode:    tc.override,
+			})
+			<-requestDone
+
+			intent, ok := d.store.LaunchIntent("snipe-session")
+			if !ok {
+				t.Fatal("no launch intent was persisted")
+			}
+			if tc.override == nil {
+				if intent.AutoMode != nil {
+					t.Errorf("intent recorded an override of %t when none was asked for", *intent.AutoMode)
+				}
+				return
+			}
+			if intent.AutoMode == nil || *intent.AutoMode != *tc.override {
+				t.Errorf("intent auto mode = %v, want %t", intent.AutoMode, *tc.override)
+			}
+			// A revive relaunches from the intent alone, so the override has to
+			// come back out of it.
+			session := &protocol.Session{ID: "snipe-session", Directory: t.TempDir(), Agent: "snipe", WorkspaceID: "workspace-snipe"}
+			revived, _ := buildStoredIntentSpawn(session, intent, 80, 24)
+			if revived.AutoMode == nil || *revived.AutoMode != *tc.override {
+				t.Errorf("revive spawn auto mode = %v, want %t", revived.AutoMode, *tc.override)
+			}
+		})
+	}
+}
+
+// A reload is the same session continuing. It must relaunch on the choice the
+// session was launched with, not on whatever enabled_default says today — and
+// it must not lose that choice when it rewrites the intent.
+func TestReloadKeepsThePerSessionAutoModeOverride(t *testing.T) {
+	backend := &fakeReloadBackend{
+		liveIDs: []string{"snipe-session"},
+		info:    ptybackend.SessionInfo{Cols: 100, Rows: 32},
+		params:  ptybackend.SessionLaunchParams{Recorded: true},
+	}
+	d := newReloadTestDaemon(t, backend)
+	addTestWorkspace(d, "ws-snipe-session", t.TempDir())
+	addReloadSession(d, "snipe-session", protocol.SessionAgent("snipe"), protocol.SessionStateIdle)
+	d.store.SetSetting(SettingNotebookRoot, t.TempDir())
+	if _, err := d.store.SetAutoModeEnabledDefault(true, time.Now().UTC()); err != nil {
+		t.Fatalf("set default: %v", err)
+	}
+	d.store.SetLaunchIntent("snipe-session", store.LaunchIntent{AutoMode: protocol.Ptr(false)})
+
+	plugin, done := startPluginPipe(t, d, "snipe-plugin", nil)
+	defer func() {
+		_ = plugin.Close()
+		<-done
+	}()
+	registerTestPluginDriver(t, plugin, "snipe", map[string]bool{
+		"resume": true, "launch_instructions": true, "auto_mode": true,
+	})
+
+	resumed := make(chan struct{})
+	go func() {
+		defer close(resumed)
+		request := decodeJSONRPCMessage(t, plugin)
+		var params pluginDriverSpawnParams
+		if err := json.Unmarshal(request.Params, &params); err != nil {
+			t.Errorf("decode resume params: %v", err)
+			return
+		}
+		if params.AutoMode == nil {
+			t.Error("resume params carry no auto mode config")
+		} else if params.AutoMode.EnabledDefault {
+			t.Error("the reload picked up enabled_default instead of the session's override")
+		}
+		respondPluginRequest(t, plugin, request, pluginDriverSpawnResult{Argv: []string{"snipe"}})
+	}()
+
+	d.reloadSessionAgent("snipe-session")
+
+	select {
+	case <-resumed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("driver.resume was never requested")
+	}
+
+	intent, ok := d.store.LaunchIntent("snipe-session")
+	if !ok {
+		t.Fatal("the reload dropped the launch intent")
+	}
+	if intent.AutoMode == nil || *intent.AutoMode {
+		t.Errorf("the reload rewrote the intent and lost the override: %v", intent.AutoMode)
+	}
 }

--- a/internal/daemon/automode_test.go
+++ b/internal/daemon/automode_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/victorarias/attn/internal/automode"
 	"github.com/victorarias/attn/internal/protocol"
@@ -216,5 +217,24 @@ func TestPromotionIsNotReachableOverTheUnixSocket(t *testing.T) {
 		if got := protocol.Deref(resp.Error); !strings.Contains(got, "unknown command") {
 			t.Fatalf("%s was refused for the wrong reason: %q", cmd, got)
 		}
+	}
+}
+
+// The launch surface needs the promoted default to show what a session would
+// get, and the settings snapshot is how it gets there — read-only: the config
+// is written through the automode verbs, never through set_setting.
+func TestSettingsSnapshotCarriesTheAutoModeDefault(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	if got := d.settingsWithAgentAvailability()[SettingAutoModeEnabledDefault]; got != "true" {
+		t.Errorf("%s = %q on a fresh database, want the shipped default", SettingAutoModeEnabledDefault, got)
+	}
+	if _, err := d.store.SetAutoModeEnabledDefault(false, time.Now().UTC()); err != nil {
+		t.Fatalf("set default: %v", err)
+	}
+	if got := d.settingsWithAgentAvailability()[SettingAutoModeEnabledDefault]; got != "false" {
+		t.Errorf("%s = %q after turning it off", SettingAutoModeEnabledDefault, got)
+	}
+	if err := d.validateSetting(SettingAutoModeEnabledDefault, "true"); err == nil {
+		t.Error("set_setting accepted the daemon-computed auto mode default")
 	}
 }

--- a/internal/daemon/reload.go
+++ b/internal/daemon/reload.go
@@ -274,7 +274,14 @@ func (d *Daemon) executePreparedSessionReload(sessionID string, opts ptybackend.
 	// Success. Do NOT clear the flag here — the killed worker's exit consumes it.
 	// AfterFunc is a backstop only (never-arriving exit), so the flag cannot wedge.
 	time.AfterFunc(reloadStuckFlagGrace, func() { d.clearReloading(sessionID) })
-	d.store.SetLaunchIntent(sessionID, launchIntentFromSpawnOptions(opts, d.isChiefOfStaffSession(sessionID)))
+	intent := launchIntentFromSpawnOptions(opts, d.isChiefOfStaffSession(sessionID))
+	// SpawnOptions does not carry the auto mode choice — it never reaches the
+	// worker — so rewriting the intent from it alone would silently drop the
+	// launcher's override on every reload.
+	if prior, ok := d.store.LaunchIntent(sessionID); ok {
+		intent.AutoMode = prior.AutoMode
+	}
+	d.store.SetLaunchIntent(sessionID, intent)
 	d.recordReviewerEvidence(sessionID, opts.ApprovalRoute.ReviewerInLoop())
 	d.publishFact(FactSessionRespawned, sessionID, nil)
 	d.logf("reload: respawned %s (agent=%s resume=%t yolo=%t)", sessionID, opts.Agent, opts.ResumeSessionID != "", opts.YoloMode)
@@ -491,6 +498,11 @@ func (d *Daemon) preparePluginReload(session *protocol.Session, opts *ptybackend
 		if err != nil {
 			prepared.abort()
 			return nil, fmt.Errorf("read auto mode config: %w", err)
+		}
+		// A reload is the same session continuing, so it keeps the choice its
+		// launch was given rather than picking up today's enabled_default.
+		if intent, ok := d.store.LaunchIntent(session.ID); ok && intent.AutoMode != nil {
+			cfg.EnabledDefault = *intent.AutoMode
 		}
 		params.AutoMode = &cfg
 	}

--- a/internal/daemon/spawn_pipeline.go
+++ b/internal/daemon/spawn_pipeline.go
@@ -354,6 +354,12 @@ func (d *Daemon) executeSpawn(req *spawnRequest, plan *spawnPlan) *spawnOutcome 
 				plan.rollback(d, msg.ID)
 				return &spawnOutcome{err: fmt.Errorf("read auto mode config: %w", err)}
 			}
+			// The launcher's per-session choice overrides the promoted default and
+			// nothing else: patterns and models stay as promoted. Absent means the
+			// session follows enabled_default, which is why the field is tri-state.
+			if msg.AutoMode != nil {
+				cfg.EnabledDefault = *msg.AutoMode
+			}
 			params.AutoMode = &cfg
 		}
 		result, err := d.resolvePluginDriverLaunch(req.pluginDriver, params, req.existingSession != nil && req.pluginDriver.Capabilities["resume"])
@@ -412,6 +418,7 @@ func (d *Daemon) executeSpawn(req *spawnRequest, plan *spawnPlan) *spawnOutcome 
 		// runtime gets this.
 		intent.InitialPrompt = req.initialPrompt
 	}
+	intent.AutoMode = msg.AutoMode
 	d.store.SetLaunchIntent(session.ID, intent)
 	if err := d.spawnSessionRuntime(req, plan.spawnOpts); err != nil {
 		if req.existingSession == nil {

--- a/internal/daemon/testdata/wire/producers.golden
+++ b/internal/daemon/testdata/wire/producers.golden
@@ -179,6 +179,7 @@
     "auto_settle_arm_seconds": "30",
     "auto_settle_countdown_seconds": "15",
     "auto_settle_enabled": "false",
+    "automode_enabled_default": "true",
     "chief_context_window_cap": "128000",
     "claude_available": "<probed>",
     "claude_cap_classifier": "true",

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -311,6 +311,7 @@ func buildStoredIntentSpawn(session *protocol.Session, intent store.LaunchIntent
 		Cols:        cols,
 		Rows:        rows,
 		YoloMode:    protocol.Ptr(intent.YoloMode),
+		AutoMode:    intent.AutoMode,
 	}
 	if intent.Executable != "" {
 		spawnMsg.Executable = protocol.Ptr(intent.Executable)

--- a/internal/daemon/ws_settings.go
+++ b/internal/daemon/ws_settings.go
@@ -92,6 +92,12 @@ const (
 	// SettingNotebookRootEffective is READ-ONLY and daemon-computed (never
 	// stored, never accepted by set_setting): the folder the notebook resolves to.
 	SettingNotebookRootEffective = "notebook.root.effective"
+	// SettingAutoModeEnabledDefault is READ-ONLY and daemon-computed: the
+	// promoted auto mode config's enabled_default. It rides the settings snapshot
+	// so the launch surface can show what auto mode will be without asking for
+	// the whole config, and it is never accepted by set_setting — the config is
+	// written through the automode verbs, not here.
+	SettingAutoModeEnabledDefault = "automode_enabled_default"
 	// SettingNotebookCronFrequency: cron expression for the notebook's nightly
 	// maintenance slot. Empty => "0 3 * * *".
 	SettingNotebookCronFrequency = "notebook.cron.frequency"
@@ -345,6 +351,9 @@ func (d *Daemon) settingsWithAgentAvailability() map[string]interface{} {
 		settings[SettingCopilotAvailable] = settings[availabilitySettingKey(string(protocol.SessionAgentCopilot))]
 	}
 	settings[SettingPTYBackendMode] = d.ptyBackendMode()
+	if cfg, err := d.store.GetAutoModeConfig(); err == nil {
+		settings[SettingAutoModeEnabledDefault] = strconv.FormatBool(cfg.EnabledDefault)
+	}
 	if root, err := d.notebookRoot(); err == nil {
 		settings[SettingNotebookRootEffective] = root
 	}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "254"
+const ProtocolVersion = "255"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -6993,6 +6993,9 @@ type SpawnSessionMessage struct {
 	// Agent corresponds to the JSON schema field "agent".
 	Agent string `json:"agent"`
 
+	// AutoMode corresponds to the JSON schema field "auto_mode".
+	AutoMode *bool `json:"auto_mode,omitempty,omitzero"`
+
 	// ChiefOfStaff corresponds to the JSON schema field "chief_of_staff".
 	ChiefOfStaff *bool `json:"chief_of_staff,omitempty,omitzero"`
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -1913,6 +1913,12 @@ model SpawnSessionMessage {
   resume_session_id?: string;
   resume_picker?: boolean;
   yolo_mode?: boolean;
+  // Per-session auto mode, for an agent whose driver advertises `auto_mode`.
+  // Tri-state on purpose: absent follows the promoted config's
+  // `enabled_default`, and true/false is the launcher overriding it for this
+  // session alone. Persisted with the launch intent, so a revive or a reload
+  // relaunches on the choice that was made rather than on today's default.
+  auto_mode?: boolean;
   chief_of_staff?: boolean;    // Launch this session already holding the chief role (guidance injected at first spawn)
   spawned_from?: string;       // The session this one was split from. Consulted only for agent "shell": the daemon resolves it to the owning agent session and stores that as the satellite's parent.
   initial_prompt?: string;

--- a/internal/store/automode.go
+++ b/internal/store/automode.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/automode"
+	"github.com/victorarias/attn/internal/config"
 )
 
 // Auto mode's persistence (migration 109): the promoted config, the proposals
@@ -58,7 +59,16 @@ func (s *Store) GetAutoModeConfig() (automode.Config, error) {
 // readAutoModeConfig takes a rowQuerier (documents.go) so the same read serves a
 // plain get and the read-back inside a promote's transaction.
 func (s *Store) readAutoModeConfig(q rowQuerier) (automode.Config, error) {
-	cfg := automode.Defaults()
+	// The shipped hard denies are resolved in on every read, so a machine whose
+	// row predates them — or whose row never mentioned them — still runs with
+	// auto mode's own surfaces denied.
+	wsPort := config.WSPort()
+	defaults := func() automode.Config {
+		cfg := automode.Defaults()
+		cfg.HardDeny = automode.ResolveHardDeny(wsPort, nil)
+		return cfg
+	}
+	cfg := defaults()
 	if s.db == nil {
 		return cfg, nil
 	}
@@ -80,14 +90,16 @@ func (s *Store) readAutoModeConfig(q rowQuerier) (automode.Config, error) {
 	}
 	cfg.EnabledDefault = enabled != 0
 	if cfg.Environment, err = decodeStringList(environment, "environment"); err != nil {
-		return automode.Defaults(), err
+		return defaults(), err
 	}
 	if cfg.Allow, err = decodeStringList(allow, "allow"); err != nil {
-		return automode.Defaults(), err
+		return defaults(), err
 	}
-	if cfg.HardDeny, err = decodeStringList(hardDeny, "hard_deny"); err != nil {
-		return automode.Defaults(), err
+	stored, err := decodeStringList(hardDeny, "hard_deny")
+	if err != nil {
+		return defaults(), err
 	}
+	cfg.HardDeny = automode.ResolveHardDeny(wsPort, stored)
 	if classifierModel != "" {
 		cfg.ClassifierModel = classifierModel
 	}
@@ -118,6 +130,13 @@ func (s *Store) SetAutoModeEnabledDefault(enabled bool, now time.Time) (automode
 
 // CreateAutoModeProposal records a proposed change. It validates first, so a
 // proposal that could never be promoted never reaches the app's review list.
+//
+// The review list is a human's, so it is defended twice. An identical pending
+// proposal returns the one already there rather than a second row — a session
+// denied the same call twice has asked once. Past that, one proposer holds at
+// most automode.MaxPendingProposalsPerProposer unresolved proposals, and the
+// refusal names the cap and what it was asked to add: a caller that hit it can
+// say what to promote or discard, and the list stays reviewable.
 func (s *Store) CreateAutoModeProposal(kind, target, value, proposedBy string, now time.Time) (AutoModeProposal, error) {
 	if err := automode.ValidateProposal(kind, target, value); err != nil {
 		return AutoModeProposal{}, err
@@ -126,6 +145,30 @@ func (s *Store) CreateAutoModeProposal(kind, target, value, proposedBy string, n
 	defer s.mu.Unlock()
 	if s.db == nil {
 		return AutoModeProposal{}, fmt.Errorf("store: no database")
+	}
+	existing, err := scanAutoModeProposal(s.db.QueryRow(`
+		SELECT id, kind, target, value, proposed_by, state, created_at, resolved_at
+		FROM automode_proposals
+		WHERE state = ? AND kind = ? AND target = ? AND value = ?
+		ORDER BY id ASC LIMIT 1`, automode.StatePending, kind, target, value))
+	if err == nil {
+		return existing, nil
+	}
+	if err != sql.ErrNoRows {
+		return AutoModeProposal{}, err
+	}
+	var pending int
+	if err := s.db.QueryRow(`
+		SELECT COUNT(*) FROM automode_proposals WHERE state = ? AND proposed_by = ?`,
+		automode.StatePending, proposedBy).Scan(&pending); err != nil {
+		return AutoModeProposal{}, err
+	}
+	if pending >= automode.MaxPendingProposalsPerProposer {
+		return AutoModeProposal{}, fmt.Errorf(
+			"%s already holds %d pending auto mode proposals (the cap is %d); "+
+				"promote or discard some in the app before proposing more. Asked to add: %s",
+			describeProposer(proposedBy), pending, automode.MaxPendingProposalsPerProposer,
+			describeProposedChange(kind, target, value))
 	}
 	stamp := now.UTC().Format(sortableTimeFormat)
 	res, err := s.db.Exec(`
@@ -353,6 +396,10 @@ func (s *Store) mutateAutoModeConfig(now time.Time, apply func(*automode.Config)
 // writeAutoModeConfig takes an execer (jobs.go) so it writes through either a
 // *sql.DB or a promote's transaction.
 func writeAutoModeConfig(e execer, cfg automode.Config, now time.Time) error {
+	// Every config here came out of a read, which resolved the shipped denies in.
+	// Persisting them would freeze today's list into the row and defeat the point
+	// of resolving at read.
+	cfg.HardDeny = automode.StripShippedHardDeny(config.WSPort(), cfg.HardDeny)
 	environment, err := encodeStringList(cfg.Environment)
 	if err != nil {
 		return err
@@ -396,6 +443,20 @@ func scanAutoModeProposal(row interface{ Scan(...any) error }) (AutoModeProposal
 	p.CreatedAt = parseStoredTime(created)
 	p.ResolvedAt = parseStoredTime(resolved)
 	return p, nil
+}
+
+func describeProposer(proposedBy string) string {
+	if proposedBy == "" {
+		return "this caller"
+	}
+	return proposedBy
+}
+
+func describeProposedChange(kind, target, value string) string {
+	if kind == automode.KindModel {
+		return fmt.Sprintf("%s %s %s", kind, target, value)
+	}
+	return fmt.Sprintf("%s %s", kind, value)
 }
 
 func parseStoredTime(value string) time.Time {

--- a/internal/store/automode_test.go
+++ b/internal/store/automode_test.go
@@ -1,11 +1,20 @@
 package store
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/victorarias/attn/internal/automode"
+	"github.com/victorarias/attn/internal/config"
 )
+
+// userHardDeny drops the shipped entries every read resolves in, leaving what a
+// promotion actually put there.
+func userHardDeny(resolved []string) []string {
+	return automode.StripShippedHardDeny(config.WSPort(), resolved)
+}
 
 func TestAutoModeConfigDefaultsOnAFreshDatabase(t *testing.T) {
 	s := New()
@@ -22,8 +31,11 @@ func TestAutoModeConfigDefaultsOnAFreshDatabase(t *testing.T) {
 	if !cfg.EnabledDefault {
 		t.Error("enabled_default = false on a fresh database, want true")
 	}
-	if len(cfg.Allow) != 0 || len(cfg.HardDeny) != 0 || len(cfg.Environment) != 0 {
+	if len(cfg.Allow) != 0 || len(cfg.Environment) != 0 {
 		t.Errorf("fresh config is not empty: %+v", cfg)
+	}
+	if diff := len(cfg.HardDeny) - len(automode.ShippedHardDeny(config.WSPort())); diff != 0 {
+		t.Errorf("hard deny = %v, want exactly the shipped denies", cfg.HardDeny)
 	}
 }
 
@@ -166,8 +178,8 @@ func TestAutoModePromoteIsIdempotentlyRefusedTwice(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get config: %v", err)
 	}
-	if len(cfg.HardDeny) != 1 {
-		t.Fatalf("hard deny = %v, want one entry after two promotes", cfg.HardDeny)
+	if got := userHardDeny(cfg.HardDeny); len(got) != 1 {
+		t.Fatalf("promoted hard deny = %v, want one entry after two promotes", got)
 	}
 }
 
@@ -235,4 +247,117 @@ func TestAutoModeMigrationCreatesItsTables(t *testing.T) {
 	if applied != 1 {
 		t.Fatalf("migration 109 applied %d times, want once", applied)
 	}
+}
+
+func TestAutoModeShippedHardDeniesSurviveAPromotedRow(t *testing.T) {
+	s := New()
+	now := time.Now().UTC()
+	p, err := s.CreateAutoModeProposal(automode.KindDeny, "", "ssh prod*", "", now)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, _, err := s.PromoteAutoModeProposal(p.ID, now); err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	cfg, err := s.GetAutoModeConfig()
+	if err != nil {
+		t.Fatalf("get config: %v", err)
+	}
+	for _, want := range automode.ShippedHardDeny(config.WSPort()) {
+		if !containsString(cfg.HardDeny, want) {
+			t.Errorf("hard deny %v is missing the shipped entry %q", cfg.HardDeny, want)
+		}
+	}
+	if got := userHardDeny(cfg.HardDeny); len(got) != 1 || got[0] != "ssh prod*" {
+		t.Errorf("stored hard deny = %v, want only the promoted pattern", got)
+	}
+	// Resolved at read means resolved at read: the row a write left behind must
+	// not have frozen today's shipped list into it.
+	var stored string
+	if err := s.db.QueryRow(`SELECT hard_deny FROM automode_config WHERE id = 1`).Scan(&stored); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if stored != `["ssh prod*"]` {
+		t.Errorf("persisted hard_deny = %s, want only the promoted pattern", stored)
+	}
+}
+
+func TestAutoModeProposalDedupesAnIdenticalPendingOne(t *testing.T) {
+	s := New()
+	now := time.Now().UTC()
+	first, err := s.CreateAutoModeProposal(automode.KindAllow, "", "git push origin*", "session-a", now)
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	again, err := s.CreateAutoModeProposal(automode.KindAllow, "", "git push origin*", "session-a", now)
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if again.ID != first.ID {
+		t.Errorf("second proposal id = %d, want the existing %d", again.ID, first.ID)
+	}
+	pending, err := s.ListAutoModeProposals(automode.StatePending)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Errorf("pending = %v, want one row", pending)
+	}
+	// A resolved proposal is not a duplicate: the same ask after a discard is a
+	// new ask.
+	if _, err := s.DiscardAutoModeProposal(first.ID, now); err != nil {
+		t.Fatalf("discard: %v", err)
+	}
+	third, err := s.CreateAutoModeProposal(automode.KindAllow, "", "git push origin*", "session-a", now)
+	if err != nil {
+		t.Fatalf("third: %v", err)
+	}
+	if third.ID == first.ID {
+		t.Error("a discarded proposal was reused instead of a new one being recorded")
+	}
+}
+
+func TestAutoModeProposalCapNamesTheLimitAndTheAsk(t *testing.T) {
+	s := New()
+	now := time.Now().UTC()
+	for i := 0; i < automode.MaxPendingProposalsPerProposer; i++ {
+		if _, err := s.CreateAutoModeProposal(
+			automode.KindAllow, "", fmt.Sprintf("curl https://example.com/%d*", i), "session-a", now,
+		); err != nil {
+			t.Fatalf("proposal %d: %v", i, err)
+		}
+	}
+	_, err := s.CreateAutoModeProposal(automode.KindAllow, "", "curl https://example.com/last*", "session-a", now)
+	if err == nil {
+		t.Fatal("the proposal past the cap was accepted")
+	}
+	for _, want := range []string{
+		"session-a",
+		fmt.Sprintf("%d", automode.MaxPendingProposalsPerProposer),
+		"curl https://example.com/last*",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("cap error %q does not name %q", err, want)
+		}
+	}
+	// The cap is per proposer, and resolving one frees a slot.
+	if _, err := s.CreateAutoModeProposal(automode.KindAllow, "", "curl https://example.com/last*", "session-b", now); err != nil {
+		t.Errorf("another proposer was capped too: %v", err)
+	}
+	pending, _ := s.ListAutoModeProposals(automode.StatePending)
+	if _, err := s.DiscardAutoModeProposal(pending[0].ID, now); err != nil {
+		t.Fatalf("discard: %v", err)
+	}
+	if _, err := s.CreateAutoModeProposal(automode.KindAllow, "", "curl https://example.com/after*", "session-a", now); err != nil {
+		t.Errorf("a freed slot was still refused: %v", err)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -66,7 +66,12 @@ type ActiveAgentDriverRun struct {
 // relaunch a session without a client. Geometry is deliberately absent:
 // the attaching client owns it.
 type LaunchIntent struct {
-	YoloMode      bool                         `json:"yolo_mode,omitempty"`
+	YoloMode bool `json:"yolo_mode,omitempty"`
+	// AutoMode is the launcher's per-session auto mode choice, or nil for "follow
+	// the promoted config". Persisted because a revive relaunches from this
+	// record alone: without it a session launched with auto mode deliberately off
+	// comes back on, which is the opposite of what the launcher asked for.
+	AutoMode      *bool                        `json:"auto_mode,omitempty"`
 	ApprovalRoute launchcontract.ApprovalRoute `json:"approval_route,omitempty"`
 	Executable    string                       `json:"executable,omitempty"`
 	Model         string                       `json:"model,omitempty"`


### PR DESCRIPTION
Slice 5a of pi auto mode ([plan](docs/plans/2026-08-16-pi-auto-mode.md)): the
attn half of the plan's slice 5 — the human surface for promoting what agents
propose, the per-session launch toggle, and auto mode's own shipped safety
defaults. Slice 5 is split in two here: denial reporting (the suite relay →
bus fact → notification) waits on slice 3 and is not in this PR.

![clip](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/cbabe654b0e1775354155c0d7d808b19fbfb1cc4/delegate-automode-panel-415b871d/clip.gif)

[Full-quality recording (mp4)](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/cbabe654b0e1775354155c0d7d808b19fbfb1cc4/delegate-automode-panel-415b871d/clip.mp4)

## What is in it

**The promotion surface.** A new settings section lists every pending
proposal — what it asks for, who asked, when — with Promote and Discard on
each row, and shows the effective policy a pi session launches with today.
Promotion is auto mode's trust boundary: `attn automode` can only propose, and
this section is the only door in the system that turns a proposal into policy.
The settings nav counts waiting proposals in the same red the bus pin alarm
uses, so nothing rots unseen. The count is read once for both surfaces, from
`useAutoModePolicy`, and only while the modal is open — a closed panel holds
nothing.

**The launch toggle.** The location picker gains an AUTO MODE bar for agents
whose driver advertises the `auto_mode` capability. It starts from the
promoted `enabled_default` (which now rides the settings snapshot as the
read-only, daemon-computed `automode_enabled_default`) and the launcher can
override it for one session. The field is tri-state end to end — absent means
"follow the promoted default", so an explicit `false` had to survive rather
than be dropped as falsy — and it is persisted with the launch intent, so a
revive or a reload relaunches on the choice that was made rather than on
today's default.

**Shipped safety defaults**, both carried from #932's follow-ups:

- Auto mode denies its own surfaces on every machine: the mutating
  `attn automode` verbs and this daemon's WebSocket port. They are resolved in
  at read (`ResolveHardDeny`) and stripped at write, so an existing row picks
  them up, the port named is the profile's own rather than a hardcoded 9849,
  and today's list is never frozen into anyone's config. Only the mutating
  verbs are denied — `show` and `denials` stay reachable, because a hard deny
  is unconditional and blanket-denying the surface would be a one-way door.
- Identical pending proposals collapse into one, and a proposer is capped at
  20 unresolved proposals. The receipt for 20 is pi's own circuit breaker: a
  session is stopped for a human question at 20 denials, and a denial is what
  prompts a proposal, so no healthy session reaches the cap. The failure names
  the limit and the ask: `this caller already holds 20 pending auto mode
  proposals (the cap is 20); promote or discard some in the app before
  proposing more. Asked to add: allow curl https://example.com/over*`

Protocol 254 → 255 (`auto_mode` on `SpawnSessionMessage`), moved in all three
lockstep spots. No new bus fact: promote and discard answer only the
requesting client through request/result, and nothing new is broadcast.

## Verification

`go test ./internal/... ./cmd/...` and the full frontend suite green; `tsc`
clean. New coverage: shipped hard-deny resolution and its inverse, the
per-session override through spawn / stored intent / reload, the settings
snapshot carrying the default and refusing to accept it as a write, proposal
dedupe and the cap message, the promote/discard flows, the nav badge, and the
launch toggle's three cases.

Live on a throwaway profile (`amberfox`, cleaned after), preflight green,
protocol 255 on both sides:

- `attn automode show` on a fresh database already lists the seven shipped
  denies with this profile's port (29785), and the persisted `hard_deny`
  column stays `[]` after a promotion — resolved at read, as designed.
- Proposing the same rule twice returned proposal 1 both times; the 21st
  pending proposal was refused with the message above and exit 1.
- Promote and Discard driven from the settings UI; `attn automode show`
  agreed after each.
- A pi session launched with the toggle left alone received
  `ATTN_PI_AUTOMODE_CONFIG` with `enabled_default: true`, the promoted allow
  rule, and the shipped denies; a second launched with the toggle off received
  `enabled_default: false`.

Not live-verified: reload carrying the override — pi has no `resume` /
`launch_instructions` capability, so the app refuses to reload a pi session at
all. Covered by `TestReloadKeepsThePerSessionAutoModeOverride`.

## Surfaces walked

CLI (propose/dedupe/cap and `automode show` all exercised), daemon + app,
protocol (regenerated, version bumped in all three spots, wire golden
updated), plugin driver payload, docs (plan's slice 5 now records the 5a/5b
split), changelog fragment. Linux: no platform-specific code added. Nothing
under `plugins/attn-pi/` is touched — slice 3 owns those files.
