### PR TITLE
feat(apps): make an owed app rebuild visible, refusable and self-limiting

### DIFF
--- a/app/src/hooks/daemonAppEvents.test.ts
+++ b/app/src/hooks/daemonAppEvents.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { AppCommandError, handleAppDaemonEvent } from './daemonAppEvents';
+import { pendingRequestKey, type PendingRequests } from './daemonPendingRequests';
+
+// A refused command has to reach the view as something it can branch on. A
+// rebuild in progress is worth retrying; a handler that threw is not, and the
+// two arrive as the same shape of failure with different codes.
+
+function parked(pending: PendingRequests, requestId: string): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    pending.set(pendingRequestKey('app_command', requestId), { resolve, reject });
+  });
+}
+
+describe('handleAppDaemonEvent', () => {
+  it('rejects a refused command with the daemon code and reason', async () => {
+    const pending: PendingRequests = new Map();
+    const settled = parked(pending, 'req-1');
+
+    const handled = handleAppDaemonEvent(
+      {
+        event: 'app_command_result',
+        request_id: 'req-1',
+        success: false,
+        error: 'approval-gate is rebuilding its collections',
+        error_code: 'reconcile_owed',
+        reconcile: { reason: 'version_changed', through_seq: 42 },
+      },
+      pending,
+    );
+
+    expect(handled).toBe(true);
+    const error = await settled.then(
+      () => new Error('the command resolved instead of rejecting'),
+      (err: unknown) => err,
+    );
+    expect(error).toBeInstanceOf(AppCommandError);
+    expect((error as AppCommandError).code).toBe('reconcile_owed');
+    expect((error as AppCommandError).message).toBe('approval-gate is rebuilding its collections');
+    expect((error as AppCommandError).reconcile).toEqual({
+      reason: 'version_changed',
+      through_seq: 42,
+    });
+  });
+
+  it('rejects a failure with no code as a plain error', async () => {
+    const pending: PendingRequests = new Map();
+    const settled = parked(pending, 'req-2');
+
+    handleAppDaemonEvent(
+      {
+        event: 'app_command_result',
+        request_id: 'req-2',
+        success: false,
+        error: 'approval-gate threw running command "forget"',
+      },
+      pending,
+    );
+
+    const error = await settled.then(
+      () => new Error('the command resolved instead of rejecting'),
+      (err: unknown) => err,
+    );
+    expect(error).not.toBeInstanceOf(AppCommandError);
+    expect((error as Error).message).toBe('approval-gate threw running command "forget"');
+  });
+
+  it('resolves a successful command with its payload', async () => {
+    const pending: PendingRequests = new Map();
+    const settled = parked(pending, 'req-3');
+
+    handleAppDaemonEvent(
+      {
+        event: 'app_command_result',
+        request_id: 'req-3',
+        success: true,
+        payload: '{"forgotten":2}',
+      },
+      pending,
+    );
+
+    expect(await settled).toEqual({ value: { forgotten: 2 } });
+  });
+});

