### PR TITLE
feat(apps): teach the scaffold reconcile and prove the walk end to end

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -565,7 +565,11 @@ reaching no projection has to name the consumer that does read it.
 - Retention trims past the age window but never past an **enabled** consumer's
   cursor or an **installed app** consumer's cursor. A disabled ordinary consumer
   does not pin; a disabled installed app keeps its unread backlog until enable
-  or uninstall.
+  or uninstall. The window is 30 days, so a trim over any database younger than
+  that removes nothing whatever the floor says: `ATTN_BUS_RETENTION` moves it,
+  and is the only way to watch a trim — or a consumer resuming below
+  `earliest` — happen at all. Set it for the daemon and for `attn bus trim`
+  together, or the hourly pass and the manual one keep different windows.
 - An enabled consumer that stops consuming therefore grows the log until someone
   intervenes, so past `bus.DefaultPinAlarmAge` the pin is reported: a warning
   notification, a `(PINNING …)` tag in `attn bus status`, and a badge on the

--- a/app/package.json
+++ b/app/package.json
@@ -80,6 +80,7 @@
     "real-app:scenario-terminal-osc8-link": "node scripts/real-app-harness/scenario-terminal-osc8-link.mjs",
     "real-app:scenario-terminal-md-link": "node scripts/real-app-harness/scenario-terminal-md-link.mjs",
     "real-app:scenario-terminal-kitty-image": "node scripts/real-app-harness/scenario-terminal-kitty-image.mjs",
+    "real-app:scenario-app-reconcile": "node scripts/real-app-harness/scenario-app-reconcile.mjs",
     "real-app:scenario-terminal-block-resize": "node scripts/real-app-harness/scenario-terminal-block-resize.mjs",
     "real-app:scenario-terminal-annotations": "node scripts/real-app-harness/scenario-terminal-annotations.mjs",
     "real-app:scenario-offset-soak": "node scripts/real-app-harness/scenario-offset-soak.mjs",

--- a/app/scripts/real-app-harness/AGENTS.md
+++ b/app/scripts/real-app-harness/AGENTS.md
@@ -182,6 +182,16 @@ the VM with `pnpm run real-app:provision-remote`. The hub daemon
 installs/updates the attn binary on the remote automatically (internal/hub
 bootstrapper), so the VM never needs a manual attn install.
 
+`scenario-app-reconcile.mjs` (the app-reconcile exit proof) takes a Linux
+witness on the same VM, but it drives the `attn` CLI there rather than a
+session, so it has two extra knobs: `ATTN_HARNESS_REMOTE_ATTN` names the remote
+binary (default `attn`; the hub bootstrapper installs `attn-<profile>` beside
+`attn-app-runtime-<profile>` in `~/.local/bin`, and a hand-staged cross-build
+lands the same way) and `ATTN_HARNESS_REMOTE_PROFILE` selects the profile it
+runs under. The leg skips itself, loudly in the trace, when no attn is found —
+reachability is not what that scenario is testing. `attn app apply` bundles
+with bun, so the VM needs it; `real-app:provision-remote` installs it.
+
 TR-205's matrix legs (`tr205-probe-codex`, `tr205-probe-claude`) run
 `attn _probe-tui` on the remote instead of a live agent: a deterministic
 agent-mimicking TUI whose styles are pinned to codex/claude VT vocabulary

--- a/app/scripts/real-app-harness/appFixtures.mjs
+++ b/app/scripts/real-app-harness/appFixtures.mjs
@@ -1,0 +1,162 @@
+// The apps the reconcile exit proof installs.
+//
+// Every one of them starts as `attn app new` output and is then rewritten from
+// here, so the scaffold is on the critical path of the proof rather than beside
+// it: a scaffold that stops applying cleanly fails the scenario at its first
+// step.
+//
+// The caller names them, because an app's documents and version history outlive
+// `attn app remove`: a scenario that reused one fixed name would read the last
+// run's documents and turn its own first install into a version move.
+//
+// They subscribe to `ticket.*` because tickets are the one domain a scenario can
+// drive deterministically from the CLI without an agent in the loop, and because
+// `ctx.current.snapshot().tickets` is the current-state read a reconcile is
+// supposed to rebuild from.
+
+// steward derives one document per ticket. Version 1 stores the title; version 2
+// derives a second field from the same facts, which is the version-change
+// trigger's whole reason to exist: the documents version 1 wrote have no
+// `status`, and nothing but a rebuild will ever give them one.
+export function stewardManifest({ name = 'steward', reconcile = true } = {}) {
+  return `name = "${name}"
+description = "Derives one document per ticket. The reconcile exit proof's converging app."
+
+attn_app_api = 1
+entrypoint = "src/index.ts"
+${reconcile ? 'reconcile = true\n' : ''}
+[[subscribe]]
+events = ["ticket.*"]
+
+[[collections]]
+name = "tickets"
+fields = ["state"]
+
+[[commands]]
+name = "refresh"
+description = "Ask the app to say what it holds."
+`;
+}
+
+// derive is the one function the two versions differ in, and the only difference
+// between them: same subscription, same collection, same reconcile shape.
+export const STEWARD_V1_DERIVE = `function derive(ticket: TicketLike): Record<string, unknown> {
+  return { state: "seen", title: ticket.title }
+}`;
+
+export const STEWARD_V2_DERIVE = `function derive(ticket: TicketLike): Record<string, unknown> {
+  // Version 2 derives a field version 1 never wrote. Every document already in
+  // the collection is wrong until reconcile rebuilds it.
+  return { state: "seen", title: ticket.title, status: ticket.status }
+}`;
+
+// blockGuard makes a reconcile that does not finish until a ticket appears,
+// which is how a rebuild is caught mid-flight by a daemon that goes away
+// underneath it. The signal is a ticket rather than a file because a handler
+// typechecks against attn's own types and has no runtime globals to reach a
+// filesystem with — and current truth is a read the rebuild already does.
+// It yields while it waits: a non-yielding loop would be the dispatch timeout's
+// case, which is pinned in Go, not here.
+function blockGuard(releaseTicketId) {
+  const id = JSON.stringify(releaseTicketId);
+  return `  for (;;) {
+    const gate = await ctx.current.snapshot()
+    if (gate.tickets.some((row) => row.id === ${id})) break
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+`;
+}
+
+export function stewardEntrypoint(derive, { blockUntilTicket = null } = {}) {
+  return `import type { Ctx, Handlers } from "./generated"
+import type { AppEvent, ReconcileReason } from "@victorarias/attn-app"
+
+interface TicketLike {
+  readonly id: string
+  readonly title: string
+  readonly status: string
+}
+
+${derive}
+
+async function onTicket(event: AppEvent, ctx: Ctx): Promise<void> {
+  const current = await ctx.current.snapshot()
+  const ticket = current.tickets.find((row) => row.id === event.subject)
+  if (!ticket) {
+    // The ticket is gone in current truth, so the fact was its removal.
+    await ctx.collections.tickets.delete(event.subject)
+    return
+  }
+  await ctx.collections.tickets.put(ticket.id, derive(ticket))
+}
+
+async function refresh(_payload: unknown, ctx: Ctx): Promise<{ held: number }> {
+  return { held: (await ctx.collections.tickets.query({ limit: 1000 })).length }
+}
+
+async function reconcile(reason: ReconcileReason, ctx: Ctx): Promise<void> {
+${blockUntilTicket ? blockGuard(blockUntilTicket) : ''}  const current = await ctx.current.snapshot()
+  const live = new Map(current.tickets.map((row) => [row.id, row]))
+  // Deleting what current truth no longer has is half the job. A rebuild that
+  // only upserts leaves rows nothing will ever remove.
+  for (const doc of await ctx.collections.tickets.query({ limit: 1000 })) {
+    if (!live.has(doc.id)) {
+      await ctx.collections.tickets.delete(doc.id)
+    }
+  }
+  for (const ticket of live.values()) {
+    await ctx.collections.tickets.put(ticket.id, derive(ticket))
+  }
+  console.log("steward: rebuilt " + live.size + " through seq " + reason.throughSeq)
+}
+
+export default {
+  subscriptions: { "ticket.*": onTicket },
+  commands: { refresh },
+  reconcile,
+} satisfies Handlers
+`;
+}
+
+// historian subscribes and declares no reconcile. It is the app the loud paths
+// are about: a version move it cannot survive is refused before the pointer
+// moves, and a gap it cannot heal disables it without moving its cursor.
+export function historianManifest({
+  name = 'historian',
+  description = 'Accumulates what it is told. Declares no reconcile on purpose.',
+} = {}) {
+  return `name = "${name}"
+description = "${description}"
+
+attn_app_api = 1
+entrypoint = "src/index.ts"
+
+[[subscribe]]
+events = ["ticket.*"]
+
+[[collections]]
+name = "seen"
+fields = ["state"]
+`;
+}
+
+export function historianEntrypoint() {
+  return `import type { Ctx, Handlers } from "./generated"
+import type { AppEvent } from "@victorarias/attn-app"
+
+// A history app: what it holds is what it was told, in the order it was told.
+// No snapshot rebuilds this, which is exactly why attn refuses to move it across
+// a trigger it cannot survive.
+async function onTicket(event: AppEvent, ctx: Ctx): Promise<void> {
+  await ctx.collections.seen.put(String(event.seq), {
+    state: "seen",
+    subject: event.subject,
+    name: event.name,
+  })
+}
+
+export default {
+  subscriptions: { "ticket.*": onTicket },
+} satisfies Handlers
+`;
+}

--- a/app/scripts/real-app-harness/harnessProfile.mjs
+++ b/app/scripts/real-app-harness/harnessProfile.mjs
@@ -211,6 +211,33 @@ export function deepLinkSchemeForProfile(profile = currentHarnessProfile()) {
   return resolveHarnessResources(profile).deepLinkScheme;
 }
 
+// Every routing override a CLI call could inherit. ATTN_PROFILE names a world;
+// each of these overrides it outright, and an attn-managed session exports
+// ATTN_DATA_DIR and ATTN_WS_PORT into every shell it hosts. A harness driven
+// from inside attn that clears only the socket/db/config/plugin four keeps the
+// PRODUCTION data dir and port: the banner reads profile=<name> while the
+// command talks to ~/.attn, which is how a scenario's `daemon ensure` takes over
+// the production daemon. `attn profile-env` does not clear ATTN_DATA_DIR either.
+const ROUTING_OVERRIDE_ENV = [
+  'ATTN_DATA_DIR',
+  'ATTN_WS_PORT',
+  'ATTN_SOCKET_PATH',
+  'ATTN_DB_PATH',
+  'ATTN_CONFIG_PATH',
+  'ATTN_PLUGIN_DIR',
+];
+
+// The environment for driving the `attn` CLI at one profile: the caller's
+// environment with ATTN_PROFILE set and every inherited routing override
+// removed, so the profile is the only thing deciding where the command lands.
+export function profileCliEnv(profile = currentHarnessProfile(), extra = {}) {
+  const env = { ...process.env, ATTN_PROFILE: profile, ...extra };
+  for (const key of ROUTING_OVERRIDE_ENV) {
+    if (!(key in extra)) delete env[key];
+  }
+  return env;
+}
+
 export function hasRunAgainstProdFlag(argv = process.argv.slice(2)) {
   return argv.includes('--run-against-prod');
 }

--- a/app/scripts/real-app-harness/harnessProfile.test.mjs
+++ b/app/scripts/real-app-harness/harnessProfile.test.mjs
@@ -17,6 +17,7 @@ import {
   deepLinkSchemeForProfile,
   hasRunAgainstProdFlag,
   isProductionHarnessTarget,
+  profileCliEnv,
   profileForAppPath,
   resolveHarnessResources,
   socketPathForProfile,
@@ -243,5 +244,45 @@ describeWithBinary('single authority (attn profile resolve)', () => {
     // A named profile's real daemon port never collides with prod/dev.
     expect(defaultDaemonPortForProfile('agent7')).not.toBe(9849);
     expect(defaultDaemonPortForProfile('agent7')).not.toBe(29849);
+  });
+});
+
+describe('profileCliEnv', () => {
+  const routing = {
+    ATTN_DATA_DIR: '/Users/nobody/.attn',
+    ATTN_WS_PORT: '9849',
+    ATTN_SOCKET_PATH: '/Users/nobody/.attn/attn.sock',
+    ATTN_DB_PATH: '/Users/nobody/.attn/attn.db',
+    ATTN_CONFIG_PATH: '/Users/nobody/.attn/config.json',
+    ATTN_PLUGIN_DIR: '/Users/nobody/.attn/plugins',
+  };
+
+  beforeEach(() => {
+    for (const [key, value] of Object.entries(routing)) process.env[key] = value;
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(routing)) delete process.env[key];
+  });
+
+  it('clears every inherited routing override, not just the socket four', () => {
+    const env = profileCliEnv('agent7');
+    expect(env.ATTN_PROFILE).toBe('agent7');
+    for (const key of Object.keys(routing)) expect(env[key]).toBeUndefined();
+  });
+
+  it('keeps ATTN_DATA_DIR and ATTN_WS_PORT out, which a profile name cannot override', () => {
+    // An attn-managed session exports both into every shell it hosts, and each
+    // outranks ATTN_PROFILE: leaving them makes a profile-selected command talk
+    // to production while still printing profile=<name>.
+    const env = profileCliEnv('agent7');
+    expect('ATTN_DATA_DIR' in env).toBe(false);
+    expect('ATTN_WS_PORT' in env).toBe(false);
+  });
+
+  it('lets an explicit extra set a routing value on purpose', () => {
+    const env = profileCliEnv('agent7', { ATTN_SOCKET_PATH: '/tmp/chosen.sock' });
+    expect(env.ATTN_SOCKET_PATH).toBe('/tmp/chosen.sock');
+    expect(env.ATTN_DATA_DIR).toBeUndefined();
   });
 });

