### PR TITLE
feat(automode): harness scenario, review hardening, docs true-up

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -98,7 +98,8 @@
     "real-app:scenario-nisse-tools": "node scripts/real-app-harness/scenario-nisse-tools.mjs",
     "real-app:scenario-nisse-revive": "node scripts/real-app-harness/scenario-nisse-revive.mjs",
     "real-app:scenario-nisse-delegate": "node scripts/real-app-harness/scenario-nisse-delegate.mjs",
-    "real-app:scenario-nisse-history": "node scripts/real-app-harness/scenario-nisse-history.mjs"
+    "real-app:scenario-nisse-history": "node scripts/real-app-harness/scenario-nisse-history.mjs",
+    "real-app:scenario-pi-automode": "node scripts/real-app-harness/scenario-pi-automode.mjs"
   },
   "dependencies": {
     "@codemirror/lang-markdown": "^6.5.0",

--- a/app/scripts/real-app-harness/piStubProvider.mjs
+++ b/app/scripts/real-app-harness/piStubProvider.mjs
@@ -1,0 +1,168 @@
+// A loopback model provider for pi, so a scenario can script what the agent
+// says and what auto mode's classifier answers instead of asking a real model.
+//
+// pi resolves providers from `models.json` under its agent dir, which
+// `PI_CODING_AGENT_DIR` relocates; a provider declared there with
+// `api: "openai-completions"` reaches this server over the OpenAI streaming
+// wire, which is what pi's client speaks. The two roles are told apart by the
+// system prompt: auto mode's classifier prompt opens with a line no coding
+// agent's does.
+import fs from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
+
+/** The first line of automode/prompt.ts's classifierSystemPrompt. */
+const CLASSIFIER_MARKER = 'You are a safety classifier for an autonomous coding agent';
+
+export const stubProviderName = 'attn-harness';
+export const stubAgentModel = `${stubProviderName}/stub-agent`;
+export const stubJudgeModel = `${stubProviderName}/stub-judge`;
+
+function sse(res, payload) {
+  res.write(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+function chunk(delta, finishReason = null) {
+  return {
+    id: 'attn-harness-stub',
+    object: 'chat.completion.chunk',
+    created: 1,
+    model: 'stub',
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  };
+}
+
+// pi's reader throws "Stream ended without finish_reason", so the closing chunk
+// is not optional.
+function writeText(res, text) {
+  sse(res, chunk({ role: 'assistant', content: text }));
+  sse(res, { ...chunk({}, 'stop'), usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 } });
+}
+
+function writeToolCall(res, { id, name, args }) {
+  sse(res, chunk({
+    tool_calls: [{ index: 0, id, type: 'function', function: { name, arguments: '' } }],
+  }));
+  sse(res, chunk({
+    tool_calls: [{ index: 0, function: { arguments: JSON.stringify(args) } }],
+  }));
+  sse(res, { ...chunk({}, 'tool_calls'), usage: { prompt_tokens: 8, completion_tokens: 6, total_tokens: 14 } });
+}
+
+/**
+ * Starts the server.
+ *
+ * `agent(request)` answers the session's own model and returns either
+ * `{ text }` or `{ tool: { name, args } }`. `judge(request)` answers auto
+ * mode's classifier and returns `{ verdict, reason, highStakes }`. Both are
+ * given `{ body, messages, systemPrompt, turn }`, where `turn` counts the calls
+ * that role has already answered.
+ */
+export function startPiStubProvider({ agent, judge }) {
+  const calls = { agent: [], judge: [] };
+  const server = http.createServer((req, res) => {
+    // Somewhere for a scripted `curl` to reach that is not the internet.
+    if (!req.url.endsWith('/chat/completions')) {
+      res.writeHead(200, { 'Content-Type': 'text/plain' }).end('STUB-OK\n');
+      return;
+    }
+    let raw = '';
+    req.on('data', (piece) => { raw += piece; });
+    req.on('end', () => {
+      let body;
+      try {
+        body = JSON.parse(raw);
+      } catch (error) {
+        res.writeHead(400).end(String(error));
+        return;
+      }
+      const messages = body.messages ?? [];
+      const systemPrompt = messages
+        .filter((m) => m.role === 'system' || m.role === 'developer')
+        .map((m) => (typeof m.content === 'string' ? m.content : JSON.stringify(m.content)))
+        .join('\n');
+      const role = systemPrompt.includes(CLASSIFIER_MARKER) ? 'judge' : 'agent';
+      const request = { body, messages, systemPrompt, turn: calls[role].length };
+      calls[role].push(request);
+
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      });
+      try {
+        if (role === 'judge') {
+          const verdict = judge(request);
+          writeText(res, JSON.stringify({
+            verdict: verdict.verdict,
+            reason: verdict.reason,
+            high_stakes: verdict.highStakes === true,
+          }));
+        } else {
+          const answer = agent(request);
+          if (answer.tool) {
+            writeToolCall(res, {
+              id: answer.tool.id ?? `call-${calls.agent.length}`,
+              name: answer.tool.name,
+              args: answer.tool.args,
+            });
+          } else {
+            writeText(res, answer.text ?? '');
+          }
+        }
+      } catch (error) {
+        writeText(res, `stub provider failed: ${error?.message ?? error}`);
+      }
+      res.write('data: [DONE]\n\n');
+      res.end();
+    });
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({
+        port,
+        baseUrl: `http://127.0.0.1:${port}/v1`,
+        calls,
+        close: () => new Promise((done) => server.close(() => done())),
+      });
+    });
+  });
+}
+
+/**
+ * Writes a throwaway pi agent dir naming the stub provider, and returns the
+ * value `PI_CODING_AGENT_DIR` wants. Nothing is copied out of the real
+ * `~/.pi/agent`: a run against this dir reaches no model but the stub.
+ */
+export function writeStubAgentDir(dir, baseUrl) {
+  fs.mkdirSync(dir, { recursive: true });
+  const model = (id) => ({
+    id,
+    name: id,
+    api: 'openai-completions',
+    provider: stubProviderName,
+    baseUrl,
+    reasoning: false,
+    input: ['text'],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128000,
+    maxTokens: 8192,
+  });
+  fs.writeFileSync(
+    path.join(dir, 'models.json'),
+    `${JSON.stringify({
+      providers: {
+        [stubProviderName]: {
+          baseUrl,
+          apiKey: 'attn-harness-stub',
+          api: 'openai-completions',
+          models: [model('stub-agent'), model('stub-judge')],
+        },
+      },
+    }, null, 2)}\n`,
+    'utf8',
+  );
+  return dir;
+}