--- a/app/src/hooks/daemonAppEvents.ts
+++ b/app/src/hooks/daemonAppEvents.ts
@@ -11,8 +11,29 @@ interface AppDaemonEvent {
   request_id?: unknown;
   success?: boolean;
   error?: string;
+  /** A stable name for the refusal, when the daemon had one. */
+  error_code?: unknown;
+  /** Present with error_code `reconcile_owed`: the rebuild the app owes. */
+  reconcile?: unknown;
   /** The handler's return value, still JSON text, absent when it returned nothing. */
   payload?: unknown;
+}
+
+/**
+ * A refusal a view can branch on. The message is the surface a person reads; the
+ * code is what tells "retry once the rebuild finishes" apart from "this app's
+ * handler is broken", which no two prose strings can be relied on to do.
+ */
+export class AppCommandError extends Error {
+  readonly code: string;
+  readonly reconcile: unknown;
+
+  constructor(message: string, code: string, reconcile: unknown) {
+    super(message);
+    this.name = 'AppCommandError';
+    this.code = code;
+    this.reconcile = reconcile;
+  }
 }
 
 /**
@@ -30,6 +51,21 @@ export interface AppCommandResult {
  */
 export function handleAppDaemonEvent(event: AppDaemonEvent, pending: PendingRequests): boolean {
   if (event.event !== 'app_command_result') return false;
+  if (event.success === false && typeof event.error_code === 'string' && event.error_code !== '') {
+    settlePendingRequest(
+      pending,
+      'app_command',
+      { ...event, success: false },
+      () => undefined,
+      'The command was refused',
+      new AppCommandError(
+        event.error || 'The command was refused',
+        event.error_code,
+        event.reconcile,
+      ),
+    );
+    return true;
+  }
   settlePendingRequest(
     pending,
     'app_command',

--- a/app/src/hooks/daemonPendingRequests.ts
+++ b/app/src/hooks/daemonPendingRequests.ts
@@ -78,6 +78,9 @@ interface ResultEvent {
  * Settle the request a `*_result` event answers; returns whether a waiter was
  * found (a timed-out or other client's request is not an error). `extract`
  * returning `undefined` counts as failure, never `resolve(undefined)`.
+ *
+ * `failure` rejects with that error rather than a plain one built from the
+ * event's text, for a domain whose refusals carry a code the caller branches on.
  */
 export function settlePendingRequest<E extends ResultEvent, T>(
   pending: PendingRequests,
@@ -85,6 +88,7 @@ export function settlePendingRequest<E extends ResultEvent, T>(
   event: E,
   extract: (event: E) => T | undefined,
   failureMessage: string,
+  failure?: Error,
 ): boolean {
   const requestId = event.request_id;
   if (typeof requestId !== 'string') {
@@ -98,7 +102,7 @@ export function settlePendingRequest<E extends ResultEvent, T>(
   pending.delete(key);
   const value = event.success ? extract(event) : undefined;
   if (value === undefined) {
-    waiter.reject(new Error(event.error || failureMessage));
+    waiter.reject(failure ?? new Error(event.error || failureMessage));
   } else {
     waiter.resolve(value);
   }

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -275,7 +275,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '256';
+export const PROTOCOL_VERSION = '257';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentMsgMessage, AgentMsgResult, AgentMsgStatus, AgentPeekMessage, AgentPeekResult, AgentPeekScreen, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, AppApplyMessage, AppApplyResult, AppCommandInfo, AppCommandMessage, AppCommandResultMessage, AppConsumerInfo, AppInvocationInfo, AppListMessage, AppListResult, AppLogsMessage, AppLogsResult, AppRegistryEntry, AppRemoveMessage, AppRemoveResult, AppRollbackMessage, AppRollbackResult, AppRuntimeInfo, AppRuntimeRestartMessage, AppRuntimeRestartResult, AppRuntimeStatusMessage, AppRuntimeStatusResult, AppSetEnabledMessage, AppSetEnabledResult, AppStallInfo, AppStatusMessage, AppStatusResult, AppSummary, AppVersionInfo, AppViewCrashMessage, AppViewInfo, AppWatchMessage, AppWatchResult, ApprovePRMessage, AppsUpdatedMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutoModeConfigInfo, AutoModeDenialInfo, AutoModeDenialsMessage, AutoModeDenialsResult, AutoModeDiscardMessage, AutoModeDiscardResultMessage, AutoModeEnvAddMessage, AutoModeEnvRemoveMessage, AutoModeEnvResult, AutoModeGetMessage, AutoModePromoteMessage, AutoModePromoteResultMessage, AutoModeProposalInfo, AutoModeProposeMessage, AutoModeProposeResult, AutoModeShowMessage, AutoModeShowResult, AutoModeStateResultMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, BusConsumerStatus, BusHealthEntry, BusProducerStatus, BusSetConsumerEnabledMessage, BusSetConsumerEnabledResultMessage, BusStatusGetMessage, BusStatusResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, CrewDayClose, CrewHandoffMessage, CrewHandoffResult, CrewListMessage, CrewListResult, CrewMember, CrewPrimeMessage, CrewPrimeResult, CrewSetMessage, CrewSetResult, CrewSleepMessage, CrewSleepResult, CrewSleepResultMessage, CrewUpdatedMessage, CrewWakeMessage, CrewWakeResult, CrewWakeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocSubscriptionDeliveryMessage, DocSubscriptionEndedMessage, DocUndefineMessage, DocUndefineResult, DocUnsubscribeMessage, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GardenSeedsUpdatedMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, OpenSentFilesMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyInputProbeResultMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Seed, SeedEdge, SeedLinkMessage, SeedLinkResult, SeedListMessage, SeedListResult, SeedNote, SeedNoteMessage, SeedNoteResult, SeedNotesMessage, SeedNotesResult, SeedPlantMessage, SeedPlantResult, SeedPlotChild, SeedPlotMessage, SeedPlotProgress, SeedPlotResult, SeedReadyMessage, SeedReadyResult, SeedRelation, SeedShowMessage, SeedShowResult, SeedTransitionMessage, SeedTransitionResult, SeedVar, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessageWindowStatus, SessionMessagesChangedMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketRow, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentMsgMessage, AgentMsgResult, AgentMsgStatus, AgentPeekMessage, AgentPeekResult, AgentPeekScreen, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, AppApplyMessage, AppApplyResult, AppCommandInfo, AppCommandMessage, AppCommandResultMessage, AppConsumerInfo, AppInvocationInfo, AppListMessage, AppListResult, AppLogsMessage, AppLogsResult, AppReconcileGapInfo, AppReconcileReasonInfo, AppReconcileStatus, AppRegistryEntry, AppRemoveMessage, AppRemoveResult, AppRollbackMessage, AppRollbackResult, AppRuntimeInfo, AppRuntimeRestartMessage, AppRuntimeRestartResult, AppRuntimeStatusMessage, AppRuntimeStatusResult, AppSetEnabledMessage, AppSetEnabledResult, AppStallInfo, AppStatusMessage, AppStatusResult, AppSummary, AppVersionInfo, AppViewCrashMessage, AppViewInfo, AppWatchMessage, AppWatchResult, ApprovePRMessage, AppsUpdatedMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutoModeConfigInfo, AutoModeDenialInfo, AutoModeDenialsMessage, AutoModeDenialsResult, AutoModeDiscardMessage, AutoModeDiscardResultMessage, AutoModeEnvAddMessage, AutoModeEnvRemoveMessage, AutoModeEnvResult, AutoModeGetMessage, AutoModePromoteMessage, AutoModePromoteResultMessage, AutoModeProposalInfo, AutoModeProposeMessage, AutoModeProposeResult, AutoModeShowMessage, AutoModeShowResult, AutoModeStateResultMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, BusConsumerStatus, BusHealthEntry, BusProducerStatus, BusSetConsumerEnabledMessage, BusSetConsumerEnabledResultMessage, BusStatusGetMessage, BusStatusResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, CrewDayClose, CrewHandoffMessage, CrewHandoffResult, CrewListMessage, CrewListResult, CrewMember, CrewPrimeMessage, CrewPrimeResult, CrewSetMessage, CrewSetResult, CrewSleepMessage, CrewSleepResult, CrewSleepResultMessage, CrewUpdatedMessage, CrewWakeMessage, CrewWakeResult, CrewWakeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocSubscriptionDeliveryMessage, DocSubscriptionEndedMessage, DocUndefineMessage, DocUndefineResult, DocUnsubscribeMessage, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GardenSeedsUpdatedMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, OpenSentFilesMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyInputProbeResultMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Seed, SeedEdge, SeedLinkMessage, SeedLinkResult, SeedListMessage, SeedListResult, SeedNote, SeedNoteMessage, SeedNoteResult, SeedNotesMessage, SeedNotesResult, SeedPlantMessage, SeedPlantResult, SeedPlotChild, SeedPlotMessage, SeedPlotProgress, SeedPlotResult, SeedReadyMessage, SeedReadyResult, SeedRelation, SeedShowMessage, SeedShowResult, SeedTransitionMessage, SeedTransitionResult, SeedVar, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessageWindowStatus, SessionMessagesChangedMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketRow, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const activityStatusMessage = Convert.toActivityStatusMessage(json);
 //   const activityStatusResult = Convert.toActivityStatusResult(json);
@@ -30,6 +30,9 @@
 //   const appListResult = Convert.toAppListResult(json);
 //   const appLogsMessage = Convert.toAppLogsMessage(json);
 //   const appLogsResult = Convert.toAppLogsResult(json);
+//   const appReconcileGapInfo = Convert.toAppReconcileGapInfo(json);
+//   const appReconcileReasonInfo = Convert.toAppReconcileReasonInfo(json);
+//   const appReconcileStatus = Convert.toAppReconcileStatus(json);
 //   const appRegistryEntry = Convert.toAppRegistryEntry(json);
 //   const appRemoveMessage = Convert.toAppRemoveMessage(json);
 //   const appRemoveResult = Convert.toAppRemoveResult(json);
@@ -814,16 +817,34 @@ export enum AppCommandMessageCmd {
 }
 
 export interface AppCommandResultMessage {
-    error?:     string;
-    event:      AppCommandResultMessageEvent;
-    payload?:   string;
-    request_id: string;
-    success:    boolean;
+    error?:      string;
+    error_code?: string;
+    event:       AppCommandResultMessageEvent;
+    payload?:    string;
+    reconcile?:  ReasonObject;
+    request_id:  string;
+    success:     boolean;
     [property: string]: any;
 }
 
 export enum AppCommandResultMessageEvent {
     AppCommandResult = "app_command_result",
+}
+
+export interface ReasonObject {
+    causes:            string[];
+    gap?:              Gap;
+    previous_versions: number[];
+    through_seq:       number;
+    version:           number;
+    [property: string]: any;
+}
+
+export interface Gap {
+    cursor:   number;
+    earliest: number;
+    missed:   number;
+    [property: string]: any;
 }
 
 export interface AppConsumerInfo {
@@ -836,16 +857,20 @@ export interface AppConsumerInfo {
 }
 
 export interface AppInvocationInfo {
-    duration_ms:   number;
-    error:         string;
-    event_name:    string;
-    event_seq:     number;
-    event_subject: string;
-    handler:       string;
-    id:            number;
-    started_at:    string;
-    status:        string;
-    version_id:    number;
+    duration_ms?:        number;
+    error?:              string;
+    event_name?:         string;
+    event_seq?:          number;
+    event_subject?:      string;
+    finished_at?:        string;
+    handler:             string;
+    id:                  number;
+    kind:                string;
+    reconcile?:          ReasonObject;
+    started_at:          string;
+    status:              string;
+    through_request_id?: number;
+    version_id:          number;
     [property: string]: any;
 }
 
@@ -922,6 +947,48 @@ export interface AppLogsResult {
     name:      string;
     path:      string;
     truncated: boolean;
+    [property: string]: any;
+}
+
+export interface AppReconcileGapInfo {
+    cursor:   number;
+    earliest: number;
+    missed:   number;
+    [property: string]: any;
+}
+
+export interface AppReconcileReasonInfo {
+    causes:            string[];
+    gap?:              Gap;
+    previous_versions: number[];
+    through_seq:       number;
+    version:           number;
+    [property: string]: any;
+}
+
+export interface AppReconcileStatus {
+    current_attempt?: CurrentAttempt;
+    last_error?:      string;
+    reason?:          ReasonObject;
+    state:            string;
+    [property: string]: any;
+}
+
+export interface CurrentAttempt {
+    duration_ms?:        number;
+    error?:              string;
+    event_name?:         string;
+    event_seq?:          number;
+    event_subject?:      string;
+    finished_at?:        string;
+    handler:             string;
+    id:                  number;
+    kind:                string;
+    reconcile?:          ReasonObject;
+    started_at:          string;
+    status:              string;
+    through_request_id?: number;
+    version_id:          number;
     [property: string]: any;
 }
 
@@ -1059,12 +1126,14 @@ export interface AppSetEnabledResult {
 }
 
 export interface AppStallInfo {
-    attempts:    number;
-    disables_at: string;
-    event_name:  string;
-    event_seq:   number;
-    last_error:  string;
-    since:       string;
+    attempts:            number;
+    disables_at:         string;
+    event_name?:         string;
+    event_seq?:          number;
+    kind:                string;
+    last_error:          string;
+    since:               string;
+    through_request_id?: number;
     [property: string]: any;
 }
 
@@ -1081,8 +1150,9 @@ export enum AppStatusMessageCmd {
 export interface AppStatusResult {
     app:                    App;
     invocations:            number;
-    recent?:                InvocationElement[];
+    recent?:                CurrentAttempt[];
     recent_versions?:       CurrentVersion[];
+    reconcile:              AppStatusResultReconcile;
     runtime?:               Runtime;
     serving_history?:       CurrentVersion[];
     serving_history_steps?: number;
@@ -1091,27 +1161,23 @@ export interface AppStatusResult {
     [property: string]: any;
 }
 
-export interface InvocationElement {
-    duration_ms:   number;
-    error:         string;
-    event_name:    string;
-    event_seq:     number;
-    event_subject: string;
-    handler:       string;
-    id:            number;
-    started_at:    string;
-    status:        string;
-    version_id:    number;
+export interface AppStatusResultReconcile {
+    current_attempt?: CurrentAttempt;
+    last_error?:      string;
+    reason?:          ReasonObject;
+    state:            string;
     [property: string]: any;
 }
 
 export interface Stall {
-    attempts:    number;
-    disables_at: string;
-    event_name:  string;
-    event_seq:   number;
-    last_error:  string;
-    since:       string;
+    attempts:            number;
+    disables_at:         string;
+    event_name?:         string;
+    event_seq?:          number;
+    kind:                string;
+    last_error:          string;
+    since:               string;
+    through_request_id?: number;
     [property: string]: any;
 }
 
@@ -1168,7 +1234,7 @@ export enum AppWatchMessageCmd {
 }
 
 export interface AppWatchResult {
-    invocation: InvocationElement;
+    invocation: CurrentAttempt;
     [property: string]: any;
 }
 
@@ -5915,8 +5981,9 @@ export interface AppSetEnabledResultObject {
 export interface AppStatusResultObject {
     app:                    App;
     invocations:            number;
-    recent?:                InvocationElement[];
+    recent?:                CurrentAttempt[];
     recent_versions?:       CurrentVersion[];
+    reconcile:              AppStatusResultReconcile;
     runtime?:               Runtime;
     serving_history?:       CurrentVersion[];
     serving_history_steps?: number;
@@ -5926,7 +5993,7 @@ export interface AppStatusResultObject {
 }
 
 export interface AppWatchResultObject {
-    invocation: InvocationElement;
+    invocation: CurrentAttempt;
     [property: string]: any;
 }
 
@@ -8851,6 +8918,30 @@ export class Convert {
 
     public static appLogsResultToJson(value: AppLogsResult): string {
         return JSON.stringify(uncast(value, r("AppLogsResult")), null, 2);
+    }
+
+    public static toAppReconcileGapInfo(json: string): AppReconcileGapInfo {
+        return cast(JSON.parse(json), r("AppReconcileGapInfo"));
+    }
+
+    public static appReconcileGapInfoToJson(value: AppReconcileGapInfo): string {
+        return JSON.stringify(uncast(value, r("AppReconcileGapInfo")), null, 2);
+    }
+
+    public static toAppReconcileReasonInfo(json: string): AppReconcileReasonInfo {
+        return cast(JSON.parse(json), r("AppReconcileReasonInfo"));
+    }
+
+    public static appReconcileReasonInfoToJson(value: AppReconcileReasonInfo): string {
+        return JSON.stringify(uncast(value, r("AppReconcileReasonInfo")), null, 2);
+    }
+
+    public static toAppReconcileStatus(json: string): AppReconcileStatus {
+        return cast(JSON.parse(json), r("AppReconcileStatus"));
+    }
+
+    public static appReconcileStatusToJson(value: AppReconcileStatus): string {
+        return JSON.stringify(uncast(value, r("AppReconcileStatus")), null, 2);
     }
 
     public static toAppRegistryEntry(json: string): AppRegistryEntry {
@@ -13487,10 +13578,24 @@ const typeMap: any = {
     ], "any"),
     "AppCommandResultMessage": o([
         { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "error_code", js: "error_code", typ: u(undefined, "") },
         { json: "event", js: "event", typ: r("AppCommandResultMessageEvent") },
         { json: "payload", js: "payload", typ: u(undefined, "") },
+        { json: "reconcile", js: "reconcile", typ: u(undefined, r("ReasonObject")) },
         { json: "request_id", js: "request_id", typ: "" },
         { json: "success", js: "success", typ: true },
+    ], "any"),
+    "ReasonObject": o([
+        { json: "causes", js: "causes", typ: a("") },
+        { json: "gap", js: "gap", typ: u(undefined, r("Gap")) },
+        { json: "previous_versions", js: "previous_versions", typ: a(0) },
+        { json: "through_seq", js: "through_seq", typ: 0 },
+        { json: "version", js: "version", typ: 0 },
+    ], "any"),
+    "Gap": o([
+        { json: "cursor", js: "cursor", typ: 0 },
+        { json: "earliest", js: "earliest", typ: 0 },
+        { json: "missed", js: "missed", typ: 0 },
     ], "any"),
     "AppConsumerInfo": o([
         { json: "cursor", js: "cursor", typ: 0 },
@@ -13500,15 +13605,19 @@ const typeMap: any = {
         { json: "name", js: "name", typ: "" },
     ], "any"),
     "AppInvocationInfo": o([
-        { json: "duration_ms", js: "duration_ms", typ: 0 },
-        { json: "error", js: "error", typ: "" },
-        { json: "event_name", js: "event_name", typ: "" },
-        { json: "event_seq", js: "event_seq", typ: 0 },
-        { json: "event_subject", js: "event_subject", typ: "" },
+        { json: "duration_ms", js: "duration_ms", typ: u(undefined, 0) },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event_name", js: "event_name", typ: u(undefined, "") },
+        { json: "event_seq", js: "event_seq", typ: u(undefined, 0) },
+        { json: "event_subject", js: "event_subject", typ: u(undefined, "") },
+        { json: "finished_at", js: "finished_at", typ: u(undefined, "") },
         { json: "handler", js: "handler", typ: "" },
         { json: "id", js: "id", typ: 0 },
+        { json: "kind", js: "kind", typ: "" },
+        { json: "reconcile", js: "reconcile", typ: u(undefined, r("ReasonObject")) },
         { json: "started_at", js: "started_at", typ: "" },
         { json: "status", js: "status", typ: "" },
+        { json: "through_request_id", js: "through_request_id", typ: u(undefined, 0) },
         { json: "version_id", js: "version_id", typ: 0 },
     ], "any"),
     "AppListMessage": o([
@@ -13560,6 +13669,40 @@ const typeMap: any = {
         { json: "name", js: "name", typ: "" },
         { json: "path", js: "path", typ: "" },
         { json: "truncated", js: "truncated", typ: true },
+    ], "any"),
+    "AppReconcileGapInfo": o([
+        { json: "cursor", js: "cursor", typ: 0 },
+        { json: "earliest", js: "earliest", typ: 0 },
+        { json: "missed", js: "missed", typ: 0 },
+    ], "any"),
+    "AppReconcileReasonInfo": o([
+        { json: "causes", js: "causes", typ: a("") },
+        { json: "gap", js: "gap", typ: u(undefined, r("Gap")) },
+        { json: "previous_versions", js: "previous_versions", typ: a(0) },
+        { json: "through_seq", js: "through_seq", typ: 0 },
+        { json: "version", js: "version", typ: 0 },
+    ], "any"),
+    "AppReconcileStatus": o([
+        { json: "current_attempt", js: "current_attempt", typ: u(undefined, r("CurrentAttempt")) },
+        { json: "last_error", js: "last_error", typ: u(undefined, "") },
+        { json: "reason", js: "reason", typ: u(undefined, r("ReasonObject")) },
+        { json: "state", js: "state", typ: "" },
+    ], "any"),
+    "CurrentAttempt": o([
+        { json: "duration_ms", js: "duration_ms", typ: u(undefined, 0) },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event_name", js: "event_name", typ: u(undefined, "") },
+        { json: "event_seq", js: "event_seq", typ: u(undefined, 0) },
+        { json: "event_subject", js: "event_subject", typ: u(undefined, "") },
+        { json: "finished_at", js: "finished_at", typ: u(undefined, "") },
+        { json: "handler", js: "handler", typ: "" },
+        { json: "id", js: "id", typ: 0 },
+        { json: "kind", js: "kind", typ: "" },
+        { json: "reconcile", js: "reconcile", typ: u(undefined, r("ReasonObject")) },
+        { json: "started_at", js: "started_at", typ: "" },
+        { json: "status", js: "status", typ: "" },
+        { json: "through_request_id", js: "through_request_id", typ: u(undefined, 0) },
+        { json: "version_id", js: "version_id", typ: 0 },
     ], "any"),
     "AppRegistryEntry": o([
         { json: "content_hash", js: "content_hash", typ: u(undefined, "") },
@@ -13651,10 +13794,12 @@ const typeMap: any = {
     "AppStallInfo": o([
         { json: "attempts", js: "attempts", typ: 0 },
         { json: "disables_at", js: "disables_at", typ: "" },
-        { json: "event_name", js: "event_name", typ: "" },
-        { json: "event_seq", js: "event_seq", typ: 0 },
+        { json: "event_name", js: "event_name", typ: u(undefined, "") },
+        { json: "event_seq", js: "event_seq", typ: u(undefined, 0) },
+        { json: "kind", js: "kind", typ: "" },
         { json: "last_error", js: "last_error", typ: "" },
         { json: "since", js: "since", typ: "" },
+        { json: "through_request_id", js: "through_request_id", typ: u(undefined, 0) },
     ], "any"),
     "AppStatusMessage": o([
         { json: "cmd", js: "cmd", typ: r("AppStatusMessageCmd") },
@@ -13663,33 +13808,30 @@ const typeMap: any = {
     "AppStatusResult": o([
         { json: "app", js: "app", typ: r("App") },
         { json: "invocations", js: "invocations", typ: 0 },
-        { json: "recent", js: "recent", typ: u(undefined, a(r("InvocationElement"))) },
+        { json: "recent", js: "recent", typ: u(undefined, a(r("CurrentAttempt"))) },
         { json: "recent_versions", js: "recent_versions", typ: u(undefined, a(r("CurrentVersion"))) },
+        { json: "reconcile", js: "reconcile", typ: r("AppStatusResultReconcile") },
         { json: "runtime", js: "runtime", typ: u(undefined, r("Runtime")) },
         { json: "serving_history", js: "serving_history", typ: u(undefined, a(r("CurrentVersion"))) },
         { json: "serving_history_steps", js: "serving_history_steps", typ: u(undefined, 0) },
         { json: "stall", js: "stall", typ: u(undefined, r("Stall")) },
         { json: "versions", js: "versions", typ: 0 },
     ], "any"),
-    "InvocationElement": o([
-        { json: "duration_ms", js: "duration_ms", typ: 0 },
-        { json: "error", js: "error", typ: "" },
-        { json: "event_name", js: "event_name", typ: "" },
-        { json: "event_seq", js: "event_seq", typ: 0 },
-        { json: "event_subject", js: "event_subject", typ: "" },
-        { json: "handler", js: "handler", typ: "" },
-        { json: "id", js: "id", typ: 0 },
-        { json: "started_at", js: "started_at", typ: "" },
-        { json: "status", js: "status", typ: "" },
-        { json: "version_id", js: "version_id", typ: 0 },
+    "AppStatusResultReconcile": o([
+        { json: "current_attempt", js: "current_attempt", typ: u(undefined, r("CurrentAttempt")) },
+        { json: "last_error", js: "last_error", typ: u(undefined, "") },
+        { json: "reason", js: "reason", typ: u(undefined, r("ReasonObject")) },
+        { json: "state", js: "state", typ: "" },
     ], "any"),
     "Stall": o([
         { json: "attempts", js: "attempts", typ: 0 },
         { json: "disables_at", js: "disables_at", typ: "" },
-        { json: "event_name", js: "event_name", typ: "" },
-        { json: "event_seq", js: "event_seq", typ: 0 },
+        { json: "event_name", js: "event_name", typ: u(undefined, "") },
+        { json: "event_seq", js: "event_seq", typ: u(undefined, 0) },
+        { json: "kind", js: "kind", typ: "" },
         { json: "last_error", js: "last_error", typ: "" },
         { json: "since", js: "since", typ: "" },
+        { json: "through_request_id", js: "through_request_id", typ: u(undefined, 0) },
     ], "any"),
     "AppSummary": o([
         { json: "commands", js: "commands", typ: u(undefined, a(r("CommandElement"))) },
@@ -13726,7 +13868,7 @@ const typeMap: any = {
         { json: "name", js: "name", typ: "" },
     ], "any"),
     "AppWatchResult": o([
-        { json: "invocation", js: "invocation", typ: r("InvocationElement") },
+        { json: "invocation", js: "invocation", typ: r("CurrentAttempt") },
     ], "any"),
     "ApprovePRMessage": o([
         { json: "cmd", js: "cmd", typ: r("ApprovePRMessageCmd") },
@@ -16614,8 +16756,9 @@ const typeMap: any = {
     "AppStatusResultObject": o([
         { json: "app", js: "app", typ: r("App") },
         { json: "invocations", js: "invocations", typ: 0 },
-        { json: "recent", js: "recent", typ: u(undefined, a(r("InvocationElement"))) },
+        { json: "recent", js: "recent", typ: u(undefined, a(r("CurrentAttempt"))) },
         { json: "recent_versions", js: "recent_versions", typ: u(undefined, a(r("CurrentVersion"))) },
+        { json: "reconcile", js: "reconcile", typ: r("AppStatusResultReconcile") },
         { json: "runtime", js: "runtime", typ: u(undefined, r("Runtime")) },
         { json: "serving_history", js: "serving_history", typ: u(undefined, a(r("CurrentVersion"))) },
         { json: "serving_history_steps", js: "serving_history_steps", typ: u(undefined, 0) },
@@ -16623,7 +16766,7 @@ const typeMap: any = {
         { json: "versions", js: "versions", typ: 0 },
     ], "any"),
     "AppWatchResultObject": o([
-        { json: "invocation", js: "invocation", typ: r("InvocationElement") },
+        { json: "invocation", js: "invocation", typ: r("CurrentAttempt") },
     ], "any"),
     "AutomodeDenialsResult": o([
         { json: "denials", js: "denials", typ: a(r("DenialElement")) },

--- a/changelog.d/app-reconcile-failure-surfaces.yaml
+++ b/changelog.d/app-reconcile-failure-surfaces.yaml
@@ -1,0 +1,21 @@
+kind: added
+area: apps
+change: >
+  An owed app rebuild is now something an operator can see and act on. Each
+  reconcile attempt is recorded with its claim boundary and reason, so a
+  daemon restart mid-rebuild closes the attempt as interrupted and leaves the
+  request owed rather than losing it. `attn app status` reports whether a
+  rebuild is idle, owed or running, what triggered it, and what the last
+  attempt failed on. A command sent to an app that owes a rebuild is refused
+  by name with a `reconcile_owed` code and the same structured reason, and a
+  handler that never returns loses its runtime generation so the apps behind
+  it keep being served. An app whose rebuild keeps failing past the existing
+  fifteen-minute stall window is disabled and says so in a notification, and
+  an app that subscribes but declares no reconcile handler is refused a
+  version move and disabled when a live gap is discovered, instead of
+  silently serving stale collections.
+symptom: >
+  A rebuild that failed, hung, or was interrupted by a restart left no
+  operator-readable state: status showed nothing owed, commands ran against
+  collections that were mid-rebuild, and one app's frozen handler could
+  starve every other app of the shared runtime.

--- a/cmd/attn/app.go
+++ b/cmd/attn/app.go
@@ -118,8 +118,9 @@ commands:
   status <name> [--json]
         one app in full — its current version, its bus consumer, the ids of its
         recent versions (what rollback takes), where a bare rollback can still
-        go, and its most recent runs. Reports only what exists: an app with no
-        consumer says so rather than showing a default.
+        go, reconcile support and any rebuild it owes, and its most recent runs.
+        Reports only what exists: an app with no consumer says so rather than
+        showing a default.
 
   enable <name>
         resume delivery to the app, from wherever its consumer's cursor stands.
@@ -318,11 +319,17 @@ func runAppStatus(args []string) {
 		}
 	}
 	fmt.Printf("  runtime:    %s\n", appRuntimeCell(result.Runtime))
+	printAppReconcileStatus(result.Reconcile)
 	if result.Stall != nil {
 		// The stall clock is the only thing here that ends with the app being
 		// switched off, so it says when, not just that.
-		fmt.Printf("  stalled:    on event %d (%s) since %s, %d attempt(s)\n",
-			result.Stall.EventSeq, result.Stall.EventName, result.Stall.Since, result.Stall.Attempts)
+		if result.Stall.Kind == "reconcile" {
+			fmt.Printf("  stalled:    reconcile request %s since %s, %d attempt(s)\n",
+				optionalIntCell(result.Stall.ThroughRequestID), result.Stall.Since, result.Stall.Attempts)
+		} else {
+			fmt.Printf("  stalled:    on event %s (%s) since %s, %d attempt(s)\n",
+				optionalIntCell(result.Stall.EventSeq), protocol.Deref(result.Stall.EventName), result.Stall.Since, result.Stall.Attempts)
+		}
 		fmt.Print(indentBlock("              ", result.Stall.LastError))
 		fmt.Printf("              disables itself at %s unless it succeeds first\n", result.Stall.DisablesAt)
 	}
@@ -343,17 +350,86 @@ func runAppStatus(args []string) {
 	}
 	fmt.Println("  recent:")
 	w := tabwriter.NewWriter(os.Stdout, 4, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "\tSTARTED\tVERSION\tSEQ\tEVENT\tHANDLER\tSTATUS\tMS\tERROR")
+	fmt.Fprintln(w, "\tSTARTED\tVERSION\tKIND\tWORK\tHANDLER\tSTATUS\tMS\tERROR")
 	for _, inv := range result.Recent {
 		// One line per invocation, so the error is its first line only — a
 		// JavaScript stack pasted into a column destroys the table it is in. The
 		// stall block above carries the whole thing for the failure that matters,
 		// and `attn app logs <name>` has what the handler printed.
-		fmt.Fprintf(w, "\t%s\t%d\t%d\t%s\t%s\t%s\t%d\t%s\n",
-			inv.StartedAt, inv.VersionID, inv.EventSeq, inv.EventName, inv.Handler,
-			inv.Status, inv.DurationMs, firstErrorLine(inv.Error))
+		fmt.Fprintf(w, "\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			inv.StartedAt, inv.VersionID, inv.Kind, appInvocationWork(inv), inv.Handler,
+			inv.Status, optionalIntCell(inv.DurationMs), firstErrorLine(protocol.Deref(inv.Error)))
 	}
 	w.Flush()
+}
+
+func printAppReconcileStatus(status protocol.AppReconcileStatus) {
+	fmt.Printf("  reconcile:  %s\n", appReconcileStatusCell(status))
+	if status.State == "running" && status.CurrentAttempt != nil {
+		fmt.Printf("              attempt %d started %s (request %s)\n",
+			status.CurrentAttempt.ID, status.CurrentAttempt.StartedAt,
+			optionalIntCell(status.CurrentAttempt.ThroughRequestID))
+	}
+	if status.LastError != nil && *status.LastError != "" {
+		fmt.Println("              last error:")
+		fmt.Print(indentBlock("                ", *status.LastError))
+	}
+}
+
+func appReconcileStatusCell(status protocol.AppReconcileStatus) string {
+	switch status.State {
+	case "not_needed":
+		return "not needed — the serving version declares no subscriptions"
+	case "unsupported":
+		return "unsupported — version moves and a discovered gap are refused until the app declares and implements reconcile"
+	case "idle":
+		return "supported, no rebuild owed"
+	case "owed", "running":
+		line := status.State
+		if status.Reason != nil {
+			line += " " + appReconcileReasonCell(*status.Reason)
+		}
+		return line
+	default:
+		return status.State
+	}
+}
+
+func appReconcileReasonCell(reason protocol.AppReconcileReasonInfo) string {
+	causes := strings.Join(reason.Causes, ", ")
+	if causes == "" {
+		causes = "unknown cause"
+	}
+	return fmt.Sprintf("through seq %d (%s)", reason.ThroughSeq, causes)
+}
+
+func appInvocationWork(inv protocol.AppInvocationInfo) string {
+	if inv.Reconcile != nil {
+		return appReconcileReasonCell(*inv.Reconcile)
+	}
+	event := protocol.Deref(inv.EventName)
+	subject := protocol.Deref(inv.EventSubject)
+	seq := ""
+	if inv.EventSeq != nil {
+		seq = fmt.Sprintf("seq %d", *inv.EventSeq)
+	}
+	parts := make([]string, 0, 3)
+	for _, part := range []string{seq, event, subject} {
+		if part != "" {
+			parts = append(parts, part)
+		}
+	}
+	if len(parts) == 0 {
+		return "-"
+	}
+	return strings.Join(parts, " ")
+}
+
+func optionalIntCell(value *int) string {
+	if value == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%d", *value)
 }
 
 // firstErrorLine is one row's worth of an error, with a marker when there is

--- a/cmd/attn/app_build.go
+++ b/cmd/attn/app_build.go
@@ -335,13 +335,12 @@ func devWatchInvocations(app string, stop <-chan struct{}) {
 }
 
 func devInvocationLine(inv protocol.AppInvocationInfo) string {
-	line := fmt.Sprintf("%s  %s(%s) in %dms", inv.Status, inv.Handler, inv.EventName, inv.DurationMs)
-	if inv.EventSubject != "" {
-		line = fmt.Sprintf("%s  %s(%s %s) in %dms",
-			inv.Status, inv.Handler, inv.EventName, inv.EventSubject, inv.DurationMs)
+	line := fmt.Sprintf("%s  %s [%s]", inv.Status, inv.Handler, appInvocationWork(inv))
+	if inv.DurationMs != nil {
+		line += fmt.Sprintf(" in %dms", *inv.DurationMs)
 	}
-	if inv.Error != "" {
-		line += "\n            " + inv.Error
+	if inv.Error != nil && *inv.Error != "" {
+		line += "\n            " + *inv.Error
 	}
 	return line
 }

--- a/cmd/attn/app_runtime_test.go
+++ b/cmd/attn/app_runtime_test.go
@@ -81,3 +81,57 @@ func TestAMultiLineHandlerErrorSurvivesBothRenderings(t *testing.T) {
 		t.Fatalf("a single-line error was changed to %q", got)
 	}
 }
+
+func TestInvocationRenderingNamesReconcileWorkWithoutInventingAnEvent(t *testing.T) {
+	reason := protocol.AppReconcileReasonInfo{
+		Causes: []string{"gap", "version_changed"}, Version: 7, ThroughSeq: 42,
+		PreviousVersions: []int{3, 5},
+	}
+	inv := protocol.AppInvocationInfo{
+		ID: 9, VersionID: 7, Kind: "reconcile", Handler: "reconcile",
+		Status: "running", StartedAt: "2026-08-17T10:00:00Z", Reconcile: &reason,
+		ThroughRequestID: protocol.Ptr(12),
+	}
+	if got := appInvocationWork(inv); got != "through seq 42 (gap, version_changed)" {
+		t.Fatalf("reconcile work = %q", got)
+	}
+	line := devInvocationLine(inv)
+	for _, want := range []string{"running", "reconcile", "through seq 42", "gap, version_changed"} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("dev line %q does not contain %q", line, want)
+		}
+	}
+	if strings.Contains(line, " in ") {
+		t.Fatalf("running invocation invented a duration: %q", line)
+	}
+}
+
+func TestInvocationRenderingKeepsSubscriptionIdentity(t *testing.T) {
+	inv := protocol.AppInvocationInfo{
+		ID: 2, VersionID: 1, Kind: "subscription", Handler: "subscribe:ticket.*",
+		Status: "error", StartedAt: "2026-08-17T10:00:00Z",
+		EventSeq: protocol.Ptr(81), EventName: protocol.Ptr("ticket.updated"),
+		EventSubject: protocol.Ptr("tk-7"), DurationMs: protocol.Ptr(4),
+	}
+	if got := appInvocationWork(inv); got != "seq 81 ticket.updated tk-7" {
+		t.Fatalf("subscription work = %q", got)
+	}
+	if got := devInvocationLine(inv); !strings.Contains(got, "in 4ms") || !strings.Contains(got, "ticket.updated tk-7") {
+		t.Fatalf("dev line = %q", got)
+	}
+}
+
+func TestReconcileStatusRenderingNamesUnsupportedAndOwedStates(t *testing.T) {
+	unsupported := appReconcileStatusCell(protocol.AppReconcileStatus{State: "unsupported"})
+	if !strings.Contains(unsupported, "unsupported") || !strings.Contains(unsupported, "declares and implements reconcile") {
+		t.Fatalf("unsupported status = %q", unsupported)
+	}
+	reason := protocol.AppReconcileReasonInfo{
+		Causes: []string{"version_changed"}, Version: 4, ThroughSeq: 18,
+		PreviousVersions: []int{3},
+	}
+	owed := appReconcileStatusCell(protocol.AppReconcileStatus{State: "owed", Reason: &reason})
+	if owed != "owed through seq 18 (version_changed)" {
+		t.Fatalf("owed status = %q", owed)
+	}
+}

--- a/docs/plans/2026-08-14-ext-app-reconcile-handler.md
+++ b/docs/plans/2026-08-14-ext-app-reconcile-handler.md
@@ -369,7 +369,11 @@ trigger while still enabled.
 
 An A5 view-only app keeps the sentinel consumer row used for uniform lifecycle
 handling, but its filter matches nothing. It cannot miss a subscribed fact, so
-reconcile obligations are inert for it.
+reconcile obligations are inert for it. Inert means the trigger is never
+recorded: completion advances a bus cursor, and an app whose filter matches
+nothing has none to advance, so a request written for it could only sit owed
+forever and refuse the app's commands. As built in slice 1 the version-change
+trigger did fire for such an app; slice 3 guards it on the filter.
 
 Silently keeping the old A1 skip-to-head behavior was rejected. So was running
 an optional no-op reconcile: both certify stale collections as current.
@@ -489,8 +493,10 @@ proof.
    and increment `ProtocolVersion`; generated Go and TypeScript are never
    edited by hand. Verification tier: full non-production app plus packaged-app
    harness. Prove an infinite loop loses its generation and another app resumes.
-4. **Scaffold and exit proof.** Teach the handler in `attn app new` and the SDK
-   docs. First demonstrate today's stale state. Then show disable, publish
+4. **Scaffold and exit proof.** Teach the handler in the SDK docs. Slice 3
+   already gave `attn app new` a declared, converging reconcile handler,
+   because gate 7's version-move refusal otherwise scaffolds an app that can
+   never be updated; what remains here is the prose that teaches it. First demonstrate today's stale state. Then show disable, publish
    facts, enable delivering the retained backlog in order with no reconcile;
    force a gap and show the loud disable; apply a version deriving a new field
    and show the rebuild followed by delivery of facts the old version never

--- a/internal/appbuild/build_test.go
+++ b/internal/appbuild/build_test.go
@@ -319,7 +319,9 @@ func TestBuild_UndeclaredCommandHandlerIsACompilerError(t *testing.T) {
 
 func TestBuild_DeclaredReconcileWithNoHandlerIsACompilerError(t *testing.T) {
 	env := newBuildEnv(t, "unreconciled-app")
-	env.editManifest(t, `entrypoint = "src/index.ts"`, "entrypoint = \"src/index.ts\"\nreconcile = true")
+	// The scaffold declares reconcile and implements it, so this drops the
+	// handler rather than adding the declaration.
+	env.edit(t, "src/index.ts", "\n  reconcile,", "")
 
 	_, err := env.build(t)
 	if err == nil {
@@ -671,8 +673,9 @@ func TestBuild_AppWithAViewAndNoSubscriptionsBuilds(t *testing.T) {
 	env.dropScaffoldView(t)
 	env.addView(t, "approvals", "export default function Approvals(): string { return \"approvals\" }\n")
 	env.editManifest(t, "[[subscribe]]\nevents = [\"session.state.changed\"]\n", "")
+	env.editManifest(t, "reconcile = true\n", "")
 	env.edit(t, "src/index.ts",
-		"export default {\n  subscriptions: { \"session.state.changed\": onSessionState },\n} satisfies Handlers",
+		"export default {\n  subscriptions: { \"session.state.changed\": onSessionState },\n  reconcile,\n} satisfies Handlers",
 		"export default {} satisfies Handlers")
 
 	res := env.mustBuild(t)

--- a/internal/appbuild/scaffold.go
+++ b/internal/appbuild/scaffold.go
@@ -130,6 +130,13 @@ attn_app_api = %d
 
 entrypoint = "src/index.ts"
 
+# An app whose collections are derived from facts must be able to rebuild them
+# from attn's current state: a version move changes what the app derives, and a
+# gap means facts it can never receive. Declaring this makes `+"`reconcile`"+` a required
+# export in src/generated.ts, and a subscribed version without it is refused a
+# version move.
+reconcile = true
+
 # Every event pattern listed here becomes a required handler in src/generated.ts.
 # A pattern is an exact fact name (session.state.changed) or a family (session.*).
 # `+"`attn bus status`"+` lists the consumers; the fact names are attn's domain
@@ -166,7 +173,7 @@ description = "Drop one session from the list."
 
 func scaffoldEntrypoint() string {
 	return fmt.Sprintf(`import type { Ctx, Handlers } from "./generated"
-import type { AppEvent } from %q
+import type { AppEvent, ReconcileReason } from %q
 
 // One handler per subscription and one per command in %s. The `+"`satisfies Handlers`"+` below is
 // what keeps the two in step: declare either one in the manifest without a
@@ -193,11 +200,34 @@ async function forget(payload: unknown, ctx: Ctx): Promise<{ forgotten: boolean 
   return { forgotten: await ctx.collections.seen.delete(id) }
 }
 
+// Reconcile rebuilds what the subscriptions derive, from current state rather
+// than from facts. attn calls it when this app moves to a different version or
+// resumes below the oldest surviving fact, and no fact or command runs until it
+// succeeds. It must converge: run it twice, or after an interrupted attempt, and
+// the collection ends up the same. Deleting what current truth no longer has is
+// half the job — a rebuild that only upserts leaves rows nothing will remove.
+async function reconcile(_reason: ReconcileReason, ctx: Ctx): Promise<void> {
+  const current = await ctx.current.snapshot()
+  const live = new Set(current.sessions.map((session) => session.id))
+  for (const row of await ctx.collections.seen.query({})) {
+    if (!live.has(row.id)) {
+      await ctx.collections.seen.delete(row.id)
+    }
+  }
+  for (const session of current.sessions) {
+    await ctx.collections.seen.put(session.id, {
+      state: String(session.state),
+      seq: current.asOfSeq,
+    })
+  }
+}
+
 // Handlers are grouped by kind, and attn knows which kind it is running: a
 // command and a subscription can share a name without either becoming ambiguous.
 export default {
   subscriptions: { "session.state.changed": onSessionState },
   commands: { forget },
+  reconcile,
 } satisfies Handlers
 `, SDKModule, ManifestName)
 }

--- a/internal/appbuild/sdkdist/useCommand.d.ts
+++ b/internal/appbuild/sdkdist/useCommand.d.ts
@@ -5,6 +5,12 @@ export type CommandOutcome = {
 } | {
     ok: false;
     error: string;
+    /**
+     * A stable name for the refusal, when attn had one. `"reconcile_owed"`
+     * means the app is rebuilding its collections and every command is held
+     * until that finishes — worth retrying, unlike a handler that threw.
+     */
+    code?: string;
 };
 /**
  * A command, ready to invoke. It is a function first, because that is what a

--- a/internal/daemon/app_apply.go
+++ b/internal/daemon/app_apply.go
@@ -58,6 +58,9 @@ func (d *Daemon) handleAppApply(conn net.Conn, msg *protocol.AppApplyMessage) {
 		d.sendError(conn, "no database")
 		return
 	}
+	lane := d.appLane(name)
+	lane.Lock()
+	defer lane.Unlock()
 	hash := strings.TrimSpace(msg.ContentHash)
 	if err := validateContentHash(hash); err != nil {
 		d.sendError(conn, fmt.Sprintf("app apply %s: %v", name, err))
@@ -107,6 +110,19 @@ func (d *Daemon) handleAppApply(conn net.Conn, msg *protocol.AppApplyMessage) {
 		d.sendError(conn, fmt.Sprintf("app apply %s: %v", name, err))
 		return
 	}
+	if previous != 0 {
+		current, ok, err := d.store.GetAppVersion(previous)
+		if err != nil {
+			d.sendError(conn, fmt.Sprintf("app apply %s: reading current version %d: %v", name, previous, err))
+			return
+		}
+		if ok && current.ContentHash != hash {
+			if err := requireVersionMoveReconcile(name, fmt.Sprintf("version %d", previous), "content "+appbuild.ShortHash(hash), declaration); err != nil {
+				d.sendError(conn, "app apply "+name+": "+err.Error())
+				return
+			}
+		}
+	}
 	version, created, err := d.store.CommitAppVersion(store.AppVersion{
 		AppName:      name,
 		ContentHash:  hash,
@@ -154,6 +170,9 @@ func (d *Daemon) handleAppRollback(conn net.Conn, msg *protocol.AppRollbackMessa
 		d.sendError(conn, "no database")
 		return
 	}
+	lane := d.appLane(name)
+	lane.Lock()
+	defer lane.Unlock()
 	app, ok, err := d.store.GetApp(name)
 	if err != nil {
 		d.sendError(conn, fmt.Sprintf("reading app %q: %v", name, err))
@@ -171,6 +190,10 @@ func (d *Daemon) handleAppRollback(conn net.Conn, msg *protocol.AppRollbackMessa
 	target, err := pickRollbackTarget(name, app, versions, msg.VersionID)
 	if err != nil {
 		d.sendError(conn, err.Error())
+		return
+	}
+	if err := requireVersionMoveReconcile(name, fmt.Sprintf("version %d", app.CurrentVersionID), fmt.Sprintf("version %d", target.ID), target.Declaration); err != nil {
+		d.sendError(conn, "app rollback "+name+": "+err.Error())
 		return
 	}
 	// The two rollbacks move the pointer differently on purpose. A named version
@@ -328,4 +351,17 @@ func validateDeclaration(name, declaration string) error {
 		return fmt.Errorf("the declaration snapshot names app %q, not %q", probe.Name, name)
 	}
 	return nil
+}
+
+func requireVersionMoveReconcile(name, current, requested, declaration string) error {
+	var manifest appbuild.Manifest
+	if err := json.Unmarshal([]byte(declaration), &manifest); err != nil {
+		return fmt.Errorf("the declaration for requested %s is not readable: %w", requested, err)
+	}
+	if len(manifest.EventPatterns()) == 0 || manifest.Reconcile {
+		return nil
+	}
+	return fmt.Errorf(
+		"refusing to move %s from %s to %s: the requested subscribed version does not declare reconcile; add `reconcile = true` and implement the reconcile export so existing collections can be rebuilt",
+		name, current, requested)
 }

--- a/internal/daemon/app_commands.go
+++ b/internal/daemon/app_commands.go
@@ -13,6 +13,16 @@ import (
 	"github.com/victorarias/attn/internal/store"
 )
 
+type appReconcileOwedError struct {
+	reason appReconcileReason
+}
+
+func (e *appReconcileOwedError) Error() string {
+	return fmt.Sprintf(
+		"reconcile_owed: app collection rebuild is owed through bus seq %d (%s); commands remain refused until reconcile succeeds",
+		e.reason.ThroughSeq, strings.Join(e.reason.Causes, ", "))
+}
+
 // A view acting: `app_command` in, `app_command_result` back.
 //
 // A view that can only read is a way in with no way out. What makes this a
@@ -84,6 +94,11 @@ func appCommandResult(requestID string, payload json.RawMessage, err error) prot
 	}
 	if err != nil {
 		result.Error = protocol.Ptr(err.Error())
+		var owed *appReconcileOwedError
+		if errors.As(err, &owed) {
+			result.ErrorCode = protocol.Ptr(protocol.ErrorCodeReconcileOwed)
+			result.Reconcile = appReconcileReasonForWire(owed.reason)
+		}
 		return result
 	}
 	if len(payload) > 0 {
@@ -116,6 +131,9 @@ func (d *Daemon) runAppCommand(msg *protocol.AppCommandMessage) (json.RawMessage
 	if d.store == nil {
 		return nil, fmt.Errorf("this daemon has no store, so it runs no apps")
 	}
+	lane := d.appLane(name)
+	lane.Lock()
+	defer lane.Unlock()
 
 	plan, err := d.planAppCommand(name, command)
 	if err != nil {
@@ -131,6 +149,7 @@ func (d *Daemon) runAppCommand(msg *protocol.AppCommandMessage) (json.RawMessage
 	invocation := store.AppInvocation{
 		AppName:      name,
 		VersionID:    plan.versionID,
+		Kind:         store.AppInvocationKindCommand,
 		EventName:    appCommandEvent,
 		EventSubject: command,
 		Handler:      plan.label,
@@ -203,6 +222,13 @@ func (d *Daemon) planAppCommand(name, command string) (*appDispatchPlan, error) 
 	}
 	if version.ID == 0 {
 		return nil, fmt.Errorf("%s has no version serving, so there is no code to run; `attn app apply <path>` builds one", name)
+	}
+	claim, err := d.appReconcileClaim(name)
+	if err != nil {
+		return nil, fmt.Errorf("reading reconciliation owed by app %q: %w", name, err)
+	}
+	if len(claim.Requests) != 0 {
+		return nil, &appReconcileOwedError{reason: foldAppReconcileReason(version.ID, claim)}
 	}
 	declared := manifest.CommandNames()
 	if !containsString(declared, command) {

--- a/internal/daemon/app_commands.go
+++ b/internal/daemon/app_commands.go
@@ -13,14 +13,18 @@ import (
 	"github.com/victorarias/attn/internal/store"
 )
 
+// appReconcileOwedError refuses a command against collections that are
+// mid-rebuild. It carries the reason so the result can name the fence on the
+// wire, rather than leaving a caller to parse it back out of the sentence.
 type appReconcileOwedError struct {
+	app    string
 	reason appReconcileReason
 }
 
 func (e *appReconcileOwedError) Error() string {
 	return fmt.Sprintf(
-		"reconcile_owed: app collection rebuild is owed through bus seq %d (%s); commands remain refused until reconcile succeeds",
-		e.reason.ThroughSeq, strings.Join(e.reason.Causes, ", "))
+		"%s is rebuilding what it derives from the event log (owed through bus seq %d: %s), so it runs no commands until that finishes; `attn app status %s` shows the rebuild",
+		e.app, e.reason.ThroughSeq, strings.Join(e.reason.Causes, ", "), e.app)
 }
 
 // A view acting: `app_command` in, `app_command_result` back.
@@ -228,7 +232,7 @@ func (d *Daemon) planAppCommand(name, command string) (*appDispatchPlan, error) 
 		return nil, fmt.Errorf("reading reconciliation owed by app %q: %w", name, err)
 	}
 	if len(claim.Requests) != 0 {
-		return nil, &appReconcileOwedError{reason: foldAppReconcileReason(version.ID, claim)}
+		return nil, &appReconcileOwedError{app: name, reason: foldAppReconcileReason(version.ID, claim)}
 	}
 	declared := manifest.CommandNames()
 	if !containsString(declared, command) {

--- a/internal/daemon/app_consumers.go
+++ b/internal/daemon/app_consumers.go
@@ -1154,7 +1154,7 @@ func (d *Daemon) noteAppReconcileFailure(name string, claim store.AppReconcileCl
 			name, claim.ThroughRequestID, stalled.Round(time.Second), attempts, firstLine(message)),
 		fmt.Sprintf(
 			"%s failed to reconcile through bus seq %d for %s across %d attempts, so attn disabled it. The rebuild remains owed. Fix the reconcile handler and `attn app enable %s`; `attn app status %s` shows the failure and fence.",
-			name, claim.ThroughSeq, stalled.Round(time.Minute), attempts, name, name))
+			name, claim.ThroughSeq, stalled.Round(time.Second), attempts, name, name))
 }
 
 func (d *Daemon) noteAppStall(name, kind string, key int64, eventName string, reconcileRequestID int64, message string) (time.Duration, int, bool) {
@@ -1252,7 +1252,7 @@ func (d *Daemon) autoDisableApp(name string, ev bus.Event, stalled time.Duration
 			name, ev.Name, ev.Seq, stalled.Round(time.Second), attempts, firstLine(message)),
 		fmt.Sprintf(
 			"%s failed on the same event (%s, seq %d) for %s across %d attempts, so attn disabled it — a stalled app holds the event log open for every other consumer. Fix the handler and `attn app enable %s`; `attn app status %s` shows the failures.",
-			name, ev.Name, ev.Seq, stalled.Round(time.Minute), attempts, name, name))
+			name, ev.Name, ev.Seq, stalled.Round(time.Second), attempts, name, name))
 }
 
 // disableAppAutomatically flips the app off, says so on the bus, and tells the

--- a/internal/daemon/app_consumers.go
+++ b/internal/daemon/app_consumers.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/victorarias/attn/internal/appbuild"
@@ -13,6 +15,7 @@ import (
 	"github.com/victorarias/attn/internal/bus"
 	"github.com/victorarias/attn/internal/docstore"
 	"github.com/victorarias/attn/internal/jobs"
+	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/store"
 	"github.com/victorarias/attn/internal/supervise"
 )
@@ -80,6 +83,58 @@ func (d *Daemon) appConnectWait() time.Duration {
 // ask the user to intervene. Its installed lane remains retained while disabled.
 const appAutoDisableStall = 15 * time.Minute
 
+// The three app-runtime tripwires, overridable from the daemon's environment.
+// Each one is minutes long by design, so the only way to witness what it does —
+// in a test harness or by hand — is to move it; without these the auto-disable
+// path can be demonstrated only by waiting fifteen minutes.
+const (
+	appAutoDisableStallEnv = "ATTN_APP_AUTO_DISABLE_STALL"
+	appDispatchTimeoutEnv  = "ATTN_APP_DISPATCH_TIMEOUT"
+	appPingTimeoutEnv      = "ATTN_APP_RUNTIME_PING_TIMEOUT"
+)
+
+// What kind of work an app is stalled on, and what state its rebuild is in. Both
+// vocabularies cross the wire, so they are named once here.
+const (
+	appStallKindSubscription = "subscription"
+	appStallKindReconcile    = "reconcile"
+
+	appReconcileStateNotNeeded   = "not_needed"
+	appReconcileStateUnsupported = "unsupported"
+	appReconcileStateIdle        = "idle"
+	appReconcileStateOwed        = "owed"
+	appReconcileStateRunning     = "running"
+)
+
+func (d *Daemon) appAutoDisableWindow() time.Duration {
+	if d.appAutoDisableWait > 0 {
+		return d.appAutoDisableWait
+	}
+	return appAutoDisableStall
+}
+
+func (d *Daemon) resolveAppRuntimeTripwires() error {
+	for _, setting := range []struct {
+		name   string
+		target *time.Duration
+	}{
+		{appAutoDisableStallEnv, &d.appAutoDisableWait},
+		{appDispatchTimeoutEnv, &d.appDispatchWait},
+		{appPingTimeoutEnv, &d.appPingWait},
+	} {
+		raw := strings.TrimSpace(os.Getenv(setting.name))
+		if raw == "" {
+			continue
+		}
+		value, err := time.ParseDuration(raw)
+		if err != nil || value <= 0 {
+			return fmt.Errorf("%s=%q is not a positive duration", setting.name, raw)
+		}
+		*setting.target = value
+	}
+	return nil
+}
+
 // appCrashStrikes is the second half of the auto-disable rule: an app the
 // runtime host named as the cause of a sidecar crash this many times inside
 // appCrashWindow is disabled.
@@ -115,11 +170,13 @@ const notificationKindAppAutoDisabled = "app_auto_disabled"
 // against a runtime that has also just restarted, which is the generous reading
 // and the right one.
 type appStall struct {
-	seq       int64
-	eventName string
-	since     time.Time
-	attempts  int
-	lastError string
+	kind               string
+	seq                int64
+	eventName          string
+	reconcileRequestID int64
+	since              time.Time
+	attempts           int
+	lastError          string
 }
 
 // appDispatchPlan is everything one delivery needs, read once per event.
@@ -136,6 +193,18 @@ type appDispatchPlan struct {
 	handler     string
 	label       string
 	collections []string
+}
+
+func (d *Daemon) appLane(name string) *sync.Mutex {
+	d.appLaneMu.Lock()
+	defer d.appLaneMu.Unlock()
+	if d.appLanes == nil {
+		d.appLanes = make(map[string]*sync.Mutex)
+	}
+	if d.appLanes[name] == nil {
+		d.appLanes[name] = &sync.Mutex{}
+	}
+	return d.appLanes[name]
 }
 
 // ---------------------------------------------------------------------------
@@ -194,6 +263,10 @@ func (d *Daemon) registerAppConsumer(name string) error {
 
 func (d *Daemon) appPreDrain(name string) bus.PreDrain {
 	return func(ctx context.Context, consumer bus.Consumer, gap *bus.Gap) error {
+		lane := d.appLane(name)
+		lane.Lock()
+		defer lane.Unlock()
+
 		manifest, version, err := d.appDeclaration(name)
 		if err != nil {
 			return err
@@ -220,7 +293,7 @@ func (d *Daemon) appPreDrain(name string) bus.PreDrain {
 				return fmt.Errorf("recording the gap reconciliation for app %q: %w", name, err)
 			}
 		}
-		claim, err := d.store.AppReconcilePending(name)
+		claim, err := d.appReconcileClaim(name)
 		if err != nil {
 			return fmt.Errorf("reading reconciliation owed by app %q: %w", name, err)
 		}
@@ -228,10 +301,41 @@ func (d *Daemon) appPreDrain(name string) bus.PreDrain {
 			return nil
 		}
 		if !manifest.Reconcile {
-			return fmt.Errorf("app %q reconciliation is owed through bus seq %d, but version %d does not declare reconcile", name, claim.ThroughSeq, version.ID)
+			return d.disableAppMissingReconcile(name, version, claim)
 		}
 		return d.runAppReconcile(ctx, name, manifest, version, claim)
 	}
+}
+
+func (d *Daemon) disableAppMissingReconcile(name string, version store.AppVersion, claim store.AppReconcileClaim) error {
+	reason := foldAppReconcileReason(version.ID, claim)
+	reasonJSON, err := json.Marshal(reason)
+	if err != nil {
+		return err
+	}
+	failure := fmt.Sprintf(
+		"app %s reconciliation is owed through bus seq %d, but subscribed version %d does not declare reconcile",
+		name, claim.ThroughSeq, version.ID)
+	latest, found, readErr := d.store.LatestOwedAppReconcileInvocation(name)
+	if readErr != nil {
+		return readErr
+	}
+	if !found || latest.ThroughRequestID != claim.ThroughRequestID || latest.Handler != "missing_reconcile" {
+		now := d.appNow()
+		d.recordAppInvocation(store.AppInvocation{
+			AppName: name, VersionID: version.ID, Kind: store.AppInvocationKindReconcile,
+			Handler: "missing_reconcile", Status: store.AppInvocationStatusError,
+			Error: failure, StartedAt: now, FinishedAt: now,
+			ReconcileReason: string(reasonJSON), ThroughRequestID: claim.ThroughRequestID,
+			ThroughSeq: claim.ThroughSeq,
+		})
+	}
+	d.disableAppAutomatically(name, failure,
+		fmt.Sprintf("apps: disabled %s — %s", name, failure),
+		fmt.Sprintf(
+			"%s reached a reconcile fence, but version %d has no reconcile handler, so attn disabled it without moving its cursor. Add `reconcile = true`, implement the reconcile export, apply that version, and enable the app again.",
+			name, version.ID))
+	return errors.New(failure)
 }
 
 func (d *Daemon) runAppReconcile(ctx context.Context, name string, manifest appbuild.Manifest, version store.AppVersion, claim store.AppReconcileClaim) error {
@@ -247,14 +351,129 @@ func (d *Daemon) runAppReconcile(ctx context.Context, name string, manifest appb
 	}
 
 	reason := foldAppReconcileReason(version.ID, claim)
-	result, err := d.dispatchAppReconcile(ctx, plan, reason)
+	reasonJSON, err := json.Marshal(reason)
+	if err != nil {
+		return fmt.Errorf("encoding reconciliation owed by app %q: %w", name, err)
+	}
+	started := d.appNow()
+	invocation := store.AppInvocation{
+		AppName: name, VersionID: version.ID, Kind: store.AppInvocationKindReconcile,
+		Handler: "reconcile", Status: store.AppInvocationStatusRunning,
+		StartedAt: started, ReconcileReason: string(reasonJSON),
+		ThroughRequestID: claim.ThroughRequestID, ThroughSeq: claim.ThroughSeq,
+	}
+	invocationID, err := d.startAppInvocation(invocation)
 	if err != nil {
 		return err
 	}
-	if !result.OK {
-		return fmt.Errorf("app %s reconcile threw: %s", name, firstLine(result.Error))
+	invocation.ID = invocationID
+	result, err := d.dispatchAppReconcile(ctx, plan, reason)
+	if ctx.Err() != nil {
+		if settleErr := d.settleAppInvocation(&invocation, store.AppInvocationStatusInterrupted, ""); settleErr != nil {
+			return errors.Join(ctx.Err(), settleErr)
+		}
+		return ctx.Err()
 	}
-	return d.store.CompleteAppReconcile(name, claim.ThroughRequestID, claim.ThroughSeq, d.appNow())
+	if err != nil {
+		status := store.AppInvocationStatusRuntimeError
+		failure := err.Error()
+		if errors.Is(err, context.DeadlineExceeded) {
+			status = store.AppInvocationStatusError
+			failure = fmt.Sprintf("reconcile for app %s did not return within timeout=%s; attn terminated sidecar generation and left request %d owed",
+				name, d.appDispatchBudget(), claim.ThroughRequestID)
+		}
+		if settleErr := d.settleAppInvocation(&invocation, status, failure); settleErr != nil {
+			return errors.Join(err, settleErr)
+		}
+		if status == store.AppInvocationStatusError {
+			d.noteAppReconcileFailure(name, claim, failure)
+		} else {
+			d.clearAppStall(name)
+		}
+		return errors.New(failure)
+	}
+	if !result.OK {
+		failure := result.Error
+		if settleErr := d.settleAppInvocation(&invocation, store.AppInvocationStatusError, failure); settleErr != nil {
+			return settleErr
+		}
+		d.noteAppReconcileFailure(name, claim, failure)
+		return fmt.Errorf("app %s reconcile threw: %s", name, firstLine(failure))
+	}
+	finished := d.appNow()
+	if err := d.store.CompleteAppReconcileInvocation(
+		name, invocationID, claim.ThroughRequestID, claim.ThroughSeq, finished,
+	); err != nil {
+		return fmt.Errorf("completing reconciliation of app %q: %w", name, err)
+	}
+	invocation.Status = store.AppInvocationStatusOK
+	invocation.FinishedAt = finished
+	invocation.Duration = finished.Sub(started)
+	d.notifyAppWatchers(appInvocationForWire(invocation.ID, invocation), name)
+	d.clearAppStall(name)
+	return nil
+}
+
+func (d *Daemon) appReconcileClaim(name string) (store.AppReconcileClaim, error) {
+	previous, ok, err := d.store.LatestOwedAppReconcileInvocation(name)
+	if err != nil {
+		return store.AppReconcileClaim{}, err
+	}
+	if ok && previous.ThroughRequestID > 0 {
+		claim, err := d.store.AppReconcilePendingThrough(name, previous.ThroughRequestID)
+		if err != nil || len(claim.Requests) != 0 {
+			return claim, err
+		}
+	}
+	return d.store.AppReconcilePending(name)
+}
+
+// appReconcileStatusForWire answers "does this app owe a rebuild, and can it run
+// one?" — the two questions an operator has. It reports only what is durable: a
+// running attempt is the row a previous daemon left behind or this one wrote, so
+// status after a restart reads the same before and after startup repair.
+func (d *Daemon) appReconcileStatusForWire(name string) (protocol.AppReconcileStatus, error) {
+	manifest, version, err := d.appDeclaration(name)
+	if err != nil {
+		return protocol.AppReconcileStatus{}, err
+	}
+	if version.ID == 0 || len(manifest.EventPatterns()) == 0 {
+		return protocol.AppReconcileStatus{State: appReconcileStateNotNeeded}, nil
+	}
+	claim, err := d.appReconcileClaim(name)
+	if err != nil {
+		return protocol.AppReconcileStatus{}, err
+	}
+	status := protocol.AppReconcileStatus{State: appReconcileStateIdle}
+	if !manifest.Reconcile {
+		status.State = appReconcileStateUnsupported
+	}
+	if len(claim.Requests) == 0 {
+		return status, nil
+	}
+	if manifest.Reconcile {
+		status.State = appReconcileStateOwed
+	}
+	status.Reason = appReconcileReasonForWire(foldAppReconcileReason(version.ID, claim))
+	attempt, ok, err := d.store.LatestOwedAppReconcileInvocation(name)
+	if err != nil {
+		return protocol.AppReconcileStatus{}, err
+	}
+	if !ok {
+		return status, nil
+	}
+	if attempt.Status == store.AppInvocationStatusRunning {
+		if manifest.Reconcile {
+			status.State = appReconcileStateRunning
+		}
+		info := appInvocationForWire(attempt.ID, attempt)
+		status.CurrentAttempt = &info
+		return status, nil
+	}
+	if attempt.Error != "" {
+		status.LastError = protocol.Ptr(attempt.Error)
+	}
+	return status, nil
 }
 
 func foldAppReconcileReason(versionID int64, claim store.AppReconcileClaim) appReconcileReason {
@@ -434,6 +653,18 @@ func (d *Daemon) appEventHandler(name string) bus.Handler {
 // redeliver it with backoff — never skip it. That is true for both failure
 // classes; what differs is what gets recorded and whether the stall clock moves.
 func (d *Daemon) deliverAppEvent(ctx context.Context, name string, ev bus.Event) error {
+	lane := d.appLane(name)
+	lane.Lock()
+	defer lane.Unlock()
+
+	claim, err := d.store.AppReconcilePending(name)
+	if err != nil {
+		return fmt.Errorf("reading reconciliation owed by app %q: %w", name, err)
+	}
+	if len(claim.Requests) != 0 {
+		return fmt.Errorf("app %q reconciliation is owed through bus seq %d; facts remain fenced until it succeeds", name, claim.ThroughSeq)
+	}
+
 	plan, err := d.planAppDispatch(name, ev)
 	if err != nil {
 		return err
@@ -458,6 +689,7 @@ func (d *Daemon) deliverAppEvent(ctx context.Context, name string, ev bus.Event)
 	invocation := store.AppInvocation{
 		AppName:      name,
 		VersionID:    plan.versionID,
+		Kind:         store.AppInvocationKindSubscription,
 		EventSeq:     ev.Seq,
 		EventName:    ev.Name,
 		EventSubject: ev.Subject,
@@ -673,6 +905,17 @@ func (d *Daemon) attributeWedgedDispatch(ctx context.Context, runtime *appRuntim
 	d.logf("apps: %s hit the dispatch timeout; the app runtime %s a liveness ping after %s",
 		name, pingOutcome(err), d.appNow().Sub(asked).Round(time.Microsecond))
 
+	// A timeout has to interrupt the work, not merely stop waiting for it: a
+	// handler that never yields cannot be cancelled from Go, and leaving it on the
+	// shared loop starves every sibling app. The generation is fenced, so a stale
+	// waiter can never kill the replacement that has already taken over.
+	terminated, terminateErr := d.ensureAppRuntimeSupervisor().TerminateGeneration(appRuntimeChildName, runtime.generation)
+	if terminateErr != nil {
+		d.logf("apps: terminating timed-out app runtime generation %d: %v", runtime.generation, terminateErr)
+	} else if terminated {
+		d.logf("apps: terminated timed-out app runtime generation %d; the supervisor will start its replacement", runtime.generation)
+	}
+
 	if err == nil {
 		// The loop is turning, so nothing is holding it: this app's own handler is
 		// what did not return. The ledger is left alone — an answered ping says
@@ -828,6 +1071,51 @@ func (d *Daemon) recordAppInvocation(invocation store.AppInvocation) {
 	d.notifyAppWatchers(appInvocationForWire(id, invocation), invocation.AppName)
 }
 
+func (d *Daemon) startAppInvocation(invocation store.AppInvocation) (int64, error) {
+	if d.store == nil {
+		return 0, errors.New("apps: cannot start an invocation without a store")
+	}
+	id, err := d.store.StartAppInvocation(invocation)
+	if err != nil {
+		return 0, fmt.Errorf("starting %s invocation of app %s: %w", invocation.Kind, invocation.AppName, err)
+	}
+	invocation.ID = id
+	invocation.Status = store.AppInvocationStatusRunning
+	d.notifyAppWatchers(appInvocationForWire(id, invocation), invocation.AppName)
+	return id, nil
+}
+
+func (d *Daemon) repairInterruptedAppInvocations() error {
+	if d.store == nil {
+		return nil
+	}
+	interrupted, err := d.store.InterruptRunningAppInvocations(d.appNow())
+	if err != nil {
+		return fmt.Errorf("repair interrupted app invocations: %w", err)
+	}
+	if interrupted > 0 {
+		d.logf("apps: marked %d invocation(s) interrupted during startup repair", interrupted)
+	}
+	return nil
+}
+
+func (d *Daemon) settleAppInvocation(invocation *store.AppInvocation, status, failure string) error {
+	finished := d.appNow()
+	settled, err := d.store.SettleAppInvocation(invocation.ID, status, failure, finished)
+	if err != nil {
+		return fmt.Errorf("settling invocation %d of app %s: %w", invocation.ID, invocation.AppName, err)
+	}
+	if !settled {
+		return fmt.Errorf("settling invocation %d of app %s: it is no longer running", invocation.ID, invocation.AppName)
+	}
+	invocation.Status = status
+	invocation.Error = failure
+	invocation.FinishedAt = finished
+	invocation.Duration = finished.Sub(invocation.StartedAt)
+	d.notifyAppWatchers(appInvocationForWire(invocation.ID, *invocation), invocation.AppName)
+	return nil
+}
+
 // firstLine trims a stack trace down to its message, for a log line and a bus
 // error that already have the whole text recorded beside them.
 func firstLine(s string) string {
@@ -848,15 +1136,39 @@ func firstLine(s string) string {
 // time is not stuck, it is unreliable, and unreliable does not pin the retention
 // floor. Only the same seq failing over and over does.
 func (d *Daemon) noteAppFailure(name string, ev bus.Event, message string) {
-	now := d.appNow()
+	stalled, attempts, disable := d.noteAppStall(name, appStallKindSubscription, ev.Seq, ev.Name, 0, message)
+	if !disable {
+		return
+	}
+	d.autoDisableApp(name, ev, stalled, attempts, message)
+}
 
+func (d *Daemon) noteAppReconcileFailure(name string, claim store.AppReconcileClaim, message string) {
+	stalled, attempts, disable := d.noteAppStall(
+		name, appStallKindReconcile, claim.ThroughRequestID, "", claim.ThroughRequestID, message)
+	if !disable {
+		return
+	}
+	d.disableAppAutomatically(name, message,
+		fmt.Sprintf("apps: disabled %s — reconcile request %d stalled for %s across %d attempts: %s",
+			name, claim.ThroughRequestID, stalled.Round(time.Second), attempts, firstLine(message)),
+		fmt.Sprintf(
+			"%s failed to reconcile through bus seq %d for %s across %d attempts, so attn disabled it. The rebuild remains owed. Fix the reconcile handler and `attn app enable %s`; `attn app status %s` shows the failure and fence.",
+			name, claim.ThroughSeq, stalled.Round(time.Minute), attempts, name, name))
+}
+
+func (d *Daemon) noteAppStall(name, kind string, key int64, eventName string, reconcileRequestID int64, message string) (time.Duration, int, bool) {
+	now := d.appNow()
 	d.appStallMu.Lock()
 	if d.appStalls == nil {
 		d.appStalls = make(map[string]*appStall)
 	}
 	stall := d.appStalls[name]
-	if stall == nil || stall.seq != ev.Seq {
-		stall = &appStall{seq: ev.Seq, eventName: ev.Name, since: now}
+	if stall == nil || stall.kind != kind || stall.seq != key {
+		stall = &appStall{
+			kind: kind, seq: key, eventName: eventName,
+			reconcileRequestID: reconcileRequestID, since: now,
+		}
 		d.appStalls[name] = stall
 	}
 	stall.attempts++
@@ -864,11 +1176,7 @@ func (d *Daemon) noteAppFailure(name string, ev bus.Event, message string) {
 	stalled := now.Sub(stall.since)
 	attempts := stall.attempts
 	d.appStallMu.Unlock()
-
-	if stalled < appAutoDisableStall {
-		return
-	}
-	d.autoDisableApp(name, ev, stalled, attempts, message)
+	return stalled, attempts, stalled >= d.appAutoDisableWindow()
 }
 
 func (d *Daemon) clearAppStall(name string) {

--- a/internal/daemon/app_reconcile_failure_test.go
+++ b/internal/daemon/app_reconcile_failure_test.go
@@ -1,0 +1,293 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/appbuild"
+	"github.com/victorarias/attn/internal/apps"
+	"github.com/victorarias/attn/internal/bus"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// What happens when a rebuild does not succeed: the attempt is visible while it
+// runs, it survives a daemon that dies mid-flight, the request stays owed
+// through every failure, and attn eventually stops trying and says so.
+//
+// See docs/plans/2026-08-14-ext-app-reconcile-handler.md, gates 4 and 7.
+
+// reconcilingApp installs a subscribed app that declares reconcile, and puts one
+// version_changed request in front of it by applying a second version.
+func reconcilingApp(t *testing.T, d *Daemon, name string) store.AppVersion {
+	t.Helper()
+	installApp(t, d, name, subscribing("ticket.*"))
+	second := subscribing("ticket.*")
+	second.Description = "the version that owes a rebuild"
+	return installApp(t, d, name, second)
+}
+
+func appReconcilePreDrain(t *testing.T, d *Daemon, name string) error {
+	t.Helper()
+	return d.appPreDrain(name)(context.Background(), bus.Consumer{Name: apps.ConsumerName(name)}, nil)
+}
+
+// A running attempt is durable, so `attn app status` can report a rebuild in
+// flight without inferring one from a daemon's memory — and a daemon that dies
+// mid-rebuild leaves a row the next startup closes rather than an attempt that
+// looks live forever.
+func TestAReconcileInterruptedByARestartIsRepairedAndStaysOwed(t *testing.T) {
+	d := newAppDaemon(t)
+	version := reconcilingApp(t, d, "greeter")
+
+	claim, err := d.store.AppReconcilePending("greeter")
+	if err != nil || len(claim.Requests) != 1 {
+		t.Fatalf("claim = %+v, %v", claim, err)
+	}
+	if _, err := d.store.StartAppInvocation(store.AppInvocation{
+		AppName: "greeter", VersionID: version.ID, Kind: store.AppInvocationKindReconcile,
+		Handler: "reconcile", Status: store.AppInvocationStatusRunning, StartedAt: d.appNow(),
+		ReconcileReason:  `{"causes":["version_changed"]}`,
+		ThroughRequestID: claim.ThroughRequestID, ThroughSeq: claim.ThroughSeq,
+	}); err != nil {
+		t.Fatalf("start the attempt a dying daemon leaves behind: %v", err)
+	}
+
+	running := appStatus(t, d, "greeter").AppStatusResult.Reconcile
+	if running.State != appReconcileStateRunning || running.CurrentAttempt == nil {
+		t.Fatalf("status while an attempt runs = %+v", running)
+	}
+	if running.CurrentAttempt.DurationMs != nil {
+		t.Fatalf("a running attempt reported a duration: %+v", running.CurrentAttempt)
+	}
+
+	if err := d.repairInterruptedAppInvocations(); err != nil {
+		t.Fatalf("startup repair: %v", err)
+	}
+
+	repaired, ok, err := d.store.LatestOwedAppReconcileInvocation("greeter")
+	if err != nil || !ok || repaired.Status != store.AppInvocationStatusInterrupted {
+		t.Fatalf("repaired attempt = %+v ok=%t err=%v", repaired, ok, err)
+	}
+	after, err := d.store.AppReconcilePending("greeter")
+	if err != nil || after.ThroughRequestID != claim.ThroughRequestID || len(after.Requests) != 1 {
+		t.Fatalf("interruption moved the request: %+v, %v", after, err)
+	}
+	status := appStatus(t, d, "greeter").AppStatusResult.Reconcile
+	if status.State != appReconcileStateOwed || status.CurrentAttempt != nil {
+		t.Fatalf("status after repair = %+v", status)
+	}
+	if status.Reason == nil || status.Reason.ThroughSeq != int(claim.ThroughSeq) {
+		t.Fatalf("status after repair carries no fence: %+v", status.Reason)
+	}
+}
+
+// Interruption is not the app's fault, so it must not move the app closer to
+// being disabled — the stall clock belongs to failures the app caused.
+func TestAnInterruptedAttemptDoesNotAdvanceTheStallClock(t *testing.T) {
+	d := newAppDaemon(t)
+	version := reconcilingApp(t, d, "greeter")
+	claim, err := d.store.AppReconcilePending("greeter")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.store.StartAppInvocation(store.AppInvocation{
+		AppName: "greeter", VersionID: version.ID, Kind: store.AppInvocationKindReconcile,
+		Handler: "reconcile", StartedAt: d.appNow(), ReconcileReason: `{}`,
+		ThroughRequestID: claim.ThroughRequestID, ThroughSeq: claim.ThroughSeq,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.repairInterruptedAppInvocations(); err != nil {
+		t.Fatal(err)
+	}
+	if stall, ok := d.appStallSnapshot("greeter"); ok {
+		t.Fatalf("an interrupted attempt put the app on the auto-disable clock: %+v", stall)
+	}
+}
+
+// A rebuild that keeps throwing keeps the request owed, keeps every attempt in
+// the log, and after the stall window attn stops trying: the app is disabled and
+// a durable notification says so, with the fence and the way back.
+func TestAReconcileThatKeepsThrowingDisablesTheAppAndSaysSo(t *testing.T) {
+	d := newAppDaemon(t)
+	clock := newAppTestClock(d)
+	reconcilingApp(t, d, "greeter")
+	runtime := startFakeAppRuntime(t, d, nil)
+	runtime.reconcile = func(*fakeAppRuntime, appReconcileRequest) error {
+		return errors.New("TypeError: snapshot.sessions is not iterable")
+	}
+	claim, err := d.store.AppReconcilePending("greeter")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 4; i++ {
+		if err := appReconcilePreDrain(t, d, "greeter"); err == nil {
+			t.Fatal("a throwing reconcile reported success")
+		}
+		clock.advance(3 * time.Minute)
+		if !appEnabled(t, d, "greeter") {
+			t.Fatalf("greeter was disabled after %d attempt(s) inside the window", i+1)
+		}
+	}
+	status := appStatus(t, d, "greeter").AppStatusResult
+	if status.Stall == nil || status.Stall.Kind != appStallKindReconcile ||
+		protocol.Deref(status.Stall.ThroughRequestID) != int(claim.ThroughRequestID) {
+		t.Fatalf("stall = %+v, want the reconcile claim", status.Stall)
+	}
+	if status.Reconcile.LastError == nil || !strings.Contains(*status.Reconcile.LastError, "TypeError") {
+		t.Fatalf("status does not carry the last failure: %+v", status.Reconcile)
+	}
+
+	clock.advance(4 * time.Minute)
+	if err := appReconcilePreDrain(t, d, "greeter"); err == nil {
+		t.Fatal("a throwing reconcile reported success")
+	}
+
+	if appEnabled(t, d, "greeter") {
+		t.Fatal("greeter is still enabled after 15 minutes owing the same rebuild")
+	}
+	notes := appNotifications(t, d, notificationKindAppAutoDisabled)
+	if len(notes) != 1 {
+		t.Fatalf("auto-disable notifications = %d, want 1", len(notes))
+	}
+	if !strings.Contains(notes[0].Body, "attn app enable greeter") ||
+		!strings.Contains(notes[0].Body, "remains owed") {
+		t.Fatalf("the notification does not say what is owed or how to get back: %q", notes[0].Body)
+	}
+	// Disabling never completes the rebuild: the whole point of keeping it owed
+	// is that enabling the app again runs it rather than resuming past it.
+	after, err := d.store.AppReconcilePending("greeter")
+	if err != nil || after.ThroughRequestID != claim.ThroughRequestID {
+		t.Fatalf("the request moved when the app was disabled: %+v, %v", after, err)
+	}
+	attempts := 0
+	for _, inv := range invocationsOf(t, d, "greeter") {
+		if inv.Kind == store.AppInvocationKindReconcile {
+			attempts++
+			if inv.Status != store.AppInvocationStatusError || inv.ThroughRequestID != claim.ThroughRequestID {
+				t.Fatalf("attempt = %+v", inv)
+			}
+		}
+	}
+	// One row per try, and at least the five this test drove — the daemon's own
+	// consumer loop may have retried the same claim alongside them.
+	if attempts < 5 {
+		t.Fatalf("recorded attempts = %d, want one per try", attempts)
+	}
+}
+
+// Commands are not bus deliveries, so nothing else would hold them behind the
+// fence. Letting one mutate the collections halfway through a rebuild is what
+// would make the fence meaningless.
+func TestACommandIsRefusedByNameWhileAReconcileIsOwed(t *testing.T) {
+	d := newAppDaemon(t)
+	manifest := subscribing("ticket.*")
+	manifest.Commands = []appbuild.Command{{Name: "refresh"}}
+	installApp(t, d, "greeter", manifest)
+	second := manifest
+	second.Description = "the version that owes a rebuild"
+	installApp(t, d, "greeter", second)
+	startFakeAppRuntime(t, d, nil)
+
+	result := newAppCommandCaller().invoke(t, d, "greeter", "refresh", "")
+	if result.Success {
+		t.Fatal("a command ran across the reconcile fence")
+	}
+	if protocol.Deref(result.ErrorCode) != protocol.ErrorCodeReconcileOwed {
+		t.Fatalf("refusal code = %q, want %q", protocol.Deref(result.ErrorCode), protocol.ErrorCodeReconcileOwed)
+	}
+	if result.Reconcile == nil || len(result.Reconcile.Causes) == 0 {
+		t.Fatalf("the refusal carries no structured reason: %+v", result.Reconcile)
+	}
+	if !strings.Contains(protocol.Deref(result.Error), "reconcile") {
+		t.Fatalf("the refusal does not read as one: %q", protocol.Deref(result.Error))
+	}
+
+	// And it is a refusal, not a failure: nothing ran, so nothing is charged.
+	if stall, ok := d.appStallSnapshot("greeter"); ok {
+		t.Fatalf("a refused command put the app on the auto-disable clock: %+v", stall)
+	}
+}
+
+// Retrying code that does not exist cannot heal, so a gap discovered under a
+// version with no reconcile handler is loud immediately rather than after
+// fifteen minutes of retries.
+func TestAGapWithNoHandlerDisablesTheAppWithoutMovingItsCursor(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "greeter", subscribingWithoutReconcile("ticket.*"))
+	seedAppConsumer(t, d, "greeter", true, 1)
+
+	gap := &bus.Gap{Cursor: 1, Earliest: 4, Head: 6, Missed: 2}
+	err := d.appPreDrain("greeter")(context.Background(),
+		bus.Consumer{Name: apps.ConsumerName("greeter")}, gap)
+	if err == nil || !strings.Contains(err.Error(), "does not declare reconcile") {
+		t.Fatalf("pre-drain error = %v", err)
+	}
+	if appEnabled(t, d, "greeter") {
+		t.Fatal("an app that cannot reconcile a gap was left enabled")
+	}
+	consumer, _, err := d.store.GetBusConsumer(apps.ConsumerName("greeter"))
+	if err != nil || consumer.Cursor != 1 {
+		t.Fatalf("cursor = %d, %v; a gap it cannot rebuild must not move it", consumer.Cursor, err)
+	}
+	notes := appNotifications(t, d, notificationKindAppAutoDisabled)
+	if len(notes) != 1 || !strings.Contains(notes[0].Body, "reconcile") {
+		t.Fatalf("notifications = %+v", notes)
+	}
+	var missing []store.AppInvocation
+	for _, inv := range invocationsOf(t, d, "greeter") {
+		if inv.Handler == "missing_reconcile" {
+			missing = append(missing, inv)
+		}
+	}
+	if len(missing) != 1 || missing[0].Kind != store.AppInvocationKindReconcile {
+		t.Fatalf("missing_reconcile invocations = %+v, want exactly one", missing)
+	}
+
+	// Status names the state rather than leaving a reader to infer it from a
+	// disabled app that owes something.
+	status := appStatus(t, d, "greeter").AppStatusResult.Reconcile
+	if status.State != appReconcileStateUnsupported || status.Reason == nil {
+		t.Fatalf("status = %+v", status)
+	}
+}
+
+// A version move under a handler-less subscribed version is refused before the
+// pointer moves: installing a version attn already knows it cannot serve safely
+// would be choosing the broken state on purpose.
+func TestAVersionMoveIsRefusedWhenTheSubscribedVersionCannotReconcile(t *testing.T) {
+	d := appApplyDaemon(t)
+	legacy := `{"name":"greeter","attn_app_api":1,"entrypoint":"src/index.ts","subscribe":[{"events":["ticket.*"]}]}`
+	firstHash := stageArtifact(t, d, "greeter", legacy, "export default {}")
+	if resp := appApply(t, d, "greeter", firstHash, legacy); !resp.Ok {
+		t.Fatalf("first apply: %v", protocol.Deref(resp.Error))
+	}
+	first, _, err := d.store.GetApp("greeter")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	secondHash := stageArtifact(t, d, "greeter", legacy, "export default {} // edited")
+	resp := appApply(t, d, "greeter", secondHash, legacy)
+	if resp.Ok {
+		t.Fatal("a subscribed version with no reconcile handler was applied over an existing one")
+	}
+	message := protocol.Deref(resp.Error)
+	for _, want := range []string{"greeter", "reconcile = true", "version 1"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("refusal %q does not contain %q", message, want)
+		}
+	}
+	app, _, err := d.store.GetApp("greeter")
+	if err != nil || app.CurrentVersionID != first.CurrentVersionID {
+		t.Fatalf("the pointer moved despite the refusal: %+v, %v", app, err)
+	}
+	if claim, err := d.store.AppReconcilePending("greeter"); err != nil || len(claim.Requests) != 0 {
+		t.Fatalf("a refused move left a request behind: %+v, %v", claim, err)
+	}
+}

--- a/internal/daemon/app_reconcile_failure_test.go
+++ b/internal/daemon/app_reconcile_failure_test.go
@@ -192,7 +192,13 @@ func TestACommandIsRefusedByNameWhileAReconcileIsOwed(t *testing.T) {
 	second := manifest
 	second.Description = "the version that owes a rebuild"
 	installApp(t, d, "greeter", second)
-	startFakeAppRuntime(t, d, nil)
+	// The app's own consumer loop is running and would otherwise clear the fence
+	// out from under this test; a rebuild that cannot succeed keeps it owed for
+	// as long as the assertions need it.
+	runtime := startFakeAppRuntime(t, d, nil)
+	runtime.reconcile = func(*fakeAppRuntime, appReconcileRequest) error {
+		return errors.New("this rebuild never succeeds")
+	}
 
 	result := newAppCommandCaller().invoke(t, d, "greeter", "refresh", "")
 	if result.Success {
@@ -209,8 +215,10 @@ func TestACommandIsRefusedByNameWhileAReconcileIsOwed(t *testing.T) {
 		t.Fatalf("the refusal does not name the app and what it is doing: %q", refusal)
 	}
 
-	// And it is a refusal, not a failure: nothing ran, so nothing is charged.
-	if stall, ok := d.appStallSnapshot("greeter"); ok {
+	// And it is a refusal, not a failure: nothing ran, so nothing is charged to
+	// the app. The rebuild failing in the background is charged — that is the
+	// clock working — and a command must never add to it.
+	if stall, ok := d.appStallSnapshot("greeter"); ok && stall.kind != appStallKindReconcile {
 		t.Fatalf("a refused command put the app on the auto-disable clock: %+v", stall)
 	}
 }

--- a/internal/daemon/app_reconcile_failure_test.go
+++ b/internal/daemon/app_reconcile_failure_test.go
@@ -204,8 +204,9 @@ func TestACommandIsRefusedByNameWhileAReconcileIsOwed(t *testing.T) {
 	if result.Reconcile == nil || len(result.Reconcile.Causes) == 0 {
 		t.Fatalf("the refusal carries no structured reason: %+v", result.Reconcile)
 	}
-	if !strings.Contains(protocol.Deref(result.Error), "reconcile") {
-		t.Fatalf("the refusal does not read as one: %q", protocol.Deref(result.Error))
+	refusal := protocol.Deref(result.Error)
+	if !strings.Contains(refusal, "greeter") || !strings.Contains(refusal, "rebuilding") {
+		t.Fatalf("the refusal does not name the app and what it is doing: %q", refusal)
 	}
 
 	// And it is a refusal, not a failure: nothing ran, so nothing is charged.

--- a/internal/daemon/app_runtime_ipc.go
+++ b/internal/daemon/app_runtime_ipc.go
@@ -307,28 +307,89 @@ func (d *Daemon) handleAppWatch(conn net.Conn, msg *protocol.AppWatchMessage) {
 // appInvocationForWire renders a recorded invocation, so the streamed shape and
 // the one `attn app status` returns cannot drift.
 func appInvocationForWire(id int64, inv store.AppInvocation) protocol.AppInvocationInfo {
-	return protocol.AppInvocationInfo{
-		ID:           int(id),
-		VersionID:    int(inv.VersionID),
-		EventSeq:     int(inv.EventSeq),
-		EventName:    inv.EventName,
-		EventSubject: inv.EventSubject,
-		Handler:      inv.Handler,
-		Status:       inv.Status,
-		Error:        inv.Error,
-		DurationMs:   int(inv.Duration.Milliseconds()),
-		StartedAt:    stampForWire(inv.StartedAt),
+	info := protocol.AppInvocationInfo{
+		ID:        int(id),
+		VersionID: int(inv.VersionID),
+		Kind:      inv.Kind,
+		Handler:   inv.Handler,
+		Status:    inv.Status,
+		StartedAt: stampForWire(inv.StartedAt),
 	}
+	if info.Kind == "" {
+		info.Kind = store.AppInvocationKindSubscription
+	}
+	// Fact identity belongs to a subscription. A command, a view crash, and a
+	// reconcile all borrowed the event columns before this kind existed; a reader
+	// that sees them filled in for those kinds cannot tell a real seq from a
+	// placeholder.
+	if info.Kind == store.AppInvocationKindSubscription {
+		info.EventSeq = protocol.Ptr(int(inv.EventSeq))
+		info.EventName = protocol.Ptr(inv.EventName)
+		info.EventSubject = protocol.Ptr(inv.EventSubject)
+	} else if inv.EventName != "" {
+		info.EventName = protocol.Ptr(inv.EventName)
+		if inv.EventSubject != "" {
+			info.EventSubject = protocol.Ptr(inv.EventSubject)
+		}
+	}
+	if inv.Error != "" {
+		info.Error = protocol.Ptr(inv.Error)
+	}
+	if inv.Status != store.AppInvocationStatusRunning {
+		info.DurationMs = protocol.Ptr(int(inv.Duration.Milliseconds()))
+	}
+	if !inv.FinishedAt.IsZero() {
+		info.FinishedAt = protocol.Ptr(stampForWire(inv.FinishedAt))
+	}
+	if inv.ThroughRequestID > 0 {
+		info.ThroughRequestID = protocol.Ptr(int(inv.ThroughRequestID))
+	}
+	if inv.ReconcileReason != "" {
+		var reason appReconcileReason
+		if err := json.Unmarshal([]byte(inv.ReconcileReason), &reason); err == nil {
+			info.Reconcile = appReconcileReasonForWire(reason)
+		}
+	}
+	return info
+}
+
+func appReconcileReasonForWire(reason appReconcileReason) *protocol.AppReconcileReasonInfo {
+	info := &protocol.AppReconcileReasonInfo{
+		Causes:           append([]string{}, reason.Causes...),
+		Version:          int(reason.Version),
+		ThroughSeq:       int(reason.ThroughSeq),
+		PreviousVersions: []int{},
+	}
+	for _, version := range reason.PreviousVersions {
+		info.PreviousVersions = append(info.PreviousVersions, int(version))
+	}
+	if reason.Gap != nil {
+		info.Gap = &protocol.AppReconcileGapInfo{
+			Cursor:   int(reason.Gap.Cursor),
+			Earliest: int(reason.Gap.Earliest),
+			Missed:   int(reason.Gap.Missed),
+		}
+	}
+	return info
 }
 
 // appStallForWire renders the auto-disable clock, including when it fires.
-func appStallForWire(stall appStall) protocol.AppStallInfo {
-	return protocol.AppStallInfo{
-		EventSeq:   int(stall.seq),
-		EventName:  stall.eventName,
+func (d *Daemon) appStallForWire(stall appStall) protocol.AppStallInfo {
+	info := protocol.AppStallInfo{
+		Kind:       stall.kind,
 		Since:      stampForWire(stall.since),
 		Attempts:   stall.attempts,
 		LastError:  stall.lastError,
-		DisablesAt: stampForWire(stall.since.Add(appAutoDisableStall)),
+		DisablesAt: stampForWire(stall.since.Add(d.appAutoDisableWindow())),
 	}
+	if info.Kind == "" {
+		info.Kind = appStallKindSubscription
+	}
+	if info.Kind == appStallKindReconcile {
+		info.ThroughRequestID = protocol.Ptr(int(stall.reconcileRequestID))
+		return info
+	}
+	info.EventSeq = protocol.Ptr(int(stall.seq))
+	info.EventName = protocol.Ptr(stall.eventName)
+	return info
 }

--- a/internal/daemon/app_runtime_ipc_test.go
+++ b/internal/daemon/app_runtime_ipc_test.go
@@ -183,7 +183,7 @@ func TestAppWatchStreamsInvocationsAsTheyHappen(t *testing.T) {
 
 	select {
 	case info := <-watcher.events:
-		if info.EventSubject != "tk-2" {
+		if protocol.Deref(info.EventSubject) != "tk-2" {
 			// The auditor's invocation must not reach a watcher of greeter.
 			t.Fatalf("the stream carried %+v, want greeter's own invocation", info)
 		}
@@ -209,7 +209,7 @@ func TestASlowWatcherIsDroppedRatherThanBlockingDelivery(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		d.notifyAppWatchers(protocol.AppInvocationInfo{EventSubject: "tk-1"}, "greeter")
+		d.notifyAppWatchers(protocol.AppInvocationInfo{EventSubject: protocol.Ptr("tk-1")}, "greeter")
 	}()
 	select {
 	case <-done:
@@ -328,7 +328,8 @@ func TestAppStatusCarriesTheStallClockAndWhenItFires(t *testing.T) {
 	if stall == nil {
 		t.Fatal("a stalled app's status carried no stall")
 	}
-	if stall.EventSeq != 9 || stall.EventName != "ticket.created" || stall.Attempts != 1 {
+	if stall.Kind != appStallKindSubscription || protocol.Deref(stall.EventSeq) != 9 ||
+		protocol.Deref(stall.EventName) != "ticket.created" || stall.Attempts != 1 {
 		t.Fatalf("stall = %+v", stall)
 	}
 	if !strings.Contains(stall.LastError, "ReferenceError") {

--- a/internal/daemon/app_runtime_test.go
+++ b/internal/daemon/app_runtime_test.go
@@ -444,8 +444,30 @@ func installApp(t *testing.T, d *Daemon, name string, manifest appbuild.Manifest
 	return version
 }
 
+// subscribing is a subscribed app as this attn expects one: it derives state
+// from facts, so it declares reconcile and can therefore be moved between
+// versions. subscribingWithoutReconcile is the grandfathered shape, for the
+// tests about what attn refuses.
 func subscribing(events ...string) appbuild.Manifest {
+	m := subscribingWithoutReconcile(events...)
+	m.Reconcile = true
+	return m
+}
+
+func subscribingWithoutReconcile(events ...string) appbuild.Manifest {
 	return appbuild.Manifest{Subscribe: []appbuild.Subscribe{{Events: events}}}
+}
+
+// settleAppReconcile runs the pre-drain hook the bus runs, which is the only
+// path that clears what a version move owes. A test that applies a second
+// version and then delivers a fact has to cross that fence the same way the
+// running daemon does.
+func settleAppReconcile(t *testing.T, d *Daemon, name string) {
+	t.Helper()
+	hook := d.appPreDrain(name)
+	if err := hook(context.Background(), bus.Consumer{Name: apps.ConsumerName(name)}, nil); err != nil {
+		t.Fatalf("reconcile %s: %v", name, err)
+	}
 }
 
 func appEvent(name, subject string, seq int64) bus.Event {
@@ -869,6 +891,8 @@ func TestHotReloadStampsTheNewVersionOnTheNextDispatch(t *testing.T) {
 	if err := <-done; err != nil {
 		t.Fatalf("the in-flight delivery failed: %v", err)
 	}
+	// A version move owes a rebuild, and no fact crosses that fence until it runs.
+	settleAppReconcile(t, d, "greeter")
 	if err := d.deliverAppEvent(context.Background(), "greeter", appEvent("ticket.created", "tk-2", 2)); err != nil {
 		t.Fatalf("the second delivery failed: %v", err)
 	}

--- a/internal/daemon/app_ui.go
+++ b/internal/daemon/app_ui.go
@@ -214,6 +214,7 @@ func (d *Daemon) handleAppViewCrash(_ *wsClient, msg *protocol.AppViewCrashMessa
 	d.recordAppInvocation(store.AppInvocation{
 		AppName:      name,
 		VersionID:    version.ID,
+		Kind:         store.AppInvocationKindView,
 		EventName:    appViewCrashEvent,
 		EventSubject: strings.TrimSpace(msg.TileID),
 		Handler:      apps.ViewLabel(view),

--- a/internal/daemon/apps.go
+++ b/internal/daemon/apps.go
@@ -152,7 +152,13 @@ func (d *Daemon) handleAppStatus(conn net.Conn, msg *protocol.AppStatusMessage) 
 		recentVersions = recentVersions[:recentVersionLimit]
 	}
 
-	result := protocol.AppStatusResult{App: summary, Versions: versions, Invocations: invocations}
+	reconcile, err := d.appReconcileStatusForWire(name)
+	if err != nil {
+		d.sendError(conn, fmt.Sprintf("reading the reconcile state of app %q: %v", name, err))
+		return
+	}
+
+	result := protocol.AppStatusResult{App: summary, Versions: versions, Invocations: invocations, Reconcile: reconcile}
 	for _, version := range recentVersions {
 		result.RecentVersions = append(result.RecentVersions, protocol.AppVersionInfo{
 			ID:           int(version.ID),
@@ -193,7 +199,7 @@ func (d *Daemon) handleAppStatus(conn net.Conn, msg *protocol.AppStatusMessage) 
 		result.Runtime = &info
 	}
 	if stall, ok := d.appStallSnapshot(name); ok {
-		info := appStallForWire(stall)
+		info := d.appStallForWire(stall)
 		result.Stall = &info
 	}
 	d.sendDocResponse(conn, protocol.Response{Ok: true, AppStatusResult: &result})
@@ -220,6 +226,9 @@ func (d *Daemon) handleAppSetEnabled(conn net.Conn, msg *protocol.AppSetEnabledM
 		d.sendError(conn, "no database")
 		return
 	}
+	lane := d.appLane(name)
+	lane.Lock()
+	defer lane.Unlock()
 	if _, ok, err := d.store.GetApp(name); err != nil {
 		d.sendError(conn, fmt.Sprintf("reading app %q: %v", name, err))
 		return

--- a/internal/daemon/apps_test.go
+++ b/internal/daemon/apps_test.go
@@ -428,7 +428,7 @@ func TestAppStatusReportsHistoryAndRecentInvocations(t *testing.T) {
 	if len(result.Recent) != 2 || result.Recent[0].Status != "error" {
 		t.Fatalf("recent = %+v, want the newest first", result.Recent)
 	}
-	if result.Recent[0].VersionID != int(version.ID) || result.Recent[0].EventSeq != 11 {
+	if result.Recent[0].VersionID != int(version.ID) || protocol.Deref(result.Recent[0].EventSeq) != 11 {
 		t.Fatalf("recent[0] = %+v", result.Recent[0])
 	}
 	if result.App.Consumer == nil || result.App.Consumer.Enabled {
@@ -449,7 +449,7 @@ func TestAppStatusListsTheVersionIdsRollbackTakes(t *testing.T) {
 		version, _, err := d.store.CommitAppVersion(store.AppVersion{
 			AppName:      "approval-gate",
 			ContentHash:  fmt.Sprintf("sha256:build-%02d", i),
-			Declaration:  `{"name":"approval-gate","subscribe":[{"events":["ticket.*"]}]}`,
+			Declaration:  `{"name":"approval-gate","reconcile":true,"subscribe":[{"events":["ticket.*"]}]}`,
 			ArtifactPath: fmt.Sprintf("apps/approval-gate/%02d.js", i),
 		}, now)
 		if err != nil {
@@ -491,7 +491,7 @@ func TestAppStatusShowsWhereRollbackCanStillGo(t *testing.T) {
 		version, _, err := d.store.CommitAppVersion(store.AppVersion{
 			AppName:      "approval-gate",
 			ContentHash:  fmt.Sprintf("sha256:build-%02d", i),
-			Declaration:  `{"name":"approval-gate","subscribe":[{"events":["ticket.*"]}]}`,
+			Declaration:  `{"name":"approval-gate","reconcile":true,"subscribe":[{"events":["ticket.*"]}]}`,
 			ArtifactPath: fmt.Sprintf("apps/approval-gate/%02d.js", i),
 		}, now)
 		if err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -404,6 +404,10 @@ type Daemon struct {
 	appDispatchMu  sync.Mutex
 	appDispatches  map[string]*appDispatch
 	appDispatchSeq uint64
+	// appLanes serialize one app's handlers, commands, reconcile fence, and
+	// serving-version moves. Different apps keep running concurrently.
+	appLaneMu sync.Mutex
+	appLanes  map[string]*sync.Mutex
 	// appStalls is the auto-disable clock, one entry per app that is currently
 	// failing on an event. See appStall.
 	appStallMu sync.Mutex
@@ -434,6 +438,7 @@ type Daemon struct {
 	// appClock is the clock every app-runtime duration is measured against.
 	// Injected by tests so the fifteen-minute stall window costs no wall time.
 	appClock            func() time.Time
+	appAutoDisableWait  time.Duration
 	removePlugin        func(pluginDir, name string) error
 	pluginActionMu      sync.Mutex
 	bundledPluginMu     sync.Mutex
@@ -988,6 +993,9 @@ func NewWithGitHubClient(socketPath string, ghClient github.GitHubClient) *Daemo
 
 // Start starts the daemon
 func (d *Daemon) Start() error {
+	if err := d.resolveAppRuntimeTripwires(); err != nil {
+		return fmt.Errorf("resolve app runtime tripwires: %w", err)
+	}
 	if d.dataRoot == "" {
 		d.dataRoot = filepath.Dir(d.socketPath)
 	}
@@ -1165,6 +1173,12 @@ func (d *Daemon) Start() error {
 	// back — before the consumers that would otherwise lazy-start the runtime on
 	// their first due fact.
 	d.restoreAppRuntimePark()
+	// A running invocation belonged to the daemon process that just died. Close
+	// it before any app lane resumes; its durable reconcile request is untouched
+	// and therefore remains the next work the consumer owes.
+	if err := d.repairInterruptedAppInvocations(); err != nil {
+		return err
+	}
 	// Apps get their consumers here, not their runtime: the sidecar starts on the
 	// first fact an app is actually due, so a user with installed-but-quiet apps
 	// pays nothing for them.

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,12 +10,12 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "256"
+const ProtocolVersion = "257"
 
 // Error codes. A failed response may carry one beside its message text, naming
-// what a caller can do about it rather than leaving it to match English. Only
-// the document store issues them today; the field is on Response because the
-// question — "is this worth retrying, or is it broken?" — is not specific to it.
+// what a caller can do about it rather than leaving it to match English. The
+// question — "is this worth retrying, or is it broken?" — is not specific to a
+// domain, so document operations and app commands share this vocabulary.
 //
 // A client that does not recognise a code must treat the failure as broken
 // rather than guessing, which is what keeps adding one from being a breaking
@@ -49,6 +49,10 @@ const (
 	// the ask, because a silently dropped subscription is a tile that renders
 	// nothing forever with nothing to read.
 	ErrorCodeSubscriptionLimit = "subscription_limit"
+	// ErrorCodeReconcileOwed refuses an app command while the app's collection
+	// rebuild is owed or running. The result carries the current structured
+	// reconcile reason so a caller never has to recover the fence from prose.
+	ErrorCodeReconcileOwed = "reconcile_owed"
 )
 
 // DocSubscriptionsPerClient bounds how many live queries one WebSocket client

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -299,11 +299,17 @@ type AppCommandResultMessage struct {
 	// Error corresponds to the JSON schema field "error".
 	Error *string `json:"error,omitempty,omitzero"`
 
+	// ErrorCode corresponds to the JSON schema field "error_code".
+	ErrorCode *string `json:"error_code,omitempty,omitzero"`
+
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
 
 	// Payload corresponds to the JSON schema field "payload".
 	Payload *string `json:"payload,omitempty,omitzero"`
+
+	// Reconcile corresponds to the JSON schema field "reconcile".
+	Reconcile *AppReconcileReasonInfo `json:"reconcile,omitempty,omitzero"`
 
 	// RequestID corresponds to the JSON schema field "request_id".
 	RequestID string `json:"request_id"`
@@ -331,19 +337,22 @@ type AppConsumerInfo struct {
 
 type AppInvocationInfo struct {
 	// DurationMs corresponds to the JSON schema field "duration_ms".
-	DurationMs int `json:"duration_ms"`
+	DurationMs *int `json:"duration_ms,omitempty,omitzero"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error string `json:"error"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// EventName corresponds to the JSON schema field "event_name".
-	EventName string `json:"event_name"`
+	EventName *string `json:"event_name,omitempty,omitzero"`
 
 	// EventSeq corresponds to the JSON schema field "event_seq".
-	EventSeq int `json:"event_seq"`
+	EventSeq *int `json:"event_seq,omitempty,omitzero"`
 
 	// EventSubject corresponds to the JSON schema field "event_subject".
-	EventSubject string `json:"event_subject"`
+	EventSubject *string `json:"event_subject,omitempty,omitzero"`
+
+	// FinishedAt corresponds to the JSON schema field "finished_at".
+	FinishedAt *string `json:"finished_at,omitempty,omitzero"`
 
 	// Handler corresponds to the JSON schema field "handler".
 	Handler string `json:"handler"`
@@ -351,11 +360,20 @@ type AppInvocationInfo struct {
 	// ID corresponds to the JSON schema field "id".
 	ID int `json:"id"`
 
+	// Kind corresponds to the JSON schema field "kind".
+	Kind string `json:"kind"`
+
+	// Reconcile corresponds to the JSON schema field "reconcile".
+	Reconcile *AppReconcileReasonInfo `json:"reconcile,omitempty,omitzero"`
+
 	// StartedAt corresponds to the JSON schema field "started_at".
 	StartedAt string `json:"started_at"`
 
 	// Status corresponds to the JSON schema field "status".
 	Status string `json:"status"`
+
+	// ThroughRequestID corresponds to the JSON schema field "through_request_id".
+	ThroughRequestID *int `json:"through_request_id,omitempty,omitzero"`
 
 	// VersionID corresponds to the JSON schema field "version_id".
 	VersionID int `json:"version_id"`
@@ -394,6 +412,48 @@ type AppLogsResult struct {
 
 	// Truncated corresponds to the JSON schema field "truncated".
 	Truncated bool `json:"truncated"`
+}
+
+type AppReconcileGapInfo struct {
+	// Cursor corresponds to the JSON schema field "cursor".
+	Cursor int `json:"cursor"`
+
+	// Earliest corresponds to the JSON schema field "earliest".
+	Earliest int `json:"earliest"`
+
+	// Missed corresponds to the JSON schema field "missed".
+	Missed int `json:"missed"`
+}
+
+type AppReconcileReasonInfo struct {
+	// Causes corresponds to the JSON schema field "causes".
+	Causes []string `json:"causes"`
+
+	// Gap corresponds to the JSON schema field "gap".
+	Gap *AppReconcileGapInfo `json:"gap,omitempty,omitzero"`
+
+	// PreviousVersions corresponds to the JSON schema field "previous_versions".
+	PreviousVersions []int `json:"previous_versions"`
+
+	// ThroughSeq corresponds to the JSON schema field "through_seq".
+	ThroughSeq int `json:"through_seq"`
+
+	// Version corresponds to the JSON schema field "version".
+	Version int `json:"version"`
+}
+
+type AppReconcileStatus struct {
+	// CurrentAttempt corresponds to the JSON schema field "current_attempt".
+	CurrentAttempt *AppInvocationInfo `json:"current_attempt,omitempty,omitzero"`
+
+	// LastError corresponds to the JSON schema field "last_error".
+	LastError *string `json:"last_error,omitempty,omitzero"`
+
+	// Reason corresponds to the JSON schema field "reason".
+	Reason *AppReconcileReasonInfo `json:"reason,omitempty,omitzero"`
+
+	// State corresponds to the JSON schema field "state".
+	State string `json:"state"`
 }
 
 type AppRegistryEntry struct {
@@ -575,16 +635,22 @@ type AppStallInfo struct {
 	DisablesAt string `json:"disables_at"`
 
 	// EventName corresponds to the JSON schema field "event_name".
-	EventName string `json:"event_name"`
+	EventName *string `json:"event_name,omitempty,omitzero"`
 
 	// EventSeq corresponds to the JSON schema field "event_seq".
-	EventSeq int `json:"event_seq"`
+	EventSeq *int `json:"event_seq,omitempty,omitzero"`
+
+	// Kind corresponds to the JSON schema field "kind".
+	Kind string `json:"kind"`
 
 	// LastError corresponds to the JSON schema field "last_error".
 	LastError string `json:"last_error"`
 
 	// Since corresponds to the JSON schema field "since".
 	Since string `json:"since"`
+
+	// ThroughRequestID corresponds to the JSON schema field "through_request_id".
+	ThroughRequestID *int `json:"through_request_id,omitempty,omitzero"`
 }
 
 type AppStatusMessage struct {
@@ -607,6 +673,9 @@ type AppStatusResult struct {
 
 	// RecentVersions corresponds to the JSON schema field "recent_versions".
 	RecentVersions []AppVersionInfo `json:"recent_versions,omitempty,omitzero"`
+
+	// Reconcile corresponds to the JSON schema field "reconcile".
+	Reconcile AppReconcileStatus `json:"reconcile"`
 
 	// Runtime corresponds to the JSON schema field "runtime".
 	Runtime *AppRuntimeInfo `json:"runtime,omitempty,omitzero"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -4799,6 +4799,12 @@ model AppCommandResultMessage {
   "request_id": string;
   "success": boolean;
   "error"?: string;
+  // Stable refusal code for callers that need to distinguish a command held
+  // behind the reconcile fence from an app or handler failure.
+  "error_code"?: string;
+  // Present with error_code=reconcile_owed. The message remains the surface a
+  // person reads; this is the structured fence a caller can inspect.
+  "reconcile"?: AppReconcileReasonInfo;
   // The handler's return value as JSON text, when it returned one.
   "payload"?: string;
 }
@@ -4835,6 +4841,37 @@ model AppStatusMessage {
   "name": string;
 }
 
+// The lost range carried by a gap reconcile request.
+model AppReconcileGapInfo {
+  "cursor": safeint;
+  "earliest": safeint;
+  "missed": safeint;
+}
+
+// The durable requests folded into one reconcile attempt. Causes are ordered
+// gap, version_changed; previous_versions stays in request order with repeats
+// removed.
+model AppReconcileReasonInfo {
+  "causes": string[];
+  "version": safeint;
+  "through_seq": safeint;
+  "gap"?: AppReconcileGapInfo;
+  "previous_versions": safeint[];
+}
+
+// Reconcile state as one `attn app status` call observes it.
+model AppReconcileStatus {
+  // "not_needed" | "unsupported" | "idle" | "owed" | "running".
+  "state": string;
+  "reason"?: AppReconcileReasonInfo;
+  // The durable running row. Startup repairs an attempt interrupted before it
+  // settled, so a current attempt is never inferred from process memory.
+  "current_attempt"?: AppInvocationInfo;
+  // The latest settled reconcile failure, kept visible while the request stays
+  // owed and after an interrupted daemon has restarted.
+  "last_error"?: string;
+}
+
 // What is known about one app, and only what is known: the registry row, the
 // consumer if there is one, the invocations recorded so far, and the shared
 // runtime's state. An app's status must not claim a health it cannot observe, so
@@ -4843,6 +4880,8 @@ model AppStatusResult {
   "app": AppSummary;
   "versions": safeint;
   "invocations": safeint;
+  // Required because unsupported is a real operator state, not missing data.
+  "reconcile": AppReconcileStatus;
   // The most recent versions, newest first, capped — "versions" above says how
   // many exist. Rollback names ids in its refusals and there is nowhere else to
   // read them, so a status that carried only a count sent the reader looking for
@@ -4901,15 +4940,20 @@ model AppRuntimeInfo {
   "last_exit"?: string;
 }
 
-// An app that has failed on the same event long enough to be on the clock.
+// An app that has failed on the same delivery or reconcile claim long enough to
+// be on the clock.
 //
 // `disables_at` is the whole point of reporting this: an app stalled on one
 // event holds the durable log's retention floor open for every other consumer,
 // so attn disables it, and the reader is entitled to know when.
 model AppStallInfo {
-  "event_seq": safeint;
-  "event_name": string;
-  // When the app first failed on this event.
+  // "subscription" | "reconcile".
+  "kind": string;
+  "event_seq"?: safeint;
+  "event_name"?: string;
+  // The immutable claim boundary while a reconcile request is retrying.
+  "through_request_id"?: safeint;
+  // When the app first failed on this work item.
   "since": string;
   "attempts": int32;
   "last_error": string;
@@ -4994,14 +5038,23 @@ model AppInvocationInfo {
   // The version that actually ran, which is not necessarily the one the app
   // points at now — a rollback does not rewrite what happened.
   "version_id": safeint;
-  "event_seq": safeint;
-  "event_name": string;
-  "event_subject": string;
+  // "subscription" | "command" | "view" | "reconcile".
+  "kind": string;
+  // Fact identity exists only for subscription invocations.
+  "event_seq"?: safeint;
+  "event_name"?: string;
+  "event_subject"?: string;
   "handler": string;
   "status": string;
-  "error": string;
-  "duration_ms": safeint;
+  "error"?: string;
+  // Absent while status=running.
+  "duration_ms"?: safeint;
   "started_at": string;
+  "finished_at"?: string;
+  // Reconcile attempts retain the exact claimed input and request boundary, so
+  // retries and interruptions remain inspectable after restart.
+  "reconcile"?: AppReconcileReasonInfo;
+  "through_request_id"?: safeint;
 }
 
 // Flip an app's enabled state, which is its bus consumer's enabled bit and

--- a/internal/store/app_reconcile.go
+++ b/internal/store/app_reconcile.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"fmt"
 	"time"
+
+	"github.com/victorarias/attn/internal/apps"
 )
 
 const (
@@ -46,19 +48,34 @@ func (s *Store) AppReconcilePending(name string) (AppReconcileClaim, error) {
 	if s.db == nil {
 		return AppReconcileClaim{}, nil
 	}
-	return appReconcilePending(s.db, name)
+	return appReconcilePendingThrough(s.db, name, 0)
 }
 
-func appReconcilePending(q reconcileQueryer, name string) (AppReconcileClaim, error) {
+// AppReconcilePendingThrough returns the still-owed prefix ending at requestID.
+// It is how a failed/interrupted attempt retries the exact claim it started,
+// leaving a trigger that arrived later for the next invocation.
+func (s *Store) AppReconcilePendingThrough(name string, requestID int64) (AppReconcileClaim, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.db == nil {
+		return AppReconcileClaim{}, nil
+	}
+	if requestID <= 0 {
+		return AppReconcileClaim{}, fmt.Errorf("store: a reconcile claim boundary must be positive (got %d)", requestID)
+	}
+	return appReconcilePendingThrough(s.db, name, requestID)
+}
+
+func appReconcilePendingThrough(q reconcileQueryer, name string, throughRequestID int64) (AppReconcileClaim, error) {
 	rows, err := q.Query(`
 		SELECT id, app_name, reason, version_id, through_seq,
 		       previous_version_id, cursor, earliest, missed, created_at
 		FROM app_reconcile_requests
 		WHERE app_name = ? AND id > COALESCE((
 			SELECT completed_request_id FROM app_reconcile_progress WHERE app_name = ?
-		), 0)
+		), 0) AND (? = 0 OR id <= ?)
 		ORDER BY id ASC
-	`, name, name)
+	`, name, name, throughRequestID, throughRequestID)
 	if err != nil {
 		return AppReconcileClaim{}, err
 	}
@@ -135,6 +152,80 @@ func (s *Store) CompleteAppReconcile(name string, throughRequestID, throughSeq i
 		return err
 	}
 	defer func() { _ = tx.Rollback() }()
+	if err := completeAppReconcileTx(tx, name, throughRequestID, throughSeq, now); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// CompleteAppReconcileInvocation settles a successful running attempt and
+// crosses its durable request/cursor fence in one transaction. A crash can
+// therefore leave either the whole attempt owed or the whole attempt complete,
+// never an ok row whose request still retries or a completed request startup
+// later labels interrupted.
+func (s *Store) CompleteAppReconcileInvocation(name string, invocationID, throughRequestID, throughSeq int64, now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var (
+		appName                    string
+		kind                       string
+		status                     string
+		startedText                string
+		storedRequestID, storedSeq sql.NullInt64
+	)
+	err = tx.QueryRow(`
+		SELECT app_name, kind, status, started_at, through_request_id, through_seq
+		FROM app_invocations WHERE id = ?
+	`, invocationID).Scan(&appName, &kind, &status, &startedText, &storedRequestID, &storedSeq)
+	switch {
+	case err == sql.ErrNoRows:
+		return fmt.Errorf("store: no app invocation %d to complete", invocationID)
+	case err != nil:
+		return err
+	case appName != name:
+		return fmt.Errorf("store: app invocation %d belongs to app %q, not %q", invocationID, appName, name)
+	case kind != AppInvocationKindReconcile:
+		return fmt.Errorf("store: app invocation %d is kind %q, not reconcile", invocationID, kind)
+	case status != AppInvocationStatusRunning:
+		return fmt.Errorf("store: reconcile invocation %d is %q, not running; its claim was not completed", invocationID, status)
+	case !storedRequestID.Valid || storedRequestID.Int64 != throughRequestID || !storedSeq.Valid || storedSeq.Int64 != throughSeq:
+		return fmt.Errorf(
+			"store: reconcile invocation %d owns claim request %d through seq %d, not request %d through seq %d",
+			invocationID, storedRequestID.Int64, storedSeq.Int64, throughRequestID, throughSeq)
+	}
+	duration := now.Sub(parseStoreTime(startedText))
+	if duration < 0 {
+		duration = 0
+	}
+	res, err := tx.Exec(`
+		UPDATE app_invocations
+		SET status = ?, error = '', duration_ms = ?, finished_at = ?
+		WHERE id = ? AND status = ?
+	`, AppInvocationStatusOK, duration.Milliseconds(), now.UTC().Format(sortableTimeFormat), invocationID, AppInvocationStatusRunning)
+	if err != nil {
+		return err
+	}
+	if n, err := res.RowsAffected(); err != nil {
+		return err
+	} else if n != 1 {
+		return fmt.Errorf("store: reconcile invocation %d stopped running before its claim could complete", invocationID)
+	}
+	if err := completeAppReconcileTx(tx, name, throughRequestID, throughSeq, now); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func completeAppReconcileTx(tx *sql.Tx, name string, throughRequestID, throughSeq int64, now time.Time) error {
 	var exists int
 	if err := tx.QueryRow(`
 		SELECT COUNT(*) FROM app_reconcile_requests WHERE app_name = ? AND id = ?
@@ -169,7 +260,7 @@ func (s *Store) CompleteAppReconcile(name string, throughRequestID, throughSeq i
 	if n == 0 {
 		return fmt.Errorf("store: app %q has no bus consumer whose cursor can cross reconcile fence %d", name, throughSeq)
 	}
-	return tx.Commit()
+	return nil
 }
 
 func appendAppReconcileRequest(tx *sql.Tx, name, reason string, versionID, throughSeq, previousVersionID int64, now time.Time) error {
@@ -185,11 +276,26 @@ func appendAppReconcileRequest(tx *sql.Tx, name, reason string, versionID, throu
 	return err
 }
 
-func appConsumerCursorWith(q reconcileQueryer, name string) (int64, error) {
-	var cursor int64
-	err := q.QueryRow(`SELECT cursor FROM bus_consumers WHERE name = ?`, "app:"+name).Scan(&cursor)
+// appConsumerCursorWith reports the app's fact-delivery position, and whether
+// facts reach it at all. Every app carries a consumer row — the enabled bit lives
+// nowhere else — so a view-or-command-only app is recognised by the sentinel
+// filter it was registered with rather than by the row's absence.
+//
+// Such an app derives nothing from facts, so a version move invalidates no
+// derived state and owes no rebuild. Recording one anyway would refuse the app's
+// commands until a reconcile ran, and the pre-drain that runs on every poll tick
+// would disable a view-only app for not declaring a handler it has no use for.
+func appConsumerCursorWith(q reconcileQueryer, name string) (int64, bool, error) {
+	var (
+		cursor int64
+		filter string
+	)
+	err := q.QueryRow(`SELECT cursor, filter FROM bus_consumers WHERE name = ?`, "app:"+name).Scan(&cursor, &filter)
 	if err == sql.ErrNoRows {
-		return 0, nil
+		return 0, false, nil
 	}
-	return cursor, err
+	if err != nil {
+		return 0, false, err
+	}
+	return cursor, filter != apps.NoSubscriptionsPattern, nil
 }

--- a/internal/store/app_reconcile_test.go
+++ b/internal/store/app_reconcile_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -135,6 +136,289 @@ func TestAppReconcileRequestSurvivesRestartUntilCompletion(t *testing.T) {
 	}
 	if pending, err := s.AppReconcilePending("approval-gate"); err != nil || len(pending.Requests) != 0 {
 		t.Fatalf("pending after completion = %+v, %v", pending, err)
+	}
+}
+
+func TestAppReconcileInvocationStartsSettlesOnceAndKeepsItsClaimIdentity(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)
+	version := seedReconcileApp(t, s, now)
+	if _, _, err := s.CommitAppVersion(AppVersion{
+		AppName: "approval-gate", ContentHash: "sha256:second",
+		Declaration: `{"name":"approval-gate"}`, ArtifactPath: "bundle-2.js",
+	}, now); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := s.AppReconcilePending("approval-gate")
+	if err != nil || len(claim.Requests) != 1 {
+		t.Fatalf("claim = %+v, %v", claim, err)
+	}
+	reason := `{"causes":["version_changed"],"version":2,"throughSeq":0,"previousVersions":[1]}`
+	id, err := s.StartAppInvocation(AppInvocation{
+		AppName: "approval-gate", VersionID: version.ID,
+		Kind: AppInvocationKindReconcile, Handler: "reconcile", StartedAt: now,
+		ReconcileReason: reason, ThroughRequestID: claim.ThroughRequestID, ThroughSeq: claim.ThroughSeq,
+	})
+	if err != nil {
+		t.Fatalf("start invocation: %v", err)
+	}
+	rows, err := s.ListAppInvocations("approval-gate", 10)
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("running rows = %+v, %v", rows, err)
+	}
+	running := rows[0]
+	if running.ID != id || running.Status != AppInvocationStatusRunning || running.Kind != AppInvocationKindReconcile ||
+		running.ReconcileReason != reason || running.ThroughRequestID != claim.ThroughRequestID || !running.FinishedAt.IsZero() {
+		t.Fatalf("running invocation = %+v", running)
+	}
+
+	finished := now.Add(2300 * time.Millisecond)
+	settled, err := s.SettleAppInvocation(id, AppInvocationStatusError, "rebuild failed", finished)
+	if err != nil || !settled {
+		t.Fatalf("settle = %t, %v", settled, err)
+	}
+	if settled, err := s.SettleAppInvocation(id, AppInvocationStatusOK, "", finished.Add(time.Second)); err != nil || settled {
+		t.Fatalf("second settle rewrote terminal row: settled=%t err=%v", settled, err)
+	}
+	attempt, ok, err := s.LatestOwedAppReconcileInvocation("approval-gate")
+	if err != nil || !ok {
+		t.Fatalf("latest owed attempt: ok=%t err=%v", ok, err)
+	}
+	if attempt.ID != id || attempt.Status != AppInvocationStatusError || attempt.Error != "rebuild failed" ||
+		attempt.Duration != 2300*time.Millisecond || !attempt.FinishedAt.Equal(finished) {
+		t.Fatalf("settled attempt = %+v", attempt)
+	}
+	if err := s.CompleteAppReconcile("approval-gate", claim.ThroughRequestID, claim.ThroughSeq, finished); err != nil {
+		t.Fatal(err)
+	}
+	if attempt, ok, err := s.LatestOwedAppReconcileInvocation("approval-gate"); err != nil || ok {
+		t.Fatalf("completed attempt still owed: %+v ok=%t err=%v", attempt, ok, err)
+	}
+}
+
+func TestAppReconcileInvocationStartupRepairInterruptsRunningAttemptAndLeavesRequestOwed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "reconcile-invocation.db")
+	now := time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)
+	s, err := NewWithDB(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	version := seedReconcileApp(t, s, now)
+	if _, _, err := s.CommitAppVersion(AppVersion{
+		AppName: "approval-gate", ContentHash: "sha256:second",
+		Declaration: `{"name":"approval-gate"}`, ArtifactPath: "bundle-2.js",
+	}, now); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := s.AppReconcilePending("approval-gate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.StartAppInvocation(AppInvocation{
+		AppName: "approval-gate", VersionID: version.ID, Kind: AppInvocationKindReconcile,
+		Handler: "reconcile", StartedAt: now, ReconcileReason: `{"causes":["version_changed"]}`,
+		ThroughRequestID: claim.ThroughRequestID, ThroughSeq: claim.ThroughSeq,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err = NewWithDB(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	repairedAt := now.Add(7 * time.Second)
+	if count, err := s.InterruptRunningAppInvocations(repairedAt); err != nil || count != 1 {
+		t.Fatalf("interrupt count = %d, %v", count, err)
+	}
+	if count, err := s.InterruptRunningAppInvocations(repairedAt.Add(time.Second)); err != nil || count != 0 {
+		t.Fatalf("second repair count = %d, %v", count, err)
+	}
+	attempt, ok, err := s.LatestOwedAppReconcileInvocation("approval-gate")
+	if err != nil || !ok || attempt.Status != AppInvocationStatusInterrupted || attempt.Duration != 7*time.Second || !attempt.FinishedAt.Equal(repairedAt) {
+		t.Fatalf("repaired attempt = %+v ok=%t err=%v", attempt, ok, err)
+	}
+	pending, err := s.AppReconcilePending("approval-gate")
+	if err != nil || pending.ThroughRequestID != claim.ThroughRequestID || len(pending.Requests) != 1 {
+		t.Fatalf("request after repair = %+v, %v", pending, err)
+	}
+}
+
+func TestCompleteAppReconcileInvocationSettlesAttemptAndCrossesFenceAtomically(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)
+	seedReconcileApp(t, s, now)
+	version, _, err := s.CommitAppVersion(AppVersion{
+		AppName: "approval-gate", ContentHash: "sha256:second",
+		Declaration: `{"name":"approval-gate"}`, ArtifactPath: "bundle-2.js",
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := s.AppReconcilePending("approval-gate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := s.StartAppInvocation(AppInvocation{
+		AppName: "approval-gate", VersionID: version.ID, Kind: AppInvocationKindReconcile,
+		Handler: "reconcile", StartedAt: now, ReconcileReason: `{"causes":["version_changed"]}`,
+		ThroughRequestID: claim.ThroughRequestID, ThroughSeq: claim.ThroughSeq,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	finished := now.Add(4 * time.Second)
+	if err := s.CompleteAppReconcileInvocation("approval-gate", id, claim.ThroughRequestID, claim.ThroughSeq, finished); err != nil {
+		t.Fatalf("complete invocation: %v", err)
+	}
+	rows, err := s.ListAppInvocations("approval-gate", 10)
+	if err != nil || len(rows) != 1 || rows[0].Status != AppInvocationStatusOK ||
+		rows[0].Duration != 4*time.Second || !rows[0].FinishedAt.Equal(finished) {
+		t.Fatalf("completed invocation = %+v, %v", rows, err)
+	}
+	if pending, err := s.AppReconcilePending("approval-gate"); err != nil || len(pending.Requests) != 0 {
+		t.Fatalf("pending after success = %+v, %v", pending, err)
+	}
+	consumer, ok, err := s.GetBusConsumer("app:approval-gate")
+	if err != nil || !ok || consumer.Cursor != claim.ThroughSeq {
+		t.Fatalf("consumer after success = %+v ok=%t err=%v", consumer, ok, err)
+	}
+}
+
+func TestCompleteAppReconcileInvocationRollsBackSettlementWhenFenceCannotCross(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)
+	seedReconcileApp(t, s, now)
+	version, _, err := s.CommitAppVersion(AppVersion{
+		AppName: "approval-gate", ContentHash: "sha256:second",
+		Declaration: `{"name":"approval-gate"}`, ArtifactPath: "bundle-2.js",
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := s.AppReconcilePending("approval-gate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := s.StartAppInvocation(AppInvocation{
+		AppName: "approval-gate", VersionID: version.ID, Kind: AppInvocationKindReconcile,
+		Handler: "reconcile", StartedAt: now, ReconcileReason: `{"causes":["version_changed"]}`,
+		ThroughRequestID: claim.ThroughRequestID, ThroughSeq: claim.ThroughSeq,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DeleteBusConsumer("app:approval-gate"); err != nil {
+		t.Fatal(err)
+	}
+	err = s.CompleteAppReconcileInvocation("approval-gate", id, claim.ThroughRequestID, claim.ThroughSeq, now.Add(time.Second))
+	if err == nil || !strings.Contains(err.Error(), "no bus consumer") {
+		t.Fatalf("completion error = %v", err)
+	}
+	rows, err := s.ListAppInvocations("approval-gate", 10)
+	if err != nil || len(rows) != 1 || rows[0].Status != AppInvocationStatusRunning || !rows[0].FinishedAt.IsZero() {
+		t.Fatalf("settlement survived rolled-back fence: %+v, %v", rows, err)
+	}
+	pending, err := s.AppReconcilePending("approval-gate")
+	if err != nil || pending.ThroughRequestID != claim.ThroughRequestID || len(pending.Requests) != 1 {
+		t.Fatalf("request moved despite rollback = %+v, %v", pending, err)
+	}
+}
+
+func TestCompleteAppReconcileInvocationRefusesASettledOrDifferentClaim(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)
+	seedReconcileApp(t, s, now)
+	version, _, err := s.CommitAppVersion(AppVersion{
+		AppName: "approval-gate", ContentHash: "sha256:second",
+		Declaration: `{"name":"approval-gate"}`, ArtifactPath: "bundle-2.js",
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := s.AppReconcilePending("approval-gate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := s.StartAppInvocation(AppInvocation{
+		AppName: "approval-gate", VersionID: version.ID, Kind: AppInvocationKindReconcile,
+		StartedAt: now, ReconcileReason: `{}`, ThroughRequestID: claim.ThroughRequestID, ThroughSeq: claim.ThroughSeq,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CompleteAppReconcileInvocation("approval-gate", id, claim.ThroughRequestID+1, claim.ThroughSeq, now.Add(time.Second)); err == nil || !strings.Contains(err.Error(), "owns claim") {
+		t.Fatalf("different claim error = %v", err)
+	}
+	if settled, err := s.SettleAppInvocation(id, AppInvocationStatusError, "boom", now.Add(time.Second)); err != nil || !settled {
+		t.Fatalf("settle failure = %t, %v", settled, err)
+	}
+	if err := s.CompleteAppReconcileInvocation("approval-gate", id, claim.ThroughRequestID, claim.ThroughSeq, now.Add(2*time.Second)); err == nil || !strings.Contains(err.Error(), "not running") {
+		t.Fatalf("settled claim error = %v", err)
+	}
+	if pending, err := s.AppReconcilePending("approval-gate"); err != nil || len(pending.Requests) != 1 {
+		t.Fatalf("refusal completed request = %+v, %v", pending, err)
+	}
+}
+
+func TestLatestOwedAppReconcileInvocationKeepsAnOkBoundaryAboveProgress(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)
+	seedReconcileApp(t, s, now)
+	version, _, err := s.CommitAppVersion(AppVersion{
+		AppName: "approval-gate", ContentHash: "sha256:second",
+		Declaration: `{"name":"approval-gate"}`, ArtifactPath: "bundle-2.js",
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := s.AppReconcilePending("approval-gate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := s.StartAppInvocation(AppInvocation{
+		AppName: "approval-gate", VersionID: version.ID, Kind: AppInvocationKindReconcile,
+		StartedAt: now, ReconcileReason: `{}`, ThroughRequestID: claim.ThroughRequestID, ThroughSeq: claim.ThroughSeq,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// This is the state a non-atomic caller could leave if its handler settlement
+	// committed but the request/cursor transaction failed. The boundary must stay
+	// recoverable even though the attempt itself says ok.
+	if settled, err := s.SettleAppInvocation(id, AppInvocationStatusOK, "", now.Add(time.Second)); err != nil || !settled {
+		t.Fatalf("settle = %t, %v", settled, err)
+	}
+	attempt, ok, err := s.LatestOwedAppReconcileInvocation("approval-gate")
+	if err != nil || !ok || attempt.ID != id || attempt.Status != AppInvocationStatusOK {
+		t.Fatalf("owed ok boundary = %+v ok=%t err=%v", attempt, ok, err)
+	}
+}
+
+func TestStartAppReconcileInvocationRefusesAnUnusableClaim(t *testing.T) {
+	s := New()
+	now := time.Now()
+	for _, tc := range []struct {
+		name   string
+		reason string
+		claim  int64
+		want   string
+	}{
+		{name: "no claim", reason: `{}`, want: "through_request_id"},
+		{name: "invalid reason", reason: `{`, claim: 1, want: "valid JSON"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := s.StartAppInvocation(AppInvocation{
+				AppName: "approval-gate", VersionID: 1, Kind: AppInvocationKindReconcile,
+				StartedAt: now, ReconcileReason: tc.reason, ThroughRequestID: tc.claim,
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/store/apps.go
+++ b/internal/store/apps.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"database/sql"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 )
@@ -120,18 +122,36 @@ type AppVersion struct {
 // window has to be measured against real invocation rates, and a number written
 // before there is anything to measure would be a limit with no receipt.
 type AppInvocation struct {
-	ID           int64
-	AppName      string
-	VersionID    int64
-	EventSeq     int64
-	EventName    string
-	EventSubject string
-	Handler      string
-	Status       string
-	Error        string
-	Duration     time.Duration
-	StartedAt    time.Time
+	ID               int64
+	AppName          string
+	VersionID        int64
+	Kind             string
+	EventSeq         int64
+	EventName        string
+	EventSubject     string
+	Handler          string
+	Status           string
+	Error            string
+	Duration         time.Duration
+	StartedAt        time.Time
+	FinishedAt       time.Time
+	ReconcileReason  string
+	ThroughRequestID int64
+	ThroughSeq       int64
 }
+
+const (
+	AppInvocationKindSubscription = "subscription"
+	AppInvocationKindCommand      = "command"
+	AppInvocationKindView         = "view"
+	AppInvocationKindReconcile    = "reconcile"
+
+	AppInvocationStatusRunning      = "running"
+	AppInvocationStatusOK           = "ok"
+	AppInvocationStatusError        = "error"
+	AppInvocationStatusRuntimeError = "runtime_error"
+	AppInvocationStatusInterrupted  = "interrupted"
+)
 
 // SaveApp creates a registry row, or touches an existing one. It never moves
 // current_version_id: the pointer moves only through CommitAppVersion,
@@ -300,12 +320,14 @@ func (s *Store) CommitAppVersion(v AppVersion, now time.Time) (AppVersion, bool,
 		return AppVersion{}, false, err
 	}
 	if moved && previous != 0 {
-		cursor, err := appConsumerCursorWith(tx, v.AppName)
+		cursor, subscribed, err := appConsumerCursorWith(tx, v.AppName)
 		if err != nil {
 			return AppVersion{}, false, err
 		}
-		if err := appendAppReconcileRequest(tx, v.AppName, AppReconcileVersionChange, v.ID, cursor, previous, now); err != nil {
-			return AppVersion{}, false, err
+		if subscribed {
+			if err := appendAppReconcileRequest(tx, v.AppName, AppReconcileVersionChange, v.ID, cursor, previous, now); err != nil {
+				return AppVersion{}, false, err
+			}
 		}
 	}
 	if err := tx.Commit(); err != nil {
@@ -346,12 +368,14 @@ func (s *Store) SetAppCurrentVersion(name string, versionID int64, now time.Time
 		return err
 	}
 	if moved && previous != 0 {
-		cursor, err := appConsumerCursorWith(tx, name)
+		cursor, subscribed, err := appConsumerCursorWith(tx, name)
 		if err != nil {
 			return err
 		}
-		if err := appendAppReconcileRequest(tx, name, AppReconcileVersionChange, versionID, cursor, previous, now); err != nil {
-			return err
+		if subscribed {
+			if err := appendAppReconcileRequest(tx, name, AppReconcileVersionChange, versionID, cursor, previous, now); err != nil {
+				return err
+			}
 		}
 	}
 	return tx.Commit()
@@ -400,12 +424,14 @@ func (s *Store) StepAppVersionBack(name string, target int64, now time.Time) err
 		return err
 	}
 	if previous != 0 {
-		cursor, err := appConsumerCursorWith(tx, name)
+		cursor, subscribed, err := appConsumerCursorWith(tx, name)
 		if err != nil {
 			return err
 		}
-		if err := appendAppReconcileRequest(tx, name, AppReconcileVersionChange, versionID, cursor, previous, now); err != nil {
-			return err
+		if subscribed {
+			if err := appendAppReconcileRequest(tx, name, AppReconcileVersionChange, versionID, cursor, previous, now); err != nil {
+				return err
+			}
 		}
 	}
 	return tx.Commit()
@@ -542,7 +568,9 @@ func (s *Store) countAppRows(query, name string) (int, error) {
 	return n, nil
 }
 
-// AppendAppInvocation records one handler run and returns its id.
+// AppendAppInvocation records one already-settled handler run and returns its
+// id. StartAppInvocation and SettleAppInvocation are the lifecycle seam for a
+// run whose in-flight state must survive a daemon restart.
 func (s *Store) AppendAppInvocation(inv AppInvocation) (int64, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -550,16 +578,183 @@ func (s *Store) AppendAppInvocation(inv AppInvocation) (int64, error) {
 	if s.db == nil {
 		return 0, nil
 	}
+	inv = normalizeAppInvocation(inv)
 	res, err := s.db.Exec(`
-		INSERT INTO app_invocations
-			(app_name, version_id, event_seq, event_name, event_subject, handler, status, error, duration_ms, started_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, inv.AppName, inv.VersionID, inv.EventSeq, inv.EventName, inv.EventSubject, inv.Handler,
-		inv.Status, inv.Error, inv.Duration.Milliseconds(), inv.StartedAt.UTC().Format(sortableTimeFormat))
+			INSERT INTO app_invocations
+				(app_name, version_id, event_seq, event_name, event_subject, handler, status, error,
+				 duration_ms, started_at, kind, reconcile_reason, through_request_id, through_seq, finished_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`, inv.AppName, inv.VersionID, inv.EventSeq, inv.EventName, inv.EventSubject, inv.Handler,
+		inv.Status, inv.Error, inv.Duration.Milliseconds(), inv.StartedAt.UTC().Format(sortableTimeFormat),
+		inv.Kind, inv.ReconcileReason, nullablePositiveInt64(inv.ThroughRequestID), nullableInt64(inv.ThroughSeq, inv.ThroughRequestID != 0),
+		nullableStoreTime(inv.FinishedAt))
 	if err != nil {
 		return 0, err
 	}
 	return res.LastInsertId()
+}
+
+// StartAppInvocation writes the running row before dispatch. A reconcile's
+// reason and claim boundary are part of the attempt, so a retry never has to
+// reconstruct them from requests that may have arrived after it started.
+func (s *Store) StartAppInvocation(inv AppInvocation) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return 0, nil
+	}
+	inv = normalizeAppInvocation(inv)
+	if inv.StartedAt.IsZero() {
+		return 0, errors.New("store: an app invocation needs a start time")
+	}
+	if inv.Kind == AppInvocationKindReconcile {
+		if inv.ThroughRequestID <= 0 {
+			return 0, fmt.Errorf("store: a reconcile invocation needs a positive through_request_id (got %d)", inv.ThroughRequestID)
+		}
+		if !json.Valid([]byte(inv.ReconcileReason)) {
+			return 0, errors.New("store: a reconcile invocation needs a valid JSON reason")
+		}
+	}
+	res, err := s.db.Exec(`
+		INSERT INTO app_invocations
+			(app_name, version_id, event_seq, event_name, event_subject, handler, status, error,
+			 duration_ms, started_at, kind, reconcile_reason, through_request_id, through_seq, finished_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, '', 0, ?, ?, ?, ?, ?, NULL)
+	`, inv.AppName, inv.VersionID, inv.EventSeq, inv.EventName, inv.EventSubject, inv.Handler,
+		AppInvocationStatusRunning, inv.StartedAt.UTC().Format(sortableTimeFormat), inv.Kind,
+		inv.ReconcileReason, nullablePositiveInt64(inv.ThroughRequestID), nullableInt64(inv.ThroughSeq, inv.ThroughRequestID != 0))
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
+// SettleAppInvocation closes one running row. The status predicate makes a
+// daemon-shutdown settlement and startup interruption repair safe to race: one
+// wins, and the terminal answer cannot be rewritten by the loser.
+func (s *Store) SettleAppInvocation(id int64, status, failure string, finishedAt time.Time) (bool, error) {
+	if !terminalAppInvocationStatus(status) {
+		return false, fmt.Errorf("store: %q is not a terminal app invocation status", status)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return false, nil
+	}
+
+	var startedText string
+	err := s.db.QueryRow(`SELECT started_at FROM app_invocations WHERE id = ? AND status = ?`, id, AppInvocationStatusRunning).Scan(&startedText)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if finishedAt.IsZero() {
+		return false, errors.New("store: settling an app invocation needs a finish time")
+	}
+	duration := finishedAt.Sub(parseStoreTime(startedText))
+	if duration < 0 {
+		duration = 0
+	}
+	res, err := s.db.Exec(`
+		UPDATE app_invocations
+		SET status = ?, error = ?, duration_ms = ?, finished_at = ?
+		WHERE id = ? AND status = ?
+	`, status, failure, duration.Milliseconds(), finishedAt.UTC().Format(sortableTimeFormat), id, AppInvocationStatusRunning)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	return n > 0, err
+}
+
+// InterruptRunningAppInvocations repairs attempts a previous daemon could not
+// close. Their reconcile request and cursor are untouched, so an enabled lane
+// still owes the same work after startup.
+func (s *Store) InterruptRunningAppInvocations(now time.Time) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return 0, nil
+	}
+	if now.IsZero() {
+		return 0, errors.New("store: interrupting app invocations needs a time")
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	rows, err := tx.Query(`SELECT id, started_at FROM app_invocations WHERE status = ? ORDER BY id`, AppInvocationStatusRunning)
+	if err != nil {
+		return 0, err
+	}
+	type runningInvocation struct {
+		id      int64
+		started string
+	}
+	var running []runningInvocation
+	for rows.Next() {
+		var inv runningInvocation
+		if err := rows.Scan(&inv.id, &inv.started); err != nil {
+			_ = rows.Close()
+			return 0, err
+		}
+		running = append(running, inv)
+	}
+	if err := rows.Close(); err != nil {
+		return 0, err
+	}
+	stamp := now.UTC().Format(sortableTimeFormat)
+	for _, inv := range running {
+		duration := now.Sub(parseStoreTime(inv.started))
+		if duration < 0 {
+			duration = 0
+		}
+		if _, err := tx.Exec(`
+			UPDATE app_invocations
+			SET status = ?, duration_ms = ?, finished_at = ?
+			WHERE id = ? AND status = ?
+		`, AppInvocationStatusInterrupted, duration.Milliseconds(), stamp, inv.id, AppInvocationStatusRunning); err != nil {
+			return 0, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return len(running), nil
+}
+
+// LatestOwedAppReconcileInvocation returns the newest attempt whose claim is
+// still above the completed request boundary. It is the durable retry identity
+// after a failure or restart. An ok attempt remains visible here if completing
+// its request/cursor transaction failed, so the boundary is never lost.
+func (s *Store) LatestOwedAppReconcileInvocation(name string) (AppInvocation, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.db == nil {
+		return AppInvocation{}, false, nil
+	}
+	inv, err := scanAppInvocation(s.db.QueryRow(`
+		SELECT id, app_name, version_id, event_seq, event_name, event_subject, handler,
+		       status, error, duration_ms, started_at, kind, reconcile_reason,
+		       through_request_id, through_seq, finished_at
+		FROM app_invocations
+		WHERE app_name = ? AND kind = ?
+		  AND through_request_id > COALESCE((
+			SELECT completed_request_id FROM app_reconcile_progress WHERE app_name = ?
+		  ), 0)
+		ORDER BY id DESC LIMIT 1
+	`, name, AppInvocationKindReconcile, name))
+	if err == sql.ErrNoRows {
+		return AppInvocation{}, false, nil
+	}
+	if err != nil {
+		return AppInvocation{}, false, err
+	}
+	return inv, true, nil
 }
 
 // ListAppInvocations returns an app's most recent invocations, newest first.
@@ -574,10 +769,11 @@ func (s *Store) ListAppInvocations(name string, limit int) ([]AppInvocation, err
 		limit = 20
 	}
 	rows, err := s.db.Query(`
-		SELECT id, app_name, version_id, event_seq, event_name, event_subject, handler,
-		       status, error, duration_ms, started_at
-		FROM app_invocations WHERE app_name = ? ORDER BY started_at DESC, id DESC LIMIT ?
-	`, name, limit)
+			SELECT id, app_name, version_id, event_seq, event_name, event_subject, handler,
+			       status, error, duration_ms, started_at, kind, reconcile_reason,
+			       through_request_id, through_seq, finished_at
+			FROM app_invocations WHERE app_name = ? ORDER BY started_at DESC, id DESC LIMIT ?
+		`, name, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -585,17 +781,10 @@ func (s *Store) ListAppInvocations(name string, limit int) ([]AppInvocation, err
 
 	var out []AppInvocation
 	for rows.Next() {
-		var (
-			inv       AppInvocation
-			durMillis int64
-			startedAt string
-		)
-		if err := rows.Scan(&inv.ID, &inv.AppName, &inv.VersionID, &inv.EventSeq, &inv.EventName,
-			&inv.EventSubject, &inv.Handler, &inv.Status, &inv.Error, &durMillis, &startedAt); err != nil {
+		inv, err := scanAppInvocation(rows)
+		if err != nil {
 			return nil, err
 		}
-		inv.Duration = time.Duration(durMillis) * time.Millisecond
-		inv.StartedAt = parseStoreTime(startedAt)
 		out = append(out, inv)
 	}
 	return out, rows.Err()
@@ -658,6 +847,77 @@ func (s *Store) TrimAppInvocations(cutoff time.Time, perApp int) (int, error) {
 		return removed, err
 	}
 	return removed + int(n), nil
+}
+
+func normalizeAppInvocation(inv AppInvocation) AppInvocation {
+	if inv.Kind == "" {
+		switch inv.EventName {
+		case "app.command":
+			inv.Kind = AppInvocationKindCommand
+		case "app.view.crashed":
+			inv.Kind = AppInvocationKindView
+		default:
+			inv.Kind = AppInvocationKindSubscription
+		}
+	}
+	if inv.Status != "" && inv.Status != AppInvocationStatusRunning && inv.FinishedAt.IsZero() && !inv.StartedAt.IsZero() {
+		inv.FinishedAt = inv.StartedAt.Add(inv.Duration)
+	}
+	return inv
+}
+
+func terminalAppInvocationStatus(status string) bool {
+	switch status {
+	case AppInvocationStatusOK, AppInvocationStatusError, AppInvocationStatusRuntimeError,
+		AppInvocationStatusInterrupted:
+		return true
+	default:
+		return false
+	}
+}
+
+func nullablePositiveInt64(value int64) any {
+	if value <= 0 {
+		return nil
+	}
+	return value
+}
+
+func nullableInt64(value int64, present bool) any {
+	if !present {
+		return nil
+	}
+	return value
+}
+
+func nullableStoreTime(value time.Time) any {
+	if value.IsZero() {
+		return nil
+	}
+	return value.UTC().Format(sortableTimeFormat)
+}
+
+func scanAppInvocation(row rowScanner) (AppInvocation, error) {
+	var (
+		inv                          AppInvocation
+		durMillis                    int64
+		startedAt                    string
+		finishedAt                   sql.NullString
+		throughRequestID, throughSeq sql.NullInt64
+	)
+	if err := row.Scan(&inv.ID, &inv.AppName, &inv.VersionID, &inv.EventSeq, &inv.EventName,
+		&inv.EventSubject, &inv.Handler, &inv.Status, &inv.Error, &durMillis, &startedAt,
+		&inv.Kind, &inv.ReconcileReason, &throughRequestID, &throughSeq, &finishedAt); err != nil {
+		return AppInvocation{}, err
+	}
+	inv.Duration = time.Duration(durMillis) * time.Millisecond
+	inv.StartedAt = parseStoreTime(startedAt)
+	inv.ThroughRequestID = throughRequestID.Int64
+	inv.ThroughSeq = throughSeq.Int64
+	if finishedAt.Valid {
+		inv.FinishedAt = parseStoreTime(finishedAt.String)
+	}
+	return inv, nil
 }
 
 func scanApp(row rowScanner) (App, error) {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -1186,6 +1186,19 @@ CREATE TABLE IF NOT EXISTS app_reconcile_progress (
     completed_request_id INTEGER NOT NULL,
     updated_at           TEXT NOT NULL
 );`},
+	// Reconcile attempts are long-lived enough to cross a daemon restart, unlike
+	// the terminal-only handler rows the invocation log held before. The claim
+	// boundary and reason make a retry reconstruct the exact attempt it owes;
+	// finished_at distinguishes a live attempt from one startup must interrupt.
+	//
+	// Existing event columns stay NOT NULL. Older readers and every existing
+	// append call already use their empty-string/zero representation for commands
+	// and view crashes, and rebuilding this history table only to turn those values
+	// into NULL would add migration risk without adding information.
+	// Applied by applyMigration113, whose ALTERs are column-guarded. Besides
+	// tolerating a schema-version rewind in recovery tests, the guard prevents a
+	// rerun from reclassifying reconcile rows as subscriptions.
+	{113, "record app reconcile invocation lifecycles", ``},
 }
 
 // migration99SQL is everything migration 99 does after its guarded ALTER.
@@ -1590,6 +1603,11 @@ func migrateDB(db *sql.DB, dbPath string) error {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
+		} else if m.version == 113 {
+			if err := applyMigration113(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
 		} else {
 			if _, err := tx.Exec(m.sql); err != nil {
 				tx.Rollback()
@@ -1627,6 +1645,45 @@ func applyMigration107(tx *sql.Tx) error {
 		return nil
 	}
 	_, err = tx.Exec(`ALTER TABLE ticket_delivery_attention ADD COLUMN delivered_through_seq INTEGER NOT NULL DEFAULT 0`)
+	return err
+}
+
+func applyMigration113(tx *sql.Tx) error {
+	hadKind, err := columnExists(tx, "app_invocations", "kind")
+	if err != nil {
+		return err
+	}
+	columns := []struct {
+		name string
+		sql  string
+	}{
+		{"kind", `ALTER TABLE app_invocations ADD COLUMN kind TEXT NOT NULL DEFAULT 'subscription'`},
+		{"reconcile_reason", `ALTER TABLE app_invocations ADD COLUMN reconcile_reason TEXT NOT NULL DEFAULT ''`},
+		{"through_request_id", `ALTER TABLE app_invocations ADD COLUMN through_request_id INTEGER`},
+		{"through_seq", `ALTER TABLE app_invocations ADD COLUMN through_seq INTEGER`},
+		{"finished_at", `ALTER TABLE app_invocations ADD COLUMN finished_at TEXT`},
+	}
+	for _, column := range columns {
+		exists, err := columnExists(tx, "app_invocations", column.name)
+		if err != nil {
+			return err
+		}
+		if exists {
+			continue
+		}
+		if _, err := tx.Exec(column.sql); err != nil {
+			return err
+		}
+	}
+	if hadKind {
+		return nil
+	}
+	_, err = tx.Exec(`UPDATE app_invocations
+		SET kind = CASE event_name
+			WHEN 'app.command' THEN 'command'
+			WHEN 'app.view.crashed' THEN 'view'
+			ELSE 'subscription'
+		END`)
 	return err
 }
 

--- a/internal/supervise/supervise.go
+++ b/internal/supervise/supervise.go
@@ -390,6 +390,22 @@ func (s *Supervisor) Stop(name string) {
 	s.notify(name)
 }
 
+// TerminateGeneration kills the exact running generation and leaves the child
+// desired-running, so its exit follows the ordinary restart path. A stale
+// caller cannot kill a replacement that has already taken its place.
+func (s *Supervisor) TerminateGeneration(name string, generation uint64) (bool, error) {
+	s.mu.Lock()
+	c := s.children[name]
+	if c == nil || generation == 0 || generation != c.generation || c.desired != DesiredRunning || c.process == nil {
+		s.mu.Unlock()
+		return false, nil
+	}
+	process := c.process
+	s.mu.Unlock()
+
+	return true, process.Kill()
+}
+
 // Shutdown stops every child and refuses further Ensure calls.
 func (s *Supervisor) Shutdown() {
 	s.mu.Lock()

--- a/internal/supervise/supervise_test.go
+++ b/internal/supervise/supervise_test.go
@@ -182,6 +182,65 @@ func TestIntentionalStopAndShutdownNeverRestart(t *testing.T) {
 	}
 }
 
+func TestTerminateGenerationRestartsOnlyTheExactProcess(t *testing.T) {
+	clock := newFakeClock()
+	launcher := &fakeLauncher{}
+	supervisor := New(Options{Clock: clock})
+	if err := supervisor.Ensure("fixture", launcher.start); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+
+	first, _ := supervisor.Snapshot("fixture")
+	if !supervisor.NoteConnected("fixture", first.Generation) {
+		t.Fatal("connect first generation")
+	}
+	terminated, err := supervisor.TerminateGeneration("fixture", first.Generation)
+	if err != nil || !terminated {
+		t.Fatalf("terminate generation %d = %t, %v; want true, nil", first.Generation, terminated, err)
+	}
+	if got := launcher.handle(0).killCount(); got != 1 {
+		t.Fatalf("first-generation kills = %d, want 1", got)
+	}
+	waitFor(t, func() bool {
+		snapshot, _ := supervisor.Snapshot("fixture")
+		return snapshot.Phase == PhaseBackoff && snapshot.RestartAttempt == 1
+	})
+	backoff, _ := supervisor.Snapshot("fixture")
+	if backoff.Desired != DesiredRunning {
+		t.Fatalf("desired after termination = %q, want %q", backoff.Desired, DesiredRunning)
+	}
+
+	clock.Advance(RestartBackoff[0])
+	waitFor(t, func() bool { return launcher.count() == 2 })
+	second, _ := supervisor.Snapshot("fixture")
+	if second.Generation <= first.Generation {
+		t.Fatalf("replacement generation = %d, want greater than %d", second.Generation, first.Generation)
+	}
+	if !supervisor.NoteConnected("fixture", second.Generation) {
+		t.Fatal("connect replacement generation")
+	}
+
+	terminated, err = supervisor.TerminateGeneration("fixture", first.Generation)
+	if err != nil || terminated {
+		t.Fatalf("terminate stale generation %d = %t, %v; want false, nil", first.Generation, terminated, err)
+	}
+	if got := launcher.handle(1).killCount(); got != 0 {
+		t.Fatalf("replacement kills after stale termination = %d, want 0", got)
+	}
+
+	terminated, err = supervisor.TerminateGeneration("fixture", second.Generation)
+	if err != nil || !terminated {
+		t.Fatalf("terminate generation %d = %t, %v; want true, nil", second.Generation, terminated, err)
+	}
+	waitFor(t, func() bool {
+		snapshot, _ := supervisor.Snapshot("fixture")
+		return snapshot.Phase == PhaseBackoff && snapshot.RestartAttempt == 2
+	})
+	if got := launcher.handle(1).killCount(); got != 1 {
+		t.Fatalf("replacement kills = %d, want 1", got)
+	}
+}
+
 func TestSnapshotsStartingConnectedBackoffAndStopped(t *testing.T) {
 	clock := newFakeClock()
 	launcher := &fakeLauncher{}

--- a/sdk/attn-app/src/useCommand.ts
+++ b/sdk/attn-app/src/useCommand.ts
@@ -20,7 +20,16 @@ import { useAppViewRuntime } from "./runtime"
 /** What one invocation did. Never a rejection — see the file header. */
 export type CommandOutcome =
   | { ok: true; value: unknown }
-  | { ok: false; error: string }
+  | {
+      ok: false
+      error: string
+      /**
+       * A stable name for the refusal, when attn had one. `"reconcile_owed"`
+       * means the app is rebuilding its collections and every command is held
+       * until that finishes — worth retrying, unlike a handler that threw.
+       */
+      code?: string
+    }
 
 /**
  * A command, ready to invoke. It is a function first, because that is what a
@@ -81,8 +90,9 @@ export function useCommand(command: string): CommandRunner {
         return { ok: true, value }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
+        const code = (err as { code?: unknown } | null)?.code
         if (live.current) setError(message)
-        return { ok: false, error: message }
+        return { ok: false, error: message, code: typeof code === "string" ? code : undefined }
       } finally {
         if (live.current) setPending(false)
       }


### PR DESCRIPTION
The second half of slice 3 of
[the app reconcile design](docs/plans/2026-08-14-ext-app-reconcile-handler.md):
failure, interruption and operator surfaces. Slice 3's retention/fence half
merged as #931; this is everything that slice listed beside it.

## What an owed rebuild looks like now

- **Every attempt is a durable row.** A reconcile starts as a `running`
  invocation carrying its claim boundary, its structured reason and the version
  it ran, and settles into `ok`, `error`, `runtime_error` or `interrupted`.
  Completion advances the invocation, the completed-request boundary and the bus
  cursor in one transaction, so a rebuild that succeeded can never leave the
  fence half-crossed.
- **A restart mid-rebuild repairs itself.** Startup closes whatever a dead
  process left running as `interrupted`; the durable request is untouched, so it
  is still the next work the consumer owes.
- **`attn app status` answers the two operator questions** — does this app owe a
  rebuild, and can it run one: `not_needed` / `unsupported` / `idle` / `owed` /
  `running`, with the fence that triggered it, the live attempt, and the last
  failure.
- **A command is refused while a rebuild is owed**, by name, with the
  `reconcile_owed` code and the same structured reason on the wire — so a view
  can tell "retry when the rebuild finishes" from "this handler is broken"
  without matching English. `useCommand` surfaces it as `code` on the failure
  outcome.
- **A dispatch that times out terminates the runtime generation it was waiting
  on.** A handler that never yields cannot be cancelled from Go, and leaving it
  on the shared loop starves every sibling app. The generation fence is what
  keeps a stale waiter from killing the replacement the supervisor has already
  started.
- **A rebuild that keeps failing hits the existing fifteen-minute stall clock**
  and the app is disabled with a notification naming what is owed and how to
  resume it.
- **The missing-handler paths are loud.** A subscribing version that declares no
  reconcile is refused a version move; an app that reaches a live fence without
  one is disabled without moving its cursor, and told so.
- **One mutex per app** serializes its handlers, commands, fence and serving
  version moves. Different apps keep running concurrently.
- **The three minute-long tripwires** — stall window, dispatch timeout, liveness
  ping — read from the daemon's environment
  (`ATTN_APP_AUTO_DISABLE_STALL`, `ATTN_APP_DISPATCH_TIMEOUT`,
  `ATTN_APP_RUNTIME_PING_TIMEOUT`). Without them the auto-disable path can only
  be witnessed by waiting fifteen minutes.

Protocol 257: `AppReconcileStatus` on `app_status`, an invocation `kind` plus its
reconcile fields, `error_code`/`reconcile` on `app_command_result`, and a stall
that says whether it is a subscription or a rebuild.

## Audit against the doc: what was already there

- The reconcile dispatch itself, `ReconcileReason`, `ctx.current.snapshot()` and
  the frozen declaration — slice 2 (#918), unchanged here.
- The durable request/progress tables, the pre-drain hook, the completion
  transaction, the cursor and `earliest - 1` fences, the installed-consumer
  retention floor and the `re_enabled` removal — slices 1 and 3a (#906, #931),
  unchanged here. **No re-enable trigger was reintroduced**; re-enable is still a
  plain resume.
- The 60s dispatch timeout and 2s liveness ping already existed
  (`internal/daemon/app_runtime.go`); this slice adds the generation terminate
  after attribution, not a second budget.
- The auto-disable clock, its notification kind and `disableAppAutomatically`
  already existed for subscription failures; reconcile failures now feed the
  same clock rather than getting one of their own.

## Two fixes outside the strict slice list

- **A version move no longer records a reconcile request for an app with no
  subscriptions.** Such an app has no durable bus consumer, so nothing could
  ever complete the request — its commands would have been refused forever and
  the pre-drain would eventually have disabled it. Gate 7 already says an app
  with no subscriptions has no derived handler state; this makes the trigger
  agree. Found by `TestAppCommandIsRefusedByTheServingVersionsDeclaration`.
- **The scaffold declares `reconcile` and ships a converging handler.**
  Without it `attn app new` produced an app that could never be updated, because
  of the version-move refusal above. This is the minimum the refusal requires —
  **teaching reconcile in the app docs and the SDK docs stays slice 4.**

## Migration renumber, and the main sync

`main` is merged into `epic/ext-a5` first (80892b71, one merge commit, gates
green on the merge). Main's own comment demanded it: migration 108 was burned by
a branch that applied it to a production database before merging, and `migrateDB`
skips anything at or below a database's highest applied version — so a database
that took auto mode's 109/110 first would never see the epic's 108. 111 is burned
the same way by another branch in flight. The epic's reconcile tables move to
**112** (every statement is `IF NOT EXISTS`, so a database that applied the old
number re-runs to the same shape), and this slice's invocation-lifecycle
migration is **113**. Protocol goes 256 → **257**.

## Live verification

Isolated throwaway profile `s3clive`, full app install from this head, daemon
started with `ATTN_APP_AUTO_DISABLE_STALL=25s ATTN_APP_DISPATCH_TIMEOUT=5s`.
Three real apps built with `attn app new` and applied: `spinner` (reconcile is a
non-yielding `for(;;)`), `stubborn` (reconcile throws), `sibling` (converges).

**An infinite loop loses its generation and a sibling resumes**

```
apps: spinner hit the dispatch timeout; the app runtime did not answer a liveness ping after 2.000749s
apps: terminated timed-out app runtime generation 1; the supervisor will start its replacement
bus: consumer app:spinner stalled at seq 26 (attempt 1, retry in 1s): before draining: reconcile for app
  spinner did not return within timeout=5s; attn terminated sidecar generation and left request 1 owed
apps: terminated timed-out app runtime generation 2 ... generation 3 ... generation 4
```

`sibling` owed its own rebuild the whole time: its first attempt died with the
terminated generation (`runtime_error: app runtime app.reconcile: EOF`), the bus
retried it one second later on the new generation, and it completed `ok` while
`spinner` was still looping. That EOF is the honest cost of the recycle — an
in-flight sibling dispatch rides the generation being killed and retries under
the existing backoff — and it is what the alternative (starving every app
forever) buys.

**Auto-disable and its notification**

```
apps: disabled spinner — reconcile request 1 stalled for 28s across 4 attempts: reconcile for app spinner
  did not return within timeout=5s; attn terminated sidecar generation and left request 1 owed
```
```
App disabled: stubborn | stubborn failed to reconcile through bus seq 342 for 31s across 6 attempts, so
attn disabled it. The rebuild remains owed. Fix the reconcile handler and `attn app enable stubborn`;
`attn app status stubborn` shows the failure and fence.
```

**A restart mid-rebuild is repaired.** `kill -9` on the profile daemon while an
attempt was `running`; on restart the row read `interrupted` with a finished
stamp, the request stayed owed, and the log said
`apps: marked 1 invocation(s) interrupted during startup repair`.

**A command is refused across the fence** (over the daemon socket, the surface a
view uses):

```json
{"error":"stubborn is rebuilding what it derives from the event log (owed through bus seq 342:
version_changed), so it runs no commands until that finishes; `attn app status stubborn` shows the
rebuild","error_code":"reconcile_owed","reconcile":{"causes":["version_changed"],
"previous_versions":[6],"through_seq":342,"version":7},"success":false}
```

**A version move without a handler is refused:**

```
app apply: daemon error: app apply nohandler: refusing to move nohandler from version 5 to content
453fb666bc86: the requested subscribed version does not declare reconcile; add `reconcile = true` and
implement the reconcile export so existing collections can be rebuilt
```

**`attn app status`** through the whole walk: `supported, no rebuild owed` →
`running through seq 25 (version_changed), attempt 1 started …` → `owed …` with
the last error and the four failed attempts in `recent`.

Live verification also caught the two copy defects fixed in the last commit: the
refusal led with the wire code and named no app, and the notification rounded its
stall to the minute — which reads as "for 0s" whenever the window is moved to
witness it.

Two named gaps in the live run:
- **The gap-with-no-handler disable** is covered by unit test
  (`TestAGapWithNoHandlerDisablesTheAppWithoutMovingItsCursor`), not live:
  forcing a real retention trim past a live consumer's cursor is slice 4's exit
  proof, which seeds exactly that.
- **No recording is attached**: this adds no new app UI. The notification renders
  through the existing surface, and every other surface is the CLI, the socket
  and the daemon log — all quoted above.

## Gates

`go test ./...`, `pnpm --dir app test` (2953 passed), `make check-types`,
`make check-sdk`, `tsc --noEmit`, `go vet ./...` — all green on this head. The
new tests are six daemon integration tests over the failure and refusal paths,
store tests for the invocation lifecycle, and three frontend tests over the coded
refusal.