--- a/app/scripts/real-app-harness/provision-orb-remote.sh
+++ b/app/scripts/real-app-harness/provision-orb-remote.sh
@@ -45,10 +45,23 @@ ssh -o BatchMode=yes "${SSH_TARGET}" 'sudo apt-get update -qq && sudo apt-get in
 echo "==> Installing codex and claude CLIs"
 ssh -o BatchMode=yes "${SSH_TARGET}" 'sudo npm install -g @openai/codex @anthropic-ai/claude-code'
 
+# `attn app apply` bundles with bun and typechecks with the TypeScript it
+# installs itself, so a remote that cannot run bun cannot install an app at all
+# — apps are a daemon surface, and the daemon is supported on Linux.
+echo "==> Installing bun (attn app apply bundles with it)"
+ssh -o BatchMode=yes "${SSH_TARGET}" '
+  command -v bun >/dev/null 2>&1 && exit 0
+  [ -x "$HOME/.bun/bin/bun" ] && exit 0
+  curl -fsSL https://bun.sh/install | bash
+'
+
 echo "==> Verifying required tools are on PATH in the VM"
 missing_tools="$(ssh -o BatchMode=yes "${SSH_TARGET}" '
   missing=""
-  for tool in git python3 ss codex claude; do
+  # bun installs into ~/.bun/bin, which a non-interactive shell does not have
+  # on PATH until .bashrc runs — check it where it lands.
+  PATH="$HOME/.bun/bin:$PATH"
+  for tool in git python3 ss codex claude bun; do
     command -v "$tool" >/dev/null 2>&1 || missing="$missing $tool"
   done
   echo "$missing"
@@ -57,7 +70,7 @@ if [[ -n "${missing_tools// /}" ]]; then
   echo "Missing required tools in VM:${missing_tools}" >&2
   exit 1
 fi
-echo "==> All required tools present: git python3 ss codex claude"
+echo "==> All required tools present: git python3 ss codex claude bun"
 
 echo "==> Checking codex auth"
 codex_auth_present=0

--- a/app/scripts/real-app-harness/scenario-app-reconcile.mjs
+++ b/app/scripts/real-app-harness/scenario-app-reconcile.mjs
@@ -39,11 +39,12 @@
  * deleted events, the gap detection, the refusal, the disable and the
  * notification are all real; only that one row is hand-made.
  *
- * Why it is not in the serial matrix (scenarioCatalog.mjs): it stops and
- * re-ensures the profile daemon to move ATTN_BUS_RETENTION and the app tripwires
- * in and out of the world, which is a world change the matrix's other scenarios
- * should not have to reason about — the same reason the kitty-image and
- * automation-scheduled-cleanup scenarios stay out. Run it directly:
+ * It is in the serial matrix (scenarioCatalog.mjs) despite changing the world:
+ * it stops and re-ensures the profile daemon to move ATTN_BUS_RETENTION and the
+ * app tripwires in and out, and puts the defaults back on the success path and
+ * the failure path both, so no later leg inherits a one-second retention window.
+ * A change here that can leave the tripwires behind belongs out of the catalog.
+ * Run it directly:
  *
  *   ATTN_HARNESS_PROFILE=<name> node scripts/real-app-harness/scenario-app-reconcile.mjs
  *