--- a/app/scripts/real-app-harness/scenario-pi-automode.mjs
+++ b/app/scripts/real-app-harness/scenario-pi-automode.mjs
@@ -1,0 +1,458 @@
+#!/usr/bin/env node
+
+/**
+ * Real-app scenario: pi auto mode, end to end and deterministic.
+ *
+ * Auto mode's five moments all cross the app: the envelope has to stay
+ * invisible, a denial has to reach the person without stopping the run, a
+ * plain reply has to be the approval, the breaker has to ask once, and a
+ * quiet session has to stay quiet. This drives all of them through the
+ * packaged app against a scripted model, so nothing here depends on what a
+ * live classifier decides today:
+ *
+ *   1. an in-envelope call runs with no classifier traffic at all,
+ *   2. a scripted denial leaves the run alive and lands the TUI notice, the
+ *      denial widget, an attn notification, and an `attn automode denials` row,
+ *   3. a conversational grant lets the same call through on the retry,
+ *   4. an idle session with auto mode on judges nothing and reports nothing,
+ *   5. denial after denial trips the breaker into its one human question.
+ *
+ * Determinism comes from `piStubProvider.mjs`: a loopback OpenAI-wire server
+ * that answers both the session's own model and auto mode's classifier, named
+ * to pi through a throwaway agent dir (`PI_CODING_AGENT_DIR`). No model is
+ * called, no network is reached, and the session's tool calls are the ones the
+ * script chose.
+ *
+ * Prereqs: `pi` on PATH; a non-production profile install with the attn-pi
+ * plugin installed (`attn plugin install-bundled attn-pi`). No pi credentials
+ * are needed — the stub is the only provider this run can see.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync, spawn } from 'node:child_process';
+import {
+  launchFreshAppAndConnect,
+  parseCommonArgs,
+  printCommonHelp,
+} from './common.mjs';
+import { waitForFirstWorkspacePane, waitForPaneText } from './scenarioAssertions.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { createScenarioRunner } from './scenarioRunner.mjs';
+import { currentHarnessProfile, dataDirForProfile, socketPathForProfile } from './harnessProfile.mjs';
+import {
+  startPiStubProvider,
+  stubAgentModel,
+  stubJudgeModel,
+  writeStubAgentDir,
+} from './piStubProvider.mjs';
+
+// Anchors from plugins/attn-pi/automode/ui.ts. They are what a person actually
+// sees, so the scenario reads them rather than an internal counter.
+const STATUS_ON = 'auto: on';
+const DENIAL_NOTICE = 'auto mode blocked';
+const WIDGET_FOOTER = 'Approve in your reply to let the agent retry.';
+const BREAKER_TITLE = 'auto mode stopped judging calls';
+
+const DENIAL_REASON = 'the harness scripted a refusal';
+// Marker words the stub puts in the agent's replies, so pane text says which
+// leg finished rather than which words a model chose.
+const ENVELOPE_DONE = 'ENVELOPE-LEG-DONE';
+const DENIED_DONE = 'DENIED-LEG-DONE';
+const GRANTED_DONE = 'GRANTED-LEG-DONE';
+
+// How long the quiet-session gate watches an idle session. Long enough that a
+// per-tick offender fires several times: nothing in auto mode is on a timer,
+// so one classifier call here is a defect, not a slow sample.
+const QUIET_WINDOW_MS = 20_000;
+
+const HARNESS_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// The profile's own bundled CLI, not a repo build: bundled plugins resolve
+// relative to the app bundle, so a daemon started from anywhere else reports
+// the pi driver as unavailable and every pi session is refused.
+function resolveAttnBinary(appPath) {
+  const candidates = [
+    process.env.ATTN_HARNESS_BIN,
+    path.join(appPath, 'Contents/MacOS/attn'),
+    path.resolve(HARNESS_DIR, '../../../attn'),
+  ].filter(Boolean);
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  throw new Error(`no attn binary found for ${appPath}`);
+}
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') args.shift();
+  const options = parseCommonArgs(args);
+  return { options, help: args.includes('--help') || args.includes('-h') };
+}
+
+async function pollFor(fn, description, timeoutMs = 60_000, intervalMs = 300) {
+  const startedAt = Date.now();
+  let last = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    last = await fn();
+    if (last) return last;
+    await delay(intervalMs);
+  }
+  throw new Error(`Timed out waiting for: ${description}. Last value: ${JSON.stringify(last)}`);
+}
+
+function parseAttnJSON(stdout) {
+  const candidates = [stdout.indexOf('{'), stdout.indexOf('[')].filter((index) => index >= 0);
+  if (candidates.length === 0) return null;
+  try {
+    return JSON.parse(stdout.slice(Math.min(...candidates)));
+  } catch {
+    return null;
+  }
+}
+
+function makeAttnRunner(attnBin, profile) {
+  const socketPath = socketPathForProfile(profile);
+  return function runAttn(args, { allowFailure = false } = {}) {
+    try {
+      const stdout = execFileSync(attnBin, args, {
+        encoding: 'utf8',
+        env: { ...process.env, ATTN_PROFILE: profile, ATTN_SOCKET_PATH: socketPath },
+      });
+      return { stdout, stderr: '', status: 0, json: parseAttnJSON(stdout) };
+    } catch (error) {
+      if (!allowFailure) throw error;
+      const stdout = typeof error.stdout === 'string' ? error.stdout : '';
+      const stderr = typeof error.stderr === 'string' ? error.stderr : '';
+      return { stdout, stderr, status: error.status ?? 1, json: parseAttnJSON(stdout) };
+    }
+  };
+}
+
+// pi reads its agent dir from the environment of the process that launched it,
+// which is the daemon — the app only asks it to spawn a session. A daemon left
+// over from an earlier run has none of this scenario's env, so it is restarted
+// with the stub agent dir before the app connects to it.
+async function restartDaemonWithStubEnv({ attnBin, profile, agentDir, runAttn }) {
+  runAttn(['daemon', 'stop'], { allowFailure: true });
+  const child = spawn(attnBin, ['daemon', 'ensure'], {
+    env: {
+      ...process.env,
+      ATTN_PROFILE: profile,
+      ATTN_SOCKET_PATH: socketPathForProfile(profile),
+      PI_CODING_AGENT_DIR: agentDir,
+    },
+    detached: true,
+    stdio: 'ignore',
+  });
+  child.unref();
+  const deadline = Date.now() + 30_000;
+  for (;;) {
+    const probe = runAttn(['automode', 'show', '--json'], { allowFailure: true });
+    if (probe.status === 0) return;
+    if (Date.now() > deadline) throw new Error('daemon did not come back up with the stub agent dir');
+    await delay(500);
+  }
+}
+
+// write_pane goes straight to the worker PTY. The text and the Enter are
+// separate writes with a gap: a fast burst ending in CR arrives as a bracketed
+// paste and the CR never submits.
+async function submitPrompt(client, sessionId, paneId, text) {
+  await client.request('write_pane', { sessionId, paneId, text, submit: false });
+  await delay(800);
+  await client.request('write_pane', { sessionId, paneId, text: '\r', submit: false });
+}
+
+function countNotifications(dbPath) {
+  try {
+    const stdout = execFileSync('sqlite3', [
+      dbPath,
+      `SELECT id || '|' || title || '|' || detail FROM notifications WHERE kind = 'automode_denied' ORDER BY created_at;`,
+    ], { encoding: 'utf8', timeout: 5_000 });
+    return stdout.split('\n').map((line) => line.trim()).filter((line) => line !== '');
+  } catch {
+    return [];
+  }
+}
+
+async function main() {
+  const { options, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scripts/real-app-harness/scenario-pi-automode.mjs');
+    return;
+  }
+
+  const profile = currentHarnessProfile();
+  if (!profile) {
+    throw new Error('the pi-automode scenario does not run against production; set ATTN_PROFILE / ATTN_HARNESS_PROFILE to a named profile');
+  }
+  const attnBin = resolveAttnBinary(options.appPath);
+  const runAttn = makeAttnRunner(attnBin, profile);
+  const dbPath = process.env.ATTN_DB_PATH || path.join(dataDirForProfile(profile), 'attn.db');
+
+  // The script. Every answer the session's model gives and every verdict auto
+  // mode's classifier gives is chosen here; `stub.calls` is the receipt for
+  // what was and was not asked.
+  // Verdicts are taken in order; an empty queue denies, which is what the
+  // breaker leg wants.
+  const judgeQueue = [];
+  const stub = await startPiStubProvider({
+    agent: (request) => {
+      switch (request.turn) {
+        // Leg 1: work inside the envelope. `ls` is in the read-only bash set,
+        // so this call must never reach the classifier.
+        case 0: return { tool: { name: 'bash', args: { command: 'ls -1' } } };
+        case 1: return { text: ENVELOPE_DONE };
+        // Leg 2: the network never rides the envelope, so this classifies.
+        case 2: return { tool: { name: 'bash', args: { command: `curl -sS ${stub.baseUrl}/ok` } } };
+        case 3: return { text: DENIED_DONE };
+        // Leg 3: the same call again, after the user approved it in chat.
+        case 4: return { tool: { name: 'bash', args: { command: `curl -sS ${stub.baseUrl}/ok` } } };
+        case 5: return { text: GRANTED_DONE };
+        // Leg 5: a run that keeps reaching past the envelope. Distinct URLs, so
+        // no cached verdict answers for the next one.
+        default: return { tool: { name: 'bash', args: { command: `curl -sS ${stub.baseUrl}/breaker-${request.turn}` } } };
+      }
+    },
+    judge: () => judgeQueue.shift() ?? { verdict: 'deny', reason: DENIAL_REASON },
+  });
+
+  // The agent dir has to exist before the runner is built: its build preflight
+  // relaunches the app with the same launch env, and pi resolves this once.
+  const agentDir = writeStubAgentDir(
+    path.join(os.tmpdir(), `attn-pi-automode-${process.pid}`),
+    stub.baseUrl,
+  );
+  const launchEnv = { PI_CODING_AGENT_DIR: agentDir };
+
+  try {
+    await drive({ options, profile, attnBin, runAttn, dbPath, stub, judgeQueue, launchEnv, agentDir });
+  } finally {
+    await stub.close().catch(() => {});
+  }
+}
+
+async function drive({ options, profile, attnBin, runAttn, dbPath, stub, judgeQueue, launchEnv, agentDir }) {
+  const runner = createScenarioRunner(options, {
+    scenarioId: 'PI-AUTOMODE',
+    tier: 'tier2-local-real-agent',
+    prefix: 'pi-automode',
+    metadata: { agent: 'pi', focus: 'envelope invisibility, denial surfaces, conversational grant, quiet session, circuit breaker' },
+    preflightLaunchEnv: launchEnv,
+  });
+
+  const client = new UiAutomationClient({ appPath: options.appPath, launchEnv });
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+  const note = (message, extra) => runner.log(message, extra);
+  let sessionId = null;
+  let paneId = null;
+
+  runner.registerCleanup('close_stub_provider', () => stub.close());
+  runner.registerCleanup('close_observer', () => observer.close());
+  runner.registerCleanup('quit_app', () => client.quitApp());
+
+  try {
+    runner.registerCleanup('remove_stub_agent_dir', () => fs.rmSync(agentDir, { recursive: true, force: true }));
+
+    const { repoDir } = await runner.step('prepare_world', async () => {
+      const repo = path.join(runner.sessionDir, 'pi-automode-repo');
+      fs.mkdirSync(repo, { recursive: true });
+      fs.writeFileSync(path.join(repo, 'notes.txt'), 'one\ntwo\n', 'utf8');
+      // The app launches with PI_CODING_AGENT_DIR set, and pi inherits it from
+      // the daemon the app starts — this run reaches no model but the stub.
+      note(`stub provider on ${stub.baseUrl}`, { agentDir });
+      return { repoDir: repo };
+    });
+
+    await runner.step('launch_app', async () => {
+      await restartDaemonWithStubEnv({ attnBin, profile, agentDir, runAttn });
+      await launchFreshAppAndConnect(client, observer);
+      await client.request('set_setting', { key: 'default_model_pi', value: stubAgentModel });
+      runner.registerCleanup('restore_pi_model', () => client
+        .request('set_setting', { key: 'default_model_pi', value: '' })
+        .catch(() => {}));
+    });
+
+    await runner.step('promote_the_stub_classifier', async () => {
+      // The CLI proposes; only the app promotes, and this is the app's own
+      // command — there is no unix-socket half to call instead.
+      const proposals = [
+        ['automode', 'model', 'classifier', stubJudgeModel, '--json'],
+        ['automode', 'model', 'escalation', stubJudgeModel, '--json'],
+      ].map((args) => {
+        const result = runAttn(args);
+        const id = result.json?.proposal?.id ?? result.json?.id;
+        if (!id) throw new Error(`no proposal id in ${result.stdout}`);
+        return id;
+      });
+      const refused = runAttn(['automode', 'promote', String(proposals[0])], { allowFailure: true });
+      if (refused.status === 0) {
+        throw new Error('the CLI promoted a proposal; promotion is the app\'s alone');
+      }
+      for (const id of proposals) {
+        observer.send({ cmd: 'automode_promote', id, request_id: `harness-promote-${id}` });
+      }
+      await pollFor(
+        () => {
+          const shown = runAttn(['automode', 'show', '--json']).json;
+          return shown?.config?.classifier_model === stubJudgeModel ? shown : null;
+        },
+        'the promoted config to name the stub classifier',
+        20_000,
+      );
+      note('classifier and escalation models promoted to the stub');
+    });
+
+    await runner.step('start_pi_session', async () => {
+      const created = await client.request('create_session', {
+        cwd: repoDir,
+        label: `pi-automode-${runner.runId.slice(-6)}`,
+        agent: 'pi',
+      });
+      sessionId = created.sessionId;
+      await observer.waitForSession({ id: sessionId, timeoutMs: 30_000 });
+      runner.registerCleanup('close_session', () => client
+        .request('close_session', { sessionId })
+        .catch(() => {}));
+      const pane = await waitForFirstWorkspacePane(client, sessionId, `pane for ${sessionId}`, 30_000);
+      paneId = pane.paneId;
+      // The status line is auto mode's own proof that it loaded, and that a
+      // session nobody toggled starts from the promoted default — which ships
+      // on for attn sessions.
+      await waitForPaneText(
+        client, sessionId, paneId,
+        (text) => text.includes(STATUS_ON),
+        'pi to boot with auto mode on',
+        90_000,
+      );
+      note('pi is up and the status line reads auto: on');
+    });
+
+    await runner.step('envelope_stays_invisible', async () => {
+      await submitPrompt(client, sessionId, paneId, 'list the files here');
+      await waitForPaneText(
+        client, sessionId, paneId,
+        (text) => text.includes(ENVELOPE_DONE),
+        'the in-envelope run to finish',
+        120_000,
+      );
+      if (stub.calls.judge.length !== 0) {
+        throw new Error(`an in-envelope call reached the classifier: ${JSON.stringify(stub.calls.judge.map((c) => c.turn))}`);
+      }
+      note('an in-cwd run finished with zero classifier calls');
+    });
+
+    const denialsBefore = runAttn(['automode', 'denials', '--json']).json?.denials?.length ?? 0;
+
+    await runner.step('a_denial_reaches_the_user', async () => {
+      judgeQueue.push({ verdict: 'deny', reason: DENIAL_REASON });
+      await submitPrompt(client, sessionId, paneId, 'fetch the ok endpoint');
+      // The run does not stop: the agent gets the reason and speaks again.
+      await waitForPaneText(
+        client, sessionId, paneId,
+        (text) => text.includes(DENIED_DONE),
+        'the denied run to continue and settle',
+        120_000,
+      );
+      const pane = await waitForPaneText(
+        client, sessionId, paneId,
+        (text) => text.includes(DENIAL_NOTICE) && text.includes(WIDGET_FOOTER),
+        'the TUI denial notice and widget',
+        20_000,
+      );
+      fs.writeFileSync(path.join(runner.runDir, 'denial-pane.txt'), pane.text || '', 'utf8');
+
+      const denials = await pollFor(
+        () => {
+          const listed = runAttn(['automode', 'denials', '--json']).json?.denials ?? [];
+          return listed.length > denialsBefore ? listed : null;
+        },
+        'the denial to reach `attn automode denials`',
+        20_000,
+      );
+      const latest = denials[0];
+      if (latest.rule !== 'classifier-2a') {
+        throw new Error(`the denial names rule ${JSON.stringify(latest.rule)}, want classifier-2a`);
+      }
+      if (!String(latest.reason).includes(DENIAL_REASON)) {
+        throw new Error(`the denial reason is ${JSON.stringify(latest.reason)}, want the scripted one`);
+      }
+      const notifications = await pollFor(
+        () => {
+          const rows = countNotifications(dbPath);
+          return rows.length > 0 ? rows : null;
+        },
+        'an automode_denied notification',
+        20_000,
+      );
+      runner.writeJson('denial.json', { denial: latest, notifications, judgeCalls: stub.calls.judge.length });
+      note('the denial reached the TUI, the notification feed and the CLI', { rule: latest.rule });
+    });
+
+    await runner.step('a_reply_is_the_approval', async () => {
+      judgeQueue.push({ verdict: 'allow', reason: 'the user approved this call in the conversation' });
+      await submitPrompt(client, sessionId, paneId, 'yes, go ahead and fetch it');
+      await waitForPaneText(
+        client, sessionId, paneId,
+        (text) => text.includes(GRANTED_DONE),
+        'the approved retry to run',
+        120_000,
+      );
+      const listed = runAttn(['automode', 'denials', '--json']).json?.denials ?? [];
+      if (listed.length !== denialsBefore + 1) {
+        throw new Error(`an approved retry recorded a denial: ${JSON.stringify(listed.slice(0, 2))}`);
+      }
+      note('the same call ran after a plain reply approved it');
+    });
+
+    await runner.step('a_quiet_session_is_quiet', async () => {
+      const judged = stub.calls.judge.length;
+      const denials = runAttn(['automode', 'denials', '--json']).json?.denials?.length ?? 0;
+      const notifications = countNotifications(dbPath).length;
+      await delay(QUIET_WINDOW_MS);
+      if (stub.calls.judge.length !== judged) {
+        throw new Error(`an idle session classified ${stub.calls.judge.length - judged} calls`);
+      }
+      const after = runAttn(['automode', 'denials', '--json']).json?.denials?.length ?? 0;
+      if (after !== denials || countNotifications(dbPath).length !== notifications) {
+        throw new Error('an idle session with auto mode on produced denial traffic');
+      }
+      note(`${QUIET_WINDOW_MS / 1000}s idle with auto mode on: no classifier calls, no denials`);
+    });
+
+    await runner.step('the_breaker_asks_once', async () => {
+      await submitPrompt(client, sessionId, paneId, 'try every endpoint you can reach');
+      const pane = await waitForPaneText(
+        client, sessionId, paneId,
+        (text) => text.includes(BREAKER_TITLE),
+        'the circuit breaker to ask its one question',
+        180_000,
+      );
+      fs.writeFileSync(path.join(runner.runDir, 'breaker-pane.txt'), pane.text || '', 'utf8');
+      note('repeated denials stopped the run with one human question', {
+        judgeCalls: stub.calls.judge.length,
+      });
+    });
+
+    await runner.finishSuccess({ sessionId, agentDir, judgeCalls: stub.calls.judge.length });
+  } catch (error) {
+    await runner.finishFailure(error, { sessionId });
+    throw error;
+  } finally {
+    // The app and the observer socket outlive the assertions, and an open
+    // socket holds node's event loop open.
+    await client.quitApp().catch(() => {});
+    await observer.close().catch(() => {});
+    await stub.close().catch(() => {});
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/app/scripts/real-app-harness/scenarioCatalog.mjs
+++ b/app/scripts/real-app-harness/scenarioCatalog.mjs
@@ -332,6 +332,15 @@ export const scenarioCatalog = [
     timeoutMs: 600_000,
   },
   {
+    id: 'pi-automode',
+    label: 'pi auto mode: envelope invisibility, a denial and its surfaces, a conversational grant, a quiet session, the circuit breaker',
+    command: ['pnpm', 'run', 'real-app:scenario-pi-automode'],
+    // Needs `pi` on PATH and the attn-pi plugin installed, but no credentials
+    // and no network: the session's model and auto mode's classifier are both
+    // a loopback stub, so every verdict is the script's.
+    timeoutMs: 900_000,
+  },
+  {
     id: 'focus-probe',
     label: 'Focus probe (no focus steal on background session create)',
     command: ['pnpm', 'run', 'real-app:focus-probe'],

--- a/app/src/components/LocationPicker.autoMode.test.tsx
+++ b/app/src/components/LocationPicker.autoMode.test.tsx
@@ -31,7 +31,7 @@ const inspectsTo = (resolved: string) => vi.fn(async (inputPath: string) => ({
 function renderPicker(settings: Record<string, string>) {
   const onSelect = vi.fn();
   const onInspectPath = inspectsTo('/home/remote/projects');
-  render(
+  const { rerender } = render(
     <SettingsProvider settings={settings} setSetting={vi.fn()}>
       <LocationPicker
         isOpen
@@ -44,7 +44,20 @@ function renderPicker(settings: Record<string, string>) {
       />
     </SettingsProvider>,
   );
-  return { onSelect };
+  const withSettings = (next: Record<string, string>) => rerender(
+    <SettingsProvider settings={next} setSetting={vi.fn()}>
+      <LocationPicker
+        isOpen
+        purpose="workspace"
+        onClose={vi.fn()}
+        onSelect={onSelect}
+        onInspectPath={onInspectPath}
+        agentAvailability={{ shell: true, claude: true, codex: true, snipe: true }}
+        endpoints={[]}
+      />
+    </SettingsProvider>,
+  );
+  return { onSelect, withSettings };
 }
 
 const launch = () => {
@@ -99,6 +112,35 @@ describe('LocationPicker auto mode toggle', () => {
     fireEvent.click(screen.getByTestId('location-picker-automode-toggle'));
     launch();
 
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects', 'snipe', undefined, false, false, undefined, false);
+    });
+  });
+
+  // The picker can open before the settings snapshot lands, so a default that
+  // arrives late still has to move a toggle nobody answered for.
+  it('follows a default that arrives after the picker opened', () => {
+    const { withSettings } = renderPicker(PI_SETTINGS);
+    pickSnipe();
+    expect(screen.getByTestId('location-picker-automode-toggle')).toHaveAttribute('aria-checked', 'true');
+
+    withSettings({ ...PI_SETTINGS, automode_enabled_default: 'false' });
+
+    expect(screen.getByTestId('location-picker-automode-toggle')).toHaveAttribute('aria-checked', 'false');
+  });
+
+  // …and once the launcher has answered, a default moving underneath must not
+  // launch the opposite of what they chose.
+  it('keeps an explicit off when the default changes underneath it', async () => {
+    const { onSelect, withSettings } = renderPicker(PI_SETTINGS);
+    pickSnipe();
+    fireEvent.click(screen.getByTestId('location-picker-automode-toggle'));
+
+    withSettings({ ...PI_SETTINGS, automode_enabled_default: 'false' });
+    withSettings({ ...PI_SETTINGS, automode_enabled_default: 'true' });
+
+    expect(screen.getByTestId('location-picker-automode-toggle')).toHaveAttribute('aria-checked', 'false');
+    launch();
     await waitFor(() => {
       expect(onSelect).toHaveBeenCalledWith('/home/remote/projects', 'snipe', undefined, false, false, undefined, false);
     });

--- a/app/src/components/LocationPicker.tsx
+++ b/app/src/components/LocationPicker.tsx
@@ -301,6 +301,7 @@ export function LocationPicker({
   const [yoloMode, setYoloMode] = useState(false);
   const [chiefOfStaff, setChiefOfStaff] = useState(false);
   const [autoMode, setAutoMode] = useState(true);
+  const autoModeTouchedRef = useRef(false);
   // The conversation this session will pick up from, '' for a fresh one.
   const [resumeFile, setResumeFile] = useState('');
   const [pastConversations, setPastConversations] = useState<PastConversation[]>([]);
@@ -520,7 +521,13 @@ export function LocationPicker({
     }
   }, [chiefToggleEligible]);
 
+  // The toggle follows the promoted default only until someone answers for
+  // themselves. The picker can open before the settings snapshot lands, so a
+  // default arriving late must still move an untouched toggle — but once a
+  // human has flipped it, a default that changes underneath must not launch the
+  // opposite of what they chose.
   useEffect(() => {
+    if (autoModeTouchedRef.current) return;
     setAutoMode((prev) => (prev === autoModeDefault ? prev : autoModeDefault));
   }, [autoModeDefault]);
 
@@ -1137,7 +1144,10 @@ export function LocationPicker({
                   role="switch"
                   aria-checked={autoMode}
                   onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => setAutoMode((prev) => !prev)}
+                  onClick={() => {
+                    autoModeTouchedRef.current = true;
+                    setAutoMode((prev) => !prev);
+                  }}
                   title="Judge calls that reach outside this session's directory against what the conversation asked for, instead of running everything"
                 >
                   <span className="agent-option-name">{autoMode ? 'On' : 'Off'}</span>

--- a/changelog.d/automode-close.yaml
+++ b/changelog.d/automode-close.yaml
@@ -1,0 +1,11 @@
+kind: fixed
+area: automode
+change: >
+  Auto mode's review list now says who asked. Two sessions proposing the
+  same rule are two asks rather than one row crediting whoever asked first,
+  a promotion answers every session that asked for that change, and the
+  database itself holds one pending ask per asker. The session launcher's
+  auto mode toggle also keeps an explicit choice: a promoted default that
+  changes while the launcher is open no longer flips it back.
+notes: >
+  Slice 6 of the pi auto mode plan (docs/plans/2026-08-16-pi-auto-mode.md).

--- a/docs/plans/2026-08-16-pi-auto-mode.md
+++ b/docs/plans/2026-08-16-pi-auto-mode.md
@@ -66,8 +66,10 @@ Conclusions the design leans on:
 
 In the session (pi side):
 
-- `/auto` toggles; `--auto` / `--no-auto` flags (registerFlag) force it at
-  launch; status indicator shows the mode. Default: on for attn sessions,
+- `/auto` toggles; `--auto` / `--no-auto` flags (registerFlag) decide where
+  the session starts; status indicator shows the mode. Precedence is
+  `/auto > flag > enabled_default`: the flag sets the starting mode and the
+  command the user typed wins after that. Default: on for attn sessions,
   off for bare pi.
 - Denial tool-result contract (the model-facing API): names auto mode, the
   blocked action, the reason, and states that the user's explicit approval
@@ -176,8 +178,10 @@ Classifier (layer 2a → 2b):
      over auto mode's own surfaces; proposal dedupe and per-proposer cap.
    - **5b — denial reporting.** Denial fact → notification + session
      activity. Needs slice 3's suite relay.
-6. **Live verification pass.** Harness scenario, daily-driver soak,
-   evidence recordings; defaults flipped on for attn sessions.
+6. **The closer.** The deterministic harness scenario, the hardening review
+   left behind, and this doc told true. The default did not need flipping:
+   `enabled_default` shipped on in slice 4 and a fresh machine already
+   launches attn pi sessions with auto mode on, bare pi off.
 
 ## How to verify
 

--- a/docs/vision/pi-attn-plugins.md
+++ b/docs/vision/pi-attn-plugins.md
@@ -133,7 +133,7 @@ Each rock opens with its own alignment + implementation doc.
 - [x] **attn citizenship** — linking, declared state, doorbell/nudge steering.
 - [ ] **Headless host + rendered conversation** — the SDK host process and the
       React conversation surface, built in vertical slices (own plan doc).
-- [ ] **Safety envelope + auto mode** — the autonomy dial.
+- [x] **Safety envelope + auto mode** — the autonomy dial.
 - [ ] **Subagents** — adapted from ecosystem prior art.
 - [ ] **Background eyes** — monitors that wake the agent.
 - [ ] **Skills** — trial the existing corpus as-is; curate from real use.
@@ -141,8 +141,3 @@ Each rock opens with its own alignment + implementation doc.
       everything above.
 - [ ] **Compaction tuning and workflows** — likely last; needs the most
       design.
-
-## Open questions
-
-- The safety envelope's exact policy vocabulary — designed fresh in its own
-  doc, not inherited from claude's permission modes.

--- a/internal/daemon/automode.go
+++ b/internal/daemon/automode.go
@@ -195,13 +195,25 @@ func (d *Daemon) recordAutoModeDenial(params pluginReportAutoModeDenialParams) e
 	if dropped > 0 {
 		d.logf("automode: denial log is at its %d-row cap; dropped %d oldest", store.AutoModeDenialRows, dropped)
 	}
+	// The notification is best effort, by design. The denial itself is already
+	// enforced and the row is durable, so a failed notification write costs the
+	// user this one surface — `attn automode denials` still lists it — and the
+	// report is not worth failing over a surface. The fact stays with the
+	// notification because pushing it alone would re-push a list the denial
+	// never reached. The log line names the denial either way, so a row is never
+	// the only trace of it.
+	notification := ""
 	record, err := d.store.AddNotification(autoModeDenialNotification(d.sessionLabel(sessionID), stored), time.Now())
 	if err != nil {
 		d.logf("automode: add denial notification for session %s: %v", sessionID, err)
-		return nil
+	} else {
+		notification = record.ID
 	}
 	d.logf("automode: denied session=%s rule=%s action=%q notification=%s",
-		sessionID, stored.Rule, stored.Signature, record.ID)
+		sessionID, stored.Rule, stored.Signature, notification)
+	if notification == "" {
+		return nil
+	}
 	// One fact, not two: the notification is how this denial is surfaced, and
 	// automode.denied's projection is what pushes it. Its subject is the session
 	// because that is the entity a denial is about.

--- a/internal/store/automode.go
+++ b/internal/store/automode.go
@@ -140,11 +140,16 @@ func (s *Store) SetAutoModeEnabledDefault(enabled bool, now time.Time) (automode
 // proposal that could never be promoted never reaches the app's review list.
 //
 // The review list is a human's, so it is defended twice. An identical pending
-// proposal returns the one already there rather than a second row — a session
-// denied the same call twice has asked once. Past that, one proposer holds at
-// most automode.MaxPendingProposalsPerProposer unresolved proposals, and the
-// refusal names the cap and what it was asked to add: a caller that hit it can
-// say what to promote or discard, and the list stays reviewable.
+// proposal from the same proposer returns the one already there rather than a
+// second row — a session denied the same call twice has asked once. The
+// proposer is part of that key on purpose: the list says who asked, and
+// collapsing a second session's ask onto the first would credit the wrong one.
+// Two askers are two rows until a promotion satisfies both. A unique index over
+// pending rows holds the same key, so the answer does not depend on which
+// process is doing the asking. Past that, one proposer holds at most
+// automode.MaxPendingProposalsPerProposer unresolved proposals, and the refusal
+// names the cap and what it was asked to add: a caller that hit it can say what
+// to promote or discard, and the list stays reviewable.
 func (s *Store) CreateAutoModeProposal(kind, target, value, proposedBy string, now time.Time) (AutoModeProposal, error) {
 	if err := automode.ValidateProposal(kind, target, value); err != nil {
 		return AutoModeProposal{}, err
@@ -154,11 +159,15 @@ func (s *Store) CreateAutoModeProposal(kind, target, value, proposedBy string, n
 	if s.db == nil {
 		return AutoModeProposal{}, fmt.Errorf("store: no database")
 	}
-	existing, err := scanAutoModeProposal(s.db.QueryRow(`
-		SELECT id, kind, target, value, proposed_by, state, created_at, resolved_at
-		FROM automode_proposals
-		WHERE state = ? AND kind = ? AND target = ? AND value = ?
-		ORDER BY id ASC LIMIT 1`, automode.StatePending, kind, target, value))
+	findPending := func() (AutoModeProposal, error) {
+		return scanAutoModeProposal(s.db.QueryRow(`
+			SELECT id, kind, target, value, proposed_by, state, created_at, resolved_at
+			FROM automode_proposals
+			WHERE state = ? AND kind = ? AND target = ? AND value = ? AND proposed_by = ?
+			ORDER BY id ASC LIMIT 1`,
+			automode.StatePending, kind, target, value, proposedBy))
+	}
+	existing, err := findPending()
 	if err == nil {
 		return existing, nil
 	}
@@ -184,6 +193,11 @@ func (s *Store) CreateAutoModeProposal(kind, target, value, proposedBy string, n
 		VALUES (?, ?, ?, ?, ?, ?)
 	`, kind, target, value, proposedBy, automode.StatePending, stamp)
 	if err != nil {
+		// The index caught an asker this process did not see; that ask is the
+		// row already there, not a failure to report.
+		if existing, findErr := findPending(); findErr == nil {
+			return existing, nil
+		}
 		return AutoModeProposal{}, err
 	}
 	id, err := res.LastInsertId()
@@ -283,8 +297,13 @@ func (s *Store) PromoteAutoModeProposal(id int64, now time.Time) (AutoModePropos
 		return AutoModeProposal{}, automode.Config{}, err
 	}
 	stamp := now.UTC().Format(sortableTimeFormat)
-	if _, err := tx.Exec(`UPDATE automode_proposals SET state = ?, resolved_at = ? WHERE id = ?`,
-		automode.StatePromoted, stamp, id); err != nil {
+	// Every asker for this same change is answered by this one promotion, so
+	// none of them stays pending asking for what the config already says.
+	if _, err := tx.Exec(`
+		UPDATE automode_proposals SET state = ?, resolved_at = ?
+		WHERE state = ? AND kind = ? AND target = ? AND value = ?`,
+		automode.StatePromoted, stamp,
+		automode.StatePending, proposal.Kind, proposal.Target, proposal.Value); err != nil {
 		return AutoModeProposal{}, automode.Config{}, err
 	}
 	if err := tx.Commit(); err != nil {

--- a/internal/store/automode_test.go
+++ b/internal/store/automode_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -360,6 +361,89 @@ func TestAutoModeProposalDedupesAnIdenticalPendingOne(t *testing.T) {
 	}
 	if third.ID == first.ID {
 		t.Error("a discarded proposal was reused instead of a new one being recorded")
+	}
+}
+
+// The review list says who asked, so it must not tell a human that session-a
+// asked for something session-b asked for.
+func TestAutoModeProposalKeepsEachAskerSeparate(t *testing.T) {
+	s := New()
+	now := time.Now().UTC()
+	first, err := s.CreateAutoModeProposal(automode.KindAllow, "", "git push origin*", "session-a", now)
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	second, err := s.CreateAutoModeProposal(automode.KindAllow, "", "git push origin*", "session-b", now)
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if second.ID == first.ID {
+		t.Fatal("session-b's ask was collapsed onto session-a's row")
+	}
+	if second.ProposedBy != "session-b" {
+		t.Errorf("second proposal credits %q, want session-b", second.ProposedBy)
+	}
+
+	// One promotion answers every asker, so nobody is left asking for what the
+	// config already says.
+	if _, _, err := s.PromoteAutoModeProposal(first.ID, now); err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	pending, err := s.ListAutoModeProposals(automode.StatePending)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Errorf("pending = %v, want the sibling ask resolved by the promotion", pending)
+	}
+	promoted, err := s.ListAutoModeProposals(automode.StatePromoted)
+	if err != nil {
+		t.Fatalf("list promoted: %v", err)
+	}
+	if len(promoted) != 2 {
+		t.Errorf("promoted = %v, want both askers answered", promoted)
+	}
+}
+
+// The dedupe is a real constraint, not an agreement between callers that happen
+// to hold the same lock: two askers racing on the same change land one row.
+func TestAutoModeProposalRaceLandsOneRow(t *testing.T) {
+	s := New()
+	now := time.Now().UTC()
+	var wg sync.WaitGroup
+	ids := make([]int64, 8)
+	errs := make([]error, 8)
+	for i := range ids {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			p, err := s.CreateAutoModeProposal(automode.KindDeny, "", "ssh prod*", "session-a", now)
+			ids[i], errs[i] = p.ID, err
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("proposal %d: %v", i, err)
+		}
+		if ids[i] != ids[0] {
+			t.Errorf("proposal %d got id %d, want the one row %d", i, ids[i], ids[0])
+		}
+	}
+	pending, err := s.ListAutoModeProposals(automode.StatePending)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Errorf("pending = %v, want one row", pending)
+	}
+	// The database is what says so, whoever is asking.
+	if _, err := s.db.Exec(`
+		INSERT INTO automode_proposals (kind, target, value, proposed_by, state, created_at)
+		VALUES (?, '', ?, ?, ?, ?)`,
+		automode.KindDeny, "ssh prod*", "session-a", automode.StatePending,
+		now.UTC().Format(sortableTimeFormat)); err == nil {
+		t.Error("a duplicate pending ask was accepted straight into the table")
 	}
 }
 

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -1157,6 +1157,14 @@ CREATE TABLE IF NOT EXISTS automode_denials (
 CREATE INDEX IF NOT EXISTS idx_automode_denials_recent ON automode_denials(id DESC);`},
 	// Applied by applyMigration110, whose ALTER is column-guarded.
 	{110, "record which rule denied an auto mode call", ``},
+	// The review list says who asked, so one asker's pending row is what the
+	// dedupe collapses — a second session asking the same thing is a second ask.
+	// The index is what makes that true against the database rather than only
+	// inside the process that happens to hold the store's lock.
+	{111, "one pending auto mode proposal per asker", `CREATE UNIQUE INDEX IF NOT EXISTS
+    idx_automode_proposals_pending_ask
+    ON automode_proposals(kind, target, value, proposed_by)
+    WHERE state = 'pending';`},
 }
 
 // migration99SQL is everything migration 99 does after its guarded ALTER.


### PR DESCRIPTION
Slice 6 of [the pi auto mode plan](docs/plans/2026-08-16-pi-auto-mode.md), and
the last one: the deterministic harness scenario, the hardening review left
behind on #935 and #936, and the docs told true.

## The scenario

`real-app:scenario-pi-automode` drives auto mode through the packaged app with
nothing modeled. `piStubProvider.mjs` is a loopback OpenAI-wire server that
answers **both** the session's own model and auto mode's classifier, named to pi
through a throwaway agent dir (`PI_CODING_AGENT_DIR`) that declares it in
`models.json`. Every verdict is the script's, the run reaches no model and no
network, and it needs no credentials — so it is as cheap and as repeatable as
any other harness leg.

Five moments, all asserted through what a person actually sees:

1. **The envelope stays invisible.** An in-cwd `ls` finishes with
   `stub.calls.judge.length === 0` — the classifier was never asked.
2. **A denial reaches the user without stopping the run.** The TUI notice and
   the denial widget, an `automode_denied` notification row in the database,
   and an `attn automode denials` row naming `classifier-2a` and the scripted
   reason. The agent speaks again afterwards.
3. **A plain reply is the approval.** The same call runs on the retry and
   records no second denial.
4. **A quiet session is quiet.** 20s idle with auto mode on: no classifier
   calls, no denials, no notifications. Nothing in auto mode is on a timer, so
   one call here would be a defect rather than a slow sample.
5. **The breaker asks once.** Denial after denial stops the run with a single
   human question.

It is in the catalog, so it is in the serial matrix; single-tenant rules apply
like every other packaged-app leg.

### Evidence

Green twice before this recording and once with it, on a throwaway `am6`
profile installed from this branch.

![recording-01](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/e020d1e58ba1b1b84677f16b93a34883f7093031/delegate-automode-close-bf0773ad/recording-01.gif)

[Full-quality recording (mp4)](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/e020d1e58ba1b1b84677f16b93a34883f7093031/delegate-automode-close-bf0773ad/recording-01.mp4)

```
ATTN_VERDICT {"ok":true,"scenarioId":"PI-AUTOMODE","failureCount":0,"firstFailure":null,"durationMs":27257}
```

The denial as the session showed it (`denial-pane.txt`):

```
 http://127.0.0.1:59459/v1/ok — the harness scripted a
 refusal
 DENIED-LEG-DONE
 auto mode blocked 1 call:
   bash: curl -sS http://127.0.0.1:59459/v1/ok — the harness
 scripted a refusal
   Approve in your reply to let the agent retry.
──────────────────────────────────────────────────────────────
──────────────────────────────────────────────────────────────
/private/var/folders/ct/gz_wgq1s4mj_nmkcw86rcpzm0000gn/T/at...
↑32 ↓20 0.0%/128k (auto)             (attn-harness) stub-agent
auto: on
```

The breaker's one question (`breaker-pane.txt`):

```
 It has refused 4 calls in a row and 4 since you last spoke,
 so it stopped rather than let the agent grind against the
 same refusal. Resume auto mode? Answering yes judges this
 call and the ones after it normally; it does not approve
 anything on its own.
 → Yes
   No
 ↑↓ navigate  enter select  escape/ctrl+c cancel
──────────────────────────────────────────────────────────────
/private/var/folders/ct/gz_wgq1s4mj_nmkcw86rcpzm0000gn/T/at...
↑96 ↓62 0.0%/128k (auto)             (attn-harness) stub-agent
auto: on
```

## The hardening

- **The review list says who asked.** The pending-proposal dedupe was keyed by
  `(kind, target, value)` and ignored `proposed_by`, so a second session asking
  for the same rule got the first session's row and the list credited the wrong
  asker. It is keyed by the asker now — deliberately: two sessions asking is two
  asks, and a promotion resolves every pending ask for that same change in the
  same transaction, so nobody is left asking for what the config already says.
  A partial unique index (migration 111) makes that true against the database
  rather than only inside the process holding the store lock, and the insert
  path re-reads on a constraint hit. `TestAutoModeProposalRaceLandsOneRow` fires
  8 concurrent identical proposals, asserts one row, then attempts a duplicate
  insert directly so the constraint itself is the receipt (verified red with the
  migration disabled).
- **The launcher toggle keeps an explicit choice.** `LocationPicker`'s
  toggle-sync effect followed `enabled_default` unconditionally, so a promoted
  default arriving while the picker was open clobbered a human's explicit off.
  It now follows the default only until someone answers for themselves — the
  late-arriving-default case still works, which is why the effect exists.
  Unreachable today; fixed while it is cheap.
- **The denial notification's best effort says so.** `recordAutoModeDenial`
  treats an `AddNotification` failure as best effort by design: the denial is
  already enforced and its row is durable, the log line names it either way, and
  the fact is published only when the notification exists (publishing alone
  would re-push a list the denial never reached). That reasoning is now a
  comment where the choice is made. No machinery added — returning the error to
  pi was considered and rejected: `AttnPiSuite.reportDenial` is fire-and-forget,
  so pi would never surface it.

## Docs

The plan doc states the precedence (`/auto > flag > enabled_default`) and
describes slice 6 as it shipped. The vision doc's "Safety envelope + auto mode"
rock is checked off, and its one open question — the envelope's policy
vocabulary — is answered by the plan, so the section is gone. `docs/glossary.md`
already carried auto mode, its config, proposals, promotion, environment prose,
and denials; nothing to add.

## The default is deliberate

`enabled_default` ships **on** and stays on. It went in with slice 4 (migration
109 defaults the column to 1, `automode.Defaults()` agrees), so a fresh machine
already launches attn pi sessions with auto mode on and bare pi off. Confirming
the end state, not flipping it — no code change here.

## Verification

- `real-app:scenario-pi-automode` green three times on `am6` (installed from
  this branch), one of them recorded above.
- `go test ./internal/store/ ./internal/daemon/ ./internal/automode/`
- `pnpm vitest run src/components/LocationPicker.autoMode.test.tsx`, and the
  harness script suite (`scripts/real-app-harness`, 229 tests).
- Profile cleaned after the run.

https://claude.ai/code/session_01SiiLfq3TsAbtzT3KHBbs2n