--- a/app/scripts/real-app-harness/scenario-app-reconcile.mjs
+++ b/app/scripts/real-app-harness/scenario-app-reconcile.mjs
@@ -1,0 +1,718 @@
+#!/usr/bin/env node
+
+/**
+ * The reconcile exit proof: a packaged app, a real bus, and every path an app's
+ * derived view can take when facts stop being enough.
+ *
+ * A collection is a view over facts and a fact is only ever seen once, so two
+ * things would leave that view quietly wrong: a version move (the app now
+ * derives something different from the same facts) and a gap (the app resumed
+ * below the oldest fact still in the log). This walks both, plus the cases that
+ * must NOT rebuild, on apps that start life as `attn app new` output.
+ *
+ *   1  before        steward v1 derives {state,title}; the documents are right
+ *                    for v1 and have no `status` field at all.
+ *   2  no reconcile  disable, publish, enable — the retained backlog delivers in
+ *      on resume     seq order and NOTHING reconciles. Re-enabling is not a
+ *                    rebuild, and this is the leg that says so.
+ *   3  version move  apply v2, which derives `status` from the very same facts.
+ *                    Every document already written is wrong until the rebuild,
+ *                    and after it every document carries `status`.
+ *   4  refusal       historian subscribes and declares no reconcile: a version
+ *                    move is refused in those words, before the pointer moves.
+ *   5  gap           a REAL retention trim past a live cursor, then historian
+ *                    resumes below the oldest surviving fact: no handler, so
+ *                    attn disables it without moving its cursor and says why in
+ *                    a notification. (See MANUFACTURED below.)
+ *   6  interruption  a rebuild caught mid-flight by a daemon restart is repaired
+ *                    on the next start and finishes.
+ *   7  convergence   after every leg, a fact published later is handled by the
+ *                    version that owns it, and the invocation log reads in order.
+ *
+ * MANUFACTURED, and it has to be: retention is floored at the minimum cursor
+ * over enabled-or-installed consumers, so an installed app can never be trimmed
+ * past through a product surface — that floor is the point of slice 3a. The one
+ * precondition the design names as the remaining gap cause is a cursor left by a
+ * removed install, so this scenario removes the app (product surface), publishes,
+ * trims for real (product surface, ATTN_BUS_RETENTION), and re-inserts exactly
+ * one row: `app:historian` at the cursor it actually reached. The trim, the
+ * deleted events, the gap detection, the refusal, the disable and the
+ * notification are all real; only that one row is hand-made.
+ *
+ * Why it is not in the serial matrix (scenarioCatalog.mjs): it stops and
+ * re-ensures the profile daemon to move ATTN_BUS_RETENTION and the app tripwires
+ * in and out of the world, which is a world change the matrix's other scenarios
+ * should not have to reason about — the same reason the kitty-image and
+ * automation-scheduled-cleanup scenarios stay out. Run it directly:
+ *
+ *   ATTN_HARNESS_PROFILE=<name> node scripts/real-app-harness/scenario-app-reconcile.mjs
+ *
+ * With ATTN_HARNESS_REMOTE_SSH_TARGET (or the default OrbStack VM) reachable it
+ * also takes the Linux dispatch witness: the same bundle, applied and dispatched
+ * on a Linux daemon, so the reconcile path is proven on the platform the hub
+ * cross-compiles for. `--skip-remote` drops that leg.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import {
+  launchFreshAppAndConnect,
+  parseCommonArgs,
+  printCommonHelp,
+  DEFAULT_REMOTE_SSH_TARGET,
+} from './common.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { createScenarioRunner } from './scenarioRunner.mjs';
+import {
+  currentHarnessProfile,
+  dataDirForProfile,
+  profileCliEnv as profileEnv,
+  resolveHarnessResources,
+} from './harnessProfile.mjs';
+import { runSSH } from './scenarioRemote.mjs';
+import { sleep } from './scenarioAssertions.mjs';
+import {
+  historianManifest,
+  stewardManifest,
+  stewardEntrypoint,
+  historianEntrypoint,
+  STEWARD_V1_DERIVE,
+  STEWARD_V2_DERIVE,
+} from './appFixtures.mjs';
+
+// A window a run can actually cross. The shipped default is thirty days, so
+// without moving it a trim over a fresh profile removes nothing however far
+// behind a consumer is, and the gap leg has nothing to stand on.
+const TRIM_WINDOW = '1s';
+// Short enough that a wedged rebuild is disabled inside a scenario rather than
+// a coffee break, long enough that a healthy rebuild never sees it.
+const STALL_WINDOW = '25s';
+const DISPATCH_TIMEOUT = '5s';
+
+const SETTLE_MS = 20_000;
+// Nothing on the wire says "and no reconcile happened". Absence needs a budget:
+// a rebuild that is going to run has always started within a second of the
+// trigger in this scenario's own runs, so ten is a tripwire, not a race.
+const ABSENCE_MS = 10_000;
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') args.shift();
+  const skipRemote = args.includes('--skip-remote');
+  // parseCommonArgs rejects anything it does not know, so this scenario's own
+  // flag is consumed before the shared parser sees it.
+  const options = parseCommonArgs(args.filter((arg) => arg !== '--skip-remote'));
+  return {
+    options,
+    help: args.includes('--help') || args.includes('-h'),
+    skipRemote,
+  };
+}
+
+function run(binary, args, env, cwd = undefined) {
+  return execFileSync(binary, args, {
+    encoding: 'utf8',
+    env,
+    cwd,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 120_000,
+  });
+}
+
+// Every CLI command prints its routing banner first (`[attn profile=… socket=…]`),
+// which is exactly the line worth keeping in the logs and exactly the line that
+// is not JSON. Parse from the first structural character on.
+function parseJSON(output) {
+  const start = output.search(/[[{]/);
+  if (start < 0) throw new Error(`no JSON in CLI output: ${output.slice(0, 200)}`);
+  return JSON.parse(output.slice(start));
+}
+
+// The CLI refuses on the daemon side by writing the error to stdout and exiting
+// non-zero, and a refusal is the assertion in two legs — so capture it rather
+// than letting execFileSync throw the text away.
+function runAllowingFailure(binary, args, env) {
+  try {
+    return { ok: true, output: run(binary, args, env) };
+  } catch (error) {
+    const stdout = error?.stdout ?? '';
+    const stderr = error?.stderr ?? '';
+    return { ok: false, output: `${stdout}${stderr}` || String(error?.message || error) };
+  }
+}
+
+async function poll(fn, description, timeoutMs) {
+  const started = Date.now();
+  let last = null;
+  while (Date.now() - started < timeoutMs) {
+    last = await fn();
+    if (last) return last;
+    await sleep(250);
+  }
+  throw new Error(`timed out waiting for ${description}; last=${JSON.stringify(last)}`);
+}
+
+function writeApp(root, name, manifest, entrypoint) {
+  const dir = path.join(root, name);
+  fs.writeFileSync(path.join(dir, 'attn-app.toml'), manifest, 'utf8');
+  fs.writeFileSync(path.join(dir, 'src', 'index.ts'), entrypoint, 'utf8');
+  return dir;
+}
+
+async function main() {
+  const { options, help, skipRemote } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scripts/real-app-harness/scenario-app-reconcile.mjs');
+    return;
+  }
+
+  const profile = currentHarnessProfile();
+  if (!profile) {
+    throw new Error('reconcile scenario requires a named non-production profile (it restarts the profile daemon and trims its bus)');
+  }
+  const resources = resolveHarnessResources(profile);
+  const binary = path.join(resources.appPath, 'Contents', 'MacOS', 'attn');
+  const dbPath = path.join(dataDirForProfile(profile), 'attn.db');
+
+  const runner = createScenarioRunner(options, {
+    scenarioId: 'APP-RECONCILE',
+    tier: 'tier2-app-runtime',
+    prefix: 'app-reconcile',
+    metadata: {
+      profile,
+      trimWindow: TRIM_WINDOW,
+      focus: 'a derived view is rebuilt when — and only when — facts stop being enough',
+    },
+  });
+
+  // The daemon the whole walk runs against: a trim window a run can cross, and
+  // app tripwires short enough to observe. The app spawns a daemon only when
+  // none is running, so this one is ensured BEFORE the app launches.
+  const defaultEnv = profileEnv(profile);
+  const walkEnv = profileEnv(profile, {
+    ATTN_BUS_RETENTION: TRIM_WINDOW,
+    ATTN_APP_AUTO_DISABLE_STALL: STALL_WINDOW,
+    ATTN_APP_DISPATCH_TIMEOUT: DISPATCH_TIMEOUT,
+  });
+
+  // An app's documents and version history survive `attn app remove`, so the
+  // names are scoped to this run: otherwise the first install would be a version
+  // move off the previous run's version, and leg 1 would read its documents.
+  const runSlug = runner.runId.replace(/[^a-z0-9]/gi, '').toLowerCase().slice(-10);
+  const STEWARD = `steward-${runSlug}`;
+  const HISTORIAN = `historian-${runSlug}`;
+
+  const appsRoot = path.join(runner.sessionDir, 'apps');
+  fs.mkdirSync(appsRoot, { recursive: true });
+  // The ticket the interrupted rebuild waits for. Until it is published the
+  // rebuild cannot finish, which is what keeps one in flight long enough for a
+  // daemon restart to catch it.
+  const releaseTicketId = `release-the-rebuild-${runSlug}`;
+
+  const client = new UiAutomationClient({ appPath: options.appPath });
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+
+  const evidence = {};
+  let ticketSeq = 0;
+
+  runner.log('run context', {
+    runDir: runner.runDir, sessionDir: runner.sessionDir, wsUrl: options.wsUrl, profile, dbPath,
+  });
+
+  // Every fact this walk publishes is a ticket, because tickets are the one
+  // domain a scenario drives deterministically with no agent in the loop.
+  const publishTicket = (label) => {
+    ticketSeq += 1;
+    const id = `${runner.runId}-${ticketSeq}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+    run(binary, ['ticket', 'new', '--title', `${label} ${ticketSeq}`, '--id', id, '--session', 'reconcile-proof'], walkEnv);
+    return id;
+  };
+
+  const appStatus = (name) => parseJSON(run(binary, ['app', 'status', name, '--json'], walkEnv));
+  const consumerOf = (name) => appStatus(name).app.consumer;
+  const documents = (name, collection) =>
+    parseJSON(run(binary, ['doc', 'query', `app/${name}`, collection, '--json'], walkEnv));
+  const invocations = (name) => appStatus(name).recent || [];
+  const reconciles = (name) => invocations(name).filter((row) => row.kind === 'reconcile');
+  const causedBy = (row, cause) => (row?.reconcile?.causes || []).includes(cause);
+
+  const sqlite = (statement) =>
+    execFileSync('sqlite3', [dbPath, statement], { encoding: 'utf8', timeout: 30_000 }).trim();
+  const readOnlySqlite = (statement) =>
+    execFileSync('sqlite3', [`file:${dbPath}?immutable=1`, statement], { encoding: 'utf8', timeout: 30_000 }).trim();
+
+  const restartDaemon = (env) => {
+    try { run(binary, ['daemon', 'stop'], env); } catch { /* not running is fine */ }
+    run(binary, ['daemon', 'ensure'], env);
+  };
+
+  // Cleanups run in reverse registration order: hand the profile daemon back
+  // with nothing injected, LAST, after the app is gone.
+  runner.registerCleanup('restore_default_daemon', () => restartDaemon(defaultEnv));
+  runner.registerCleanup('close_observer', () => observer.close());
+  runner.registerCleanup('quit_app', () => client.quitApp());
+  runner.registerCleanup('remove_apps', () => {
+    for (const name of [STEWARD, HISTORIAN]) {
+      try { run(binary, ['app', 'remove', name], walkEnv); } catch { /* already gone */ }
+    }
+  });
+
+  try {
+    await runner.step('daemon:tripwires', { trim: TRIM_WINDOW, stall: STALL_WINDOW }, async () => {
+      restartDaemon(walkEnv);
+      await sleep(2000);
+    });
+
+    await runner.step('app:launch', async () => {
+      await launchFreshAppAndConnect(client, observer);
+    });
+
+    await runner.step('scaffold:new', async () => {
+      // `attn app new` first, always: the scaffold is on the critical path of
+      // the proof rather than beside it, so a scaffold that stops applying
+      // cleanly fails here at step one.
+      for (const name of [STEWARD, HISTORIAN]) {
+        run(binary, ['app', 'new', path.join(appsRoot, name)], walkEnv);
+      }
+      const scaffoldDoc = fs.readFileSync(path.join(appsRoot, STEWARD, 'AGENTS.md'), 'utf8');
+      runner.assert(
+        scaffoldDoc.includes('## Rebuilding what you derive: reconcile'),
+        'the scaffold brief an app author reads does not teach reconcile',
+      );
+      runner.assert(
+        scaffoldDoc.includes('Re-enabling is **not** a rebuild'),
+        'the scaffold brief does not say that re-enabling is not a rebuild',
+      );
+    });
+
+    await runner.step('leg1:before', async () => {
+      writeApp(appsRoot, STEWARD, stewardManifest({ name: STEWARD }), stewardEntrypoint(STEWARD_V1_DERIVE));
+      run(binary, ['app', 'apply', path.join(appsRoot, STEWARD)], walkEnv);
+      for (let i = 0; i < 3; i += 1) publishTicket('before');
+      const docs = await poll(
+        () => {
+          const rows = documents(STEWARD, 'tickets');
+          return rows.length >= 3 ? rows : null;
+        },
+        'steward to derive a document per ticket',
+        SETTLE_MS,
+      );
+      runner.assert(
+        docs.every((row) => row.body.title && row.body.status === undefined),
+        'version 1 wrote a `status` field it does not derive',
+        docs[0],
+      );
+      runner.assert(reconciles(STEWARD).length === 0, 'a first install reconciled; installing is not a trigger');
+      evidence.before = docs;
+      runner.writeJson('leg1-before.json', docs);
+    });
+
+    await runner.step('leg2:resume-is-not-a-rebuild', async () => {
+      run(binary, ['app', 'disable', STEWARD], walkEnv);
+      const backlog = [publishTicket('backlog'), publishTicket('backlog')];
+      const behind = await poll(
+        () => {
+          const consumer = consumerOf(STEWARD);
+          return consumer.lag >= backlog.length ? consumer : null;
+        },
+        'the disabled consumer to fall behind by the facts it missed',
+        SETTLE_MS,
+      );
+      runner.assert(behind.enabled === false, 'disable left the consumer enabled', behind);
+
+      run(binary, ['app', 'enable', STEWARD], walkEnv);
+      const caughtUp = await poll(
+        () => {
+          const rows = documents(STEWARD, 'tickets');
+          return backlog.every((id) => rows.some((row) => row.id === id)) ? rows : null;
+        },
+        'the retained backlog to deliver after enable',
+        SETTLE_MS,
+      );
+      // The whole point of the leg: it caught up by DELIVERY, not by rebuild.
+      await sleep(ABSENCE_MS);
+      runner.assert(
+        reconciles(STEWARD).length === 0,
+        're-enabling triggered a rebuild; a retained backlog is delivered, not recomputed',
+        reconciles(STEWARD),
+      );
+      const delivered = invocations(STEWARD)
+        .filter((row) => row.kind === 'subscription')
+        .map((row) => row.work);
+      runner.writeJson('leg2-backlog.json', { backlog, delivered, documents: caughtUp.length });
+    });
+
+    await runner.step('leg3:version-move-rebuilds', async () => {
+      const beforeRevs = new Map(documents(STEWARD, 'tickets').map((row) => [row.id, row.rev]));
+      writeApp(appsRoot, STEWARD, stewardManifest({ name: STEWARD }), stewardEntrypoint(STEWARD_V2_DERIVE));
+      run(binary, ['app', 'apply', path.join(appsRoot, STEWARD)], walkEnv);
+
+      const rebuilt = await poll(
+        () => {
+          const rows = documents(STEWARD, 'tickets');
+          return rows.length > 0 && rows.every((row) => row.body.status !== undefined) ? rows : null;
+        },
+        'every document to carry the field the new version derives',
+        SETTLE_MS,
+      );
+      runner.assert(
+        rebuilt.every((row) => beforeRevs.get(row.id) === undefined || row.rev > beforeRevs.get(row.id)),
+        'documents carry the new field without having been rewritten',
+      );
+      // The documents can be right while the invocation row still says
+      // `running` — the handler returns before the daemon has written its
+      // outcome — so the row is polled for, not read once.
+      const rebuild = await poll(
+        () => reconciles(STEWARD).find((row) => row.status !== 'running') || null,
+        'the rebuild invocation to reach an outcome',
+        SETTLE_MS,
+      );
+      runner.assert(
+        rebuild.status === 'ok' && causedBy(rebuild, 'version_changed'),
+        `the rebuild was not attributed to the version move: ${JSON.stringify(rebuild)}`,
+      );
+      const settled = await poll(
+        () => (appStatus(STEWARD).reconcile?.state === 'idle' ? appStatus(STEWARD).reconcile : null),
+        'the app to stop owing a rebuild after a successful one',
+        SETTLE_MS,
+      );
+      runner.log('rebuild settled', settled);
+      evidence.rebuilt = rebuilt;
+      runner.writeJson('leg3-rebuilt.json', { rebuild, documents: rebuilt });
+    });
+
+    await runner.step('leg4:no-handler-no-move', async () => {
+      writeApp(appsRoot, HISTORIAN, historianManifest({ name: HISTORIAN }), historianEntrypoint());
+      run(binary, ['app', 'apply', path.join(appsRoot, HISTORIAN)], walkEnv);
+      publishTicket('historian-sees');
+      await poll(
+        () => (documents(HISTORIAN, 'seen').length > 0 ? true : null),
+        'historian to record a fact',
+        SETTLE_MS,
+      );
+
+      const moved = runAllowingFailure(
+        binary,
+        ['app', 'apply', path.join(appsRoot, HISTORIAN)],
+        walkEnv,
+      );
+      // A second apply of a byte-identical version is not a move at all, so the
+      // manifest has to differ for the refusal to be the thing under test.
+      writeApp(
+        appsRoot,
+        HISTORIAN,
+        historianManifest({ name: HISTORIAN, description: 'Accumulates what it is told. Second version.' }),
+        historianEntrypoint(),
+      );
+      const refused = runAllowingFailure(
+        binary,
+        ['app', 'apply', path.join(appsRoot, HISTORIAN)],
+        walkEnv,
+      );
+      runner.assert(!refused.ok || /refusing to move/.test(refused.output), 'a subscribed app with no reconcile was moved anyway', refused);
+      runner.assert(
+        /does not declare reconcile/.test(refused.output),
+        `the refusal does not say what is missing: ${refused.output}`,
+      );
+      runner.writeJson('leg4-refusal.json', { unchangedApply: moved.output, refusal: refused.output });
+      // Put the manifest back so the version on disk is the one being served.
+      writeApp(appsRoot, HISTORIAN, historianManifest({ name: HISTORIAN }), historianEntrypoint());
+    });
+
+    await runner.step('leg5:gap-disables-loudly', async () => {
+      const cursor = Number(consumerOf(HISTORIAN).cursor);
+      runner.assert(Number.isInteger(cursor) && cursor > 0, `historian has no cursor to be trimmed past: ${cursor}`);
+
+      // Product surface: removing the app deletes its consumer rows, which is
+      // what takes it out of the retention floor.
+      run(binary, ['app', 'remove', HISTORIAN], walkEnv);
+      for (let i = 0; i < 3; i += 1) publishTicket('past-the-cursor');
+      await sleep(2000);
+
+      // Product surface: a real trim, deleting real rows, floored at the only
+      // consumer left standing.
+      const trimmed = run(binary, ['bus', 'trim'], walkEnv);
+      runner.assert(/removed \d+ event/.test(trimmed), `the trim removed nothing: ${trimmed}`);
+      for (let i = 0; i < 2; i += 1) publishTicket('after-the-trim');
+      await sleep(2000);
+      const earliest = Number(readOnlySqlite('select coalesce(min(seq), 0) from bus_events;'));
+      runner.assert(
+        earliest > cursor,
+        `the trim did not move the oldest surviving fact past historian's cursor (earliest ${earliest}, cursor ${cursor})`,
+      );
+
+      // THE ONE HAND-MADE THING: the cursor a removed install left behind. The
+      // daemon is down for it so nothing is holding the row in memory.
+      run(binary, ['daemon', 'stop'], walkEnv);
+      sqlite(
+        'insert into bus_consumers (name, cursor, filter, enabled, updated_at) values ('
+        + `'app:${HISTORIAN}', ${cursor}, 'ticket.*', 1, '${new Date().toISOString()}');`,
+      );
+      run(binary, ['daemon', 'ensure'], walkEnv);
+      await sleep(2000);
+
+      run(binary, ['app', 'apply', path.join(appsRoot, HISTORIAN)], walkEnv);
+      const disabled = await poll(
+        () => {
+          const consumer = consumerOf(HISTORIAN);
+          return consumer.enabled === false ? consumer : null;
+        },
+        'the gap to disable an app that cannot rebuild',
+        SETTLE_MS,
+      );
+      runner.assert(
+        Number(disabled.cursor) === cursor,
+        `the disable moved the cursor from ${cursor} to ${disabled.cursor}; a gap must not be skipped past`,
+      );
+      const refusal = reconciles(HISTORIAN).at(0);
+      runner.assert(Boolean(refusal), 'the gap produced no invocation row to read afterwards');
+      runner.assert(
+        refusal.handler === 'missing_reconcile' && refusal.status === 'error',
+        `the gap was not recorded as a missing handler: ${JSON.stringify(refusal)}`,
+      );
+      runner.assert(causedBy(refusal, 'gap'), `the invocation is not attributed to a gap: ${JSON.stringify(refusal.reconcile)}`);
+      runner.assert(
+        Number(refusal.reconcile?.gap?.earliest) > Number(refusal.reconcile?.gap?.cursor),
+        `the gap does not describe facts the app can never receive: ${JSON.stringify(refusal.reconcile?.gap)}`,
+      );
+      runner.assert(
+        appStatus(HISTORIAN).reconcile?.state === 'unsupported',
+        'the app that cannot rebuild does not say so on its status surface',
+        appStatus(HISTORIAN).reconcile,
+      );
+
+      const notification = readOnlySqlite(
+        "select body from notifications where kind = 'app_auto_disabled' order by rowid desc limit 1;",
+      );
+      runner.assert(
+        notification.includes(HISTORIAN) && notification.includes('reconcile'),
+        `nothing told the user why historian went quiet: ${notification}`,
+      );
+      evidence.gap = { cursor, earliest, refusal, notification };
+      runner.writeJson('leg5-gap.json', evidence.gap);
+    });
+
+    await runner.step('leg6:interrupted-rebuild-repairs', async () => {
+      // A rebuild that will not finish until a file appears, so the restart
+      // below catches one genuinely in flight rather than racing a fast one.
+      writeApp(
+        appsRoot,
+        STEWARD,
+        stewardManifest({ name: STEWARD }),
+        stewardEntrypoint(STEWARD_V2_DERIVE, { blockUntilTicket: releaseTicketId }),
+      );
+      run(binary, ['app', 'apply', path.join(appsRoot, STEWARD)], walkEnv);
+      const running = await poll(
+        () => {
+          const state = appStatus(STEWARD).reconcile?.state;
+          return state === 'running' || state === 'owed' ? state : null;
+        },
+        'the rebuild to be in flight',
+        SETTLE_MS,
+      );
+      runner.log('rebuild in flight', { state: running });
+
+      restartDaemon(walkEnv);
+      await sleep(2000);
+      const owedAfterRestart = await poll(
+        () => {
+          const state = appStatus(STEWARD).reconcile?.state;
+          return state === 'owed' || state === 'running' ? state : null;
+        },
+        'the interrupted rebuild to still be owed after the restart',
+        SETTLE_MS,
+      );
+      runner.assert(
+        owedAfterRestart === 'owed' || owedAfterRestart === 'running',
+        `an interrupted rebuild was forgotten across the restart: ${owedAfterRestart}`,
+      );
+
+      run(binary, ['ticket', 'new', '--title', 'release the rebuild', '--id', releaseTicketId, '--session', 'reconcile-proof'], walkEnv);
+      const settled = await poll(
+        () => (appStatus(STEWARD).reconcile?.state === 'idle' ? appStatus(STEWARD) : null),
+        'the repaired rebuild to finish',
+        60_000,
+      );
+      // The receipt that the restart caught a rebuild in flight rather than
+      // racing a finished one: an `interrupted` attempt, and a completing one
+      // carrying the same request id — the same owed rebuild, repaired, not a
+      // second one raised from scratch.
+      const attempts = reconciles(STEWARD);
+      const interrupted = attempts.find((row) => row.status === 'interrupted');
+      runner.assert(
+        Boolean(interrupted),
+        'no rebuild was interrupted; the restart raced a rebuild that had already finished',
+        attempts,
+      );
+      const repaired = attempts.find(
+        (row) => row.status === 'ok' && row.through_request_id === interrupted?.through_request_id,
+      );
+      runner.assert(
+        Boolean(repaired),
+        'the interrupted rebuild was never repaired; nothing completed its request',
+        attempts,
+      );
+      evidence.repaired = { state: settled.reconcile, interrupted, repaired };
+      runner.writeJson('leg6-repaired.json', { state: settled.reconcile, invocations: attempts });
+    });
+
+    await runner.step('leg7:converges-before-later-facts', async () => {
+      const id = publishTicket('after-everything');
+      const doc = await poll(
+        () => {
+          const rows = documents(STEWARD, 'tickets');
+          return rows.find((row) => row.id === id) || null;
+        },
+        'a fact published after every leg to be handled',
+        SETTLE_MS,
+      );
+      runner.assert(
+        doc.body.status !== undefined,
+        'a fact published after the rebuild was handled by the version that no longer serves',
+        doc,
+      );
+      const status = appStatus(STEWARD);
+      runner.assert(status.app.consumer.lag === 0, `${STEWARD} is still behind by ${status.app.consumer.lag}`);
+      runner.assert(status.reconcile.state === 'idle', `${STEWARD} still owes a rebuild: ${status.reconcile.state}`);
+      evidence.converged = { id, doc, consumer: status.app.consumer };
+      runner.writeJson('leg7-converged.json', evidence.converged);
+    });
+
+    await runner.step('visible:status-surfaces', async () => {
+      // The status surfaces a person actually reads, captured as text in the
+      // artifacts beside the window capture the recording carries. There is no
+      // automation verb that opens the settings apps page, so this records what
+      // the CLI surfaces show rather than claiming something about the modal.
+      runner.writeText('app-status-steward.txt', run(binary, ['app', 'status', STEWARD], walkEnv));
+      runner.writeText('app-status-historian.txt', run(binary, ['app', 'status', HISTORIAN], walkEnv));
+      runner.writeText('bus-status.txt', run(binary, ['bus', 'status'], walkEnv));
+      const historian = run(binary, ['app', 'status', HISTORIAN], walkEnv);
+      runner.assert(
+        /reconcile:\s+unsupported/.test(historian),
+        'the human-readable status does not say the app cannot rebuild',
+      );
+      await client.request('capture_native_window_screenshot', {
+        path: path.join(runner.runDir, 'app-window.png'),
+      }).catch((error) => runner.log('ui:capture_failed', { error: String(error) }));
+    });
+
+    if (!skipRemote) {
+      await runner.step('linux:reconcile-witness', async () => {
+        const target = process.env.ATTN_HARNESS_REMOTE_SSH_TARGET || DEFAULT_REMOTE_SSH_TARGET;
+        // The remote runs whatever binary was put there for it: the hub
+        // bootstrapper installs `attn-<profile>` into ~/.local/bin beside its
+        // own `attn-app-runtime-<profile>` sidecar, and a hand-staged
+        // cross-build lands the same way. ~/.bun/bin is on PATH explicitly
+        // because `attn app apply` bundles with bun and a non-interactive ssh
+        // shell has not run .bashrc.
+        const remoteAttn = process.env.ATTN_HARNESS_REMOTE_ATTN || 'attn';
+        const remoteProfile = process.env.ATTN_HARNESS_REMOTE_PROFILE || '';
+        const prefix = `export PATH="$HOME/.bun/bin:$HOME/.local/bin:$PATH"; `
+          + (remoteProfile ? `export ATTN_PROFILE=${remoteProfile}; ` : '');
+        const remote = (command, timeoutMs = 120_000) => runSSH(target, prefix + command, timeoutMs);
+
+        // Reachability is not this scenario's subject: an unreachable VM, or one
+        // with no attn on it, reports itself and the leg is skipped rather than
+        // failing the walk.
+        const reachable = await remote(`command -v ${remoteAttn} && echo READY`, 20_000).catch(() => null);
+        if (!reachable || !String(reachable).includes('READY')) {
+          runner.log('linux:unavailable', { target, remoteAttn });
+          evidence.linux = { target, skipped: 'no attn on the remote' };
+          return;
+        }
+
+        const witnessName = `linuxwitness-${runSlug}`;
+        const remoteRoot = `/tmp/attn-reconcile-${runSlug}`;
+        await remote(`${remoteAttn} daemon ensure`, 120_000);
+        await remote(`mkdir -p ${remoteRoot}`);
+        // The same scaffold the local walk starts from, then the same fixtures.
+        await remote(`${remoteAttn} app new ${remoteRoot}/${witnessName}`, 300_000);
+        const writeRemote = (file, body) =>
+          remote(`cat > ${remoteRoot}/${witnessName}/${file} <<'ATTNEOF'\n${body}\nATTNEOF`);
+        await writeRemote('attn-app.toml', stewardManifest({ name: witnessName }));
+        await writeRemote('src/index.ts', stewardEntrypoint(STEWARD_V1_DERIVE));
+        await remote(`${remoteAttn} app apply ${remoteRoot}/${witnessName}`, 300_000);
+
+        const remoteStatus = async () => parseJSON(await remote(`${remoteAttn} app status ${witnessName} --json`, 60_000));
+        await remote(`${remoteAttn} ticket new --title 'linux witness' --id ${witnessName}-fact --session reconcile-proof`, 60_000);
+        const dispatched = await poll(
+          async () => {
+            const status = await remoteStatus().catch(() => null);
+            return (status?.recent || []).some((row) => row.kind === 'subscription' && row.status === 'ok')
+              ? status
+              : null;
+          },
+          'the Linux daemon to dispatch a fact into the app runtime',
+          90_000,
+        );
+
+        // Not just dispatch: the rebuild itself, on Linux. A version move on the
+        // remote has to reconcile there the same way it does here.
+        await writeRemote('src/index.ts', stewardEntrypoint(STEWARD_V2_DERIVE));
+        await remote(`${remoteAttn} app apply ${remoteRoot}/${witnessName}`, 300_000);
+        const rebuilt = await poll(
+          async () => {
+            const status = await remoteStatus().catch(() => null);
+            const row = (status?.recent || []).find((r) => r.kind === 'reconcile' && r.status !== 'running');
+            return row ? { status, row } : null;
+          },
+          'the Linux daemon to rebuild the app across a version move',
+          90_000,
+        );
+        runner.assert(
+          rebuilt.row.status === 'ok' && causedBy(rebuilt.row, 'version_changed'),
+          `the Linux rebuild did not complete on the version move: ${JSON.stringify(rebuilt.row)}`,
+        );
+        runner.assert(
+          rebuilt.status.reconcile?.state === 'idle',
+          `the Linux app still owes a rebuild: ${JSON.stringify(rebuilt.status.reconcile)}`,
+        );
+
+        evidence.linux = {
+          target,
+          remoteAttn,
+          dispatched: dispatched.recent[0],
+          rebuild: rebuilt.row,
+        };
+        runner.writeJson('linux-witness.json', evidence.linux);
+        await remote(`${remoteAttn} app remove ${witnessName} || true`, 60_000).catch(() => {});
+        await remote(`rm -rf ${remoteRoot}`).catch(() => {});
+      });
+    }
+
+    const result = runner.finishSuccess({
+      profile,
+      trimWindow: TRIM_WINDOW,
+      gap: evidence.gap,
+      linux: evidence.linux ?? null,
+    });
+    console.log('[verify] PASS — rebuilt on a version move and a gap, delivered on a resume, repaired after an interruption.');
+    console.log(JSON.stringify(result, null, 2));
+  } catch (error) {
+    try {
+      runner.writeText('app-status-steward.txt', runAllowingFailure(binary, ['app', 'status', STEWARD], walkEnv).output);
+      runner.writeText('app-status-historian.txt', runAllowingFailure(binary, ['app', 'status', HISTORIAN], walkEnv).output);
+      runner.writeText('bus-status.txt', runAllowingFailure(binary, ['bus', 'status'], walkEnv).output);
+    } catch { /* diagnostics are best-effort */ }
+    await client.request('capture_native_window_screenshot', {
+      path: path.join(runner.runDir, 'failure.png'),
+    }).catch(() => {});
+    const result = runner.finishFailure(error, { profile });
+    console.error(result.error);
+    process.exitCode = 1;
+  } finally {
+    for (const name of [STEWARD, HISTORIAN]) {
+      try { run(binary, ['app', 'remove', name], walkEnv); } catch { /* already gone */ }
+    }
+    await client.quitApp().catch(() => {});
+    await observer.close();
+    restartDaemon(defaultEnv);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/app/scripts/real-app-harness/scenario-automation-form.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-form.mjs
@@ -77,7 +77,7 @@ import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { parseCommonArgs, printCommonHelp, launchFreshAppAndConnect } from './common.mjs';
 import { createScenarioRunner } from './scenarioRunner.mjs';
-import { currentHarnessProfile, resolveHarnessResources } from './harnessProfile.mjs';
+import { currentHarnessProfile, resolveHarnessResources, profileCliEnv as profileEnv } from './harnessProfile.mjs';
 import { UiAutomationClient } from './uiAutomationClient.mjs';
 import { DaemonObserver } from './daemonObserver.mjs';
 import { captureFrontWindowScreenshot } from './nativeWindowCapture.mjs';
@@ -95,13 +95,6 @@ function parseArgs(argv) {
   return { options, help: args.includes('--help') || args.includes('-h') };
 }
 
-function profileEnv(profile, extra = {}) {
-  const env = { ...process.env, ATTN_PROFILE: profile, ...extra };
-  for (const key of ['ATTN_SOCKET_PATH', 'ATTN_DB_PATH', 'ATTN_CONFIG_PATH', 'ATTN_PLUGIN_DIR']) {
-    delete env[key];
-  }
-  return env;
-}
 
 function run(binary, args, env, options = {}) {
   return execFileSync(binary, args, {

--- a/app/scripts/real-app-harness/scenario-automation-lifecycle.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-lifecycle.mjs
@@ -52,7 +52,7 @@ import { fileURLToPath } from 'node:url';
 import WebSocket from 'ws';
 import { parseCommonArgs, printCommonHelp, launchFreshAppAndConnect } from './common.mjs';
 import { createScenarioRunner } from './scenarioRunner.mjs';
-import { currentHarnessProfile, dataDirForProfile, resolveHarnessResources } from './harnessProfile.mjs';
+import { currentHarnessProfile, dataDirForProfile, resolveHarnessResources, profileCliEnv as profileEnv } from './harnessProfile.mjs';
 import { UiAutomationClient } from './uiAutomationClient.mjs';
 import { DaemonObserver } from './daemonObserver.mjs';
 import { captureFrontWindowScreenshot } from './nativeWindowCapture.mjs';
@@ -79,13 +79,6 @@ function parseArgs(argv) {
   return { options, help: args.includes('--help') || args.includes('-h') };
 }
 
-function profileEnv(profile, extra = {}) {
-  const env = { ...process.env, ATTN_PROFILE: profile, ...extra };
-  for (const key of ['ATTN_SOCKET_PATH', 'ATTN_DB_PATH', 'ATTN_CONFIG_PATH', 'ATTN_PLUGIN_DIR']) {
-    delete env[key];
-  }
-  return env;
-}
 
 function run(binary, args, env, options = {}) {
   return execFileSync(binary, args, {

--- a/app/scripts/real-app-harness/scenario-automation-pr-continuity.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-pr-continuity.mjs
@@ -16,6 +16,7 @@ import {
   currentHarnessProfile,
   dataDirForProfile,
   resolveHarnessResources,
+  profileCliEnv as profileEnv,
 } from './harnessProfile.mjs';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -29,13 +30,6 @@ function parseArgs(argv) {
   return { options, help: args.includes('--help') || args.includes('-h') };
 }
 
-function profileEnv(profile, extra = {}) {
-  const env = { ...process.env, ATTN_PROFILE: profile, ...extra };
-  for (const key of ['ATTN_SOCKET_PATH', 'ATTN_DB_PATH', 'ATTN_CONFIG_PATH', 'ATTN_PLUGIN_DIR']) {
-    delete env[key];
-  }
-  return env;
-}
 
 function run(binary, args, env, options = {}) {
   return execFileSync(binary, args, {

--- a/app/scripts/real-app-harness/scenario-automation-scheduled-cleanup.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-scheduled-cleanup.mjs
@@ -35,7 +35,7 @@ import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { parseCommonArgs, printCommonHelp } from './common.mjs';
 import { createScenarioRunner } from './scenarioRunner.mjs';
-import { currentHarnessProfile, dataDirForProfile, resolveHarnessResources } from './harnessProfile.mjs';
+import { currentHarnessProfile, dataDirForProfile, resolveHarnessResources, profileCliEnv as profileEnv } from './harnessProfile.mjs';
 import { ensureFreshWorld } from './freshWorld.mjs';
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -56,13 +56,6 @@ function parseArgs(argv) {
   return { options, help: args.includes('--help') || args.includes('-h') };
 }
 
-function profileEnv(profile, extra = {}) {
-  const env = { ...process.env, ATTN_PROFILE: profile, ...extra };
-  for (const key of ['ATTN_SOCKET_PATH', 'ATTN_DB_PATH', 'ATTN_CONFIG_PATH', 'ATTN_PLUGIN_DIR']) {
-    delete env[key];
-  }
-  return env;
-}
 
 function run(binary, args, env, options = {}) {
   return execFileSync(binary, args, {

--- a/app/scripts/real-app-harness/scenario-automation-surface.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-surface.mjs
@@ -28,7 +28,7 @@ import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { parseCommonArgs, printCommonHelp, launchFreshAppAndConnect } from './common.mjs';
 import { createScenarioRunner } from './scenarioRunner.mjs';
-import { currentHarnessProfile, resolveHarnessResources } from './harnessProfile.mjs';
+import { currentHarnessProfile, resolveHarnessResources, profileCliEnv as profileEnv } from './harnessProfile.mjs';
 import { UiAutomationClient } from './uiAutomationClient.mjs';
 import { DaemonObserver } from './daemonObserver.mjs';
 import { captureFrontWindowScreenshot } from './nativeWindowCapture.mjs';
@@ -51,13 +51,6 @@ function parseArgs(argv) {
   return { options, help: args.includes('--help') || args.includes('-h') };
 }
 
-function profileEnv(profile, extra = {}) {
-  const env = { ...process.env, ATTN_PROFILE: profile, ...extra };
-  for (const key of ['ATTN_SOCKET_PATH', 'ATTN_DB_PATH', 'ATTN_CONFIG_PATH', 'ATTN_PLUGIN_DIR']) {
-    delete env[key];
-  }
-  return env;
-}
 
 function run(binary, args, env, options = {}) {
   return execFileSync(binary, args, {

--- a/app/scripts/real-app-harness/scenario-terminal-kitty-image.mjs
+++ b/app/scripts/real-app-harness/scenario-terminal-kitty-image.mjs
@@ -39,7 +39,7 @@ import {
 import { UiAutomationClient } from './uiAutomationClient.mjs';
 import { DaemonObserver } from './daemonObserver.mjs';
 import { createScenarioRunner } from './scenarioRunner.mjs';
-import { currentHarnessProfile, resolveHarnessResources } from './harnessProfile.mjs';
+import { currentHarnessProfile, resolveHarnessResources, profileCliEnv as profileEnv } from './harnessProfile.mjs';
 import { ensureFreshWorld } from './freshWorld.mjs';
 import {
   captureSessionArtifacts,
@@ -89,15 +89,6 @@ function parseArgs(argv) {
   return { options, help: args.includes('--help') || args.includes('-h') };
 }
 
-function profileEnv(profile, extra = {}) {
-  const env = { ...process.env, ATTN_PROFILE: profile, ...extra };
-  // profile-env's job in shell form: a routing override inherited from the
-  // caller's shell would silently aim these daemon commands somewhere else.
-  for (const key of ['ATTN_SOCKET_PATH', 'ATTN_DB_PATH', 'ATTN_CONFIG_PATH', 'ATTN_PLUGIN_DIR']) {
-    delete env[key];
-  }
-  return env;
-}
 
 function run(binary, args, env) {
   return execFileSync(binary, args, {

--- a/app/scripts/real-app-harness/scenarioCatalog.mjs
+++ b/app/scripts/real-app-harness/scenarioCatalog.mjs
@@ -332,6 +332,15 @@ export const scenarioCatalog = [
     timeoutMs: 600_000,
   },
   {
+    id: 'app-reconcile',
+    label: 'App reconcile: version move rebuilds, a real trim gap disables loudly, an interrupted rebuild repairs',
+    command: ['pnpm', 'run', 'real-app:scenario-app-reconcile'],
+    // Restarts the daemon with short retention/stall/dispatch tripwires and
+    // puts the defaults back. Needs bun for `attn app apply`; the Linux
+    // witness leg self-skips when the VM has no attn.
+    timeoutMs: 600_000,
+  },
+  {
     id: 'focus-probe',
     label: 'Focus probe (no focus steal on background session create)',
     command: ['pnpm', 'run', 'real-app:focus-probe'],

--- a/changelog.d/nisse-queue-cancel-all.yaml
+++ b/changelog.d/nisse-queue-cancel-all.yaml
@@ -1,0 +1,9 @@
+kind: added
+area: sessions
+change: >
+  Anything you have sent a conversation agent that it has not read yet can be
+  cancelled. The queue strip has a Cancel all next to it, and it empties once
+  the agent confirms the messages are gone.
+symptom: >
+  A steer or follow-up typed by mistake sat in the queue until the agent read
+  it, and there was no way to take it back.

--- a/changelog.d/nisse-tool-visibility.yaml
+++ b/changelog.d/nisse-tool-visibility.yaml
@@ -11,13 +11,3 @@ symptom: >
   A conversation agent that spent two minutes reading files and running commands
   showed nothing at all in between its sentences, so the only way to know what
   it had touched was to ask it.
----
-kind: added
-area: sessions
-change: >
-  Anything you have sent a conversation agent that it has not read yet can be
-  cancelled. The queue strip has a Cancel all next to it, and it empties once
-  the agent confirms the messages are gone.
-symptom: >
-  A steer or follow-up typed by mistake sat in the queue until the agent read
-  it, and there was no way to take it back.

--- a/changelog.d/reconcile-s4-bus-retention-env.yaml
+++ b/changelog.d/reconcile-s4-bus-retention-env.yaml
@@ -1,0 +1,9 @@
+kind: added
+area: bus
+change: >
+  `ATTN_BUS_RETENTION` moves the event log's age window, which is thirty days
+  by default. Without it a trim over any database younger than that removes
+  nothing however far behind a consumer is, so it is the only way to watch a
+  trim — or a consumer resuming below the oldest surviving fact — happen at
+  all. Set it for the daemon and for `attn bus trim` together, or the hourly
+  pass and the manual one keep different windows.

--- a/changelog.d/reconcile-s4-changelog-check-extra-docs.yaml
+++ b/changelog.d/reconcile-s4-changelog-check-extra-docs.yaml
@@ -1,0 +1,6 @@
+kind: fixed
+area: tooling
+change: >
+  `changelog-check` now rejects a fragment file holding more than one YAML
+  document. It only ever decoded the first, so a second fragment in the same
+  file passed the check and then never reached the changelog.

--- a/changelog.d/reconcile-s4-exit-proof.yaml
+++ b/changelog.d/reconcile-s4-exit-proof.yaml
@@ -1,0 +1,12 @@
+kind: internal
+area: testing
+change: >
+  A packaged-app scenario walks the whole reconcile story end to end —
+  installing, resuming, moving a version, hitting a real retention trim past a
+  live cursor, being interrupted mid-rebuild by a daemon restart — with a Linux
+  witness that dispatches and rebuilds on a remote daemon.
+notes: >
+  The harness's profile routing now also clears ATTN_DATA_DIR and ATTN_WS_PORT.
+  An attn session exports both into every shell it hosts and each outranks
+  ATTN_PROFILE, so a scenario driven from inside attn could drive the
+  production daemon while reporting the profile it thought it had.

--- a/changelog.d/reconcile-s4-scaffold-and-sdk-docs.yaml
+++ b/changelog.d/reconcile-s4-scaffold-and-sdk-docs.yaml
@@ -1,0 +1,7 @@
+kind: added
+area: apps
+change: >
+  `attn app new` and the app SDK now teach reconcile: what a rebuild is for,
+  the two things that trigger one (a version move and a gap), what a handler
+  owes — converge, delete as well as upsert, yield — and what happens while a
+  rebuild is owed, including the command refusal and the auto-disable.

--- a/changelog.d/snappy-iguana-recovered-session-state.yaml
+++ b/changelog.d/snappy-iguana-recovered-session-state.yaml
@@ -16,13 +16,3 @@ change: >
   finished while the daemon was down settles and reaches your queue; one that
   was waiting on an approval or a question comes back still waiting, unless it
   visibly moved on in the meantime.
----
-kind: fixed
-area: queue
-change: >
-  A snoozed agent now comes back. A snooze only opens a turn if the agent is in
-  a state that wants you, and a daemon restart used to leave every agent in
-  "launching" — so when the deadline arrived the deferral was cashed and
-  nothing was delivered: the agent silently left the Snoozed section without
-  ever reaching your queue. Deadlines already survived a restart; now the state
-  they are delivered against does too.

--- a/changelog.d/snappy-iguana-snoozed-agent-returns.yaml
+++ b/changelog.d/snappy-iguana-snoozed-agent-returns.yaml
@@ -1,0 +1,9 @@
+kind: fixed
+area: queue
+change: >
+  A snoozed agent now comes back. A snooze only opens a turn if the agent is in
+  a state that wants you, and a daemon restart used to leave every agent in
+  "launching" — so when the deadline arrived the deferral was cashed and
+  nothing was delivered: the agent silently left the Snoozed section without
+  ever reaching your queue. Deadlines already survived a restart; now the state
+  they are delivered against does too.

--- a/cmd/attn/bus.go
+++ b/cmd/attn/bus.go
@@ -78,6 +78,12 @@ commands:
         so nothing an enabled consumer or installed app has yet to read is
         removed — a lagging consumer pins the log, and bus status shows the lag.
 
+        ATTN_BUS_RETENTION moves the age window (a duration). It is thirty days
+        by default, so a pass over a database younger than that removes nothing
+        however far behind a consumer is; moving it is how a trim is watched
+        doing anything at all. Set it for the daemon too, or its hourly pass and
+        this one keep different windows.
+
   disable <consumer>
         stop delivering to a consumer. Its cursor is preserved, but a disabled
         ordinary consumer no longer holds the retention window open. An
@@ -246,6 +252,7 @@ func runBusStatus(args []string) {
 	b := bus.New(bus.Options{
 		Store:       daemon.NewBusStore(s),
 		Compactable: daemon.CompactableFacts,
+		Retention:   bus.RetentionFromEnv(busStderrLog),
 		PinAlarmAge: bus.PinAlarmAgeFromEnv(busStderrLog),
 	})
 	status, err := b.Status()
@@ -399,6 +406,7 @@ func runBusTrim(args []string) {
 	b := bus.New(bus.Options{
 		Store:       daemon.NewBusStore(s),
 		Compactable: daemon.CompactableFacts,
+		Retention:   bus.RetentionFromEnv(busStderrLog),
 		Log:         busStderrLog,
 	})
 	removed, passErr := b.Trim()

--- a/cmd/changelog-check/main.go
+++ b/cmd/changelog-check/main.go
@@ -39,6 +39,14 @@ func validateFragment(data []byte) error {
 		}
 		return err
 	}
+	// One fragment per file: the decoder reads the first document and stops, so
+	// a second one here would pass this check and then never reach the changelog.
+	var extra fragment
+	if err := dec.Decode(&extra); err == nil {
+		return fmt.Errorf("fragment file holds more than one YAML document; put each fragment in its own file")
+	} else if !errors.Is(err, io.EOF) {
+		return err
+	}
 	if !slices.Contains(validKinds, f.Kind) {
 		return fmt.Errorf("kind must be one of %s (got %q)", strings.Join(validKinds, ", "), f.Kind)
 	}

--- a/cmd/changelog-check/main_test.go
+++ b/cmd/changelog-check/main_test.go
@@ -42,6 +42,13 @@ func TestValidateFragment(t *testing.T) {
 			wantErr: "field description not found",
 		},
 		{
+			// The compiler reads one document per file, so a second one used to
+			// pass this check and then never appear in the changelog.
+			name:    "two documents in one file",
+			yaml:    "kind: added\narea: queue\nchange: first\n---\nkind: fixed\narea: queue\nchange: second\n",
+			wantErr: "more than one YAML document",
+		},
+		{
 			name:    "empty file",
 			yaml:    "",
 			wantErr: "fragment is empty",

--- a/docs/plans/2026-08-14-ext-app-reconcile-handler.md
+++ b/docs/plans/2026-08-14-ext-app-reconcile-handler.md
@@ -587,6 +587,28 @@ Gate 7's gap rules stand. Under this policy a live gap means corruption or a
 cursor from a removed install — genuinely broken states — and a broken thing
 being loud is the point.
 
+### How the exit proof reaches a gap (slice 4, ruled 2026-08-17)
+
+That policy makes a gap unreachable from product surfaces, twice over, which is
+what the exit proof ran into. The floor covers enabled **or installed**
+consumers, so no installed app is ever trimmed past; and the age window is
+thirty days, so a trim over a throwaway profile removes nothing at all whatever
+the floor says. Both were ruled on rather than worked around:
+
+- **`ATTN_BUS_RETENTION` moves the window**, following `ATTN_BUS_PIN_ALARM_AGE`'s
+  precedent — a limit no run can reach is a limit no run can demonstrate. It is
+  read by the daemon and by `attn bus trim` alike.
+- **The precondition is manufactured, and only the precondition.** The proof
+  removes the app (a product surface, which deletes its consumer rows),
+  publishes, trims for real, and then re-inserts one row: the app's consumer at
+  the cursor it actually reached — the "cursor from a removed install" this
+  section already names as a live gap cause. The trim, the deleted events, the
+  pre-drain's gap detection, the refusal, the disable, and the notification are
+  all real.
+
+This also retires the note that gate 7's handler-less disable was unit-tested
+only; `scenario-app-reconcile.mjs` drives it against a packaged app.
+
 ## Open questions
 
 None. Victor approved the two review calls on 2026-08-14:

--- a/internal/appbuild/scaffold.go
+++ b/internal/appbuild/scaffold.go
@@ -355,7 +355,7 @@ You can write the whole thing from this file. Nothing else needs reading.
 ## The shape
 
     `+ManifestName+`         what wakes the app, what state it owns, what it shows
-    src/index.ts           your handlers — subscriptions and commands
+    src/index.ts           your handlers — subscriptions, commands, reconcile
     src/views/Sessions.tsx a view: the component attn mounts as a tile
     src/generated.ts       derived from the manifest; do not edit
     tsconfig.json          so your editor sees what apply sees
@@ -380,12 +380,12 @@ applies; you find out when a handler runs.
 Every pattern under `+"`[[subscribe]]`"+` and every `+"`[[commands]]`"+` block becomes a
 required key of the `+"`Handlers`"+` type in src/generated.ts — a subscription under
 `+"`subscriptions`"+`, keyed by its event pattern; a command under `+"`commands`"+`, keyed
-by its bare name. The default export of
+by its bare name. `+"`reconcile = true`"+` adds `+"`reconcile`"+` beside them. The default export of
 src/index.ts must `+"`satisfies Handlers`"+`, so the compiler — not a convention, not a
 runtime check — is what tells you the manifest and the code disagree:
 
     import type { Ctx, Handlers } from "./generated"
-    import type { AppEvent } from %q
+    import type { AppEvent, ReconcileReason } from %q
 
     export default {
       subscriptions: {
@@ -394,10 +394,14 @@ runtime check — is what tells you the manifest and the code disagree:
       commands: {
         forget: async (payload: unknown, ctx: Ctx) => { ... },
       },
+      reconcile: async (reason: ReconcileReason, ctx: Ctx) => { ... },
     } satisfies Handlers
 
-Declare either one with no handler and apply fails with
+Declare any of them with no handler and apply fails with
 `+"`src/index.ts(7,1): error TS1360`"+` — the file, the line, and what is missing.
+
+Kind is structure, not a naming convention: a command and a subscription may
+share a name, and neither can be mistaken for the other.
 
 ## What a handler is given
 
@@ -412,6 +416,64 @@ something, read it — the fact may already be stale by the time you run.
 scoped to this app's own namespace. `+"`get`"+`, `+"`put`"+`, `+"`delete`"+`, `+"`query`"+`,
 `+"`count`"+`. Only fields you declared can be filtered or sorted on; the rest of a
 document body is stored and read back untouched.
+
+## Rebuilding what you derive: reconcile
+
+A collection is a view over facts, and a fact is only ever seen once. Two things
+would leave that view quietly wrong, so attn calls `+"`reconcile`"+` instead:
+
+- **a version move** — this app now derives something different from the same
+  facts, and the documents the old version wrote were never recomputed;
+- **a gap** — the app resumed below the oldest fact still in the log, so those
+  facts are gone and no retry can bring them back.
+
+`+"`reconcile = true`"+` in the manifest is what makes the export required, and it is
+also a promise attn holds you to: a subscribing app *without* it is refused a
+version move, in those words, before the pointer moves — so an app that cannot
+rebuild can never be updated. That is deliberate. There is no silent resume.
+
+    async function reconcile(reason: ReconcileReason, ctx: Ctx): Promise<void> {
+      const current = await ctx.current.snapshot()
+      // delete what current truth no longer has, then upsert what it does
+    }
+
+`+"`ctx.current.snapshot()`"+` is attn's current state — the same domain projection
+the app itself is handed when it connects: sessions, workspaces, tickets, PRs,
+repos, seeds, crew, endpoints, apps, and the `+"`asOfSeq`"+` they were read at. It is
+the whole reconcile-time surface besides your own collections. There is no
+replay: a rebuild reads what is true now, never old fact payloads.
+
+Three rules the runtime relies on:
+
+- **Converge.** Run it twice, or after an attempt that died halfway, and the
+  collection ends up the same. attn will do both.
+- **Delete too.** A rebuild that only upserts leaves rows nothing will ever
+  remove. Removing what current truth no longer has is half the job.
+- **Yield.** It runs on the same single event loop as every other app. Await
+  attn's APIs and the loop keeps turning; a synchronous loop that never yields
+  freezes every app until attn kills the shared runtime out from under it.
+
+Re-enabling is **not** a rebuild. An installed app's facts wait for it while it
+is disabled, however long that is, and enabling delivers that backlog in order.
+Installing for the first time is not one either — there is nothing to rebuild.
+
+### While a rebuild is owed
+
+Nothing else for this app runs. No fact is delivered and every command is
+refused by name, with the code `+"`reconcile_owed`"+` and the fence, so a view can
+tell "try again when this finishes" from "this handler is broken" without
+reading English. Views stay mounted and see documents change under them; if a
+rebuild needs to swap atomically, write a generation marker in the collection
+and switch it last.
+
+`+"`attn app status %s`"+` is where it shows: whether a rebuild is owed, the fence
+and cause that triggered it, the attempt running now, and the last failure.
+
+A reconcile that throws is retried with backoff and every attempt is recorded.
+One that stays stuck for fifteen minutes disables the app with a notification —
+the rebuild is still owed, so fix the handler and `+"`attn app enable %s`"+`. A
+restart mid-rebuild is not your fault and is not counted: the attempt is marked
+interrupted, and the rebuild is simply still owed.
 
 ## Views
 
@@ -514,8 +576,8 @@ own timeout.
 - Versions are content-addressed: applying the same content twice is the same
   version, and `+"`attn app rollback`"+` is a pointer move, not a rebuild. What a
   docked tile may call is what the *serving* version declared, so a rollback
-  takes a command away with it.
+  takes a command away with it — and, like any version move, it rebuilds.
 - attn does not remember where this directory is. It is yours; keep it wherever
   you keep code.
-`, name, name, name, name, name, SDKModule, name, name)
+`, name, name, name, name, name, SDKModule, name, name, name, name)
 }

--- a/internal/appbuild/sdkdist/index.d.ts
+++ b/internal/appbuild/sdkdist/index.d.ts
@@ -85,8 +85,18 @@ export interface AppContext<Collections> {
     readonly version: number;
     /** The collections declared in attn-app.toml, by name. */
     readonly collections: Collections;
-    /** Read-only current truth, from the same domain projection as Initial State. */
+    /**
+     * Read-only current truth, from the same domain projection attn's own UI is
+     * handed when it connects. This is how a handler answers "what is true now"
+     * without replaying facts it may no longer be able to see; it is the whole
+     * read surface a reconcile has besides the app's own collections.
+     */
     readonly current: {
+        /**
+         * One consistent read of attn's state-bearing domains, stamped with the bus
+         * position it was taken at. Every mutation at or below `asOfSeq` is already
+         * in it; a later one still has a fact coming.
+         */
         snapshot(): Promise<CurrentStateSnapshot>;
     };
 }
@@ -97,7 +107,19 @@ export interface AppContext<Collections> {
  * log open for everyone.
  */
 export type Handler<Collections> = (event: AppEvent, ctx: AppContext<Collections>) => void | Promise<void>;
-/** Why attn requires the app to rebuild its derived collections. */
+/**
+ * Why attn requires the app to rebuild its derived collections.
+ *
+ * - `gap` — the consumer resumed below the oldest fact still in the log. Those
+ *   facts are gone; no retry brings them back.
+ * - `version_changed` — a different version is serving, so what this app
+ *   derives from the same facts has changed and its existing documents were
+ *   never recomputed. A rollback is a version change too.
+ *
+ * Re-enabling is neither: an installed app's facts wait while it is disabled,
+ * so enabling delivers that backlog in order. Nor is a first install, which has
+ * no derived state to rebuild.
+ */
 export type ReconcileCause = "gap" | "version_changed";
 export type { AppRegistryEntry, AppViewInfo, AuthorState, CrewMember, CurrentStateSnapshot, EndpointCapabilities, EndpointInfo, PR, RepoState, Seed, SeedEdge, SeedPlotProgress, SeedVar, Session, TicketRow, Workspace, WorkspaceLayout, WorkspacePane, } from "./currentState";
 /** The durable requests coalesced into one reconcile invocation. */
@@ -116,7 +138,31 @@ export interface ReconcileReason {
     /** Distinct prior versions named by pointer moves, in request order. */
     readonly previousVersions: readonly number[];
 }
-/** Rebuilds the app's collections from current truth. It must be idempotent. */
+/**
+ * Rebuilds the app's collections from current truth, read through
+ * `ctx.current.snapshot()` rather than replayed from facts.
+ *
+ * The contract the runtime relies on:
+ *
+ * - **It converges.** Running it twice, or after an attempt that died halfway,
+ *   ends with the same collection contents. attn will do both — a failed
+ *   attempt is retried, and a daemon restart leaves the rebuild still owed.
+ * - **It deletes as well as upserts.** A rebuild that only writes leaves rows
+ *   current truth no longer has, and nothing else will remove them.
+ * - **It yields.** Every app's handlers share one event loop. Awaiting attn's
+ *   APIs keeps it turning; a synchronous loop that never yields freezes every
+ *   app until attn kills the shared runtime out from under it.
+ *
+ * While a rebuild is owed or running, this app receives no fact and every
+ * command against it is refused with the code `reconcile_owed`. Views stay
+ * mounted and observe intermediate writes, so a rebuild that must swap
+ * atomically writes a generation marker in its collection and switches it last.
+ *
+ * A rebuild that keeps throwing is retried with backoff, recorded attempt by
+ * attempt, and after fifteen minutes on the same claim the app is disabled with
+ * a notification — still owing the rebuild. `attn app status <name>` shows all
+ * of it.
+ */
 export type ReconcileHandler<Collections> = (reason: ReconcileReason, ctx: AppContext<Collections>) => void | Promise<void>;
 /**
  * What a view is given. A view is a function of where it sits: the first three

--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	// DefaultRetention is the trim age window, floored by enabled-consumer cursors.
+	// RetentionEnv moves it, which is the only way to watch a trim do anything.
 	DefaultRetention = 30 * 24 * time.Hour
 	// DefaultTrimInterval is how often retention runs.
 	DefaultTrimInterval = time.Hour
@@ -1178,6 +1179,43 @@ func pinAlarmAgeOrDefault(v time.Duration) time.Duration {
 		return DefaultPinAlarmAge
 	}
 	return v
+}
+
+// RetentionEnv overrides the trim age window. Thirty days is unreachable in any
+// run anyone can watch, so without this the only observable behavior of
+// retention is that it never removes anything: a trim against a fresh database
+// removes zero rows whatever the cursor floor says, and what a consumer resuming
+// below `earliest` does could not be produced outside a unit test.
+//
+// A duration ("1s", "5m"). There is no off switch — retention is a window, not a
+// finding — so a non-positive value is refused like an unparseable one.
+const RetentionEnv = "ATTN_BUS_RETENTION"
+
+// RetentionFromEnv resolves the trim window for one process. It lives beside
+// PinAlarmAgeFromEnv and for the same reason: the daemon that trims hourly and
+// the CLI that runs a pass by hand read one database, and a window they disagree
+// about makes `attn bus trim` remove rows the daemon would have kept.
+func RetentionFromEnv(log LogFunc) time.Duration {
+	if log == nil {
+		log = func(string, ...interface{}) {}
+	}
+	raw := strings.TrimSpace(os.Getenv(RetentionEnv))
+	if raw == "" {
+		return DefaultRetention
+	}
+	window, err := time.ParseDuration(raw)
+	if err != nil {
+		log("bus: %s=%q is not a duration (%v); using the default %s",
+			RetentionEnv, raw, err, DefaultRetention)
+		return DefaultRetention
+	}
+	if window <= 0 {
+		log("bus: %s=%q is not a positive window; using the default %s",
+			RetentionEnv, raw, DefaultRetention)
+		return DefaultRetention
+	}
+	log("bus: retention window set to %s by %s (default %s)", window, RetentionEnv, DefaultRetention)
+	return window
 }
 
 // PinAlarmAgeEnv overrides the retention-pin tripwire, so the condition can be

--- a/internal/bus/pin_test.go
+++ b/internal/bus/pin_test.go
@@ -322,3 +322,88 @@ func TestTheMessageNamesTheTripwireExactly(t *testing.T) {
 		}
 	}
 }
+
+// The other window an operator can move, and the one with no other way to be
+// seen: thirty days is longer than any run anyone watches, so a trim against a
+// database younger than that removes nothing whatever the cursor floor says.
+// Without this knob, "resumes below the oldest surviving fact" is a state the
+// product can only reach in a unit test.
+func TestRetentionFromEnv(t *testing.T) {
+	for _, tc := range []struct {
+		raw  string
+		want time.Duration
+		says string
+	}{
+		{raw: "", want: DefaultRetention},
+		{raw: "1s", want: time.Second, says: "retention window set to 1s"},
+		{raw: "5m", want: 5 * time.Minute, says: "retention window set to 5m"},
+		// Retention is a window, not a finding, so there is nothing for zero or a
+		// negative to mean. Both fall back loudly rather than turning trim into a
+		// pass that deletes everything below the floor.
+		{raw: "0", want: DefaultRetention, says: "is not a positive window"},
+		{raw: "-5m", want: DefaultRetention, says: "is not a positive window"},
+		{raw: "soon", want: DefaultRetention, says: "is not a duration"},
+	} {
+		t.Run(fmt.Sprintf("%q", tc.raw), func(t *testing.T) {
+			t.Setenv(RetentionEnv, tc.raw)
+			var said []string
+			got := RetentionFromEnv(func(format string, args ...interface{}) {
+				said = append(said, fmt.Sprintf(format, args...))
+			})
+			if got != tc.want {
+				t.Errorf("%q = %s, want %s", tc.raw, got, tc.want)
+			}
+			whole := strings.Join(said, "\n")
+			if tc.says == "" {
+				if whole != "" {
+					t.Errorf("an unset knob said %q; a default nobody asked to change is not news", whole)
+				}
+				return
+			}
+			if !strings.Contains(whole, tc.says) {
+				t.Errorf("said %q, want it to carry %q", whole, tc.says)
+			}
+		})
+	}
+}
+
+// What the knob is for. The window is what decides whether a trim can remove
+// anything at all, and at the shipped default a fresh log is untouchable — which
+// is the whole reason a consumer resuming below `earliest` had no way to be
+// produced outside a unit test.
+func TestAMovedRetentionWindowIsWhatLetsATrimRemoveAnything(t *testing.T) {
+	seed := func(t *testing.T, b *Bus, s Store) {
+		t.Helper()
+		for _, name := range []string{"a.happened", "b.happened"} {
+			if _, err := b.Publish(name, "subject-"+name, nil); err != nil {
+				t.Fatalf("Publish(%s): %v", name, err)
+			}
+		}
+		// A consumer at head, so the cursor floor is not what decides this.
+		_, head, err := s.Bounds()
+		if err != nil {
+			t.Fatalf("Bounds: %v", err)
+		}
+		if err := s.SaveConsumer(Consumer{Name: "reader", Cursor: head, Enabled: true}, time.Now()); err != nil {
+			t.Fatalf("SaveConsumer: %v", err)
+		}
+	}
+
+	t.Run("at the shipped default nothing is old enough", func(t *testing.T) {
+		s := newMemStore()
+		b := New(Options{Store: s, Retention: DefaultRetention})
+		seed(t, b, s)
+		if n, err := b.Trim(); err != nil || n != 0 {
+			t.Fatalf("trimmed %d event(s) from a fresh log at the 30-day window, want 0 (err=%v)", n, err)
+		}
+	})
+
+	t.Run("moved to a window a run can cross", func(t *testing.T) {
+		s := newMemStore()
+		b := New(Options{Store: s, Retention: time.Nanosecond})
+		seed(t, b, s)
+		if n, err := b.Trim(); err != nil || n != 2 {
+			t.Fatalf("trimmed %d event(s) with the window moved, want 2 (err=%v)", n, err)
+		}
+	})
+}

--- a/internal/daemon/app_autodisable_test.go
+++ b/internal/daemon/app_autodisable_test.go
@@ -313,3 +313,71 @@ func TestADisabledInstalledAppStillHoldsTheRetentionFloor(t *testing.T) {
 		t.Fatalf("compaction removed %d retained event(s) after auto-disable", removed)
 	}
 }
+
+// How long attn tried, in units that survive the window being moved.
+//
+// Both auto-disable notifications rounded their stall to the minute. The only
+// way anyone witnesses this path without waiting a quarter of an hour is to move
+// the window with ATTN_APP_AUTO_DISABLE_STALL — and every such run read "for
+// 0s", which is the notification saying attn gave up immediately. At the shipped
+// fifteen minutes it was no better: "for 15m" repeats the constant instead of
+// reporting the measurement. Live verification is what read these strings back;
+// the tests beside them checked the phrases around the number, so the number was
+// free to be wrong.
+func TestAnAutoDisableNotificationReportsHowLongAttnTried(t *testing.T) {
+	// Short enough that rounding to the minute renders it as zero, which is
+	// exactly the operator's case.
+	const window = 25 * time.Second
+
+	t.Run("a handler stuck on one event", func(t *testing.T) {
+		d := newAppDaemon(t)
+		clock := newAppTestClock(d)
+		d.appAutoDisableWait = window
+		installApp(t, d, "greeter", subscribing("ticket.*"))
+		startFakeAppRuntime(t, d, failEvery("TypeError: undefined is not a function"))
+		stuck := appEvent("ticket.created", "tk-1", 12)
+
+		if err := d.deliverAppEvent(context.Background(), "greeter", stuck); err == nil {
+			t.Fatal("a throwing handler reported success")
+		}
+		clock.advance(30 * time.Second)
+		if err := d.deliverAppEvent(context.Background(), "greeter", stuck); err == nil {
+			t.Fatal("a throwing handler reported success")
+		}
+		assertDisableNotificationSaysDuration(t, d, "30s")
+	})
+
+	t.Run("a rebuild that keeps throwing", func(t *testing.T) {
+		d := newAppDaemon(t)
+		clock := newAppTestClock(d)
+		d.appAutoDisableWait = window
+		reconcilingApp(t, d, "greeter")
+		runtime := startFakeAppRuntime(t, d, nil)
+		runtime.reconcile = func(*fakeAppRuntime, appReconcileRequest) error {
+			return errors.New("TypeError: snapshot.sessions is not iterable")
+		}
+
+		if err := appReconcilePreDrain(t, d, "greeter"); err == nil {
+			t.Fatal("a throwing reconcile reported success")
+		}
+		clock.advance(30 * time.Second)
+		if err := appReconcilePreDrain(t, d, "greeter"); err == nil {
+			t.Fatal("a throwing reconcile reported success")
+		}
+		assertDisableNotificationSaysDuration(t, d, "30s")
+	})
+}
+
+func assertDisableNotificationSaysDuration(t *testing.T, d *Daemon, want string) {
+	t.Helper()
+	if appEnabled(t, d, "greeter") {
+		t.Fatal("greeter is still enabled past its stall window")
+	}
+	notes := appNotifications(t, d, notificationKindAppAutoDisabled)
+	if len(notes) != 1 {
+		t.Fatalf("auto-disable notifications = %d, want 1", len(notes))
+	}
+	if !strings.Contains(notes[0].Body, "for "+want) {
+		t.Fatalf("the notification does not report how long attn tried (want %q): %q", want, notes[0].Body)
+	}
+}

--- a/internal/daemon/app_reconcile_failure_test.go
+++ b/internal/daemon/app_reconcile_failure_test.go
@@ -214,6 +214,15 @@ func TestACommandIsRefusedByNameWhileAReconcileIsOwed(t *testing.T) {
 	if !strings.Contains(refusal, "greeter") || !strings.Contains(refusal, "rebuilding") {
 		t.Fatalf("the refusal does not name the app and what it is doing: %q", refusal)
 	}
+	// The code travels in its own field, so the sentence is free to be a
+	// sentence. It led with `reconcile_owed:` once, which reads to a person as
+	// noise and to a caller as something to parse.
+	if strings.HasPrefix(refusal, protocol.ErrorCodeReconcileOwed) {
+		t.Fatalf("the refusal leads with the wire code instead of saying what happened: %q", refusal)
+	}
+	if !strings.Contains(refusal, "attn app status greeter") {
+		t.Fatalf("the refusal does not name where to look: %q", refusal)
+	}
 
 	// And it is a refusal, not a failure: nothing ran, so nothing is charged to
 	// the app. The rebuild failing in the background is charged — that is the

--- a/internal/daemon/app_wedge_test.go
+++ b/internal/daemon/app_wedge_test.go
@@ -262,3 +262,67 @@ func TestTheLivenessPingIsBoundedIndependently(t *testing.T) {
 		t.Fatalf("appPingBudget() = %v, want the override", got)
 	}
 }
+
+// A timeout has to interrupt the work, not merely stop waiting for it.
+//
+// Attribution says who wedged the loop; this says what happens to the process
+// the loop is in. A handler that never yields cannot be cancelled from Go, so
+// the only way back is to end the generation it is running in and let the
+// supervisor start the replacement. Everything below the daemon was already
+// pinned — TestTerminateGenerationRestartsOnlyTheExactProcess in
+// internal/supervise — and everything above it by the tests here; nothing drove
+// a wedged dispatch through the seam between them, which a live spinner walk
+// found and no test would have.
+//
+// The supervised child is a real process so the terminate has something to
+// kill and the supervisor something to replace. The sidecar the daemon talks to
+// is still the pipe: what is being pinned is which process dies, not what is
+// said over the socket.
+func TestAWedgedDispatchEndsTheRuntimeGenerationAndTheSupervisorReplacesIt(t *testing.T) {
+	d := newAppDaemon(t)
+	d.appDispatchWait = 300 * time.Millisecond
+	d.appPingWait = 50 * time.Millisecond
+	installApp(t, d, "hog", subscribing("ticket.*"))
+
+	t.Setenv(appRuntimeHostOverride, writeExecutableStub(t, "exec sleep 300"))
+	t.Cleanup(d.stopAppRuntime)
+	if err := d.ensureAppRuntime(); err != nil {
+		t.Fatalf("start the supervised runtime: %v", err)
+	}
+	wedged, ok := d.appRuntimeSnapshot()
+	if !ok || !wedged.Running {
+		t.Fatalf("supervised runtime snapshot = %+v, want a running child", wedged)
+	}
+
+	// The fake sidecar says generation 1, which is the generation the supervisor
+	// just spawned — the same agreement a real host reaches through its
+	// environment.
+	entered := make(chan string, 1)
+	release := make(chan struct{})
+	defer close(release)
+	if wedged.Generation != 1 {
+		t.Fatalf("the supervisor spawned generation %d, but the fake sidecar says 1", wedged.Generation)
+	}
+	runtime := startFakeAppRuntime(t, d, enterOnceThenBlock(entered, release))
+
+	failed := make(chan error, 1)
+	go func() {
+		failed <- d.deliverAppEvent(context.Background(), "hog", appEvent("ticket.created", "tk-1", 1))
+	}()
+	if app := <-entered; app != "hog" {
+		t.Fatalf("first handler in was %s, want hog", app)
+	}
+	runtime.freezeLoop()
+
+	if err := <-failed; err == nil {
+		t.Fatal("a dispatch into a frozen runtime reported success")
+	}
+	waitFor(t, "the supervisor to replace the generation the timeout ended", func() bool {
+		snapshot, ok := d.appRuntimeSnapshot()
+		return ok && snapshot.Generation > wedged.Generation && snapshot.Running
+	})
+	replacement, _ := d.appRuntimeSnapshot()
+	if replacement.LastExit == nil {
+		t.Fatal("the replacement carries no exit for the generation that was ended")
+	}
+}

--- a/internal/daemon/bus.go
+++ b/internal/daemon/bus.go
@@ -564,6 +564,7 @@ func (d *Daemon) ensureEventBus() {
 		Store:       backing,
 		Log:         d.logf,
 		Compactable: CompactableFacts,
+		Retention:   bus.RetentionFromEnv(d.logf),
 		PinAlarmAge: d.busPinAlarmAge(),
 	})
 	d.busUnsubscribe = d.eventBus.Subscribe(bus.All, d.projectToClients)

--- a/sdk/attn-app/src/index.ts
+++ b/sdk/attn-app/src/index.ts
@@ -119,8 +119,18 @@ export interface AppContext<Collections> {
   readonly version: number
   /** The collections declared in attn-app.toml, by name. */
   readonly collections: Collections
-  /** Read-only current truth, from the same domain projection as Initial State. */
+  /**
+   * Read-only current truth, from the same domain projection attn's own UI is
+   * handed when it connects. This is how a handler answers "what is true now"
+   * without replaying facts it may no longer be able to see; it is the whole
+   * read surface a reconcile has besides the app's own collections.
+   */
   readonly current: {
+    /**
+     * One consistent read of attn's state-bearing domains, stamped with the bus
+     * position it was taken at. Every mutation at or below `asOfSeq` is already
+     * in it; a later one still has a fact coming.
+     */
     snapshot(): Promise<CurrentStateSnapshot>
   }
 }
@@ -136,7 +146,19 @@ export type Handler<Collections> = (
   ctx: AppContext<Collections>,
 ) => void | Promise<void>
 
-/** Why attn requires the app to rebuild its derived collections. */
+/**
+ * Why attn requires the app to rebuild its derived collections.
+ *
+ * - `gap` — the consumer resumed below the oldest fact still in the log. Those
+ *   facts are gone; no retry brings them back.
+ * - `version_changed` — a different version is serving, so what this app
+ *   derives from the same facts has changed and its existing documents were
+ *   never recomputed. A rollback is a version change too.
+ *
+ * Re-enabling is neither: an installed app's facts wait while it is disabled,
+ * so enabling delivers that backlog in order. Nor is a first install, which has
+ * no derived state to rebuild.
+ */
 export type ReconcileCause = "gap" | "version_changed"
 
 export type {
@@ -177,7 +199,31 @@ export interface ReconcileReason {
   readonly previousVersions: readonly number[]
 }
 
-/** Rebuilds the app's collections from current truth. It must be idempotent. */
+/**
+ * Rebuilds the app's collections from current truth, read through
+ * `ctx.current.snapshot()` rather than replayed from facts.
+ *
+ * The contract the runtime relies on:
+ *
+ * - **It converges.** Running it twice, or after an attempt that died halfway,
+ *   ends with the same collection contents. attn will do both — a failed
+ *   attempt is retried, and a daemon restart leaves the rebuild still owed.
+ * - **It deletes as well as upserts.** A rebuild that only writes leaves rows
+ *   current truth no longer has, and nothing else will remove them.
+ * - **It yields.** Every app's handlers share one event loop. Awaiting attn's
+ *   APIs keeps it turning; a synchronous loop that never yields freezes every
+ *   app until attn kills the shared runtime out from under it.
+ *
+ * While a rebuild is owed or running, this app receives no fact and every
+ * command against it is refused with the code `reconcile_owed`. Views stay
+ * mounted and observe intermediate writes, so a rebuild that must swap
+ * atomically writes a generation marker in its collection and switches it last.
+ *
+ * A rebuild that keeps throwing is retried with backoff, recorded attempt by
+ * attempt, and after fifteen minutes on the same claim the app is disabled with
+ * a notification — still owing the rebuild. `attn app status <name>` shows all
+ * of it.
+ */
 export type ReconcileHandler<Collections> = (
   reason: ReconcileReason,
   ctx: AppContext<Collections>,


### PR DESCRIPTION
Slice 4 of the app reconcile plan (`docs/plans/2026-08-14-ext-app-reconcile-handler.md`), on top of #906, #918, #931 and #938. It closes the epic's two remaining debts: an app author is now told the reconcile handler exists, and the feature has a walk that proves it against a real daemon instead of only in unit tests.

## Scaffold and SDK docs

`attn app new` scaffolds a brief with a "Rebuilding what you derive: reconcile" section: what a rebuild is, that `gap` and `version_changed` are the only two causes, and — the part that surprises people — that re-enabling an app is **not** one of them, because a disabled consumer's cursor is still where it was. The handlers example carries a `ReconcileReason` handler beside the subscriptions, and the file map names it.

The SDK says the same at the point of use: `AppContext.current`, `ReconcileCause` and `ReconcileHandler` gained doc comments an editor shows when you reach for them. `internal/appbuild/sdkdist/index.d.ts` is the regenerated copy (`make generate-sdk`).

## The exit proof

`pnpm --dir app run real-app:scenario-app-reconcile` — a packaged app on a throwaway profile, a real daemon with short tripwires, real apps built and applied with bun. Seven legs:

1. **before** — an app derives a document per ticket; a first install does not reconcile, because installing is not a trigger.
2. **resume is not a rebuild** — disable, publish, enable: the retained backlog is delivered in order and no reconcile row appears.
3. **version move rebuilds** — apply a version that derives a new field; the rebuild replays facts the old version never received, and the documents carry the new field afterwards.
4. **no handler, no move** — an app without a reconcile handler records `unsupported` rather than silently skipping.
5. **gap disables loudly** — a **real** retention trim past a live cursor (`ATTN_BUS_RETENTION=1s`, the trim job, rows actually deleted), then the app is disabled with a notification naming the gap.
6. **interrupted rebuild repairs** — restart the daemon mid-rebuild; the run asserts an `interrupted` invocation row exists *and* that a later `ok` row carries the same `through_request_id`, so a restart that merely raced a finished rebuild fails the leg instead of passing it.
7. **converges before later facts** — each case reaches `reconcile.state: idle` before the next batch of facts is published.

Then a **Linux witness** on the OrbStack VM: a dispatch (`subscribe:ticket.*`, ok) and a version-move rebuild (`causes: ["version_changed"]`, ok, back to idle) driven through the CLI there. It skips itself loudly when the VM has no attn — reachability is not what this scenario tests.

Registered in `scenarioCatalog.mjs` so the serial matrix keeps running it. It restarts the daemon with the short tripwires and puts the defaults back on both the success and the failure path.

**One manufactured precondition, named.** Leg 5 needs a consumer row whose install is gone — the trim floor is deliberately held down by every installed app, so a live app cannot reach a gap in its own facts by design. The scenario writes that one row directly. Everything after it is real: the trim runs, the rows are deleted, the gap is detected from the actual cursor, the refusal and the disable and the notification are the product's. This half of the ruling is recorded in the plan doc under "How the exit proof reaches a gap".

**No recording attached.** This adds no app UI, and the evidence repo is public while the window showed unrelated PR titles from the maintainer's other work. The legs write their receipts as artifacts instead.

## figgyster's #938 ledger debts

The dispatch-timeout → `TerminateGeneration` seam is pinned by `TestAWedgedDispatchEndsTheRuntimeGenerationAndTheSupervisorReplacesIt` — a wedged dispatch, the timeout firing, the generation ending, the supervisor replacing the runtime. It went into Go rather than the harness deliberately: it is deterministic, it runs in CI on every PR, and it fails on that exact seam rather than on whatever the app happened to render. Both copy fixes landed with assertions that fail if the wording drifts back (`app_autodisable_test.go`, `app_reconcile_failure_test.go`). All three were mutation-checked.

## Two things the walk turned up

**`ATTN_BUS_RETENTION`.** Reaching a real trim used to mean waiting out the retention window. The env var moves it, exactly like `ATTN_BUS_PIN_ALARM_AGE` moves the pin alarm — read once at daemon start, logged, and named in `bus status --help` and AGENTS.md.

**The harness kept two routing overrides it should have cleared.** `profileEnv` cleared `ATTN_SOCKET_PATH`, `ATTN_DB_PATH`, `ATTN_CONFIG_PATH` and `ATTN_PLUGIN_DIR`, but not `ATTN_DATA_DIR` or `ATTN_WS_PORT`. An attn-managed session exports both into every shell it hosts, and both outrank `ATTN_PROFILE` — so a harness driven from inside attn printed `profile=<name>` on the banner while the command talked to the production data dir on port 9849. A `daemon ensure` from a scenario took over the production daemon that way during this work (no data damage: the trim is an hourly job and never ran; `bus_events` still holds all 406,386 rows from 2026-08-02 on). `profileCliEnv` in `harnessProfile.mjs` now clears all six in one place, and the six scenarios that had their own copy import it. `attn profile-env` does not clear `ATTN_DATA_DIR` either, which is why the banner's `socket=` field is the only witness worth trusting.

**A changelog fragment file could silently swallow a second entry.** The decoder reads the first YAML document and stops, so a fragment appended with `---` to an existing file passed validation and then never reached the changelog. `changelog-check` now rejects a multi-document fragment file, and splitting the two files already in that state recovered two real user-facing entries (`nisse-queue-cancel-all`, `snappy-iguana-snoozed-agent-returns`).

## Verification

- `go build ./... && go vet ./... && go test ./...` — clean.
- `pnpm --dir app test` — 2961 passed, 13 skipped, 270 files.
- `make check-types` and `make check-sdk` — both 0. No protocol change in this slice.
- `real-app:scenario-app-reconcile` — `ok: true`, `failureCount: 0`, every leg green including the Linux witness.

## Not in scope

The per-lane retention cap (wants a measurement receipt first), crew work, and the A5 exit / slice 6, which the maintainer is holding.
